### PR TITLE
Fix issues with the include and exclude traits.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -34,8 +34,8 @@
       <XunitCommandLine>corerun.exe xunit.console.netcore.exe</XunitCommandLine>
       
       <XunitOptions Condition="'@(ThisDirectoryAssemblies)'!=''">$(XunitOptions) "%(ThisDirectoryAssemblies.Identity)" </XunitOptions>
-      <XunitOptions Condition="'@(IncludeTraitsItems)'!=''">$(XunitOptions)-trait "%(IncludeTraitsItems.Identity)" </XunitOptions>
-      <XunitOptions Condition="'@(ExcludeTraitsItems)'!=''">$(XunitOptions)-notrait "%(ExcludeTraitsItems.Identity)" </XunitOptions>
+      <XunitOptions Condition="'@(IncludeTraitsItems)'!=''">$(XunitOptions)-trait @(IncludeTraitsItems, ' -trait ') </XunitOptions>
+      <XunitOptions Condition="'@(ExcludeTraitsItems)'!=''">$(XunitOptions)-notrait @(ExcludeTraitsItems, ' -notrait ') </XunitOptions>
     </PropertyGroup>
 
     <Exec

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools</id>
-    <version>1.0.20-prerelease</version>
+    <version>1.0.21-prerelease</version>
     <title>Microsoft DotNet BuildTools</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
The way we were attempting to expand the properties for the exclude traits was only including the last trait.  Hence we were running outerloop tests when we shouldn't have been.