### PR TITLE
Remove the SourceAPIKey property.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-1</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-3</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-1" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-3" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" />
 </packages>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -49,8 +49,8 @@
 
     <!-- push all packages to a server if one has been specified -->
     <Exec
-      Condition="'@(PackagesForPublishing)' != '' and '$(SourceAPIKey)' != '' and '$(PublishPackageSource)' != ''"
-      Command="$(NuGetExe) push &quot;%(PackagesForPublishing.Identity)&quot; $(SourceAPIKey) -s $(PublishPackageSource)" />
+      Condition="'@(PackagesForPublishing)' != '' and '$(PublishPackageSource)' != ''"
+      Command="$(NuGetExe) push &quot;%(PackagesForPublishing.Identity)&quot; -s $(PublishPackageSource)" />
 
   </Target>
 


### PR DESCRIPTION
Providing the API key as a property exposes the key via the build
definition and build logs which is a security risk.  We will configure
the build machine with the appropriate API key instead.