### PR TITLE
Modify report generator and coveralls working dirs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
@@ -75,7 +75,8 @@
          Condition="'$(GenerateFullCoverageReport)'=='true'">
 
     <Exec Command="$(CoverageReportGeneratorCommandLine) -reports:$(CoverageReportDir)\*.coverage.xml"
-          ContinueOnError="ErrorAndContinue" />
+          ContinueOnError="ErrorAndContinue"
+          WorkingDirectory="$(ProjectDir)" />
 
     <PropertyGroup>
       <CoverallsUploaderCommandLine>$(PackagesDir)coveralls.io.$(CoverallsUploaderVersion)\tools\coveralls.net.exe</CoverallsUploaderCommandLine>
@@ -84,6 +85,7 @@
 
     <Exec Command="$(CoverallsUploaderCommandLine) $(CoverallsUploaderOptions)"
           ContinueOnError="ErrorAndContinue"
+          WorkingDirectory="$(ProjectDir)"
           Condition="'$(UploadCoverallsData)'=='true'" />
 
   </Target>


### PR DESCRIPTION
This ensures that when gathering relative paths to the source files in the reports, we are relative to the root of the repository.  Report generator doesn't have an issue with this per-se, but coveralls.io looks up the github sources based on the root of the repo.