### PR TITLE
Run OpenSourceSign target after Compile target

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <Target Name="OpenSourceSign" 
-          BeforeTargets="CopyFilesToOutputDirectory"
+          AfterTargets="Compile"
           Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != ''"
           Inputs="@(IntermediateAssembly)"
           Outputs="%(IntermediateAssembly.Identity).oss_signed"


### PR DESCRIPTION
It used to run before 'CopyFilesToOutputDirectory', but that target has a different name on Mono's xbuild (namely 'DeployOutputFiles'), so it doesn't run there.

Using AfterTargets="Compile" shouldn't make a difference and works on Mono as well.

Note: I'm not that well versed in the intricacies of MSBuild targets, so if this causes problems on Windows please let me know.