### PR TITLE
Bump xunit.console.netcore version (for Ctrl+F5 pause)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit.console.netcore" version="1.0.0-prerelease" />
+  <package id="xunit.console.netcore" version="1.0.1-prerelease" />
   <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
 

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools</id>
-    <version>1.0.22-prerelease</version>
+    <version>1.0.23-prerelease</version>
     <title>Microsoft DotNet BuildTools</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
@@ -15,7 +15,7 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags></tags>
     <dependencies>
-      <dependency id="xunit.console.netcore" version="1.0.0-prerelease" />
+      <dependency id="xunit.console.netcore" version="1.0.1-prerelease" />
       <dependency id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
       <dependency id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
     </dependencies>

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>xunit.console.netcore</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>xUnit.net [Runners - .NET Core]</title>
     <authors>James Newkirk, Brad Wilson (.NET Core package by Matt Cohn)</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
This is needed so that I can upload a new package to myget to get -wait support, 
which in turn will allow me to wire things up so that Ctrl+F5 in VS actually pauses
after a test run.