### PR TITLE
Use Console.ResetColor() to restore color settings

### DIFF
--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -18,8 +18,6 @@ namespace Xunit.ConsoleClient
         [STAThread]
         public static int Main(string[] args)
         {
-            var originalForegroundColor = Console.ForegroundColor;
-
             try
             {
                 Console.ForegroundColor = ConsoleColor.White;
@@ -86,7 +84,7 @@ namespace Xunit.ConsoleClient
             }
             finally
             {
-                Console.ForegroundColor = originalForegroundColor;
+                Console.ResetColor();
             }
         }
 


### PR DESCRIPTION
Reading current foreground color is not supported on Unix