### PR TITLE
Test only binaries which end with test or tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -7,7 +7,8 @@
     Condition="'$(SkipTests)' != 'True'">
     
     <ItemGroup>
-      <_TestsAssemblies Include="$(OutDir)**\*test*.dll" />
+      <_TestsAssemblies Include="$(OutDir)**\*.test.dll" />
+      <_TestsAssemblies Include="$(OutDir)**\*.tests.dll" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Currently we have problems with Visual Studio runner and potentially more binaries in the future that runner is trying to run assemblies which are not tests but do contain Test word in them.

This will change it so it will pick up assemblies which end with test.dll or tests.dll
