### PR TITLE
Make incremental build conditional on selected test categories

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -144,6 +144,11 @@
     <PropertyGroup>
       <TestDisabled Condition="'@(TestCategoriesToRun)'==''">true</TestDisabled>
     </PropertyGroup>
+
+    <PropertyGroup>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithTraits)' != ''">$(TestsSuccessfulSemaphore).with.@(RunWithTraits, '.')</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore Condition="'@(RunWithoutTraits)' != ''">$(TestsSuccessfulSemaphore).without.@(RunWithoutTraits, '.')</TestsSuccessfulSemaphore>
+    </PropertyGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
This fixes dotnet/corefx#1275.

The semaphore file now includes the test categories that were selected to run or not run; selecting new categories will re-run the test if that set of category inclusions/exclusions is out of date.