### PR TITLE
Obey SkipSigning Property in OpenSourceSign target

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
@@ -12,7 +12,7 @@
   
   <Target Name="OpenSourceSign" 
           AfterTargets="Compile"
-          Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != ''"
+          Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != '' and '$(SkipSigning)' != 'true'"
           Inputs="@(IntermediateAssembly)"
           Outputs="%(IntermediateAssembly.Identity).oss_signed"
           >


### PR DESCRIPTION
The OpenSourceSign target does not obey the SkipSigning property.  It's possible that I don't understand the intent of this property, but in my mind it is used to opt out of the open source signing system entirely.

If the property is not true, then a few properties are not set, but there is still an attempt to run the OpenSourceSign target.  This can cause an issue if you're expecting to use the property to opt out of open source signing and use your own custom signing because the file will try to be signed twice.  Whichever signing task happened to run first, will sign the assembly, and the second will throw an error trying to sign an already signed assembly.