### PR TITLE
Build bootstrapper looks for both WOW and native x86 msbuild

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -9,7 +9,7 @@ setlocal
 :: Check prerequisites
 set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see http://go.microsoft.com/fwlink/?LinkID=518812 for build instructions. && goto :eof
+if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corefx/blob/master/docs/Developers.md for build instructions. && goto :eof
 
 :: Log build command line
 set _buildprefix=echo


### PR DESCRIPTION
This change causes the build bootstrapper to look for the x86 MSBuild
in both the WOW and native Program Files, to enable building on x86
machines.  This change also provides a friendly error if MSBuild.exe
cannot be found in either location, directing users to our
contributing guide via http://go.microsoft.com/fwlink/?LinkID=518812

I will make the same PR for corefx once this one is accepted.

@Petermarcu you were looking at this.
