### PR TITLE
Allow skipping package build in packages.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -15,7 +15,8 @@
   </PropertyGroup>
 
   <Target Name="BuildPackages"
-    DependsOnTargets="GetNuGetPackageVersions">
+    DependsOnTargets="GetNuGetPackageVersions"
+    Condition="'$(SkipBuildPackages)' != 'true'">
     
     <!-- Create package output directory -->
     <MakeDir Directories="$(PackagesOutDir)" />


### PR DESCRIPTION
Introduced a property 'SkipBuildPackages' that allows to skip
creating NuGet packages (similar to ['SkipTests'](https://github.com/dotnet/buildtools/blob/1fe1371d44b58c20117ade7c6b79e258833b2da0/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets#L24) and ['SkipSigning'](https://github.com/dotnet/buildtools/blob/2dc23399c4ac1b2c6496dd8e600697c666005e29/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets#L6)).

This helps on Mono/Linux where getting the correct libgit2 version
is a bit cumbersome and I'm not interested in the packages atm.
