### PR TITLE
Centralize authoring for real signing.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-3</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-5</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-3" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-5" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" />
 </packages>

--- a/src/JSon2Txt/JSon2Txt.csproj
+++ b/src/JSon2Txt/JSon2Txt.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>JSon2Txt</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- metadata used for Authenticode and strong-name signing in official VSO builds -->
+  <ItemGroup>
+    <FilesToSign Include="$(TargetPath)">
+      <Authenticode>Microsoft</Authenticode>
+      <StrongName Condition="'$(SkipSigning)' != 'true'">StrongName</StrongName>
+    </FilesToSign>
+  </ItemGroup>
+
   <UsingTask AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="OpenSourceSign" />
   
   <PropertyGroup Condition="'$(SkipSigning)'!='true'">
@@ -8,11 +16,12 @@
     <AssemblyOriginatorKeyFile>$(ToolsDir)MSFT.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
+    <UseOpenSourceSign Condition="'$(UseOpenSourceSign)' == ''">true</UseOpenSourceSign>
   </PropertyGroup>
   
   <Target Name="OpenSourceSign" 
           AfterTargets="Compile"
-          Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != '' and '$(SkipSigning)' != 'true'"
+          Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != '' and '$(SkipSigning)' != 'true' and '$(UseOpenSourceSign)' == 'true'"
           Inputs="@(IntermediateAssembly)"
           Outputs="%(IntermediateAssembly.Identity).oss_signed"
           >

--- a/src/ResourceGenerator/ResourceGenerator.csproj
+++ b/src/ResourceGenerator/ResourceGenerator.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>ResourceGenerator</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -1,9 +1,4 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- metadata used for Authenticode signing in official VSO builds -->
-  <ItemGroup>
-    <FilesToSign Include="$(TargetPath)">
-      <Authenticode>Microsoft</Authenticode>
-    </FilesToSign>
-  </ItemGroup>
+  <Import Project="$(ToolsDir)sign.targets" Condition="Exists('$(ToolsDir)sign.targets')" />
 </Project>


### PR DESCRIPTION
Moved metadata for real signing in VSO builds to sign.targets file;
this way all projects that reference build tools will automatically
have real signing enabled.

Added metadata to enable strong name signing with a new MSBuild
property UseOpenSourceSign to toggle between OSS and real signing.

Updated build tools dependency to latest version.