### PR TITLE
Update perf tools version property.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
@@ -11,7 +11,7 @@
     Perf tools package versions go here and in the test-runtime-packages.config
   -->
   <PropertyGroup>
-    <PerfToolsVersion>0.0.1-prerelease-00018</PerfToolsVersion>
+    <PerfToolsVersion>0.0.1-prerelease-00022</PerfToolsVersion>
     <PerfToolsDir Condition="'$(PerfToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.PerfTools.$(PerfToolsVersion)\tools\</PerfToolsDir>
     <EventTracer>"$(PerfToolsDir)EventTracer.exe"</EventTracer>
     <!-- by default delete the trace files after consumption -->


### PR DESCRIPTION
The nuget package dependency was updated in change 33cb4e but the msbuild
property wasn't updated to match; this brings them both in sync.