### PR TITLE
Fix issues with BuildNumber property.

### DIFF
--- a/src/BuildValues.props
+++ b/src/BuildValues.props
@@ -2,12 +2,12 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!--
-      the value of BuildNumber must be numeric and contain enough
+      the value of RevisionNumber must be numeric and contain enough
       leading zeroes to satisfy a 16-bit integer in base-10 format.  this
       is needed because SemVer v1 performs a lexical comparison of the
       prerelease version number and without the leading zeroes foo-20 is
       smaller than foo-4.
     -->
-    <BuildNumber>00010</BuildNumber>
+    <RevisionNumber>00010</RevisionNumber>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/GetNextRevisionNumber.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetNextRevisionNumber.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using LibGit2Sharp;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
@@ -11,39 +10,39 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GetNextBuildNumber : Task
+    public class GetNextRevisionNumber : Task
     {
         [Required]
         public string VersionPropsFile { get; set; }
 
         [Output]
-        public string BuildNumber { get; set; }
+        public string RevisionNumber { get; set; }
 
         public override bool Execute()
         {
-            Log.LogMessage("Starting GetNextBuildNumber");
+            Log.LogMessage("Starting GetNextRevisionNumber");
 
             XDocument versionProps = XDocument.Load(VersionPropsFile);
             var defaultNS = versionProps.Root.GetDefaultNamespace();
 
             var buildNode =
-                (from el in versionProps.Descendants(defaultNS + "BuildNumber")
+                (from el in versionProps.Descendants(defaultNS + "RevisionNumber")
                  select el).FirstOrDefault();
 
             Debug.Assert(buildNode != null, "buildNode shouldn't be null");
-            var incBuildNum = int.Parse(buildNode.Value) + 1;
+            var incRevNum = int.Parse(buildNode.Value) + 1;
 
-            // the value of BuildNumber must be numeric and contain enough
+            // the value of RevisionNumber must be numeric and contain enough
             // leading zeroes to satisfy a 16-bit integer in base-10 format.  this
             // is needed because SemVer v1 performs a lexical comparison of the
             // prerelease version number and without the leading zeroes foo-20 is
             // smaller than foo-4.
-            BuildNumber = incBuildNum.ToString("D5");
+            RevisionNumber = incRevNum.ToString("D5");
 
-            buildNode.Value = BuildNumber;
+            buildNode.Value = RevisionNumber;
             versionProps.Save(VersionPropsFile);
 
-            Log.LogMessage(string.Format("GetNextBuildNumber completed successfully - the build number is now {0}", BuildNumber));
+            Log.LogMessage(string.Format("GetNextRevisionNumber completed successfully - the revision number is now {0}", RevisionNumber));
 
             return true;
         }

--- a/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Build.Tasks
     public class GetPackageVersion : Task
     {
         [Required]
-        public string BuildNumber { get; set; }
+        public string RevisionNumber { get; set; }
 
         [Required]
         public string NuSpecFile { get; set; }
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Build.Tasks
             // if this is a prerelease version then append the build number to the end
             Regex preReleaseMatch = new Regex("-[0-9A-Za-z]+$");
             if (preReleaseMatch.Match(embeddedVerNode.Value).Success)
-                PackageVersion = string.Format("{0}-{1}", embeddedVerNode.Value, BuildNumber);
+                PackageVersion = string.Format("{0}-{1}", embeddedVerNode.Value, RevisionNumber);
             else
                 PackageVersion = embeddedVerNode.Value;
 

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -25,7 +25,7 @@
     <Compile Include="GetPackageVersion.cs" />
     <Compile Include="GetPackageDependencies.cs" />
     <Compile Include="GitPush.cs" />
-    <Compile Include="GetNextBuildNumber.cs" />
+    <Compile Include="GetNextRevisionNumber.cs" />
     <Compile Include="NormalizePaths.cs" />
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="OpenSourceSign.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildValues.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildValues.targets
@@ -1,23 +1,23 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="GetNextBuildNumber" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GetNextRevisionNumber" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <GitWorkingBranch Condition="'$(GitWorkingBranch)' == ''">master</GitWorkingBranch>
   </PropertyGroup>
 
-  <Target Name="GetNextBuildNumber"
-    BeforeTargets="Build"
-    Condition="'$(UpdateBuildNumber)' == 'true'"
+  <Target Name="GetNextRevisionNumber"
+    BeforeTargets="Build;BuildAllProjects"
+    Condition="'$(UpdateBuildValues)' == 'true'"
     >
-    <GetNextBuildNumber
-      VersionPropsFile="$(SourceDir)BuildNumber.props">
-      <Output PropertyName="BuildNumber" TaskParameter="BuildNumber" />
-    </GetNextBuildNumber>
+    <GetNextRevisionNumber
+      VersionPropsFile="$(SourceDir)BuildValues.props">
+      <Output PropertyName="RevisionNumber" TaskParameter="RevisionNumber" />
+    </GetNextRevisionNumber>
   </Target>
 
-  <Target Name="CommitBuildNumber"
+  <Target Name="CommitBuildValues"
     AfterTargets="BuildPackages"
-    Condition="'$(UpdateBuildNumber)' == 'true'"
+    Condition="'$(UpdateBuildValues)' == 'true'"
     >
     <!-- configure the commit to show up as the dotnet bot -->
     <Exec
@@ -34,7 +34,7 @@
     <Exec
       WorkingDirectory="$(SourceDir)"
       StandardOutputImportance="Low"
-      Command="git commit -m &quot;Automated commit of build number value $(BuildNumber).&quot; $(SourceDir)BuildNumber.props" />
+      Command="git commit -m &quot;Automated commit of revision number value $(RevisionNumber).&quot; $(SourceDir)BuildValues.props" />
 
     <Exec
       WorkingDirectory="$(SourceDir)"

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -60,12 +60,12 @@
 
   <Target
     Name="GetNuGetPackageVersions"
-    Condition="'@(PackagesNuSpecFiles)'!='' and '$(BuildNumber)' != ''"
+    Condition="'@(PackagesNuSpecFiles)'!='' and '$(RevisionNumber)' != ''"
     Outputs="%(PackagesNuSpecFiles.Identity)">
 
     <GetPackageVersion
       Condition="Exists('$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll')"
-      BuildNumber="$(BuildNumber)"
+      RevisionNumber="$(RevisionNumber)"
       NuSpecFile="%(PackagesNuSpecFiles.Identity)">
       <Output PropertyName="_TempPackageVersion" TaskParameter="PackageVersion" />
     </GetPackageVersion>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -1,6 +1,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="RestoreAllPackages;VerifyBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
-  <Import Project="BuildNumber.props" />
+  <Import Project="BuildValues.props" />
 
   <Target Name="VerifyBuildTools" 
     Inputs="$(BuildToolsTargetInputs)"
@@ -19,7 +19,7 @@
     <CallTarget Targets="EnsureDependencies" />
   </Target>
 
-  <Import Project="$(ToolsDir)UpdateBuildNumber.targets" Condition="Exists('$(ToolsDir)UpdateBuildNumber.targets')" />
+  <Import Project="$(ToolsDir)UpdateBuildValues.targets" Condition="Exists('$(ToolsDir)UpdateBuildValues.targets')" />
 
   <ItemGroup>
     <Project Include="*\*.csproj" />

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -24,7 +24,7 @@
   <files>
     <file src="Microsoft.DotNet.Build.Tasks\MSFT.snk" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\PriConfig.xml" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks\UpdateBuildNumber.targets" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\UpdateBuildValues.targets" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\depending.targets" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\gitpush.targets" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\packages.targets" target="lib" />


### PR DESCRIPTION
The VSO official build defines global property BuildNumber which is
colliding with our property with the same name.  I have renamed the
property to RevisionNumber to avoid the collision.

Rename BuildNumber.props to the more generic BuildValues.props as it's
likely we'll have other build values in the in the future.