### PR TITLE
Add xml report generation support to xunit runner.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -28,6 +28,7 @@
   <package id="System.Text.RegularExpressions" version="4.0.10-beta-22512" />
   <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
+  <package id="System.Threading.ThreadPool" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22512" />
 </packages>

--- a/src/xunit.console.netcore/Utility/TransformFactory.cs
+++ b/src/xunit.console.netcore/Utility/TransformFactory.cs
@@ -21,12 +21,12 @@ namespace Xunit.ConsoleClient
 
         protected TransformFactory()
         {
+            availableTransforms.Add("xml", new Transform { CommandLine = "xml", Description = "output results to xUnit.net v2 style XML file", OutputHandler = Handler_DirectWrite });
 #if !NETCORE
             var executablePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().GetLocalCodeBase());
             var exeConfiguration = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
             var configSection = (XunitConsoleConfigurationSection)exeConfiguration.GetSection("xunit") ?? new XunitConsoleConfigurationSection();
 
-            availableTransforms.Add("xml", new Transform { CommandLine = "xml", Description = "output results to xUnit.net v2 style XML file", OutputHandler = Handler_DirectWrite });
 
             configSection.Transforms.Cast<TransformConfigurationElement>().ToList().ForEach(configElement =>
             {

--- a/src/xunit.console.netcore/packages.config
+++ b/src/xunit.console.netcore/packages.config
@@ -15,6 +15,7 @@
   <package id="System.Text.RegularExpressions" version="4.0.10-beta-22512" />
   <package id="System.Threading" version="4.0.0-beta-22512" />
   <package id="System.Threading.Tasks" version="4.0.10-beta-22512" />
+  <package id="System.Threading.ThreadPool" version="4.0.10-beta-22512" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22512" />
   <package id="System.Xml.XDocument" version="4.0.0-beta-22512" />
   <package id="xunit.runner.dependencies.netcore" version="1.0.0-prerelease" />


### PR DESCRIPTION
This change adds the ability to create an xml report when running xunit.
The package changes are required because System.IO.FileStream has a dependency on System.Threading.ThreadPool