### PR TITLE
Make xunit runner task take IncludeTraits and ExcludeTraits properties

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -10,7 +10,7 @@
       <_TestsAssemblies Include="$(OutDir)**\*test*.dll" />
     </ItemGroup>
     
-    <xunit Condition="'@(_TestsAssemblies)'!=''" Assemblies="@(_TestsAssemblies)" ShadowCopy="false" />
+    <xunit Condition="'@(_TestsAssemblies)'!=''" Assemblies="@(_TestsAssemblies)" ShadowCopy="false" IncludeTraits="$(IncludeTraits)" ExcludeTraits="$(ExcludeTraits)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Make xunit runner task take IncludeTraits and ExcludeTraits properties. This way we can specify which tests are or not gonna run. It is needed for excluding outer loop tests in corefx from default build
