### PR TITLE
build.cmd uses either MSBuild 12 or MSBuild 14

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -9,6 +9,8 @@ setlocal
 :: Check prerequisites
 set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
+if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corefx/blob/master/docs/Developers.md for build instructions. && goto :eof
 
 :: Log build command line


### PR DESCRIPTION
Previously our repositories would build in either a Dev12 or a Dev14
Developer Command Prompt, but only if Dev12 (for MSBuild 12) was
on the box due to a hard-coded path to MSBuild 12.  This change
will use MSBuild 14 if MSBuild 12 is not available.
