### PR TITLE
Fix publishing of NuGet packages.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -49,8 +49,8 @@
 
     <!-- push all packages to a server if one has been specified -->
     <Exec
-      Condition="'@(PackagesForPublishing)' != '' and '$(PublishPackageSource)' != ''"
-      Command="$(NuGetExe) push &quot;%(PackagesForPublishing.Identity)&quot; -s $(PublishPackageSource)" />
+      Condition="'@(PackagesForPublishing)' != '' and '$(SourceAPIKey)' != '' and '$(PublishPackageSource)' != ''"
+      Command="$(NuGetExe) push &quot;%(PackagesForPublishing.Identity)&quot; $(SourceAPIKey) -s $(PublishPackageSource)" />
 
   </Target>
 


### PR DESCRIPTION
The original testing performed was against a private feed which didn't
require an API key.  For public feeds we need to provide an API key.
I've added a new property SourceAPIKey where this is specified.