### PR TITLE
Split the Microsoft.DotNet.TestHost into 2 packages.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -2,7 +2,8 @@
 <packages>
   <package id="xunit.console.netcore" version="1.0.2-prerelease" />
   <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
-  <package id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
+  <package id="Microsoft.DotNet.TestHost" version="1.0.3-prerelease" />
+  <package id="Microsoft.DotNet.CoreCLR" version="1.0.0-prerelease" />
 
   <package id="System.Collections" version="4.0.10-beta-22512" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -17,7 +17,8 @@
     <dependencies>
       <dependency id="xunit.console.netcore" version="1.0.2-prerelease" />
       <dependency id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
-      <dependency id="Microsoft.DotNet.TestHost" version="1.0.2-prerelease" />
+      <dependency id="Microsoft.DotNet.TestHost" version="1.0.3-prerelease" />
+      <dependency id="Microsoft.DotNet.CoreCLR" version="1.0.0-prerelease" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
One that will match the package produced from CoreCLR and one that will contain the additional assemblies required but not produced from the CoreCLR repo