### PR TITLE
Create the infrastructure to allow testing changes across repos.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -18,6 +18,10 @@
     <NuGetOutputDirectory>&quot;$(PackagesOutDir.TrimEnd('\'))&quot;</NuGetOutputDirectory>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <LocalPublishPropsFile Condition="'$(LocalPublishPropsFile)'==''">$(PackagesDir)\localpublish.props</LocalPublishPropsFile>
+  </PropertyGroup>
+
   <Target Name="BuildPackages"
     DependsOnTargets="GetNuGetPackageVersions"
     Condition="'$(SkipBuildPackages)' != 'true'">
@@ -75,5 +79,45 @@
     <PropertyGroup>
       <_TempPackageVersion />
     </PropertyGroup>
+  </Target>
+
+  <Import Condition="Exists('$(LocalPublishPropsFile)')"  Project="$(LocalPublishPropsFile)"/>
+  
+  <!-- Publish the packages locally -->
+  <Target Name="LocalPackagePublish" Condition="'@(LocalPackages)'!=''"
+          Inputs="%(LocalPackages.Identity)\%(LocalPackages.PackageName).%(LocalPackages.PackageVersion).nupkg;%(LocalPackages.InstallLocation)\%(LocalPackages.PackageName).%(LocalPackages.PackageVersion)" 
+          Outputs="%(LocalPackages.InstallLocation)\%(LocalPackages.PackageName).%(LocalPackages.PackageVersion)\MODIFIED.txt" >
+    
+    <!-- Generate the packages.config -->
+    <ItemGroup>
+      <LocalPackageConfigLine Include="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot;?&gt;" />
+      <LocalPackageConfigLine Include="&lt;packages&gt;" />
+      <LocalPackageConfigLine Include="&lt;package id=&quot;%(LocalPackages.PackageName)&quot; version=&quot;%(LocalPackages.PackageVersion)&quot; /&gt;"/>
+      <LocalPackageConfigLine Include="&lt;/packages&gt;" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <RestoreConfig>%(LocalPackages.InstallLocation)\packages.%(LocalPackages.PackageName).config</RestoreConfig>
+    </PropertyGroup>
+    
+    <WriteLinesToFile File="$(RestoreConfig)" Lines="@(LocalPackageConfigLine)" Overwrite="true" />
+    <Message Text="Generated $(RestoreConfig) for '%(LocalPackages.PackageName).%(LocalPackages.PackageVersion).nupkg'" />
+    
+    <PropertyGroup>
+      <LocalPackagesSources>@(LocalPackages, ';')</LocalPackagesSources>
+    </PropertyGroup>
+    <Message Text="Generated to package source to be '$(LocalPackages)'"/>
+
+    <!-- Remove existing directories -->
+    <RemoveDir Directories="%(LocalPackages.InstallLocation)\%(LocalPackages.PackageName).%(LocalPackages.PackageVersion)" />
+
+    <!-- Restoring the packages -->
+    <Exec Command="$(NuGetExe) install $(RestoreConfig) -Source $(LocalPackagesSources) -NoCache -Prerelease -OutputDirectory %(LocalPackages.InstallLocation)" />
+
+    <!-- Write a file in the packages folder to let the user know this is not the original package -->
+    <ItemGroup>
+      <NotOriginalPackages Include="The package was restored from $(LocalPackagesSources)" />
+    </ItemGroup>
+    <WriteLinesToFile File="%(LocalPackages.InstallLocation)\%(LocalPackages.PackageName).%(LocalPackages.PackageVersion)\MODIFIED.txt" Lines="@(NotOriginalPackages)" Overwrite="true" />
   </Target>
 </Project>


### PR DESCRIPTION
This is going to be driven by the localpublish.props file at the source root
of the repo. By default this file does not exist and it is not tracked by git.

You can create the file with contents similar to this to enable the repo that
is currently built from publishing to a local path. This enables the scenario
when one package has a dependency to the other and you want to test your
changes locally.

If the file is present the following are going to happen:
- The package folder in the target repo is going to be removed
- A packages.config file is going to be created for the package that we are
installing. This is required to bypass the resolving of dependencies that is
triggered by installing a packaged referenced by name.
- A nuget install command is issued to install the package in the target repo

Structure of localpublish.props file:
<Project ToolsVersion="12.0" DefaultTargets="Build"
         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <ItemGroup>
    <Packages Include="<directory of the package created by the repo>">
      <PackageName><name of the package></PackageName>
      <PackageVersion><version, including -prerelease></PackageVersion>
      <InstallLocation><Location in the other repo where the package
      					should be installed</InstallLocation>
    </Packages>
</Project>