### PR TITLE
Ensure required properties are set prior to copying files for testing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -65,7 +65,7 @@
     <PackagesConfigs Include="$(TestRuntimePackageConfig)" />
   </ItemGroup>
 
-  <Target Name="DiscoverTestInputs">
+  <Target Name="DiscoverTestInputs" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences;GetCopyToOutputDirectoryItems">
     <ItemGroup>
       <RunTestsForProjectInputs Include="@(PackagesConfigs)" />
       <RunTestsForProjectInputs Include="@(ReferenceCopyLocalPaths)" />


### PR DESCRIPTION
Fixes dotnet/corefx#1286

ReferenceCopyLocalPaths is populated by ResolveAssemblyReferences, which requires (but does not depend on) ResolveProjectReferences. AllItemsFullPathWithTargetPath is populated by GetCopyToOutputDirectoryItems. These targets are executed during Build; executing Test without Build was leaving these items unpopulated, causing them to not be copied to the test directory.