### PR TITLE
Only run tests (and copy test files) if test results are out of date

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -37,7 +37,7 @@
       <PackagesConfigs Include="$(ProjectPackagesConfigFile)" />
       <PackagesConfigs Include="$(TestRuntimePackageConfig)" />
     </ItemGroup>
-    
+
     <ResolveNuGetPackages PackagesConfigs="@(PackagesConfigs)"
                           PackageRoot="$(PackagesDir)"
                           Platform="$(PlatformTarget)"
@@ -48,14 +48,15 @@
 
       <Output TaskParameter="ResolvedCopyLocal" ItemName="TestCopyLocal" />
     </ResolveNuGetPackages>
-    
+
     <ItemGroup>
       <TestCopyLocal Include="@(ReferenceCopyLocalPaths)" />
       <TestCopyLocal Include="@(Content)" />
       <TestCopyLocal Include="@(IntermediateAssembly)" />
       <TestCopyLocal Include="@(_DebugSymbolsIntermediatePath)" />
+      <TestCopyLocal Include="@(AllItemsFullPathWithTargetPath)" />
     </ItemGroup>
-    
+
     <Copy
       SourceFiles="@(TestCopyLocal)"
       DestinationFolder="$(TestPath)%(TestTargetFramework.Folder)"

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -23,20 +23,9 @@
   <PropertyGroup>
     <CopyTestToTestDirectory Condition="'$(CopyTestToTestDirectory)'==''">$(IsTestProject)</CopyTestToTestDirectory>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <TestTargetFramework Include="ASP.NetCore, version=v5.0">
-      <Folder>aspnetcore50</Folder>
-    </TestTargetFramework>
-  </ItemGroup>
 
   <Target Name="CopyTestToTestDirectory"
     Condition="'$(CopyTestToTestDirectory)'=='true'">
-    
-    <ItemGroup>
-      <PackagesConfigs Include="$(ProjectPackagesConfigFile)" />
-      <PackagesConfigs Include="$(TestRuntimePackageConfig)" />
-    </ItemGroup>
 
     <ResolveNuGetPackages PackagesConfigs="@(PackagesConfigs)"
                           PackageRoot="$(PackagesDir)"
@@ -50,11 +39,7 @@
     </ResolveNuGetPackages>
 
     <ItemGroup>
-      <TestCopyLocal Include="@(ReferenceCopyLocalPaths)" />
-      <TestCopyLocal Include="@(Content)" />
-      <TestCopyLocal Include="@(IntermediateAssembly)" />
-      <TestCopyLocal Include="@(_DebugSymbolsIntermediatePath)" />
-      <TestCopyLocal Include="@(AllItemsFullPathWithTargetPath)" />
+      <TestCopyLocal Include="@(RunTestsForProjectInputs)" Exclude="@(PackagesConfigs)" />
     </ItemGroup>
 
     <Copy

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -21,11 +21,6 @@
   </Target>
 
   <PropertyGroup>
-    <PrepareForRunDependsOn>
-      $(PrepareForRunDependsOn);
-      CopyTestToTestDirectory;
-    </PrepareForRunDependsOn>
-
     <CopyTestToTestDirectory Condition="'$(CopyTestToTestDirectory)'==''">$(IsTestProject)</CopyTestToTestDirectory>
   </PropertyGroup>
   
@@ -36,8 +31,6 @@
   </ItemGroup>
 
   <Target Name="CopyTestToTestDirectory"
-    Inputs="@(PackagesConfig);$(TestRuntimePackageConfig);@(ReferenceCopyLocalPaths);@(Content);@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)"
-    Outputs="$(TestPath)%(TestTargetFramework.Folder)\*.*"
     Condition="'$(CopyTestToTestDirectory)'=='true'">
     
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -11,6 +11,8 @@
 
     <TestDisabled>false</TestDisabled>
     <TestDisabled Condition="'$(IsTestProject)'!='true' Or '$(SkipTests)'=='true' Or '$(RunTestsForProject)'=='false'">true</TestDisabled>
+
+    <TestsSuccessfulSemaphore>$(MSBuildProjectFile).tests.lastsucceeded</TestsSuccessfulSemaphore>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,15 +52,34 @@
     <StartArguments Condition="'$(StartArguments)'==''">$(VSStartArguments)</StartArguments>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <TestTargetFramework Include="ASP.NetCore, version=v5.0">
+      <Folder>aspnetcore50</Folder>
+    </TestTargetFramework>
+  </ItemGroup>
 
-  <PropertyGroup>
-    <TestsSuccessfulSemaphore>$(MSBuildProjectFile).tests.lastsucceeded</TestsSuccessfulSemaphore>
-  </PropertyGroup>
+  <ItemGroup>
+    <PackagesConfigs Include="$(ProjectPackagesConfigFile)" />
+    <PackagesConfigs Include="$(TestRuntimePackageConfig)" />
+  </ItemGroup>
+
+  <Target Name="DiscoverTestInputs">
+    <ItemGroup>
+      <RunTestsForProjectInputs Include="@(PackagesConfigs)" />
+      <RunTestsForProjectInputs Include="@(ReferenceCopyLocalPaths)" />
+      <RunTestsForProjectInputs Include="@(Content)" />
+      <RunTestsForProjectInputs Include="@(IntermediateAssembly)" />
+      <RunTestsForProjectInputs Include="@(_DebugSymbolsIntermediatePath)" />
+      <RunTestsForProjectInputs Include="@(AllItemsFullPathWithTargetPath)" />
+    </ItemGroup>
+  </Target>
 
   <!-- On command line run unit tests on CoreCLR after the Test target -->
   <Target Name="RunTestsForProject"
+          DependsOnTargets="DiscoverTestInputs"
           AfterTargets="CheckTestCategories"
-          Inputs="@(PackagesConfig);$(TestRuntimePackageConfig);@(ReferenceCopyLocalPaths);@(Content);@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath);@(AllItemsFullPathWithTargetPath)"
+          Inputs="@(RunTestsForProjectInputs)"
           Outputs="$(TestPath)%(TestTargetFramework.Folder)\$(TestsSuccessfulSemaphore);$(TestPath)%(TestTargetFramework.Folder)\$(XunitResultsFileName)"
           Condition="'$(TestDisabled)'!='true'">
 

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -58,7 +58,7 @@
   <!-- On command line run unit tests on CoreCLR after the Test target -->
   <Target Name="RunTestsForProject"
           AfterTargets="CheckTestCategories"
-          Inputs="@(PackagesConfig);$(TestRuntimePackageConfig);@(ReferenceCopyLocalPaths);@(Content);@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)"
+          Inputs="@(PackagesConfig);$(TestRuntimePackageConfig);@(ReferenceCopyLocalPaths);@(Content);@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath);@(AllItemsFullPathWithTargetPath)"
           Outputs="$(TestPath)%(TestTargetFramework.Folder)\$(TestsSuccessfulSemaphore);$(TestPath)%(TestTargetFramework.Folder)\$(XunitResultsFileName)"
           Condition="'$(TestDisabled)'!='true'">
 

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -24,8 +24,9 @@
   <PropertyGroup>
     <XunitHost>corerun.exe</XunitHost>
     <TestHost>$(XunitHost)</TestHost>
+    <XunitResultsFileName>testResults.xml</XunitResultsFileName>
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
-    <XunitOptions>$(XunitOptions) -xml .\testResults.xml</XunitOptions>
+    <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
 
     <!-- We need to exclude xunit traits and add wait option for VS -->
@@ -50,10 +51,18 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <TestsSuccessfulSemaphore>$(MSBuildProjectFile).tests.lastsucceeded</TestsSuccessfulSemaphore>
+  </PropertyGroup>
+
   <!-- On command line run unit tests on CoreCLR after the Test target -->
   <Target Name="RunTestsForProject"
           AfterTargets="CheckTestCategories"
+          Inputs="@(PackagesConfig);$(TestRuntimePackageConfig);@(ReferenceCopyLocalPaths);@(Content);@(IntermediateAssembly);@(_DebugSymbolsIntermediatePath)"
+          Outputs="$(TestPath)%(TestTargetFramework.Folder)\$(TestsSuccessfulSemaphore);$(TestPath)%(TestTargetFramework.Folder)\$(XunitResultsFileName)"
           Condition="'$(TestDisabled)'!='true'">
+
+    <CallTarget Targets="CopyTestToTestDirectory"/>
 
     <PropertyGroup>
       <XunitTraitOptions Condition="'@(RunWithTraits)'!=''">$(XunitTraitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitTraitOptions>
@@ -83,6 +92,7 @@
 
     <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)%(TestTargetFramework.Folder)\$(EventTracerDataFile)" />
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
+    <Touch Condition="'$(TestRunExitCode)' == '0'" Files="$(TestPath)%(TestTargetFramework.Folder)\$(TestsSuccessfulSemaphore)" AlwaysCreate="true" />
   </Target>
 
   <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->


### PR DESCRIPTION
Fixes #60 

Uses a marker file and Inputs/Outputs on the RunTestsForProject target to skip running tests when nothing has changed since the last successful test run. Also moves copying of the test files into the RunTestsForProject target so that they are only copied if the tests are going to run.

On my machine, this change cuts the build time for CoreFX for an incremental build with no changes from 45-55 seconds to 5 seconds*.