### PR TITLE
Fix build break when System.Collections.Immutable is GAC'd.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>true</Private>
     </Reference>
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>


### PR DESCRIPTION
In certain configurations the version of System.Collections.Immutable that Microsoft.DotNet.Build.Tasks references is also located in the GAC.  One such example is having Visual Studio 2013 Community Edition + Visual Studio 2015 Preview installed on Windows 10 Technical Preview.  I suspect (but have not confirmed) that the real issue is VS 2015 Preview, as I believe it is what causes the assembly to be GAC'd.

Because of this, ResolveAssemblyReferences will not copy System.Collections.Immutable into the output directory when build Microsoft.DotNet.Build.Tasks.  Because of this, when we later go try to build the NuGet package for Microsoft.DotNet.Build.Tasks, we fail because the file is not present.

The fix is to mark this reference with the <Private>true</Private> metadata so that it is always copied to the output directory.
