### PR TITLE
Make value of PackagesOutDir consistent with corefx repo.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Build Tools Version -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00011</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00012</BuildToolsVersion>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00011" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00012" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" />
 </packages>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packages.targets
@@ -48,7 +48,7 @@
       Text="%(PackagesNuSpecFiles.Filename) NuGet Package -> $(PackagesOutDir)%(PackagesNuSpecFiles.Filename).%(PackagesNuSpecFiles.PackageVersion).nupkg" />
 
     <ItemGroup>
-      <PackagesForPublishing Include="$(PackagesOutDir)\*.nupkg" />
+      <PackagesForPublishing Include="$(PackagesOutDir)*.nupkg" />
     </ItemGroup>
 
     <!-- push all packages to a server if one has been specified -->

--- a/src/dir.props
+++ b/src/dir.props
@@ -36,7 +36,7 @@
     <TestPath Condition="'$(Platform)' != 'AnyCPU'">$(TestWorkingDir)$(MSBuildProjectName)\$(Configuration)\$(Platform)\</TestPath>
 
     <PackagesBasePath>$(BaseOutputPathWithConfig)</PackagesBasePath>
-    <PackagesOutDir>$(PackagesBasePath)Packages</PackagesOutDir>
+    <PackagesOutDir>$(PackagesBasePath)Packages\</PackagesOutDir>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
The corefx repro ends PackagesOutDir with a trailing '\' character while
build tools does not.  In packages.targets property PackagesForPublishing
adds a backslash to PackagesOutDir which works for build tools but fails
for corefx.  This change removes the inconsistency.

Updated build tools package dependency to latest build with this fix.