### PR TITLE
Add nonwindowstests category to skip running linux and mac specific tests on windows

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -30,6 +30,7 @@
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
     <XunitOptions>$(XunitOptions) -notrait category=failing</XunitOptions>
+    <XunitOptions Condition="'$(OS)'=='Windows_NT'">$(XunitOptions) -notrait category=nonwindowstests</XunitOptions>
 
     <!-- We need to exclude xunit traits and add wait option for VS -->
     <VSStartArguments>$(XunitCommandLine) $(XunitOptions) -wait</VSStartArguments>


### PR DESCRIPTION
corresponds to https://github.com/dotnet/corefx/pull/1276.

cc @stephentoub @krwq 