### PR TITLE
Add NeutralResourcesLanguageAttribute to assemblies which contain resources

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/versioning.targets
@@ -52,6 +52,7 @@
       <AssemblyInfoLines Include="[assembly:AssemblyVersion(&quot;$(AssemblyVersion)&quot;)]" />
       <AssemblyInfoLines Include="[assembly:AssemblyFileVersion(&quot;$(AssemblyFileVersion)&quot;)]" />
       <AssemblyInfoLines Include="[assembly:AssemblyInformationalVersion(@&quot;$(AssemblyFileVersion)$(BuiltByString)&quot;)]" />
+      <AssemblyInfoLines Condition="'$(StringResourcesPath)' != ''" Include="[assembly:System.Resources.NeutralResourcesLanguage(&quot;en-US&quot;)]" />
       <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="[assembly:CLSCompliant(true)]" />
       <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="[assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))]" />
     </ItemGroup>
@@ -68,6 +69,7 @@
       <AssemblyInfoLines Include="&lt;Assembly:AssemblyVersion(&quot;$(AssemblyVersion)&quot;)&gt;" />
       <AssemblyInfoLines Include="&lt;Assembly:AssemblyFileVersion(&quot;$(AssemblyFileVersion)&quot;)&gt;" />
       <AssemblyInfoLines Include="&lt;Assembly:AssemblyInformationalVersion(&quot;$(AssemblyFileVersion)$(BuiltByString)&quot;)&gt;" />
+      <AssemblyInfoLines Condition="'$(StringResourcesPath)' != ''" Include="&lt;Assembly:System.Resources.NeutralResourcesLanguage(&quot;en-US&quot;):gt;" />
       <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="&lt;Assembly:CLSCompliant(True)&gt;" />
       <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="&lt;Assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))&gt;" />
     </ItemGroup>


### PR DESCRIPTION
This is needed by the store toolchain when generating PRI files from the embedded resources.