### PR TITLE
Official builds in VSO override the $(OutDir) value so the build agent k...

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -9,11 +9,11 @@
 
   <Target Name="FindTestDirectories">
     <ItemGroup>
-      <AllTestAssemblies Include="$(BaseOutputPathWithConfig)*Tests\*Tests.dll" />
+      <AllTestAssemblies Include="$(OutDir)*Tests\*Tests.dll" />
       <AllTestAssembliesWithParent Include="@(AllTestAssemblies)">
         <ParentDir>$([System.IO.Path]::GetDirectoryName(%(AllTestAssemblies.Identity)))</ParentDir>
       </AllTestAssembliesWithParent>
-      <TestDirectories Include="@(AllTestAssembliesWithParent -> '%(ParentDir)')" Exclude="@(_SkipTestAssemblies -> '$(BaseOutputPathWithConfig)%(Identity)')" />
+      <TestDirectories Include="@(AllTestAssembliesWithParent -> '%(ParentDir)')" Exclude="@(_SkipTestAssemblies -> '$(OutDir)%(Identity)')" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Unblock official builds in VSO.

Official builds in VSO override the $(OutDir) value so the build agent
knows where to find the build output. The FindTestDirectories target
uses $(BaseOutputPathWithConfig) instead of $(OutDir), so when $(OutDir)
is overridden the test binaries aren't found and the build fails.