### PR TITLE
Remove dependency on System.Threading.Overlapped.

### DIFF
--- a/src/xunit.console.netcore/Utility/TransformFactory.cs
+++ b/src/xunit.console.netcore/Utility/TransformFactory.cs
@@ -57,7 +57,7 @@ namespace Xunit.ConsoleClient
 
         static void Handler_DirectWrite(XElement xml, string outputFileName)
         {
-            using (var fileStream = new FileStream(outputFileName, FileMode.Create))
+            using (var fileStream = new FileStream(outputFileName, FileMode.Create, FileAccess.Write, FileShare.Read, 4096, false))
             {
                 xml.Save(fileStream);
             }


### PR DESCRIPTION
When I cleaned up my previous PR I removed the explicit setting async to false.
This results in a runtime dependency on System.Threading.Overlapped.
Setting async to false removes this dependency.