### PR TITLE
Fix missing coverage dependency

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -81,7 +81,7 @@
           DependsOnTargets="DiscoverTestInputs"
           AfterTargets="CheckTestCategories"
           Inputs="@(RunTestsForProjectInputs)"
-          Outputs="$(TestPath)%(TestTargetFramework.Folder)\$(TestsSuccessfulSemaphore);$(TestPath)%(TestTargetFramework.Folder)\$(XunitResultsFileName)"
+          Outputs="$(TestPath)%(TestTargetFramework.Folder)\$(TestsSuccessfulSemaphore);$(TestPath)%(TestTargetFramework.Folder)\$(XunitResultsFileName);$(CoverageOutputFilePath)"
           Condition="'$(TestDisabled)'!='true'">
 
     <CallTarget Targets="CopyTestToTestDirectory"/>


### PR DESCRIPTION
If the coverage.xml got deleted after running coverage once, and then the build was run with coverage again, it would not rerun the actual coverage step.  It still would attempt to recreate then coverage report, which would fail because of a missing coverage file.  Fix this by adding the coverage output to the outputs of the test target (only set when coverage is set to true).

Fixes dotnet/corefx#1308