### PR TITLE
Change properties with paths to use forward slash to be friendly with bo...

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -4,7 +4,7 @@
   <UsingTask TaskName="ResolveNuGetPackages" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
-    <ProjectPackagesConfigFile Condition="'$(ProjectPackagesConfigFile)'=='' and Exists('$(MSBuildProjectDirectory)\packages.config')">$(MSBuildProjectDirectory)\packages.config</ProjectPackagesConfigFile>
+    <ProjectPackagesConfigFile Condition="'$(ProjectPackagesConfigFile)'=='' and Exists('$(MSBuildProjectDirectory)/packages.config')">$(MSBuildProjectDirectory)/packages.config</ProjectPackagesConfigFile>
 
     <RestorePackages Condition="'$(RestorePackages)'!='false' and Exists('$(ProjectPackagesConfigFile)')">true</RestorePackages>
     <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)'!='false' and Exists('$(ProjectPackagesConfigFile)')">true</ResolveNuGetPackages>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
@@ -3,8 +3,8 @@
   <UsingTask TaskName="GenerateResourcesCode" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
-    <ResourcesSourceOutputDirectory Condition="'$(ResourcesSourceOutputDirectory)' == ''">$(MSBuildProjectDirectory)\Resources\</ResourcesSourceOutputDirectory>
-    <StringResourcesPath Condition="'$(StringResourcesPath)'=='' And Exists('$(ResourcesSourceOutputDirectory)Strings.resx')">$(ResourcesSourceOutputDirectory)\Strings.resx</StringResourcesPath>
+    <ResourcesSourceOutputDirectory Condition="'$(ResourcesSourceOutputDirectory)' == ''">$(MSBuildProjectDirectory)/Resources/</ResourcesSourceOutputDirectory>
+    <StringResourcesPath Condition="'$(StringResourcesPath)'=='' And Exists('$(ResourcesSourceOutputDirectory)Strings.resx')">$(ResourcesSourceOutputDirectory)/Strings.resx</StringResourcesPath>
     <IntermediateResOutputFileFullPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(IntermediateOutputPath)SR.cs</IntermediateResOutputFileFullPath>
     <IntermediateResOutputFileFullPath Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(IntermediateOutputPath)SR.vb</IntermediateResOutputFileFullPath>
   </PropertyGroup>


### PR DESCRIPTION
...th Unix and Windows.

This will enable updating the projects depending on .net buildtools so that they can build with MSBuild on Unix. This change is only necessary with properties as includes will be "Windows normalized" by MSBuild.

Note that Windows can care less about slash direction outside of root locations (C:\, \\Server\Share, \\?\). Unix only allows forward slash as a separator.

I tested this out on Unix with additional pending changes on CoreFx. I expect I'll probably find more issues in the build tools, but this is an important first step.