### PR TITLE
Correct package dependency version to xunit.run..dep..netcore

### DIFF
--- a/src/xunit.console.netcore/packages.config
+++ b/src/xunit.console.netcore/packages.config
@@ -17,5 +17,5 @@
   <package id="System.Threading.Tasks" version="4.0.10-beta-22412" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22412" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22412" />
-  <package id="xunit.runner.dependencies.netcore" version="2.0.0-beta5-build2785" />
+  <package id="xunit.runner.dependencies.netcore" version="1.0.0-prerelease" />
 </packages>


### PR DESCRIPTION
xunit.console.netcore project had an incorrect package dependency
version on xunit.runner.dependencies.netcore, which failed appvoyer.
Correct the version to 1.0.0-prerelease