### PR TITLE
Bump the version number for the CoreCLR package used

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -3,7 +3,7 @@
   <package id="xunit.console.netcore" version="1.0.2-prerelease" />
   <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.3-prerelease" />
-  <package id="Microsoft.DotNet.CoreCLR" version="1.0.0-prerelease" />
+  <package id="Microsoft.DotNet.CoreCLR" version="1.0.2-prerelease" />
 
   <package id="System.Collections" version="4.0.10-beta-22512" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22512" />


### PR DESCRIPTION
There is a new package for the CoreCLR package on the myget feed that matches the version that we produce from the CoreCLR repo.

This change updates the version of the CoreCLR package used by tests to the latest one available.