### PR TITLE
Add InvariantCulture to xml output.

### DIFF
--- a/src/common/XmlTestExecutionVisitor.cs
+++ b/src/common/XmlTestExecutionVisitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 using Xunit.Abstractions;
@@ -40,7 +41,7 @@ namespace Xunit
                     new XAttribute("name", XmlEscape(testResult.Test.DisplayName)),
                     new XAttribute("type", testResult.TestCase.TestMethod.TestClass.Class.Name),
                     new XAttribute("method", testResult.TestCase.TestMethod.Method.Name),
-                    new XAttribute("time", testResult.ExecutionTime.ToString()),
+                    new XAttribute("time", testResult.ExecutionTime.ToString(CultureInfo.InvariantCulture)),
                     new XAttribute("result", resultText)
                 );
 
@@ -106,7 +107,7 @@ namespace Xunit
                     new XAttribute("passed", Total - Failed - Skipped),
                     new XAttribute("failed", Failed),
                     new XAttribute("skipped", Skipped),
-                    new XAttribute("time", Time.ToString("0.000")),
+                    new XAttribute("time", Time.ToString("0.000", CultureInfo.InvariantCulture)),
                     new XAttribute("errors", Errors)
                 );
 
@@ -125,8 +126,8 @@ namespace Xunit
                     new XAttribute("name", assemblyStarting.TestAssembly.Assembly.AssemblyPath),
                     new XAttribute("environment", assemblyStarting.TestEnvironment),
                     new XAttribute("test-framework", assemblyStarting.TestFrameworkDisplayName),
-                    new XAttribute("run-date", assemblyStarting.StartTime.ToString("yyyy-MM-dd")),
-                    new XAttribute("run-time", assemblyStarting.StartTime.ToString("HH:mm:ss"))
+                    new XAttribute("run-date", assemblyStarting.StartTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+                    new XAttribute("run-time", assemblyStarting.StartTime.ToString("HH:mm:ss", CultureInfo.InvariantCulture))
                 );
 
                 if (assemblyStarting.TestAssembly.ConfigFileName != null)
@@ -147,7 +148,7 @@ namespace Xunit
                     new XAttribute("failed", testCollectionFinished.TestsFailed),
                     new XAttribute("skipped", testCollectionFinished.TestsSkipped),
                     new XAttribute("name", XmlEscape(testCollectionFinished.TestCollection.DisplayName)),
-                    new XAttribute("time", testCollectionFinished.ExecutionTime.ToString("0.000"))
+                    new XAttribute("time", testCollectionFinished.ExecutionTime.ToString("0.000", CultureInfo.InvariantCulture))
                 );
             }
 

--- a/src/xunit.console.netcore/packages.config
+++ b/src/xunit.console.netcore/packages.config
@@ -4,6 +4,7 @@
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />
   <package id="System.Console" version="4.0.0-beta-22512" />
   <package id="System.Diagnostics.Tools" version="4.0.0-beta-22512" />
+  <package id="System.Globalization" version="4.0.10-beta-22512" />
   <package id="System.IO" version="4.0.10-beta-22512" />
   <package id="System.IO.FileSystem" version="4.0.0-beta-22512" />
   <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22512" />

--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -50,6 +50,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.Console.4.0.0-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Console.dll</HintPath>
     </Reference>
+    <Reference Include="System.Globalization">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Globalization.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.Globalization.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.IO.4.0.10-beta-22512\lib\portable-wpa80+win80+net45+aspnetcore50\System.IO.dll</HintPath>


### PR DESCRIPTION
This change sets the IFormatProvider for number formatting in the xml output to CultureInfo.InvariantCulture

The test results were output with mixed british and regular decimal places. This resulted in multiplying durations by 1000 when the results were processed.