### PR TITLE
Fix the end of line mark in generated code

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -36,12 +36,8 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public bool DebugOnly { get; set; }
 
-        [Output]
-        public string Message { get; set; } 
-
         public override bool Execute()
         {
-            Message = "";
             try
             {
                 using (_resxReader = new ResXResourceReader(ResxFilePath))
@@ -75,15 +71,11 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 Log.LogError(message);
 
-                Message = message;
-
                 return false; // fail the task
             }
 
             // don't fail the task if this operation failed as we just updating intermediate file and the task already did the needed functionality of generating the code
             try { File.Move(_intermediateFile, IntermediateFilePath); } catch { }
-
-            Message = "Resources code generation is succeeded.";
 
             return true;
         }

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
@@ -27,12 +27,21 @@
         ResxFilePath="$(StringResourcesPath)" 
         IntermediateFilePath="$(IntermediateResOutputFileFullPath)" 
         OutputSourceFilePath="$(ResourceSRPath)" 
-        AssemblyName="$(AssemblyName)" >
+        AssemblyName="$(AssemblyName)" 
+        ContinueOnError="ErrorAndStop" >
+        
+        <Output PropertyName="GenerateResourcesCodeOutputMessage" TaskParameter="Message" />
     </GenerateResourcesCode>
 
     <ItemGroup>
       <FileWrites Include="$(IntermediateResOutputFileFullPath)" />
     </ItemGroup>
+  
+     <OnError ExecuteTargets="FailTheBuildWithResourceGenerationError" />
+  </Target>
+    
+  <Target Name="FailTheBuildWithResourceGenerationError">
+      <Error Text="$(GenerateResourcesCodeOutputMessage)" />
   </Target>
   
   <Import Project="ResourcesIncludes.targets" Condition="Exists('$(StringResourcesPath)') And Exists('$(ResourceSRPath)') And '$(SkipResourcesIncludesTarget)'==''"/>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
@@ -27,22 +27,14 @@
         ResxFilePath="$(StringResourcesPath)" 
         IntermediateFilePath="$(IntermediateResOutputFileFullPath)" 
         OutputSourceFilePath="$(ResourceSRPath)" 
-        AssemblyName="$(AssemblyName)" 
-        ContinueOnError="ErrorAndStop" >
+        AssemblyName="$(AssemblyName)" >
         
-        <Output PropertyName="GenerateResourcesCodeOutputMessage" TaskParameter="Message" />
     </GenerateResourcesCode>
 
     <ItemGroup>
       <FileWrites Include="$(IntermediateResOutputFileFullPath)" />
     </ItemGroup>
-  
-     <OnError ExecuteTargets="FailTheBuildWithResourceGenerationError" />
   </Target>
     
-  <Target Name="FailTheBuildWithResourceGenerationError">
-      <Error Text="$(GenerateResourcesCodeOutputMessage)" />
-  </Target>
-  
   <Import Project="ResourcesIncludes.targets" Condition="Exists('$(StringResourcesPath)') And Exists('$(ResourceSRPath)') And '$(SkipResourcesIncludesTarget)'==''"/>
 </Project>


### PR DESCRIPTION
This fix is fixing the issue of generating resource code lines
ended with consistent marks (CRLF on Windows and LF on Linux)
Also fixed the task to fail the build when there is any code
generation failure