### PR TITLE
Fix code coverage in common targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <OpenCoverVersion>4.5.3809-rc94</OpenCoverVersion>
     <ReportGeneratorVersion>2.0.4.0</ReportGeneratorVersion>
-    <CoverallsUploaderVersion>1.2</CoverallsUploaderVersion>
+    <CoverallsUploaderVersion>1.3</CoverallsUploaderVersion>
   </PropertyGroup>
   
   <!-- Coverage options -->
@@ -79,7 +79,7 @@
 
     <PropertyGroup>
       <CoverallsUploaderCommandLine>$(PackagesDir)coveralls.io.$(CoverallsUploaderVersion)\tools\coveralls.net.exe</CoverallsUploaderCommandLine>
-      <CoverallsUploaderOptions>--opencover $(CoverageReportDir)\*.coverage.xml -t $(CoverallsToken)</CoverallsUploaderOptions>
+      <CoverallsUploaderOptions>--opencover $(CoverageReportDir)\*.coverage.xml --repo-token $(CoverallsToken)</CoverallsUploaderOptions>
     </PropertyGroup>
 
     <Exec Command="$(CoverallsUploaderCommandLine) $(CoverallsUploaderOptions)"

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
@@ -21,8 +21,8 @@
     <CoverageEnabledForProject Condition="'$(GenerateCodeCoverageReportForAll)'=='true'">false</CoverageEnabledForProject>
     <CoverageEnabledForProject Condition="'$(CoverageEnabledForProject)'=='' and '$(IsTestProject)'=='true'">$(CodeCoverageEnabled)</CoverageEnabledForProject>
 
-    <GenerateIndividualCoverageReport Condition="'$(BuildAllProjects)'!='true' and '$(CoverageEnabledForProject)'=='true'">true"</GenerateIndividualCoverageReport>
-    <GenerateFullCoverageReport Condition="'$(GenerateCodeCoverageForAll)'!='' and $(CodeCoverageEnabled)">true</GenerateFullCoverageReport>
+    <GenerateIndividualCoverageReport Condition="'$(BuildAllProjects)'!='true' and '$(CoverageEnabledForProject)'=='true'">true</GenerateIndividualCoverageReport>
+    <GenerateFullCoverageReport Condition="'$(GenerateCodeCoverageReportForAll)'=='true' and '$(CodeCoverageEnabled)'=='true'">true</GenerateFullCoverageReport>
 
     <!-- 
       When coverage is enabled, we disallow building projects in parallel. 
@@ -54,7 +54,7 @@
 
   <!-- Generate coverage reports for individual projects. -->
   <Target Name="GenerateIndividualCoverageReport"
-          AfterTargets="$(GenerateIndividualCoverageReportAfterTargets"
+          AfterTargets="$(GenerateIndividualCoverageReportAfterTargets)"
           Inputs="$(CoverageOutputFilePath)"
           Outputs="$(CoverageReportDir)index.htm"
           Condition="'$(GenerateIndividualCoverageReport)'=='true'">

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -34,6 +34,6 @@
   <package id="System.Xml.XDocument" version="4.0.10-beta-22703" />
 
   <package id="OpenCover" version="4.5.3809-rc94" />
-  <package id="coveralls.io" version="1.2" />
+  <package id="coveralls.io" version="1.3" />
   <package id="ReportGenerator" version="2.0.4.0" />
 </packages>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -25,6 +25,7 @@
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
     <XunitOptions>$(XunitOptions) -xml .\testResults.xml</XunitOptions>
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
+    <XunitOptions>$(XunitOptions) {XunitTraitOptions}</XunitOptions>
   </PropertyGroup>
   
   <!-- xUnit command line without coverage enabled -->
@@ -59,7 +60,7 @@
 
     <!-- Append the xunit trait options to the end of the TestCommandLine -->
     <PropertyGroup>
-      <TestCommandLine>$(TestCommandLine) $(XunitTraitOptions)</TestCommandLine>
+      <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
     </PropertyGroup>
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />


### PR DESCRIPTION
Pull in https://github.com/dotnet/corefx/pull/1116 into the build tools repo and fix command line options to correctly handle the xunit traits that are computed in the target.