### PR TITLE
A few fixes for handling of BuildNumber.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Utilities;
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
@@ -34,7 +35,13 @@ namespace Microsoft.DotNet.Build.Tasks
                 select el).FirstOrDefault();
 
             Debug.Assert(embeddedVerNode != null, "embeddedVerNode shouldn't be null");
-            PackageVersion = string.Format("{0}-{1}", embeddedVerNode.Value, BuildNumber);
+
+            // if this is a prerelease version then append the build number to the end
+            Regex preReleaseMatch = new Regex("-[0-9A-Za-z]+$");
+            if (preReleaseMatch.Match(embeddedVerNode.Value).Success)
+                PackageVersion = string.Format("{0}-{1}", embeddedVerNode.Value, BuildNumber);
+            else
+                PackageVersion = embeddedVerNode.Value;
 
             Log.LogMessage(string.Format("GetPackageVersion completed successfully - chose version {0}", PackageVersion));
 

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -36,7 +36,7 @@
       Condition="'@(PackagesNuSpecFiles)'!=''"
       IgnoreStandardErrorWarningFormat="true"
       StandardOutputImportance="Low"
-      Command="$(NuGetExe) pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath $(NuGetBasePath) -OutputDirectory $(NuGetOutputDirectory) -Version %(PackagesNuSpecFiles.PackageVersion)" />
+      Command="$(NuGetExe) pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath $(NuGetBasePath) -OutputDirectory $(NuGetOutputDirectory) %(PackagesNuSpecFiles.PackageVersion)" />
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"
@@ -56,7 +56,7 @@
 
   <Target
     Name="GetNuGetPackageVersions"
-    Condition="'@(PackagesNuSpecFiles)'!=''"
+    Condition="'@(PackagesNuSpecFiles)'!='' and '$(BuildNumber)' != ''"
     Outputs="%(PackagesNuSpecFiles.Identity)">
 
     <GetPackageVersion
@@ -68,7 +68,7 @@
     
     <ItemGroup>
       <PackagesNuSpecFiles Condition="'%(PackagesNuSpecFiles.Identity)' == '%(Identity)'">
-        <PackageVersion>$(_TempPackageVersion)</PackageVersion>
+        <PackageVersion>-Version $(_TempPackageVersion)</PackageVersion>
       </PackagesNuSpecFiles>
     </ItemGroup>
 


### PR DESCRIPTION
If BuildNumber is not defined then skip target GetNuGetPackageVersions
and use the package version embedded in the NuSpec file.

For task GetPackageVersion only append the build number to prerelease
packages to comply with the SemVer v1.0 spec.