### PR TITLE
Shift signing to avoid collision with IntelliSense build

### DIFF
--- a/src/BuildNumber.props
+++ b/src/BuildNumber.props
@@ -8,6 +8,6 @@
       prerelease version number and without the leading zeroes foo-20 is
       smaller than foo-4.
     -->
-    <BuildNumber>00009</BuildNumber>
+    <BuildNumber>00010</BuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/sign.targets
@@ -18,9 +18,13 @@
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <UseOpenSourceSign Condition="'$(UseOpenSourceSign)' == ''">true</UseOpenSourceSign>
   </PropertyGroup>
-  
-  <Target Name="OpenSourceSign" 
-          AfterTargets="Compile"
+
+  <!--
+    Compile gets hit directly by Intellisense builds in VS- while @(IntermediateAssembly) is set it won't actually exist.
+    PrepareForRun is the outer target in the core build depends chain that copies the intermediate assemblies to the output folder.
+  -->
+  <Target Name="OpenSourceSign"
+          BeforeTargets="PrepareForRun"
           Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != '' and '$(SkipSigning)' != 'true' and '$(UseOpenSourceSign)' == 'true'"
           Inputs="@(IntermediateAssembly)"
           Outputs="%(IntermediateAssembly.Identity).oss_signed"


### PR DESCRIPTION
Intellisense hits the Compile target directly-- pushing the signing to before deployment to the output directory avoids colliding with it.