### PR TITLE
Feature work to support official daily builds from VSO.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -35,7 +35,10 @@
       Address="http://nuget.org/nuget.exe"
       FileName="$(NuGetToolPath)" />
 
-    <!-- No tools package is required for this repo -->
+    <!-- Restore build tools -->
+    <Exec
+      StandardOutputImportance="Low"
+      Command="&quot;$(NuGetToolPath)&quot; install &quot; $(SourceDir).nuget\packages.config &quot;  -o &quot; $(PackagesDir) &quot; $(NuGetConfigCommandLine)" />
 
     <Touch Files="$(BuildToolsInstallSempahore)" AlwaysCreate="true" />
   </Target>

--- a/dir.props
+++ b/dir.props
@@ -1,18 +1,23 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Build Tools Version -->
+  <PropertyGroup>
+    <BuildToolsVersion>1.0.21-prerelease</BuildToolsVersion>
+  </PropertyGroup>
+
   <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
     <BinDir>$(ProjectDir)bin\</BinDir>
-    <ToolsDir>$(BinDir)tools\</ToolsDir>
     <TestWorkingDir>$(BinDir)tests\</TestWorkingDir>
     <PackagesDir>$(SourceDir)packages\</PackagesDir>
+    <ToolsDir>$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\</ToolsDir>
   </PropertyGroup>
 
   <!-- Common nuget properties -->
   <PropertyGroup>
     <NuGetToolPath>$(ToolsDir)NuGet.exe</NuGetToolPath>
-    <NuGetConfigFile>$(SourceDir)nuget\NuGet.Config</NuGetConfigFile>
+    <NuGetConfigFile>$(SourceDir)NuGet.Config</NuGetConfigFile>
     <NuGetConfigCommandLine
       Condition="Exists('$(NuGetConfigFile)')">-ConfigFile &quot;$(NuGetConfigFile)&quot;</NuGetConfigCommandLine>
   </PropertyGroup>

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.21-prerelease" />
+  <package id="xunit.runners" version="2.0.0-beta5-build2785" />
+</packages>

--- a/src/BuildNumber.props
+++ b/src/BuildNumber.props
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- the value of DailyBuildNumber must be numeric -->
+    <DailyBuildNumber>1</DailyBuildNumber>
+  </PropertyGroup>
+</Project>

--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks", "Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.csproj", "{17C66BCE-EB35-44CA-893C-8AAFB67708E9}"
 EndProject
@@ -9,6 +9,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JSon2Txt", "JSon2Txt\JSon2Txt.csproj", "{7BB5B857-6585-4A65-85A6-865286DC2CD7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.console.netcore", "xunit.console.netcore\xunit.console.netcore.csproj", "{83FC1994-BCE0-427A-803B-02F20233A2D1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{8B5A7D0F-2BD5-4892-9662-8FDC3589D938}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/JSon2Txt/JSon2Txt.csproj
+++ b/src/JSon2Txt/JSon2Txt.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{7BB5B857-6585-4A65-85A6-865286DC2CD7}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)\bin\$(Configuration)\</OutputPath>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>JSon2Txt</RootNamespace>
     <AssemblyName>JSon2Txt</AssemblyName>

--- a/src/Microsoft.DotNet.Build.Tasks/GetNextDailyBuildNumber.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetNextDailyBuildNumber.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using LibGit2Sharp;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class GetNextDailyBuildNumber : Task
+    {
+        [Required]
+        public string VersionPropsFile { get; set; }
+
+        [Output]
+        public string DailyBuildNumber { get; set; }
+
+        public override bool Execute()
+        {
+            Log.LogMessage("Starting GetNextDailyBuildNumber");
+
+            XDocument versionProps = XDocument.Load(VersionPropsFile);
+            var defaultNS = versionProps.Root.GetDefaultNamespace();
+
+            var dailyBuildNode =
+                (from el in versionProps.Descendants(defaultNS + "DailyBuildNumber")
+                 select el).FirstOrDefault();
+
+            Debug.Assert(dailyBuildNode != null, "dailyBuildNode shouldn't be null");
+            var incDailyBuildNum = int.Parse(dailyBuildNode.Value) + 1;
+
+            DailyBuildNumber = incDailyBuildNum.ToString();
+
+            dailyBuildNode.Value = DailyBuildNumber;
+            versionProps.Save(VersionPropsFile);
+
+            Log.LogMessage(string.Format("GetNextDailyBuildNumber completed successfully - the daily build number is now {0}", DailyBuildNumber));
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -25,6 +25,7 @@
     <Compile Include="GetPackageVersion.cs" />
     <Compile Include="GetPackageDependencies.cs" />
     <Compile Include="GitPush.cs" />
+    <Compile Include="GetNextDailyBuildNumber.cs" />
     <Compile Include="NormalizePaths.cs" />
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="OpenSourceSign.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildNumber.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildNumber.targets
@@ -1,0 +1,41 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="GetNextDailyBuildNumber" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <Target Name="GetNextDailyBuildNumber"
+    BeforeTargets="Build"
+    Condition="'$(UpdateDailyBuildNumber)' == 'true'"
+    >
+    <GetNextDailyBuildNumber
+      VersionPropsFile="$(SourceDir)BuildNumber.props">
+      <Output PropertyName="DailyBuildNumber" TaskParameter="DailyBuildNumber" />
+    </GetNextDailyBuildNumber>
+  </Target>
+
+  <Target Name="CommitDailyBuildNumber"
+    AfterTargets="BuildPackages"
+    Condition="'$(UpdateDailyBuildNumber)' == 'true'"
+    >
+    <!-- configure the commit to show up as the dotnet bot -->
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git config user.name &quot;dotnet-bot&quot;" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git config user.email &quot;dotnet-bot@microsoft.com&quot;" />
+
+    <!-- commit and push to origin -->
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git commit -m &quot;Automated commit of daily build number value $(DailyBuildNumber).&quot; $(SourceDir)BuildNumber.props" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git push origin" />
+
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="GetPackageVersion" 
-    AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"
-    Condition="Exists('$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll')" />
+  <UsingTask TaskName="GetPackageVersion" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <ItemGroup>
     <PackagesNuSpecFiles Include="$(SourceDir)nuget\*.nuspec" />
@@ -14,17 +12,18 @@
     <PackagesBasePath Condition="'$(PackagesBasePath)' == ''">$(OutDir)</PackagesBasePath>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NuGetExe>&quot;$(NuGetToolPath)&quot;</NuGetExe>
+    <NuGetBasePath>&quot;$(PackagesBasePath.TrimEnd('\'))&quot;</NuGetBasePath>
+    <NuGetOutputDirectory>&quot;$(PackagesOutDir.TrimEnd('\'))&quot;</NuGetOutputDirectory>
+  </PropertyGroup>
+
   <Target Name="BuildPackages"
     DependsOnTargets="GetNuGetPackageVersions"
     Condition="'$(SkipBuildPackages)' != 'true'">
     
     <!-- Create package output directory -->
     <MakeDir Directories="$(PackagesOutDir)" />
-    
-    <PropertyGroup>
-      <VersionCmdLine></VersionCmdLine>
-      <VersionCmdLine Condition="'%(PackagesNuSpecFiles.PackageVersion)' != ''">-Version %(PackagesNuSpecFiles.PackageVersion)</VersionCmdLine>
-    </PropertyGroup>
 
     <!-- Make package -->
     <!-- We ignore warnings because NuGet will warn when libraries are not placed
@@ -37,12 +36,22 @@
       Condition="'@(PackagesNuSpecFiles)'!=''"
       IgnoreStandardErrorWarningFormat="true"
       StandardOutputImportance="Low"
-      Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath &quot;$(PackagesBasePath.TrimEnd('\'))&quot; -OutputDirectory &quot;$(PackagesOutDir.TrimEnd('\'))&quot; $(VersionCmdLine)" />
+      Command="$(NuGetExe) pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath $(NuGetBasePath) -OutputDirectory $(NuGetOutputDirectory) -Version %(PackagesNuSpecFiles.PackageVersion)" />
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"
       Importance="High"
       Text="%(PackagesNuSpecFiles.Filename) NuGet Package -> $(PackagesOutDir)%(PackagesNuSpecFiles.Filename).%(PackagesNuSpecFiles.PackageVersion).nupkg" />
+
+    <ItemGroup>
+      <PackagesForPublishing Include="$(PackagesOutDir)\*.nupkg" />
+    </ItemGroup>
+
+    <!-- push all packages to a server if one has been specified -->
+    <Exec
+      Condition="'@(PackagesForPublishing)' != '' and '$(PublishPackageSource)' != ''"
+      Command="$(NuGetExe) push &quot;%(PackagesForPublishing.Identity)&quot; -s $(PublishPackageSource)" />
+
   </Target>
 
   <Target
@@ -52,9 +61,8 @@
 
     <GetPackageVersion
       Condition="Exists('$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll')"
-      RepositoryRoot="$(ProjectDir)"
-      PackageName="%(PackagesNuSpecFiles.Filename)"
-      RequireExplicitVersions="false">
+      DailyBuildNumber="$(DailyBuildNumber)"
+      NuSpecFile="%(PackagesNuSpecFiles.Identity)">
       <Output PropertyName="_TempPackageVersion" TaskParameter="PackageVersion" />
     </GetPackageVersion>
     
@@ -63,10 +71,9 @@
         <PackageVersion>$(_TempPackageVersion)</PackageVersion>
       </PackagesNuSpecFiles>
     </ItemGroup>
-    
+
     <PropertyGroup>
       <_TempPackageVersion />
     </PropertyGroup>
   </Target>
-
 </Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -1,3 +1,9 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- metadata used for Authenticode signing in official VSO builds -->
+  <ItemGroup>
+    <FilesToSign Include="$(TargetPath)">
+      <Authenticode>Microsoft</Authenticode>
+    </FilesToSign>
+  </ItemGroup>
 </Project>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,5 +1,6 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="VerifyBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="RestoreAllPackages;VerifyBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
+  <Import Project="BuildNumber.props" />
 
   <Target Name="VerifyBuildTools" 
     Inputs="$(BuildToolsTargetInputs)"
@@ -11,13 +12,14 @@
     <!-- If we enter this target at all then the inputs are newer then the outputs so give a warning. -->
     <Warning Text="Looks like there may be an update to the build tools. Please run build.cmd from the root of the repo to refresh the build tools." /> 
   </Target>
-  
-  <PropertyGroup>
-    <TargetsPath>$(SourceDir)Microsoft.DotNet.Build.Tasks\targets\</TargetsPath>
-  </PropertyGroup>
 
-  <Import Project="$(TargetsPath)depending.targets" />
-  <Target Name="RestoreAllPackages" BeforeTargets="Build" DependsOnTargets="EnsureDependencies" />
+  <Import Project="$(ToolsDir)depending.targets" Condition="Exists('$(ToolsDir)depending.targets')" />
+  <Target Name="RestoreAllPackages">
+    <Message Importance="High" Text="Restoring all package dependencies..." />
+    <CallTarget Targets="EnsureDependencies" />
+  </Target>
+
+  <Import Project="$(ToolsDir)UpdateBuildNumber.targets" Condition="Exists('$(ToolsDir)UpdateBuildNumber.targets')" />
 
   <ItemGroup>
     <Project Include="*\*.csproj" />
@@ -25,7 +27,6 @@
 
   <Import Project="..\dir.traversal.targets" />
 
-  <Import Project="$(TargetsPath)packages.targets" />
+  <Import Project="$(ToolsDir)packages.targets" />
   <Target Name="BuidDirPackages" AfterTargets="Build" DependsOnTargets="BuildPackages" />
-
 </Project>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools</id>
@@ -12,7 +12,7 @@
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <summary>.NET Core Framework Build Tools</summary>
     <description>This package provides build-time support for the .NET Core Framework libraries.  You should not need to reference this package from your project.</description>
-    <copyright>Copyright � Microsoft Corporation</copyright>
+    <copyright>Copyright © Microsoft Corporation</copyright>
     <tags></tags>
     <dependencies>
       <dependency id="xunit.console.netcore" version="1.0.0-prerelease" />

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata minClientVersion="2.8.1">
     <id>xunit.console.netcore</id>
@@ -16,7 +16,7 @@
       Supported platforms: .NET Core.
       Based on xunit.runners - https://github.com/xunit/xunit
     </description>
-    <copyright>Copyright � Microsoft Corporation</copyright>
+    <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <dependency id="System.Collections" version="4.0.10-beta-22512" />
       <dependency id="System.Collections.Concurrent" version="4.0.10-beta-22512" />


### PR DESCRIPTION
Add necessary metadata to enable Authenticode signing in VSO builds.

Nuget packages can now automatically be pushed to a nuget server
specified via MSBuild var PublishPackageSource.

Added a daily build number in version.prop to be used in file and
nuget packages.  By setting MSBuild var DailyBuildNumGenEnabled to
true when building the build will increment the value before building
and commit and push to origin after package publishing.

Updated MSBuild task GetPackageVersion to generate a nuget package
verison by combining the embedded package version in the nuspec file
with the daily build number.

Added a dependency on the build tools nuget package so this repo can
take advantage of this new functionality.