### PR TITLE
Embed the resources with different names

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/resources.targets
@@ -7,6 +7,7 @@
     <StringResourcesPath Condition="'$(StringResourcesPath)'=='' And Exists('$(ResourcesSourceOutputDirectory)Strings.resx')">$(ResourcesSourceOutputDirectory)/Strings.resx</StringResourcesPath>
     <IntermediateResOutputFileFullPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(IntermediateOutputPath)SR.cs</IntermediateResOutputFileFullPath>
     <IntermediateResOutputFileFullPath Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(IntermediateOutputPath)SR.vb</IntermediateResOutputFileFullPath>
+    <DefineConstants Condition="'$(ConfigurationGroup)' == 'Debug'">$(DefineConstants);DEBUGRESOURCES</DefineConstants>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(StringResourcesPath)'!=''">
@@ -39,7 +40,7 @@
   <ItemGroup Condition="'$(StringResourcesPath)'!=''">
     <EmbeddedResource Include="$(StringResourcesPath)">
       <Visible>true</Visible>
-      <LogicalName>System.SR.resources</LogicalName>
+      <LogicalName>FxResources.$(AssemblyName).SR.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   


### PR DESCRIPTION
This change is to embed the resources with different name for each assembly
to avoid the resource merge conflict in the store app scenario as
the resources get merged into the app PRI file.