### PR TITLE
Fix VS command line arguments used for debugging

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -22,16 +22,15 @@
 
   <!-- General xunit options -->
   <PropertyGroup>
+    <XunitHost>corerun.exe</XunitHost>
+    <TestHost>$(XunitHost)</TestHost>
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
     <XunitOptions>$(XunitOptions) -xml .\testResults.xml</XunitOptions>
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
+
+    <!-- We need to exclude xunit traits and add wait option for VS -->
+    <VSStartArguments>$(XunitCommandLine) $(XunitOptions) -wait</VSStartArguments>
     <XunitOptions>$(XunitOptions) {XunitTraitOptions}</XunitOptions>
-  </PropertyGroup>
-  
-  <!-- xUnit command line without coverage enabled -->
-  <PropertyGroup>
-    <XunitHost>corerun.exe</XunitHost>
-    <TestHost>$(XunitHost)</TestHost>
     <TestCommandLine>$(XunitCommandLine) $(XunitOptions)</TestCommandLine>
   </PropertyGroup>
 
@@ -41,10 +40,10 @@
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">
     <DebugTestFrameworkFolder>aspnetcore50</DebugTestFrameworkFolder>
-    <StartWorkingDirectory Condition="'$(StartWorkingDirectory)' == ''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
-    <StartAction Condition="'$(StartAction)' == ''">Program</StartAction>
-    <StartProgram Condition="'$(StartProgram)' == ''">$(StartWorkingDirectory)\$(TestHost)</StartProgram>
-    <StartArguments Condition="'$(StartArguments)' == ''">$(TestCommandLine) -wait</StartArguments>
+    <StartWorkingDirectory Condition="'$(StartWorkingDirectory)'==''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
+    <StartAction Condition="'$(StartAction)'==''">Program</StartAction>
+    <StartProgram Condition="'$(StartProgram)'==''">$(StartWorkingDirectory)\$(TestHost)</StartProgram>
+    <StartArguments Condition="'$(StartArguments)'==''">$(VSStartArguments)</StartArguments>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 


### PR DESCRIPTION
We don't have a way to set the xunit traits for debugging in VS as they have to be computed via a target. We are just going to exclude the trait options while launching in VS by default.

This should fix https://github.com/dotnet/buildtools/issues/112, although I don't have a way to test right now so if anyone would like to test this that would be helpful.

cc @ellismg @nguerrera 