### PR TITLE
Add error to build.cmd when running in a non DevEnv command prompt.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -11,7 +11,9 @@ set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
-if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corefx/blob/master/docs/Developers.md for build instructions. && goto :eof
+if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corefx/wiki/Developer%20Guide for build instructions. && goto :eof
+
+if not defined VSINSTALLDIR echo Error: build.cmd should be run from a Visual Studio Command Prompt. Please see https://github.com/dotnet/corefx/wiki/Developer%20Guide for build instructions. && goto :eof
 
 :: Log build command line
 set _buildprefix=echo


### PR DESCRIPTION
Update links to developer guide in error messages to new location
on the dotnet/corefx wiki.
