### PR TITLE
Removed duplicate string.Format

### DIFF
--- a/src/JSon2Txt/Program.cs
+++ b/src/JSon2Txt/Program.cs
@@ -48,7 +48,7 @@ namespace JSon2Txt
             Converter converter = new Converter();
             if (!ParseArgs(args, converter))
             {
-                Console.WriteLine(String.Format("Usage: {0} <json file list> /out <output file>", Process.GetCurrentProcess().ProcessName));
+                Console.WriteLine("Usage: {0} <json file list> /out <output file>", Process.GetCurrentProcess().ProcessName);
                 return 1;
             }
 


### PR DESCRIPTION
Console.WriteLine 'includes' a string.Format so the string.Format inside
Console.WriteLine is not needed.
