### PR TITLE
Register msbuild.log as an asset on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,6 @@
 build_script: "\"%VS120COMNTOOLS%VsDevCmd.bat\" && build.cmd"
 test: off  # disable automatic test discovery, xUnit already runs as part of build.cmd
+
+artifacts:
+  - path: msbuild.log
+    name: MSBuild Log


### PR DESCRIPTION
If we need to debug the build issues it's pretty convenient if we can directly download the diagnostic log.

**Note:**

This is conceptually the same as [PR #314 on corefx](https://github.com/dotnet/corefx/pull/314).

/cc @weshaggard @ellismg 
