### PR TITLE
Initial integration of perf testing tools into the build system.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- properties for consumptive metric testing -->
+  <PropertyGroup Condition="'$(TestConsumptiveMetrics)' == 'true'">
+    <BaselineDataFile>$(MSBuildProjectDirectory)\CBM.$(MSBuildProjectName).xml</BaselineDataFile>
+    <CollectConsumptiveMetrics>true</CollectConsumptiveMetrics>
+    <CollectPerfEvents>true</CollectPerfEvents>
+    <CompareLiveToBaseline>true</CompareLiveToBaseline>
+  </PropertyGroup>
+
+  <!-- properties for generating consumptive metrics baselines -->
+  <PropertyGroup Condition="'$(BaselineConsumptiveMetrics)' == 'true'">
+    <CollectConsumptiveMetrics>true</CollectConsumptiveMetrics>
+    <CollectPerfEvents>true</CollectPerfEvents>
+    <CreatePerfBaseline>true</CreatePerfBaseline>
+    <MultipleTestIterations>true</MultipleTestIterations>
+    <OutputBaselineFile>$(MSBuildProjectDirectory)\CBM.$(MSBuildProjectName).xml</OutputBaselineFile>
+  </PropertyGroup>
+
+  <!--
+    Perf tools package versions go here and in the test-runtime-packages.config
+  -->
+  <PropertyGroup>
+    <PerfToolsVersion>0.0.1-prerelease-00018</PerfToolsVersion>
+    <PerfToolsDir Condition="'$(PerfToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.PerfTools.$(PerfToolsVersion)\tools\</PerfToolsDir>
+    <ComparePerfData>"$(PerfToolsDir)ComparePerfEventsData.exe"</ComparePerfData>
+    <EventTracer>"$(PerfToolsDir)EventTracer.exe"</EventTracer>
+    <GenPerfBaseline>"$(PerfToolsDir)GenPerfBaseline.exe"</GenPerfBaseline>
+    <!-- by default delete the trace files after consumption -->
+    <DeletePerfDataFile Condition="'$(DeletePerfDataFile)' == ''">true</DeletePerfDataFile>
+    <!-- run tests is serial when collecting perf data so they don't all bleed together -->
+    <SerializeProjects Condition="'$(CollectPerfEvents)' == 'true'">true</SerializeProjects>
+  </PropertyGroup>
+
+  <!-- perf events for consumptive metrics testing -->
+  <PropertyGroup Condition="'$(CollectConsumptiveMetrics)' == 'true'">
+    <ClrMetrics>GCSampledObjectAllocationHigh,GCSampledObjectAllocationLow</ClrMetrics>
+    <KernelMetrics>ImageLoad</KernelMetrics>
+  </PropertyGroup>
+
+  <!-- when enabled, run target RunTestsForProject five times -->
+  <ItemGroup Condition="'$(MultipleTestIterations)' == 'true'">
+    <IterationCount Include="1" />
+    <IterationCount Include="2" />
+    <IterationCount Include="3" />
+    <IterationCount Include="4" />
+    <IterationCount Include="5" />
+  </ItemGroup>
+
+  <!-- compares live perf data to a specific baseline -->
+  <Target Name="ComparePerfData"
+          AfterTargets="RunTestsForProject"
+          Condition="'$(CompareLiveToBaseline)' == 'true'">
+
+    <PropertyGroup>
+      <LiveDataFile>Perf.$(MSBuildProjectName)%(TestTargetFrameworkBatch.Count).xml</LiveDataFile>
+    </PropertyGroup>
+
+    <Exec Command="$(ComparePerfData) -b $(BaselineDataFile) -l $(LiveDataFile)"
+          WorkingDirectory="$(TestPath)%(TestTargetFrameworkBatch.Folder)" />
+
+  </Target>
+
+  <!-- generates a new perf baseline file -->
+  <Target Name="CreatePerfBaseline"
+          AfterTargets="RunTestsForProject"
+          Condition="'$(CreatePerfBaseline)' == 'true'">
+
+    <PropertyGroup>
+      <InputFilesPattern>$(TestPath)%(TestTargetFrameworkBatch.Folder)\Perf.$(MSBuildProjectName)?.xml</InputFilesPattern>
+      <LiveDataFile>$(TestPath)%(TestTargetFrameworkBatch.Folder)\Perf.$(MSBuildProjectName).xml</LiveDataFile>
+    </PropertyGroup>
+
+    <!-- if there's a live data file delete it so it doesn't get rolled into the baseline results -->
+    <Delete Condition="Exists('$(LiveDataFile)')" Files="$(LiveDataFile)" />
+    <Exec Command="$(GenPerfBaseline) -i $(InputFilesPattern) -o $(OutputBaselineFile)" />
+
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -4,6 +4,7 @@
   <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.4-prerelease" />
   <package id="Microsoft.DotNet.CoreCLR" version="1.0.3-prerelease" />
+  <package id="Microsoft.DotNet.PerfTools" version="0.0.1-prerelease-00018" />
 
   <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22703" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -37,6 +37,9 @@
   <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
   <Import Project="$(MSBuildThisFileDirectory)CodeCoverage.targets" />
 
+  <!-- import settings for perf testing -->
+  <Import Project="$(MSBuildThisFileDirectory)PerfTesting.targets" />
+
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">
     <DebugTestFrameworkFolder>aspnetcore50</DebugTestFrameworkFolder>
@@ -47,10 +50,29 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 
+  <!--
+    combine the TestTargetFramework with IterationCount.  by batching on TestTargetFrameworkBatch
+    in the RunTestsForProject Outputs it effectively allows us to run the target multiple times,
+    once for each IterationCount.  if IterationCount isn't defined there is no effect.  right now
+    this is used for perf testing which requires us to run a test multiple iterations and aggregate
+    the results.
+  -->
+  <Target Name="InitIterationBatch"
+          BeforeTargets="RunTestsForProject">
+
+    <ItemGroup>
+      <TestTargetFrameworkBatch Include="@(TestTargetFramework)">
+        <Count>%(IterationCount.Identity)</Count>
+      </TestTargetFrameworkBatch>
+    </ItemGroup>
+
+  </Target>
+
   <!-- On command line run unit tests on CoreCLR after the Test target -->
   <Target Name="RunTestsForProject"
           AfterTargets="CheckTestCategories"
-          Condition="'$(TestDisabled)'!='true'">
+          Condition="'$(TestDisabled)'!='true'"
+          Outputs="%(TestTargetFrameworkBatch.Folder) %(TestTargetFrameworkBatch.Count)">
 
     <PropertyGroup>
       <XunitTraitOptions Condition="'@(RunWithTraits)'!=''">$(XunitTraitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitTraitOptions>
@@ -60,16 +82,28 @@
     <!-- Append the xunit trait options to the end of the TestCommandLine -->
     <PropertyGroup>
       <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
+      <EventTracerDataFile>$(TargetFileName)%(TestTargetFrameworkBatch.Count).etl</EventTracerDataFile>
+      <EventTracerMetrics>-c $(ClrMetrics) -k $(KernelMetrics)</EventTracerMetrics>
+      <EventTracerReport>Perf.$(MSBuildProjectName)%(TestTargetFrameworkBatch.Count).xml</EventTracerReport>
     </PropertyGroup>
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
 
+    <Exec Command="$(EventTracer) -m start -t $(TargetFileName) -d $(EventTracerDataFile) $(EventTracerMetrics)"
+          WorkingDirectory="$(TestPath)%(TestTargetFrameworkBatch.Folder)"
+          Condition="'$(CollectPerfEvents)' == 'true'" />
+
     <Exec Command="$(TestHost) $(TestCommandLine)"
-          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          WorkingDirectory="$(TestPath)%(TestTargetFrameworkBatch.Folder)"
           ContinueOnError="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
     </Exec>
 
+    <Exec Command="$(EventTracer) -m stop -t $(TargetFileName) -d $(EventTracerDataFile) $(EventTracerMetrics) -x $(EventTracerReport) -p CoreRun"
+          WorkingDirectory="$(TestPath)%(TestTargetFrameworkBatch.Folder)"
+          Condition="'$(CollectPerfEvents)' == 'true'" />
+
+    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)%(TestTargetFrameworkBatch.Folder)\$(EventTracerDataFile)" />
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
   </Target>
 


### PR DESCRIPTION
Add PerfTesting.targets file defining properties and targets used to
enable perf testing during the build.  Testing is enabled via msbuild
properties.  At present there are two properties, TestConsumptiveMetrics
and BaselineConsumptiveMetrics.  The former is used to compare live perf
data against a checked in baseline and the latter is used to generate
baseline data.

Added a reference to the perf tools nuget package.

Updated tests.targets to start/stop collection of perf data.  Also added
functionality allowing this target to be called for multiple iterations
(see comments for details).