### PR TITLE
Initial integration of perf testing tools into the build system.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- properties for consumptive metric testing -->
+  <PropertyGroup Condition="'$(TestConsumptiveMetrics)' == 'true'">
+    <CollectConsumptiveMetrics>true</CollectConsumptiveMetrics>
+    <CollectPerfEvents>true</CollectPerfEvents>
+  </PropertyGroup>
+
+  <!--
+    Perf tools package versions go here and in the test-runtime-packages.config
+  -->
+  <PropertyGroup>
+    <PerfToolsVersion>0.0.1-prerelease-00018</PerfToolsVersion>
+    <PerfToolsDir Condition="'$(PerfToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.PerfTools.$(PerfToolsVersion)\tools\</PerfToolsDir>
+    <EventTracer>"$(PerfToolsDir)EventTracer.exe"</EventTracer>
+    <!-- by default delete the trace files after consumption -->
+    <DeletePerfDataFile Condition="'$(DeletePerfDataFile)' == ''">true</DeletePerfDataFile>
+    <!-- run tests is serial when collecting perf data so they don't all bleed together -->
+    <SerializeProjects Condition="'$(CollectPerfEvents)' == 'true'">true</SerializeProjects>
+  </PropertyGroup>
+
+  <!-- perf events for consumptive metrics testing -->
+  <PropertyGroup Condition="'$(CollectConsumptiveMetrics)' == 'true'">
+    <ClrMetrics>GCSampledObjectAllocationHigh,GCSampledObjectAllocationLow</ClrMetrics>
+    <KernelMetrics>ImageLoad</KernelMetrics>
+  </PropertyGroup>
+
+  <!-- command line args to EventTracer.exe -->
+  <PropertyGroup>
+    <EventTracerDataFile>$(TargetFileName).etl</EventTracerDataFile>
+    <EventTracerMetrics>-c $(ClrMetrics) -k $(KernelMetrics)</EventTracerMetrics>
+    <EventTracerReport>Perf.$(MSBuildProjectName).xml</EventTracerReport>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -4,6 +4,7 @@
   <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
   <package id="Microsoft.DotNet.TestHost" version="1.0.4-prerelease" />
   <package id="Microsoft.DotNet.CoreCLR" version="1.0.3-prerelease" />
+  <package id="Microsoft.DotNet.PerfTools" version="0.0.1-prerelease-00018" />
 
   <package id="System.Collections" version="4.0.10-beta-22703" />
   <package id="System.Collections.Concurrent" version="4.0.10-beta-22703" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -37,6 +37,9 @@
   <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
   <Import Project="$(MSBuildThisFileDirectory)CodeCoverage.targets" />
 
+  <!-- import settings for perf testing -->
+  <Import Project="$(MSBuildThisFileDirectory)PerfTesting.targets" />
+
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">
     <DebugTestFrameworkFolder>aspnetcore50</DebugTestFrameworkFolder>
@@ -64,12 +67,21 @@
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
 
+    <Exec Command="$(EventTracer) -m start -t $(TargetFileName) -d $(EventTracerDataFile) $(EventTracerMetrics)"
+          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          Condition="'$(CollectPerfEvents)' == 'true'" />
+
     <Exec Command="$(TestHost) $(TestCommandLine)"
           WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
           ContinueOnError="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
     </Exec>
 
+    <Exec Command="$(EventTracer) -m stop -t $(TargetFileName) -d $(EventTracerDataFile) $(EventTracerMetrics) -x $(EventTracerReport) -p CoreRun"
+          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          Condition="'$(CollectPerfEvents)' == 'true'" />
+
+    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)%(TestTargetFramework.Folder)\$(EventTracerDataFile)" />
     <Error Condition="'$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
   </Target>
 


### PR DESCRIPTION
Add PerfTesting.targets file defining properties and targets used to
enable perf testing during the build. Testing is enabled via msbuild
properties. At present there is one properties, TestConsumptiveMetrics
used to enable collection of perf data.

Added a reference to the perf tools nuget package.

Updated tests.targets to start/stop collection of perf data.