### PR TITLE
Add initial set of perf tools.

### DIFF
--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -14,6 +14,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{097CEB51-8AD7-454B-A027-475C58C16A1A}"
 	ProjectSection(SolutionItems) = preProject
 		nuget\Microsoft.DotNet.BuildTools.nuspec = nuget\Microsoft.DotNet.BuildTools.nuspec
+		nuget\Microsoft.DotNet.PerfTools.nuspec = nuget\Microsoft.DotNet.PerfTools.nuspec
 		nuget\xunit.console.netcore.nuspec = nuget\xunit.console.netcore.nuspec
 	EndProjectSection
 EndProject
@@ -21,6 +22,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{DEEA
 	ProjectSection(SolutionItems) = preProject
 		Scripts\set-package-build.cmd = Scripts\set-package-build.cmd
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventTracer", "EventTracer\EventTracer.csproj", "{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfEventsData", "PerfEventsData\PerfEventsData.csproj", "{4214C1AE-1605-445C-A737-3FDA8528DABA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComparePerfEventsData", "ComparePerfEventsData\ComparePerfEventsData.csproj", "{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenPerfBaseline", "GenPerfBaseline\GenPerfBaseline.csproj", "{A5960E6C-6D41-47B2-B7DA-F662C12110A9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,6 +57,38 @@ Global
 		{83FC1994-BCE0-427A-803B-02F20233A2D1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{83FC1994-BCE0-427A-803B-02F20233A2D1}.Release|ARM.ActiveCfg = Release|Any CPU
 		{83FC1994-BCE0-427A-803B-02F20233A2D1}.Release|x86.ActiveCfg = Release|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Release|ARM.ActiveCfg = Release|Any CPU
+		{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}.Release|x86.ActiveCfg = Release|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Release|ARM.ActiveCfg = Release|Any CPU
+		{4214C1AE-1605-445C-A737-3FDA8528DABA}.Release|x86.ActiveCfg = Release|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Release|ARM.ActiveCfg = Release|Any CPU
+		{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}.Release|x86.ActiveCfg = Release|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Release|ARM.ActiveCfg = Release|Any CPU
+		{A5960E6C-6D41-47B2-B7DA-F662C12110A9}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ComparePerfEventsData/AggregateEventsDataComparer.cs
+++ b/src/ComparePerfEventsData/AggregateEventsDataComparer.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PerfEventsData;
+using System;
+using System.Collections.Generic;
+
+namespace ComparePerfEventsData
+{
+    /// <summary>
+    /// Class for comparing baseline and live events data.
+    /// </summary>
+    class AggregateEventsDataComparer
+    {
+        AggregateEventsData m_baseline;
+        AggregateEventsData m_live;
+
+        public AggregateEventsDataComparer(AggregateEventsData baseline, AggregateEventsData live)
+        {
+            if (baseline == null)
+                throw new ArgumentNullException("baseline");
+
+            if (live == null)
+                throw new ArgumentNullException("live");
+
+            // ensure that the data being compared is from the same architecture, platform and test
+
+            if (string.Compare(baseline.TestName, live.TestName, StringComparison.OrdinalIgnoreCase) != 0)
+                throw new ArgumentException(string.Format("Cannot compare results across different tests.  Baseline is {0} and live is {1}.", baseline.TestName, live.TestName));
+
+            // TODO: there might be cases where cross-platform comparisons make sense
+            if (baseline.Platform != live.Platform)
+                throw new ArgumentException(string.Format("Cannot compare results across different platforms.  Baseline is {0} and live is {1}.", baseline.Platform, live.Platform));
+
+            if (baseline.Architecture != live.Architecture)
+                throw new ArgumentException(string.Format("Cannot compare results across different architectures.  Baseline is {0} and live is {1}.", baseline.Architecture, live.Architecture));
+
+            m_baseline = baseline;
+            m_live = live;
+        }
+
+        /// <summary>
+        /// Performs the comparison.
+        /// </summary>
+        /// <returns>True if live is within acceptable tolerance of baseline, else false.</returns>
+        public bool CompareResults()
+        {
+            bool comparisonFailed = false;
+
+            comparisonFailed |= CompareResults(m_baseline.ClrEventsData, m_live.ClrEventsData);
+            comparisonFailed |= CompareResults(m_baseline.KernelEventsData, m_live.KernelEventsData);
+
+            return !comparisonFailed;
+        }
+
+        private bool CompareResults<T>(Dictionary<T, BaseEventData<T>> baselineCollection, Dictionary<T, BaseEventData<T>> liveCollection)
+        {
+            bool comparisonFailed = false;
+
+            foreach (var baselineEvent in baselineCollection.Values)
+            {
+                if (liveCollection.ContainsKey(baselineEvent.Event))
+                {
+                    // perform the comparison
+                    var liveEvent = liveCollection[baselineEvent.Event];
+
+                    var resultMessage = baselineEvent.CompareValues(liveEvent);
+                    if (resultMessage != null)
+                    {
+                        Console.WriteLine(resultMessage);
+                        comparisonFailed = true;
+                    }
+                    else
+                    {
+                        Console.WriteLine("PASS: {0}", baselineEvent.Event);
+                    }
+
+                    // remove the entry from live so we can track any remaining data
+                    liveCollection.Remove(baselineEvent.Event);
+                }
+                else
+                {
+                    // live data was a subset of baseline data
+                    Console.WriteLine("ERROR: Live data set contains no data for {0}.", baselineEvent.Event);
+                    comparisonFailed = true;
+                }
+            }
+
+            if (liveCollection.Count > 0)
+            {
+                // live data set contained data not in the baseline
+                foreach (var liveEvent in liveCollection.Values)
+                    Console.WriteLine("ERROR: Live data set contains data for {0} which is not in the baseline.", liveEvent.Event);
+
+                comparisonFailed = true;
+            }
+
+            return comparisonFailed;
+        }
+    }
+}

--- a/src/ComparePerfEventsData/App.config
+++ b/src/ComparePerfEventsData/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/src/ComparePerfEventsData/CommandLineOptions.cs
+++ b/src/ComparePerfEventsData/CommandLineOptions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PowerArgs;
+using System;
+using System.Collections.Generic;
+
+namespace ComparePerfEventsData
+{
+    class CommandLineOptions
+    {
+        [ArgDescription("Baseline data file."), ArgExistingFile, ArgRequired]
+        public string Baseline { get; set; }
+
+        [ArgDescription("Live data file."), ArgExistingFile, ArgRequired]
+        public string Live { get; set; }
+    }
+}

--- a/src/ComparePerfEventsData/ComparePerfEventsData.csproj
+++ b/src/ComparePerfEventsData/ComparePerfEventsData.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{580DB26D-AEB5-48AE-9FC2-467FF8B91D86}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ComparePerfEventsData</RootNamespace>
+    <AssemblyName>ComparePerfEventsData</AssemblyName>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PowerArgs">
+      <HintPath>..\..\packages\PowerArgs.2.6.0.1\lib\net40\PowerArgs.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AggregateEventsDataComparer.cs" />
+    <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PerfEventsData\PerfEventsData.csproj">
+      <Project>{4214c1ae-1605-445c-a737-3fda8528daba}</Project>
+      <Name>PerfEventsData</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ComparePerfEventsData/Program.cs
+++ b/src/ComparePerfEventsData/Program.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PerfEventsData;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+
+namespace ComparePerfEventsData
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var exitCode = 1;
+
+            try
+            {
+                var cmdOptions = PowerArgs.Args.Parse<CommandLineOptions>(args);
+
+                if (string.Compare(cmdOptions.Baseline, cmdOptions.Live, StringComparison.OrdinalIgnoreCase) == 0)
+                    throw new ArgumentException("The values of baseline and live parameters cannot be identical.");
+
+                var xmls = new XmlSerializer(typeof(AggregateEventsData));
+
+                AggregateEventsData baseline = null;
+                AggregateEventsData live = null;
+
+                using (StreamReader reader = new StreamReader(cmdOptions.Baseline))
+                {
+                    baseline = (AggregateEventsData)xmls.Deserialize(reader);
+                }
+
+                using (StreamReader reader = new StreamReader(cmdOptions.Live))
+                {
+                    live = (AggregateEventsData)xmls.Deserialize(reader);
+                }
+
+                var dataComparer = new AggregateEventsDataComparer(baseline, live);
+
+                if (dataComparer.CompareResults())
+                {
+                    Console.WriteLine("PASS: perf results are ok");
+                    exitCode = 0;
+                }
+                else
+                {
+                    Console.WriteLine("FAIL: perf results out of tolerance");
+                }
+            }
+            catch (PowerArgs.ArgException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(PowerArgs.ArgUsage.GenerateUsageFromTemplate<CommandLineOptions>());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+            }
+
+            return exitCode;
+        }
+    }
+}

--- a/src/ComparePerfEventsData/packages.config
+++ b/src/ComparePerfEventsData/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="PowerArgs" version="2.6.0.1" targetFramework="net45" />
+</packages>

--- a/src/EventTracer/App.config
+++ b/src/EventTracer/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/src/EventTracer/CollectTraceEventsHelper.cs
+++ b/src/EventTracer/CollectTraceEventsHelper.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Session;
+using System;
+
+namespace EventTracer
+{
+    /// <summary>
+    /// Helper class to start or stop collecting ETW data.
+    /// </summary>
+    internal class CollectTraceEventsHelper : IDisposable
+    {
+        private TraceEventSession m_traceSession;
+
+        public CollectTraceEventsHelper(CommandLineOptions options)
+        {
+            if (TraceEventSession.IsElevated() != true)
+                throw new InvalidOperationException("Collecting perf events requires administrative privileges.");
+
+            if (options.ClrEvents.Events == ClrTraceEventParser.Keywords.None && options.KernelEvents == KernelTraceEventParser.Keywords.None)
+                throw new PowerArgs.ArgException("Must specify at least one CLR or kernel event.");
+
+            // verify session name
+            var existingSessions = TraceEventSession.GetActiveSessionNames();
+
+            if (options.Mode == ExecutionMode.Start && existingSessions.Contains(options.TestName))
+                throw new InvalidOperationException(string.Format("The session name '{0}' is already in use.", options.TestName));
+            else if (options.Mode == ExecutionMode.Stop && !existingSessions.Contains(options.TestName))
+                throw new InvalidOperationException(string.Format("The session name '{0}' does not exist.", options.TestName));
+
+            m_traceSession = new TraceEventSession(options.TestName, options.DataFile);
+
+            if (options.Mode == ExecutionMode.Start)
+            {
+                // starting a new session, enable providers
+                m_traceSession.EnableKernelProvider(options.KernelEvents);
+                m_traceSession.EnableProvider(ClrTraceEventParser.ProviderGuid, TraceEventLevel.Informational, (ulong)options.ClrEvents.Events);
+
+                // keep the session active after the process terminates
+                m_traceSession.StopOnDispose = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            m_traceSession.Dispose();
+        }
+    }
+}

--- a/src/EventTracer/CommandLineOptions.cs
+++ b/src/EventTracer/CommandLineOptions.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Diagnostics.Tracing.Parsers;
+using PowerArgs;
+using System;
+using System.Collections.Generic;
+
+namespace EventTracer
+{
+    /// <summary>
+    /// Indicates mode of execution for handling ETW data.
+    /// </summary>
+    [Flags]
+    enum ExecutionMode
+    {
+        /// <summary>
+        /// Start collecting ETW data.
+        /// </summary>
+        [ArgDescription("Start collecting ETW data.")]
+        Start = 1,
+
+        /// <summary>
+        /// Stop collecting ETW data.
+        /// </summary>
+        [ArgDescription("Stop collecting ETW data.")]
+        Stop = 2
+    }
+
+    /// <summary>
+    /// Class to contain CLR trace events to record.
+    /// This is part of the workaround for reviving CLR events.
+    /// </summary>
+    class ClrEvents
+    {
+        private ClrTraceEventParser.Keywords m_events;
+
+        public ClrEvents(ClrTraceEventParser.Keywords events)
+        {
+            m_events = events;
+        }
+
+        public ClrTraceEventParser.Keywords Events { get { return m_events; } }
+    }
+
+    /// <summary>
+    /// Class to contain command line argument values.
+    /// </summary>
+    class CommandLineOptions
+    {
+        [ArgDescription("How the tool should run.")]
+        [ArgRequired]
+        public ExecutionMode Mode { get; set; }
+
+        [ArgDescription("The test name for event collection.")]
+        [ArgRequired]
+        public string TestName { get; set; }
+
+        [ArgDescription("The results data file.")]
+        [ArgRequired]
+        public string DataFile { get; set; }
+
+        [ArgDefaultValue(ClrTraceEventParser.Keywords.All)]
+        [ArgDescription("The CLR events to capture.")]
+        public ClrEvents ClrEvents { get; set; }
+
+        [ArgDefaultValue(KernelTraceEventParser.Keywords.All)]
+        [ArgDescription("The kernel events to capture.")]
+        public KernelTraceEventParser.Keywords KernelEvents { get; set; }
+
+        [ArgDescription("The name of the XML report file to generate.")]
+        public string XmlReport { get; set; }
+
+        [ArgDescription("The name of the process that contains the metrics of interest.")]
+        public string ProcessName { get; set; }
+
+        [ArgReviver]
+        public static ClrEvents Revive(string key, string value)
+        {
+            // this reviver is a workaround due to a limitation in PowerArgs,
+            // it doesn't support enums with an underlying type other than int.
+
+            ClrTraceEventParser.Keywords events = ClrTraceEventParser.Keywords.None;
+
+            var options = value.Split(new char[] { ',' });
+            foreach (var option in options)
+            {
+                ClrTraceEventParser.Keywords result;
+                var success = Enum.TryParse<ClrTraceEventParser.Keywords>(option, true, out result);
+                if (!success)
+                    throw new ArgException(string.Format("Bad value '{0}' parsing CLR events.", option));
+
+                events |= result;
+            }
+
+            return new ClrEvents(events);
+        }
+    }
+}

--- a/src/EventTracer/EventTracer.csproj
+++ b/src/EventTracer/EventTracer.csproj
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A5F5AD4E-D20D-4CAB-A81E-B7F7448637F9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EventTracer</RootNamespace>
+    <AssemblyName>EventTracer</AssemblyName>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent">
+      <HintPath>..\..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.25\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
+    </Reference>
+    <Reference Include="PowerArgs">
+      <HintPath>..\..\packages\PowerArgs.2.6.0.1\lib\net40\PowerArgs.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.XML" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CollectTraceEventsHelper.cs" />
+    <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="TraceEventsReportGenerator.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PerfEventsData\PerfEventsData.csproj">
+      <Project>{4214c1ae-1605-445c-a737-3fda8528daba}</Project>
+      <Name>PerfEventsData</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/EventTracer/Program.cs
+++ b/src/EventTracer/Program.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PerfEventsData;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+
+namespace EventTracer
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var exitCode = 1;
+
+            try
+            {
+                var cmdOptions = PowerArgs.Args.Parse<CommandLineOptions>(args);
+
+                using (var cteHelper = new CollectTraceEventsHelper(cmdOptions))
+                {
+                    Console.WriteLine("{0} collecting events for session {1}.", cmdOptions.Mode, cmdOptions.TestName);
+                }
+
+                // after stopping, generate an XML report of the data if the necessary params were provided
+                if (cmdOptions.Mode == ExecutionMode.Stop && !string.IsNullOrEmpty(cmdOptions.XmlReport) && !string.IsNullOrEmpty(cmdOptions.ProcessName))
+                {
+                    TraceEventsReportGenerator report = new TraceEventsReportGenerator(cmdOptions);
+                    var reportData = report.Generate();
+
+                    XmlSerializer xmls = new XmlSerializer(typeof(AggregateEventsData));
+
+                    using (StreamWriter writer = new StreamWriter(cmdOptions.XmlReport))
+                    {
+                        xmls.Serialize(writer, reportData);
+                    }
+                }
+
+                exitCode = 0;
+            }
+            catch (PowerArgs.ArgException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(PowerArgs.ArgUsage.GenerateUsageFromTemplate<CommandLineOptions>());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+            }
+
+            return exitCode;
+        }
+    }
+}

--- a/src/EventTracer/TraceEventsReportGenerator.cs
+++ b/src/EventTracer/TraceEventsReportGenerator.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Session;
+using PerfEventsData;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace EventTracer
+{
+    /// <summary>
+    /// Class used to generate PerfEventsData from ETW data.
+    /// </summary>
+    class TraceEventsReportGenerator
+    {
+        private string m_testName;
+        private string m_etlFile;
+        private string m_process;
+        private ClrTraceEventParser.Keywords m_clrEvents;
+        private KernelTraceEventParser.Keywords m_kernelEvents;
+        private AggregateEventsData m_aed;
+
+        public TraceEventsReportGenerator(CommandLineOptions commandLineOptions)
+        {
+            if (!File.Exists(commandLineOptions.DataFile))
+                throw new FileNotFoundException("Couldn't find the specified data file.", commandLineOptions.DataFile);
+
+            m_testName = commandLineOptions.TestName;
+            m_etlFile = commandLineOptions.DataFile;
+            m_process = commandLineOptions.ProcessName;
+            m_clrEvents = commandLineOptions.ClrEvents.Events;
+            m_kernelEvents = commandLineOptions.KernelEvents;
+        }
+
+        /// <summary>
+        /// Generate the PerfEventsData from the info provided to the ctor.
+        /// </summary>
+        /// <returns>A new instance of the AggregateEventsData class.</returns>
+        public AggregateEventsData Generate()
+        {
+            // TODO: what about other architectures?
+            m_aed = new AggregateEventsData(m_testName, Platform.Windows, Environment.Is64BitProcess ? Architecture.Amd64 : Architecture.X86);
+
+            using (var eventSource = new ETWTraceEventSource(m_etlFile))
+            {
+                ParseClrTraceEvents(eventSource);
+                ParseKernelTraceEvents(eventSource);
+
+                // process the stream of events
+                eventSource.Process();
+            }
+
+            return m_aed;
+        }
+
+        /// <summary>
+        /// Wire up parsing of CLR event data from the specified ETWTraceEventSource.
+        /// </summary>
+        /// <param name="eventSource">The ETWTraceEventSource from which to parse the data.</param>
+        private void ParseClrTraceEvents(ETWTraceEventSource eventSource)
+        {
+            if (m_clrEvents == ClrTraceEventParser.Keywords.None)
+                return;
+
+            var clrTraceEventParser = new ClrTraceEventParser(eventSource);
+
+            // iterate over each set bit, wiring up a callback to parse the data
+            ulong eventBits = (ulong)m_clrEvents;
+            int bitPos = 0;
+
+            while (eventBits > 0)
+            {
+                // cycle through until a set bit is found
+                while ((((ulong)eventBits) & (ulong)(1 << bitPos)) == 0)
+                {
+                    ++bitPos;
+                    Debug.Assert(bitPos < 64);
+                }
+
+                var bitVal = (ulong)(1 << bitPos);
+
+                // now strip it from eventBits and covert it to its enum value
+                eventBits ^= bitVal;
+                ClrTraceEventParser.Keywords clrEvent = (ClrTraceEventParser.Keywords)bitVal;
+
+                // aggregate the high and low events if both are available (enabling both provides a more complete value)
+                if ((clrEvent & ClrTraceEventParser.Keywords.GCSampledObjectAllocationHigh) == ClrTraceEventParser.Keywords.GCSampledObjectAllocationHigh ||
+                    (clrEvent & ClrTraceEventParser.Keywords.GCSampledObjectAllocationLow) == ClrTraceEventParser.Keywords.GCSampledObjectAllocationLow)
+                {
+                    if (!m_aed.ClrEventsData.ContainsKey(ClrPerfEvents.GCBytesAllocated))
+                        m_aed.AddData(new EventDataScalarLong<ClrPerfEvents>(ClrPerfEvents.GCBytesAllocated));
+
+                    var gcBytesAllocated = (EventDataScalarLong<ClrPerfEvents>)m_aed.ClrEventsData[ClrPerfEvents.GCBytesAllocated];
+
+                    clrTraceEventParser.GCSampledObjectAllocation += delegate(GCSampledObjectAllocationTraceData data)
+                    {
+                        if (string.Compare(data.ProcessName, m_process, true) == 0)
+                            gcBytesAllocated.Value += data.TotalSizeForTypeSample;
+                    };
+                }
+                else
+                {
+                    Console.WriteLine("WARNING: CLR event {0} NYI for reporting.", clrEvent);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wire up parsing of kernel event data from the specified ETWTraceEventSource.
+        /// </summary>
+        /// <param name="eventSource">The ETWTraceEventSource from which to parse the data.</param>
+        private void ParseKernelTraceEvents(ETWTraceEventSource eventSource)
+        {
+            if (m_kernelEvents == KernelTraceEventParser.Keywords.None)
+                return;
+
+            var kernelParser = new KernelTraceEventParser(eventSource);
+
+            // iterate over each set bit, wiring up a callback to parse the data
+            uint eventBits = (uint)m_kernelEvents;
+            int bitPos = 0;
+
+            while (eventBits > 0)
+            {
+                // cycle through until a set bit is found
+                while ((((uint)eventBits) & (uint)(1 << bitPos)) == 0)
+                {
+                    ++bitPos;
+                    Debug.Assert(bitPos < 32);
+                }
+
+                var bitVal = (uint)(1 << bitPos);
+
+                // now strip it from eventBits and covert it to its enum value
+                eventBits ^= bitVal;
+                KernelTraceEventParser.Keywords kernelEvent = (KernelTraceEventParser.Keywords)bitVal;
+
+                if ((kernelEvent & KernelTraceEventParser.Keywords.ImageLoad) == KernelTraceEventParser.Keywords.ImageLoad)
+                {
+                    var modLoads = new EventDataListString<KernelPerfEvents>(KernelPerfEvents.ModuleLoad);
+
+                    modLoads.Values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                    kernelParser.ImageLoad += delegate(ImageLoadTraceData data)
+                    {
+                        if (string.Compare(data.ProcessName, m_process, true) == 0)
+                        {
+                            var modName = Path.GetFileName(data.FileName);
+                            if (!modLoads.Values.Contains(modName))
+                                modLoads.Values.Add(modName);
+                        }
+                    };
+
+                    m_aed.AddData(modLoads);
+                }
+                else
+                {
+                    Console.WriteLine("WARNING: Kernel event {0} NYI for reporting.", kernelEvent);
+                }
+            }
+        }
+    }
+}

--- a/src/EventTracer/packages.config
+++ b/src/EventTracer/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.25" targetFramework="net45" />
+  <package id="PowerArgs" version="2.6.0.1" targetFramework="net45" />
+</packages>

--- a/src/GenPerfBaseline/App.config
+++ b/src/GenPerfBaseline/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/src/GenPerfBaseline/CommandLineOptions.cs
+++ b/src/GenPerfBaseline/CommandLineOptions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PowerArgs;
+using System;
+using System.Collections.Generic;
+
+namespace GenPerfBaseline
+{
+    class CommandLineOptions
+    {
+        [ArgDescription("Pattern of input files to merge."), ArgRequired]
+        public string Input { get; set; }
+
+        [ArgDescription("Destination output file."), ArgRequired]
+        public string Output { get; set; }
+    }
+}

--- a/src/GenPerfBaseline/GenPerfBaseline.csproj
+++ b/src/GenPerfBaseline/GenPerfBaseline.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A5960E6C-6D41-47B2-B7DA-F662C12110A9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GenPerfBaseline</RootNamespace>
+    <AssemblyName>GenPerfBaseline</AssemblyName>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PowerArgs">
+      <HintPath>..\..\packages\PowerArgs.2.6.0.1\lib\net40\PowerArgs.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PerfEventsData\PerfEventsData.csproj">
+      <Project>{4214c1ae-1605-445c-a737-3fda8528daba}</Project>
+      <Name>PerfEventsData</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/GenPerfBaseline/Program.cs
+++ b/src/GenPerfBaseline/Program.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PerfEventsData;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+
+namespace GenPerfBaseline
+{
+    class Program
+    {
+        static AggregateEventsData MegeData(ICollection<AggregateEventsData> eventsData)
+        {
+            if (eventsData == null)
+                throw new ArgumentNullException("eventsData");
+
+            // verify that the test and platform values are homogenous
+
+            string testName = null;
+            Platform? platform = null;
+            Architecture? arch = null;
+
+            foreach (var eventData in eventsData)
+            {
+                if (testName == null)
+                    testName = eventData.TestName;
+                else if (string.Compare(testName, eventData.TestName, StringComparison.OrdinalIgnoreCase) != 0)
+                    throw new InvalidOperationException();
+
+                if (platform == null)
+                    platform = eventData.Platform;
+                else if (platform.Value != eventData.Platform)
+                    throw new InvalidOperationException();
+
+                if (arch == null)
+                    arch = eventData.Architecture;
+                else if (arch.Value != eventData.Architecture)
+                    throw new InvalidOperationException();
+            }
+
+            AggregateEventsData mergedEventsData = new AggregateEventsData(testName, platform.Value, arch.Value);
+
+            var clrEvents = new List<BaseEventData<ClrPerfEvents>>(eventsData.Count);
+            var kernelEvents = new List<BaseEventData<KernelPerfEvents>>(eventsData.Count);
+
+            foreach (var eventData in eventsData)
+            {
+                foreach (var clrEventData in eventData.ClrEventsData.Values)
+                    clrEvents.Add(clrEventData);
+
+                foreach (var kernelEventData in eventData.KernelEventsData.Values)
+                    kernelEvents.Add(kernelEventData);
+            }
+
+            mergedEventsData.AddData(clrEvents[0].MergeEventData(clrEvents));
+            mergedEventsData.AddData(kernelEvents[0].MergeEventData(kernelEvents));
+
+            return mergedEventsData;
+        }
+
+        static int Main(string[] args)
+        {
+            var exitCode = 1;
+
+            try
+            {
+                var cmdOptions = PowerArgs.Args.Parse<CommandLineOptions>(args);
+
+                string path = Environment.CurrentDirectory;
+                string pattern = cmdOptions.Input;
+
+                if (cmdOptions.Input.IndexOf(Path.DirectorySeparatorChar) > -1)
+                {
+                    path = Path.GetDirectoryName(cmdOptions.Input);
+                    pattern = Path.GetFileName(cmdOptions.Input);
+                }
+
+                var files = Directory.GetFiles(path, pattern);
+                if (files == null)
+                    throw new FileNotFoundException();
+
+                if (files.Length < 3)
+                    throw new InvalidOperationException();
+
+                var eventsDataList = new List<AggregateEventsData>(files.Length);
+                var xmls = new XmlSerializer(typeof(AggregateEventsData));
+
+                foreach (var file in files)
+                {
+                    using (StreamReader reader = new StreamReader(file))
+                    {
+                        var eventsData = (AggregateEventsData)xmls.Deserialize(reader);
+                        eventsDataList.Add(eventsData);
+                    }
+                }
+
+                // merge the data and write the result
+                var result = MegeData(eventsDataList);
+                using (StreamWriter writer = new StreamWriter(cmdOptions.Output))
+                {
+                    xmls.Serialize(writer, result);
+                }
+
+                exitCode = 0;
+            }
+            catch (PowerArgs.ArgException ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(PowerArgs.ArgUsage.GenerateUsageFromTemplate<CommandLineOptions>());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+            }
+
+            return exitCode;
+        }
+    }
+}

--- a/src/GenPerfBaseline/packages.config
+++ b/src/GenPerfBaseline/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="PowerArgs" version="2.6.0.1" targetFramework="net45" />
+</packages>

--- a/src/PerfEventsData/AggregateEventsData.cs
+++ b/src/PerfEventsData/AggregateEventsData.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Class containing the aggregate CLR and kernel performance data.
+    /// This class implements IXmlSerializable for data reporting and restoration purposes.
+    /// </summary>
+    public class AggregateEventsData : IXmlSerializable
+    {
+        private string m_testName;
+        private Platform m_platform;
+        private Architecture m_arch;
+        private Dictionary<ClrPerfEvents, BaseEventData<ClrPerfEvents>> m_clrEventsData;
+        private Dictionary<KernelPerfEvents, BaseEventData<KernelPerfEvents>> m_kernelEventsData;
+
+        public AggregateEventsData()
+        {
+            // used for serialization
+            m_clrEventsData = new Dictionary<ClrPerfEvents, BaseEventData<ClrPerfEvents>>();
+            m_kernelEventsData = new Dictionary<KernelPerfEvents, BaseEventData<KernelPerfEvents>>();
+        }
+
+        public AggregateEventsData(string testName, Platform platform, Architecture architecture) : this()
+        {
+            m_testName = testName;
+            m_platform = platform;
+            m_arch = architecture;
+        }
+
+        /// <summary>
+        /// Gets the test name for this set of performance data.
+        /// </summary>
+        public string TestName { get { return m_testName; } }
+
+        /// <summary>
+        /// Gets the OS platform for this set of performance data.
+        /// </summary>
+        public Platform Platform { get { return m_platform; } }
+
+        /// <summary>
+        /// Gets the architecture for this set of performance data.
+        /// </summary>
+        public Architecture Architecture { get { return m_arch; } }
+
+        /// <summary>
+        /// Gets the collection of CLR events data.
+        /// </summary>
+        public Dictionary<ClrPerfEvents, BaseEventData<ClrPerfEvents>> ClrEventsData { get { return m_clrEventsData; } }
+
+        /// <summary>
+        /// Gets the collection of kernel events data.
+        /// </summary>
+        public Dictionary<KernelPerfEvents, BaseEventData<KernelPerfEvents>> KernelEventsData { get { return m_kernelEventsData; } }
+
+        /// <summary>
+        /// Adds CLR event data.  Duplicates are not allowed.
+        /// </summary>
+        /// <param name="clrEventData">An instance of BaseEventData with ClrPerfEvents.</param>
+        public void AddData(BaseEventData<ClrPerfEvents> clrEventData)
+        {
+            if (clrEventData == null)
+                throw new ArgumentNullException("clrEventData", "Argument cannot be null.");
+
+            if (m_clrEventsData.ContainsKey(clrEventData.Event))
+                throw new ArgumentException(string.Format("Data for {0} CLR event already exists.", clrEventData.Event));
+
+            m_clrEventsData.Add(clrEventData.Event, clrEventData);
+        }
+
+        /// <summary>
+        /// Adds kernel event data.  Duplicates are not allowed.
+        /// </summary>
+        /// <param name="kernelEventData">An instance of BaseEventData with KernelPerfEvents.</param>
+        public void AddData(BaseEventData<KernelPerfEvents> kernelEventData)
+        {
+            if (kernelEventData == null)
+                throw new ArgumentNullException("kernelEventData", "Argument cannot be null.");
+
+            if (m_kernelEventsData.ContainsKey(kernelEventData.Event))
+                throw new ArgumentException(string.Format("Data for {0} kernel event already exists.", kernelEventData.Event));
+
+            m_kernelEventsData.Add(kernelEventData.Event, kernelEventData);
+        }
+
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            if (string.CompareOrdinal(reader.Name, typeof(AggregateEventsData).Name) != 0)
+                throw new InvalidOperationException(string.Format("Root element '{0}' was unexpected.", reader.Name));
+
+            var archAttrVal = reader.GetAttribute(typeof(Architecture).Name);
+            Debug.Assert(!string.IsNullOrEmpty(archAttrVal));
+
+            var result = Enum.TryParse<Architecture>(archAttrVal, out m_arch);
+            if (!result)
+                throw new XmlException(string.Format("The value '{0}' is not valid for {1}@{2}.", archAttrVal, typeof(AggregateEventsData).Name, typeof(Architecture).Name));
+
+            var platformAttrVal = reader.GetAttribute(typeof(Platform).Name);
+            Debug.Assert(!string.IsNullOrEmpty(platformAttrVal));
+
+            result = Enum.TryParse<Platform>(platformAttrVal, out m_platform);
+            if (!result)
+                throw new XmlException(string.Format("The value '{0}' is not valid for {1}@{2}.", platformAttrVal, typeof(AggregateEventsData).Name, typeof(Platform).Name));
+
+            m_testName = reader.GetAttribute(XmlSchemaValues.TestName);
+            Debug.Assert(!string.IsNullOrEmpty(m_testName));
+
+            while (reader.Read())
+            {
+                if (string.CompareOrdinal(reader.Name, typeof(ClrPerfEvents).Name) == 0)
+                {
+                    while (reader.Read() && reader.NodeType != XmlNodeType.EndElement)
+                    {
+                        BaseEventData<ClrPerfEvents> clrEventData = (BaseEventData<ClrPerfEvents>)ReadXmlEventData(reader);
+                        m_clrEventsData.Add(clrEventData.Event, clrEventData);
+                    }
+
+                    // reached the end of ClrEvents
+                    Debug.Assert(string.CompareOrdinal(reader.Name, typeof(ClrPerfEvents).Name) == 0 && reader.NodeType == XmlNodeType.EndElement);
+                }
+                else if (string.CompareOrdinal(reader.Name, typeof(KernelPerfEvents).Name) == 0)
+                {
+                    while (reader.Read() && reader.NodeType != XmlNodeType.EndElement)
+                    {
+                        BaseEventData<KernelPerfEvents> kernelEventData = (BaseEventData<KernelPerfEvents>)ReadXmlEventData(reader);
+                        m_kernelEventsData.Add(kernelEventData.Event, kernelEventData);
+                    }
+
+                    // reached the end of KernelEvents
+                    Debug.Assert(string.CompareOrdinal(reader.Name, typeof(KernelPerfEvents).Name) == 0 && reader.NodeType == XmlNodeType.EndElement);
+                }
+                else
+                {
+                    // there are two reasons for ending up in this else block,
+                    // either we are at the end of the document or we've come
+                    // across an element type that we don't understand.
+                    if (string.CompareOrdinal(reader.Name, typeof(AggregateEventsData).Name) != 0)
+                        throw new InvalidOperationException(string.Format("Unrecognized element '{0}'.", reader.Name));
+                    else
+                        Debug.Assert(reader.NodeType == XmlNodeType.EndElement);
+                }
+            }
+        }
+
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            writer.WriteStartAttribute(m_arch.GetType().Name);
+            writer.WriteValue(m_arch.ToString());
+            writer.WriteEndAttribute();
+
+            writer.WriteStartAttribute(m_platform.GetType().Name);
+            writer.WriteValue(m_platform.ToString());
+            writer.WriteEndAttribute();
+
+            writer.WriteStartAttribute(XmlSchemaValues.TestName);
+            writer.WriteValue(m_testName);
+            writer.WriteEndAttribute();
+
+            writer.WriteStartElement(typeof(ClrPerfEvents).Name);
+            foreach (var clrEventData in m_clrEventsData.Values)
+                ((IXmlSerializable)clrEventData).WriteXml(writer);
+            writer.WriteEndElement();
+
+            writer.WriteStartElement(typeof(KernelPerfEvents).Name);
+            foreach (var kernelEventData in m_kernelEventsData.Values)
+                ((IXmlSerializable)kernelEventData).WriteXml(writer);
+            writer.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Generic helper for reading XML event data.
+        /// </summary>
+        /// <param name="reader">The XML reader provided by the deserializer.</param>
+        /// <returns>An object that derives from BaseEventData of T.</returns>
+        private object ReadXmlEventData(XmlReader reader)
+        {
+            Type eventDataType = Type.GetType(reader.GetAttribute(XmlSchemaValues.AttrType));
+            object eventData = Activator.CreateInstance(eventDataType);
+
+            // invoke the IXmlSerializable.ReadXml(XmlReader) method
+            eventDataType.GetInterface("IXmlSerializable").GetMethod("ReadXml").Invoke(eventData, new object[] { reader });
+            return eventData;
+        }
+    }
+}

--- a/src/PerfEventsData/Architecture.cs
+++ b/src/PerfEventsData/Architecture.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Indicates the architecture where the performance data was collected.
+    /// </summary>
+    public enum Architecture
+    {
+        Amd64,
+        X86
+    }
+}

--- a/src/PerfEventsData/BaseEventData.cs
+++ b/src/PerfEventsData/BaseEventData.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Base class for event data, providing common functionality.
+    /// </summary>
+    /// <typeparam name="T">The event type (i.e. ClrEvents or KernelEvents).</typeparam>
+    public abstract class BaseEventData<T> : IXmlSerializable
+    {
+        private T m_event;
+        private Comparison m_comparison;
+        private double m_tolerance;
+
+        public BaseEventData()
+        {
+            // used for serialization
+            m_comparison = Comparison.LowerTheBetter;
+            m_tolerance = 0.0;
+        }
+
+        public BaseEventData(T eventName) : this()
+        {
+            m_event = eventName;
+        }
+
+        /// <summary>
+        /// Gets the event value with respect to T.
+        /// </summary>
+        public T Event { get { return m_event; } }
+
+        /// <summary>
+        /// Gets the comparison type for this event.
+        /// </summary>
+        public Comparison Comparison { get { return m_comparison; } }
+
+        /// <summary>
+        /// Gets the tolerance of deviation from the baseline.
+        /// </summary>
+        public double Tolerance { get { return m_tolerance; } protected set { m_tolerance = value; } }
+
+        /// <summary>
+        /// Compares the values of this baseline event to the values in the specified live event.
+        /// </summary>
+        /// <param name="other">The live event to compare.</param>
+        /// <returns>Null if the live values are within acceptable limits with respect to the baseline, else a string with a failure report.</returns>
+        public string CompareValues(BaseEventData<T> other)
+        {
+            // ensure we're comparing similar types (e.g. scalar int to scalar int etc.)
+            if (this.GetType() != other.GetType())
+                throw new InvalidOperationException(string.Format("Baseline type {0} cannot be compared against live type {1}.", this.GetType().Name, other.GetType().Name));
+
+            return CompareValuesImpl(other);
+        }
+
+        /// <summary>
+        /// Merges event data from the specified collection of events.  The collection must be homogenous.
+        /// </summary>
+        /// <param name="eventsData">Collection of data to merge.</param>
+        /// <returns>An object deriving from BaseEventData of T containing the merged data.</returns>
+        public BaseEventData<T> MergeEventData(IList<BaseEventData<T>> eventsData)
+        {
+            // ensure the collection is homogenous
+            for (int i = 1; i < eventsData.Count; ++i)
+            {
+                if (eventsData[i].GetType() != eventsData[i - 1].GetType())
+                    throw new InvalidOperationException();
+
+                if (!eventsData[i].Event.Equals(eventsData[i - 1].Event))
+                    throw new InvalidOperationException();
+            }
+
+            return MergeEventDataImpl(eventsData);
+        }
+
+        public override int GetHashCode()
+        {
+            return m_event.GetHashCode();
+        }
+
+        protected abstract string CompareValuesImpl(BaseEventData<T> other);
+
+        protected abstract BaseEventData<T> MergeEventDataImpl(IList<BaseEventData<T>> eventsData);
+
+        // the following methods and properties are all helpers for XML serialization
+
+        XmlSchema IXmlSerializable.GetSchema()
+        {
+            return null;
+        }
+
+        void IXmlSerializable.ReadXml(XmlReader reader)
+        {
+            m_event = (T)Enum.Parse(typeof(T), reader.Name);
+
+            // the Comparison attribute is optional
+            var comparison = reader.GetAttribute(typeof(Comparison).Name);
+            if (comparison != null)
+            {
+                var result = Enum.TryParse<Comparison>(comparison, out m_comparison);
+                if (!result)
+                    throw new XmlException(string.Format("Invalid value '{0}' for attribute {1}@{2}.", reader.Name, typeof(Comparison).Name));
+            }
+
+            // the Tolerance attribute is optional
+            var tolerance = reader.GetAttribute(XmlSchemaValues.Tolerance);
+            if (tolerance != null)
+            {
+                var result = double.TryParse(tolerance, out m_tolerance);
+                if (!result)
+                    throw new XmlException(string.Format("Invalid value '{0}' for attribute {1}@{2}, value should be of type double.", tolerance, reader.Name, XmlSchemaValues.Tolerance));
+            }
+
+            ReadXmlValue(reader);
+        }
+
+        void IXmlSerializable.WriteXml(XmlWriter writer)
+        {
+            writer.WriteStartElement(m_event.ToString());
+
+            if (m_tolerance != 0.0)
+            {
+                writer.WriteStartAttribute(XmlSchemaValues.Tolerance);
+                writer.WriteValue(m_tolerance);
+                writer.WriteEndAttribute();
+            }
+
+            writer.WriteStartAttribute(XmlSchemaValues.AttrType);
+            writer.WriteValue(this.GetType().ToString());
+            writer.WriteEndAttribute();
+
+            WriteXmlValue(writer);
+            writer.WriteEndElement();
+        }
+
+        protected abstract void ReadXmlValue(XmlReader reader);
+
+        protected abstract void WriteXmlValue(XmlWriter writer);
+    }
+}

--- a/src/PerfEventsData/ClrEvents.cs
+++ b/src/PerfEventsData/ClrEvents.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// List of supported CLR performance event metrics.
+    /// </summary>
+    public enum ClrPerfEvents
+    {
+        /// <summary>
+        /// The number of bytes allocated on the managed heap.
+        /// </summary>
+        GCBytesAllocated
+    }
+}

--- a/src/PerfEventsData/Comparison.cs
+++ b/src/PerfEventsData/Comparison.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Behavior when comparing baseline and live data.
+    /// </summary>
+    public enum Comparison
+    {
+        /// <summary>
+        /// If live is less than baseline this is good; this is the default.
+        /// </summary>
+        LowerTheBetter,
+
+        /// <summary>
+        /// If live is greater than baseline this is good.
+        /// </summary>
+        GreaterTheBetter
+    }
+}

--- a/src/PerfEventsData/EventDataListString.cs
+++ b/src/PerfEventsData/EventDataListString.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Class containing non-scalar event data.
+    /// </summary>
+    /// <typeparam name="T">The event type (i.e. ClrEvents or KernelEvents).</typeparam>
+    public class EventDataListString<T> : BaseEventData<T>
+    {
+        private ICollection<string> m_values;
+
+        public EventDataListString()
+        {
+            // used for serialization
+        }
+
+        public EventDataListString(T eventName)
+            : base(eventName)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the ICollection of string values.
+        /// </summary>
+        public ICollection<string> Values { get { return m_values; } set { m_values = value; } }
+
+        protected override string CompareValuesImpl(BaseEventData<T> other)
+        {
+            var otherT = (EventDataListString<T>)other;
+
+            var sb = new StringBuilder();
+
+            foreach (var value in m_values)
+            {
+                if (!otherT.Values.Contains(value) && Comparison != Comparison.LowerTheBetter)
+                    sb.AppendLine(string.Format("FAIL: comparison for event {0}, baseline data contains value {1} not in live date.", Event, value));
+            }
+
+            foreach (var value in otherT.Values)
+            {
+                if (!m_values.Contains(value) && Comparison != Comparison.GreaterTheBetter)
+                    sb.AppendLine(string.Format("FAIL: comparison for event {0}, live data contains value {1} not in baseline.", Event, value));
+            }
+
+            if (sb.Length == 0)
+                return null;
+            else
+                return sb.ToString();
+        }
+
+        protected override BaseEventData<T> MergeEventDataImpl(IList<BaseEventData<T>> eventsData)
+        {
+            var mergedEvent = new EventDataListString<T>(eventsData[0].Event);
+            var mergedValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var eventData in eventsData)
+            {
+                foreach (var value in ((EventDataListString<T>)eventData).Values)
+                {
+                    if (!mergedValues.Contains(value))
+                        mergedValues.Add(value);
+                }
+            }
+
+            mergedEvent.Values = mergedValues;
+            return mergedEvent;
+        }
+
+        // the following methods and properties are all helpers for XML serialization
+
+        protected override void ReadXmlValue(XmlReader reader)
+        {
+            // reader should be pointing to the opening element
+            Debug.Assert(reader.NodeType == XmlNodeType.Element);
+
+            //     <ImageLoad Scalar="false" Type="System.String">
+            //       <Value>advapi32.dll</Value>
+            //       <Value>bcrypt.dll</Value>
+            //     </ImageLoad>
+
+            string elementName = reader.Name;
+            var values = new List<string>();
+
+            while (reader.Read() && reader.NodeType != XmlNodeType.EndElement)
+            {
+                Debug.Assert(string.CompareOrdinal(reader.Name, XmlSchemaValues.AttrValue) == 0);
+
+                // move to the value
+                var read = reader.Read();
+                Debug.Assert(read);
+
+                values.Add(reader.Value);
+
+                // move to the end element
+                read = reader.Read();
+                Debug.Assert(read && reader.NodeType == XmlNodeType.EndElement);
+            }
+
+            m_values = values;
+
+            // should be at the end of list of values
+            Debug.Assert(reader.NodeType == XmlNodeType.EndElement && string.CompareOrdinal(reader.Name, elementName) == 0);
+        }
+
+        protected override void WriteXmlValue(XmlWriter writer)
+        {
+            if (m_values == null || m_values.Count == 0)
+                throw new InvalidOperationException(string.Format("Non-scalar data for event {0} contains no data.", Event));
+
+            // sort the data before writing it out
+            var sortedValues = m_values.OrderBy(val => val);
+
+            foreach (var value in sortedValues)
+            {
+                writer.WriteStartElement(XmlSchemaValues.AttrValue);
+                writer.WriteValue(value);
+                writer.WriteEndElement();
+            }
+        }
+    }
+}

--- a/src/PerfEventsData/EventDataScalarLong.cs
+++ b/src/PerfEventsData/EventDataScalarLong.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Xml;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Class containing scalar event data of type long.
+    /// </summary>
+    /// <typeparam name="T">The event type (i.e. ClrEvents or KernelEvents).</typeparam>
+    public class EventDataScalarLong<T> : BaseEventData<T>
+    {
+        private long m_value;
+
+        public EventDataScalarLong()
+        {
+            // used for serialization
+        }
+
+        public EventDataScalarLong(T eventName)
+            : base(eventName)
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the data value.
+        /// </summary>
+        public long Value { get { return m_value; } set { m_value = value; } }
+
+        protected override string CompareValuesImpl(BaseEventData<T> other)
+        {
+            var otherT = (EventDataScalarLong<T>)other;
+
+            string errorMessage = null;
+
+            if (m_value != otherT.Value)
+            {
+                // check that the variance is within acceptable limits
+                double difference;
+
+                if (otherT.Value > m_value && Comparison != Comparison.GreaterTheBetter)
+                    difference = otherT.Value - m_value;
+                else if (otherT.Value < m_value && Comparison != Comparison.LowerTheBetter)
+                    difference = m_value - otherT.Value;
+                else
+                    difference = 0; // difference is ok
+
+                if (difference > Tolerance)
+                    errorMessage = string.Format("FAIL: comparison for event {0}, baseline = {1}, live = {2}, difference = {3}, tolerance = {4}", Event, m_value, otherT.Value, difference, Tolerance);
+            }
+
+            return errorMessage;
+        }
+
+        protected override BaseEventData<T> MergeEventDataImpl(IList<BaseEventData<T>> eventsData)
+        {
+            var mergedEvent = new EventDataScalarLong<T>(eventsData[0].Event);
+
+            long sum = 0;
+            foreach (var eventData in eventsData)
+                sum += ((EventDataScalarLong<T>)eventData).Value;
+
+            mergedEvent.Value = sum / eventsData.Count;
+
+            // set a default tolerance based on the standard deviation
+
+            double variance = 0;
+            foreach (var eventData in eventsData)
+                variance += Math.Pow(((EventDataScalarLong<T>)eventData).Value - mergedEvent.Value, 2);
+
+            mergedEvent.Tolerance = Math.Sqrt(variance / eventsData.Count);
+
+            return mergedEvent;
+        }
+
+        // the following methods and properties are all helpers for XML serialization
+
+        protected override void ReadXmlValue(XmlReader reader)
+        {
+            // reader should be pointing to the opening element
+            Debug.Assert(reader.NodeType == XmlNodeType.Element);
+
+            // <GCSampledObjectAllocationHigh Scalar="true" Type="System.Int64">567113780</GCSampledObjectAllocationHigh>
+
+            // move to the value
+            var read = reader.Read();
+            Debug.Assert(read);
+
+            m_value = long.Parse(reader.Value);
+
+            // move to the closing element
+            read = reader.Read();
+            Debug.Assert(read && reader.NodeType == XmlNodeType.EndElement);
+        }
+
+        protected override void WriteXmlValue(XmlWriter writer)
+        {
+            writer.WriteValue(m_value);
+        }
+    }
+}

--- a/src/PerfEventsData/KernelEvents.cs
+++ b/src/PerfEventsData/KernelEvents.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// List of supported kernel performance event metrics.
+    /// </summary>
+    public enum KernelPerfEvents
+    {
+        /// <summary>
+        /// The list of modules loaded in the process.
+        /// </summary>
+        ModuleLoad
+    }
+}

--- a/src/PerfEventsData/PerfEventsData.csproj
+++ b/src/PerfEventsData/PerfEventsData.csproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4214C1AE-1605-445C-A737-3FDA8528DABA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PerfEventsData</RootNamespace>
+    <AssemblyName>PerfEventsData</AssemblyName>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Architecture.cs" />
+    <Compile Include="BaseEventData.cs" />
+    <Compile Include="ClrEvents.cs" />
+    <Compile Include="Comparison.cs" />
+    <Compile Include="EventDataListString.cs" />
+    <Compile Include="EventDataScalarLong.cs" />
+    <Compile Include="AggregateEventsData.cs" />
+    <Compile Include="KernelEvents.cs" />
+    <Compile Include="Platform.cs" />
+    <Compile Include="XmlSchemaValues.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/PerfEventsData/Platform.cs
+++ b/src/PerfEventsData/Platform.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Indicates the OS where the performance data was collected.
+    /// </summary>
+    public enum Platform
+    {
+        Linux,
+        Mac,
+        Windows
+    }
+}

--- a/src/PerfEventsData/XmlSchemaValues.cs
+++ b/src/PerfEventsData/XmlSchemaValues.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace PerfEventsData
+{
+    /// <summary>
+    /// Helper containing various XML schema item names.
+    /// </summary>
+    class XmlSchemaValues
+    {
+        public static readonly string TestName   = "TestName";
+        public static readonly string Tolerance  = "Tolerance";
+        public static readonly string AttrType   = "Type";
+        public static readonly string AttrValue  = "Value";
+    }
+}

--- a/src/nuget/Microsoft.DotNet.PerfTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.PerfTools.nuspec
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.PerfTools</id>
+    <version>0.0.1-prerelease</version>
+    <title>Microsoft DotNet PerfTools</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>.NET Core Framework Perf Tools</summary>
+    <description>This package provides performance testing tooling for the .NET Core Framework libraries.  You should not need to reference this package from your project.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+      <dependency id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.25" />
+      <dependency id="PowerArgs" version="2.6.0.1" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="ComparePerfEventsData\ComparePerfEventsData.exe" target="tools" />
+    <file src="EventTracer\EventTracer.exe" target="tools" />
+    <file src="EventTracer\Microsoft.Diagnostics.Tracing.TraceEvent.dll" target="tools" />
+    <file src="EventTracer\PerfEventsData.dll" target="tools" />
+    <file src="EventTracer\PowerArgs.dll" target="tools" />
+    <file src="GenPerfBaseline\GenPerfBaseline.exe" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
This adds project and NuGet package infrastructure for bring up perf
tooling.  At present the tooling is split into a platform-specific
collection mechanism and a platform-agnostic model of the data used for
reporting purposes.

Created a new NuGet package Microsoft.DotNet.PerfTools to contain all of
the perf tools.

EventTracer
This is a console app used to start and stop collection of ETW data and
can optionally generate an XML report of the data collected.  Since it
relies on ETW it is applicable to Windows only.

PerfEventsData
This library contains a platform agnostic model of performance data.  At
present it only contains performance data types applicable to our
"consumptive" metrics.