### PR TITLE
Add script to bump package build numbers and use it

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -4,30 +4,30 @@
   <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
 
-  <package id="System.Collections" version="4.0.10-beta-22412" />
-  <package id="System.Collections.Concurrent" version="4.0.10-beta-22412" />
-  <package id="System.Console" version="4.0.0-beta-22412" />
-  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22412" />
-  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22412" />
-  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22412" />
-  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22412" />
-  <package id="System.Globalization" version="4.0.10-beta-22412" />
-  <package id="System.IO" version="4.0.10-beta-22412" />
-  <package id="System.IO.FileSystem" version="4.0.0-beta-22412" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22412" />
-  <package id="System.Linq" version="4.0.0-beta-22412" />
-  <package id="System.Reflection" version="4.0.10-beta-22412" />
-  <package id="System.Reflection.Extensions" version="4.0.0-beta-22412" />
-  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22412" />
-  <package id="System.Runtime" version="4.0.20-beta-22412" />
-  <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
-  <package id="System.Runtime.Handles" version="4.0.0-beta-22412" />
-  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22412" />
-  <package id="System.Text.Encoding" version="4.0.10-beta-22412" />
-  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22412" />
-  <package id="System.Text.RegularExpressions" version="4.0.10-beta-22412" />
-  <package id="System.Threading" version="4.0.0-beta-22412" />
-  <package id="System.Threading.Tasks" version="4.0.10-beta-22412" />
-  <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22412" />
-  <package id="System.Xml.XDocument" version="4.0.0-beta-22412" />
+  <package id="System.Collections" version="4.0.10-beta-22512" />
+  <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
+  <package id="System.Console" version="4.0.0-beta-22512" />
+  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22512" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22512" />
+  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22512" />
+  <package id="System.Diagnostics.Tracing" version="4.0.10-beta-22512" />
+  <package id="System.Globalization" version="4.0.10-beta-22512" />
+  <package id="System.IO" version="4.0.10-beta-22512" />
+  <package id="System.IO.FileSystem" version="4.0.0-beta-22512" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22512" />
+  <package id="System.Linq" version="4.0.0-beta-22512" />
+  <package id="System.Reflection" version="4.0.10-beta-22512" />
+  <package id="System.Reflection.Extensions" version="4.0.0-beta-22512" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22512" />
+  <package id="System.Runtime" version="4.0.20-beta-22512" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22512" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22512" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22512" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Text.RegularExpressions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
+  <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
+  <package id="System.Xml.XDocument" version="4.0.0-beta-22512" />
 </packages>

--- a/src/Scripts/set-package-build.cmd
+++ b/src/Scripts/set-package-build.cmd
@@ -1,0 +1,26 @@
+@echo off
+if "%1" == ""   goto :usage
+if "%2" == ""   goto :usage
+goto :main
+
+:usage
+echo Usage: %~n0 [directory] [build]
+echo.
+echo Recursively replaces all occurrences of 4.0.XX-beta-YYYYY in
+echo [directory]\*.config;*.csproj;*.nuspec with 4.0.XX-beta-[build]
+goto :eof
+
+:main
+pushd %1 && git clean -f packages && call :replace %2 && call :cleanup && popd
+goto :eof
+
+:replace
+for /r %%f in (*.config *.csproj *.nuspec) do (
+   perl -i.tmp_spb -p -e "s/(4\.0\.[0-9]+-beta)-([0-9]+)/$1-%1/" %%f || goto :eof
+)
+goto :eof
+
+
+:cleanup
+del /s *.tmp_spb
+goto :eof

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -18,23 +18,23 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <dependency id="System.Collections" version="4.0.10-beta-22412" />
-      <dependency id="System.Collections.Concurrent" version="4.0.10-beta-22412" />
-      <dependency id="System.Console" version="4.0.0-beta-22412" />
-      <dependency id="System.Diagnostics.Tools" version="4.0.0-beta-22412" />
-      <dependency id="System.IO" version="4.0.10-beta-22412" />
-      <dependency id="System.IO.FileSystem" version="4.0.0-beta-22412" />
-      <dependency id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22412" />
-      <dependency id="System.Linq" version="4.0.0-beta-22412" />
-      <dependency id="System.Reflection" version="4.0.10-beta-22412" />
-      <dependency id="System.Runtime" version="4.0.20-beta-22412" />
-      <dependency id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
-      <dependency id="System.Runtime.Handles" version="4.0.0-beta-22412" />
-      <dependency id="System.Text.RegularExpressions" version="4.0.10-beta-22412" />
-      <dependency id="System.Threading" version="4.0.0-beta-22412" />
-      <dependency id="System.Threading.Tasks" version="4.0.10-beta-22412" />
-      <dependency id="System.Xml.ReaderWriter" version="4.0.10-beta-22412" />
-      <dependency id="System.Xml.XDocument" version="4.0.0-beta-22412" />
+      <dependency id="System.Collections" version="4.0.10-beta-22512" />
+      <dependency id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
+      <dependency id="System.Console" version="4.0.0-beta-22512" />
+      <dependency id="System.Diagnostics.Tools" version="4.0.0-beta-22512" />
+      <dependency id="System.IO" version="4.0.10-beta-22512" />
+      <dependency id="System.IO.FileSystem" version="4.0.0-beta-22512" />
+      <dependency id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22512" />
+      <dependency id="System.Linq" version="4.0.0-beta-22512" />
+      <dependency id="System.Reflection" version="4.0.10-beta-22512" />
+      <dependency id="System.Runtime" version="4.0.20-beta-22512" />
+      <dependency id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+      <dependency id="System.Runtime.Handles" version="4.0.0-beta-22512" />
+      <dependency id="System.Text.RegularExpressions" version="4.0.10-beta-22512" />
+      <dependency id="System.Threading" version="4.0.0-beta-22512" />
+      <dependency id="System.Threading.Tasks" version="4.0.10-beta-22512" />
+      <dependency id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
+      <dependency id="System.Xml.XDocument" version="4.0.0-beta-22512" />
     </dependencies>
   </metadata>
   <files>

--- a/src/xunit.console.netcore/packages.config
+++ b/src/xunit.console.netcore/packages.config
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections" version="4.0.10-beta-22412" />
-  <package id="System.Collections.Concurrent" version="4.0.10-beta-22412" />
-  <package id="System.Console" version="4.0.0-beta-22412" />
-  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22412" />
-  <package id="System.IO" version="4.0.10-beta-22412" />
-  <package id="System.IO.FileSystem" version="4.0.0-beta-22412" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22412" />
-  <package id="System.Linq" version="4.0.0-beta-22412" />
-  <package id="System.Reflection" version="4.0.10-beta-22412" />
-  <package id="System.Runtime" version="4.0.20-beta-22412" />
-  <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
-  <package id="System.Runtime.Handles" version="4.0.0-beta-22412" />
-  <package id="System.Text.RegularExpressions" version="4.0.10-beta-22412" />
-  <package id="System.Threading" version="4.0.0-beta-22412" />
-  <package id="System.Threading.Tasks" version="4.0.10-beta-22412" />
-  <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22412" />
-  <package id="System.Xml.XDocument" version="4.0.0-beta-22412" />
+  <package id="System.Collections" version="4.0.10-beta-22512" />
+  <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
+  <package id="System.Console" version="4.0.0-beta-22512" />
+  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22512" />
+  <package id="System.IO" version="4.0.10-beta-22512" />
+  <package id="System.IO.FileSystem" version="4.0.0-beta-22512" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22512" />
+  <package id="System.Linq" version="4.0.0-beta-22512" />
+  <package id="System.Reflection" version="4.0.10-beta-22512" />
+  <package id="System.Runtime" version="4.0.20-beta-22512" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22512" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22512" />
+  <package id="System.Text.RegularExpressions" version="4.0.10-beta-22512" />
+  <package id="System.Threading" version="4.0.0-beta-22512" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
+  <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
+  <package id="System.Xml.XDocument" version="4.0.0-beta-22512" />
   <package id="xunit.runner.dependencies.netcore" version="1.0.0-prerelease" />
 </packages>

--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -40,71 +40,71 @@
   <ItemGroup>
     <Reference Include="System.Collections">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Collections.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Collections.dll</HintPath>
+      <HintPath>..\packages\System.Collections.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Collections.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Concurrent">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Collections.Concurrent.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Collections.Concurrent.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Concurrent.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Collections.Concurrent.dll</HintPath>
     </Reference>
     <Reference Include="System.Console">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Console.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Console.dll</HintPath>
+      <HintPath>..\packages\System.Console.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.IO">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IO.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.dll</HintPath>
+      <HintPath>..\packages\System.IO.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IO.FileSystem.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.FileSystem.dll</HintPath>
+      <HintPath>..\packages\System.IO.FileSystem.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.FileSystem.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem.Primitives">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.FileSystem.Primitives.dll</HintPath>
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Linq">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Linq.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Linq.dll</HintPath>
+      <HintPath>..\packages\System.Linq.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Reflection">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Runtime.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Reflection.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Reflection.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Runtime.4.0.20-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.4.0.20-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Extensions">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Runtime.Extensions.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.Extensions.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.Extensions.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Handles">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Runtime.Handles.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.Handles.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.Handles.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Runtime.Handles.dll</HintPath>
     </Reference>
     <Reference Include="System.Text.RegularExpressions">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Text.RegularExpressions.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Text.RegularExpressions.dll</HintPath>
+      <HintPath>..\packages\System.Text.RegularExpressions.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Text.RegularExpressions.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Threading.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Threading.dll</HintPath>
+      <HintPath>..\packages\System.Threading.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Threading.Tasks.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Threading.Tasks.dll</HintPath>
+      <HintPath>..\packages\System.Threading.Tasks.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Threading.Tasks.dll</HintPath>
     </Reference>
     <Reference Include="System.Diagnostics.Tools">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Diagnostics.Tools.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Diagnostics.Tools.dll</HintPath>
+      <HintPath>..\packages\System.Diagnostics.Tools.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Diagnostics.Tools.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.ReaderWriter">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Xml.ReaderWriter.4.0.10-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Xml.ReaderWriter.dll</HintPath>
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Xml.ReaderWriter.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.XDocument">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Xml.XDocument.4.0.0-beta-22412\lib\portable-wpa80+win80+net45+aspnetcore50\System.Xml.XDocument.dll</HintPath>
+      <HintPath>..\packages\System.Xml.XDocument.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Xml.XDocument.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
We're getting in to a state where building is restoring 3 copies of every package. We should keep the build numbers bumped until we have either a wildcard (latest build) mechanism or we have RTM'ed most packages and most dependencies are stable.

This bumps *.config, *.nuspec, and *.csproj to 22512 in the buildtools repo.

A script is included to do this again next time and I will do the same in the corefx repo.