### PR TITLE
Use separate obj directory per project.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/beforecommon.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/beforecommon.targets
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" TreatAsLocalProperty="BaseIntermediateOutputPath">
   <Import Project="resources.targets" />
   <Import Project="sign.targets" />
+  
+  <PropertyGroup>
+    <BaseIntermediateOutputPath>$(BaseIntermediateOutputPath)\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The buildtools were overriding the intermediate path to be the same for every
project. This causes issues because not all intermediate files have unique
names. In particular, incremental or parallel builds could silently put the
resources from a different project in to an assembly!
