### PR TITLE
When loading supported frameworks for a PCL profile, only look at files with .xml extension

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackages.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Build.Tasks
 
                 if (Directory.Exists(folder))
                 {
-                    foreach (var framework in Directory.EnumerateFiles(folder))
+                    foreach (var framework in Directory.EnumerateFiles(folder, "*.xml"))
                     {
                         var xml = XDocument.Load(framework).Root;
                         targetFrameworks.Add(new FrameworkName(xml.Attribute("Identifier").Value, Version.Parse(xml.Attribute("MinimumVersion").Value)));


### PR DESCRIPTION
As described [here](https://github.com/dotnet/corefx/issues/449), builds of the corefx repo will fail if Xamarin has installed its frameworks into the PCL profiles.  A workaround that has worked in the past for these type of issues has been to rename the XML files that Xamarin adds to something else to disable them.  This doesn't currently work for corefx builds, because Microsoft.DotNet.Build.Tasks looks at all the files in the SupportedFrameworks folder, not just XML files.

This PR changes it to only look at XML files, bringing it in line with Visual Studio and NuGet.