### PR TITLE
Use NuGet.config at root so VS can see it

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
@@ -8,7 +8,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <NuGetConfigFile>$(SourceDir)nuget\NuGet.Config</NuGetConfigFile>
+      <NuGetConfigFile>$(SourceDir)NuGet.Config</NuGetConfigFile>
       <NuGetConfigCommandLine
       Condition="Exists($(NuGetConfigFile))">-ConfigFile &quot;$(NuGetConfigFile)&quot;</NuGetConfigCommandLine>
     </PropertyGroup>


### PR DESCRIPTION
See also https://github.com/dotnet/corefx/pull/233

Once that is in and this is adopted in a new buildtools version, we can delete the copy in the nuget/ sub-folder.
