### PR TITLE
Correct package dependency version to xunit.run..dep..netcore - part 2

### DIFF
--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -30,11 +30,11 @@
   <ItemGroup>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\xunit.runner.dependencies.netcore.2.0.0-beta5-build2785\tools\xunit.abstractions.dll</HintPath>
+      <HintPath>..\packages\xunit.runner.dependencies.netcore.1.0.0-prerelease\lib\portable-wpa80+win8+net45+aspnetcore50\xunit.abstractions.dll</HintPath>
     </Reference>
     <Reference Include="xunit.runner.utility, Version=2.0.0.2785, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\xunit.runner.dependencies.netcore.2.0.0-beta5-build2785\tools\xunit.runner.utility.dll</HintPath>
+      <HintPath>..\packages\xunit.runner.dependencies.netcore.1.0.0-prerelease\lib\portable-wpa80+win8+net45+aspnetcore50\xunit.runner.utility.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
xunit.console.netcore.csproj to reference its dependencies from the
new package version set in commit
79df2888b464f96b840c7f7f17136d1058873887