### PR TITLE
Clean up depending.targets file to make it more general purpose

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
@@ -1,18 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="EnsureDependencies">
-    <ItemGroup>
-      <PackageConfigs Include="$(SourceDir)**\packages.config" />
-    </ItemGroup>
+  <PropertyGroup>
+    <RestoreAllPackageDependenciesSemaphoreFile>$(PackagesDir)\RestoreAllPackageDependencies.complete</RestoreAllPackageDependenciesSemaphoreFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageConfigs Include="$(SourceDir)**\packages.config" Exclude="@(PackageConfigsToExclude)" />
+  </ItemGroup>
+
+  <!-- Keep this target around until we can update depending repros to use the new name -->
+  <Target Name="EnsureDependencies" DependsOnTargets="RestoreAllPackageDependencies" />
+
+  <Target Name="RestoreAllPackageDependencies"
+    Inputs="@(PackageConfigs)"
+    Outputs="$(RestoreAllPackageDependenciesSemaphoreFile)"
+    DependsOnTargets="$(RestoreAllPackageDependenciesDependsOn)"
+    Condition="'@(PackageConfigs)'!=''"
+    >
+    <Message Importance="High" Text="Restoring all package dependencies..." />
 
     <!-- Restore Packages -->
     <Exec
-      Condition="'@(PackageConfigs)'!=''"
       StandardOutputImportance="Low"
       Command="&quot;$(NuGetToolPath)&quot; restore &quot;%(PackageConfigs.FullPath)&quot; -PackagesDirectory &quot;$(PackagesDir.TrimEnd('\'))&quot; $(NuGetConfigCommandLine)" 
       />
 
+    <Touch Files="$(RestoreAllPackageDependenciesSemaphoreFile)" AlwaysCreate="true" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depending.targets
@@ -19,6 +19,8 @@
     Condition="'@(PackageConfigs)'!=''"
     >
     <Message Importance="High" Text="Restoring all package dependencies..." />
+    
+    <Error Condition="'$(PackagesDir)' == ''" Text="PackagesDir property needs to be set before calling RestoreAllPackageDependencies targets" />
 
     <!-- Restore Packages -->
     <Exec


### PR DESCRIPTION
Renamed the target to make it more descriptive to RestoreAllPackageDependencies
while keeping the old EnsureDependencies target as a wrapper for now.

Added inputs/outputs to make incremental build work without requiring the
restore of all the packages on every build.

Added an empty PackageConfigsToExclude so people can override the wildcard Include
if needed.

Started outputing a message whenever the target starts as it tends to take a little
while and it is useful for people to know that restore is happening.