### PR TITLE
Add support to skip whole test projects based on platform.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -20,6 +20,7 @@
     <TestCategoriesItems Include="$(TestCategories)" />
     <RunTestsWithCategoriesItems Include="$(RunTestsWithCategories)" />
     <RunTestsWithoutCategoriesItems Include="$(RunTestsWithoutCategories)" />
+    <UnsupportedPlatformsItems Include="$(UnsupportedPlatforms)"/>
   </ItemGroup>
 
   <!-- General xunit options -->
@@ -53,7 +54,7 @@
     <StartArguments Condition="'$(StartArguments)'==''">$(VSStartArguments)</StartArguments>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <TestTargetFramework Include="ASP.NetCore, version=v5.0">
       <Folder>aspnetcore50</Folder>
@@ -119,7 +120,7 @@
 
   <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->
   <Target Name="CheckTestCategories"
-          AfterTargets="Test"
+          AfterTargets="CheckTestPlatforms"
           Condition="'$(TestDisabled)'!='true'">
 
     <Error Condition="'$(RunTestsWithCategories)' != '' And '$(RunTestsWithoutCategories)' != ''"
@@ -141,7 +142,7 @@
       <RunWithoutTraits Condition="'@(RunWithInnerLoopItems)'!=''" Include="@(TestCategoriesItems)" Exclude="@(TestCategoriesToRun)" />
     </ItemGroup>
 
-    <!-- If there is nothing to run then disable the test -->
+    <!-- If there is nothing to run, then disable the test -->
     <PropertyGroup>
       <TestDisabled Condition="'@(TestCategoriesToRun)'==''">true</TestDisabled>
     </PropertyGroup>
@@ -152,4 +153,12 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="CheckTestPlatforms"
+  		  AfterTargets="Test"
+  		  Condition="'$(TestDisabled)'!='true'">
+  	<PropertyGroup>
+      <IsWindowsAssembly Condition="'$(OS)'=='Windows_NT' And '%(UnsupportedPlatformsItems.Identity)'=='Windows_NT'">false</IsWindowsAssembly>
+      <TestDisabled Condition="'$(IsWindowsAssembly)'=='false'">true</TestDisabled>
+    </PropertyGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Adding <UnsupportedPlatforms>OSX;Windows_NT;Linux</UnsupportedPlatforms> in csproj will exclude tests from the specified OS'es. Corresponding change to run-test.sh to rename UnsupportedOperatingSystems to UnsupportedPlatforms for linux will follow in corefx.

cc @stephentoub @mmitche 