### PR TITLE
Trim backslash from commands instead of adding space

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
@@ -10,7 +10,7 @@
     <Exec
       Condition="'@(PackageConfigs)'!=''"
       StandardOutputImportance="Low"
-      Command="&quot;$(NuGetToolPath)&quot; restore &quot;%(PackageConfigs.FullPath)&quot; -PackagesDirectory &quot;$(PackagesDir) &quot; $(NuGetConfigCommandLine)" 
+      Command="&quot;$(NuGetToolPath)&quot; restore &quot;%(PackageConfigs.FullPath)&quot; -PackagesDirectory &quot;$(PackagesDir.TrimEnd('\'))&quot; $(NuGetConfigCommandLine)" 
       />
 
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -30,13 +30,13 @@
          in framework specific subfolders.  Our build tools do this because the
          libraries are used during build, and do not depend on the framework being
          targeted by the build -->
-    <!-- We also add a space after all of the properties which could end with a
-         backslash, to prevent it from escaping the closing quote -->
+    <!-- We trim the last backslash from properties which could end with one,
+         to prevent it from escaping the closing quote -->
     <Exec
       Condition="'@(PackagesNuSpecFiles)'!=''"
       IgnoreStandardErrorWarningFormat="true"
       StandardOutputImportance="Low"
-      Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath &quot;$(PackagesBasePath) &quot; -OutputDirectory &quot;$(PackagesOutDir) &quot; $(VersionCmdLine)" />
+      Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath &quot;$(PackagesBasePath.TrimEnd('\'))&quot; -OutputDirectory &quot;$(PackagesOutDir.TrimEnd('\'))&quot; $(VersionCmdLine)" />
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"


### PR DESCRIPTION
This solves a problem on Mono where the path would be created as
specified (i.e. including the spaces).

The spaces are only necessary to avoid an ending backslash escaping
the quote char on Windows. Trimming the backslash has the same effect.