### PR TITLE
Remove another reference to PackagesConfigFile.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -20,12 +20,12 @@
   </ItemGroup>
 
   <Target Name="CopyTestToTestDirectory"
-    Inputs="@(PackagesConfigFile);$(ToolsDir)test-runtime\packages.config;@(ReferenceCopyLocalPaths);@(Content);@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)"
+    Inputs="@(PackagesConfig);$(ToolsDir)test-runtime\packages.config;@(ReferenceCopyLocalPaths);@(Content);@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)"
     Outputs="$(TestPath)%(TestTargetFramework.Folder)\*.*"
     Condition="'$(CopyTest)'=='True'">
     
     <ItemGroup>
-      <PackagesConfigs Include="$(PackagesConfigFile)"/>
+      <PackagesConfigs Include="$(PackagesConfig)"/>
       <PackagesConfigs Include="$(ToolsDir)test-runtime\packages.config" Condition="Exists('$(ToolsDir)test-runtime\packages.config')"/>
     </ItemGroup>
     


### PR DESCRIPTION
This fixes one more issue where we reference PackagesConfigFile and instead reference PackagesConfig.