### PR TITLE
Fix build script to use default web proxy to download remote files.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -31,7 +31,10 @@
         <![CDATA[
            var directory = System.IO.Path.GetDirectoryName(FileName);
            System.IO.Directory.CreateDirectory(directory);
-           new System.Net.WebClient().DownloadFile(Address, FileName);
+           var client = new System.Net.WebClient();
+           client.Proxy = System.Net.WebRequest.DefaultWebProxy;
+           client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
+           client.DownloadFile(Address, FileName);
         ]]>
       </Code>
     </Task>


### PR DESCRIPTION
Applying fix from corefx to buildtools
https://github.com/dotnet/corefx/commit/423f9ec7e322d8d22da7f006b245f9770732ba5e
