### PR TITLE
Add project.json support to build tools

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/MSBuildDependencyResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/MSBuildDependencyResolver.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NuGet.Build.Tasks
+{
+    internal sealed class MSBuildDependencyProvider : IDependencyProvider
+    {
+        private readonly string _msbuildProjectFilePath;
+
+        public MSBuildDependencyProvider(string projectFilePath)
+        {
+            _msbuildProjectFilePath = projectFilePath;
+        }
+
+        public Library GetDescription(LibraryRange libraryRange, NuGetFramework targetFramework)
+        {
+            if (libraryRange.Name != _msbuildProjectFilePath)
+            {
+                return null;
+            }
+
+            var dependencies = new List<LibraryDependency>();
+
+            var projectJsonPath = Path.Combine(Path.GetDirectoryName(_msbuildProjectFilePath), "project.json");
+
+            using (var fileStream = new FileStream(projectJsonPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                var packageSpec = JsonPackageSpecReader.GetPackageSpec(fileStream, projectJsonPath, projectJsonPath);
+
+                // Grab dependencies from here too
+                var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
+
+                dependencies.AddRange(packageSpec.Dependencies);
+                dependencies.AddRange(targetFrameworkInfo.Dependencies);
+            }
+
+            var description = new Library
+            {
+                LibraryRange = libraryRange,
+                Identity = new LibraryIdentity
+                {
+                    Name = libraryRange.Name,
+                    Version = new NuGetVersion(new Version(1, 0)), // TODO: Make up something better
+                    Type = LibraryTypes.MSBuild,
+                },
+                Path = _msbuildProjectFilePath,
+                Dependencies = dependencies
+            };
+
+            return description;
+        }
+
+        public bool SupportsType(string libraryType)
+        {
+            return libraryType == LibraryTypes.MSBuild || libraryType == null;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -30,12 +30,17 @@
     <Compile Include="GetPackageDependencies.cs" />
     <Compile Include="GitPush.cs" />
     <Compile Include="GetNextRevisionNumber.cs" />
+    <Compile Include="MSBuildDependencyResolver.cs" />
     <Compile Include="NormalizePaths.cs" />
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="OpenSourceSign.cs" />
+    <Compile Include="PatternDefinitions.cs" />
+    <Compile Include="PropertyDefinitions.cs" />
+    <Compile Include="ResolveNuGetPackageAssets.cs" />
     <Compile Include="ResolveNuGetPackages.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="mscorlib" />
     <Reference Include="LibGit2Sharp">
       <HintPath>..\..\packages\LibGit2Sharp.0.19.0.0\lib\net40\LibGit2Sharp.dll</HintPath>
@@ -46,9 +51,27 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.NuManifest.DotNet.1.0.1-alpha\lib\net45\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.ContentModel">
+      <HintPath>..\..\packages\NuGet.ContentModel.3.0.0\lib\net45\NuGet.ContentModel.dll</HintPath>
+    </Reference>
     <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.NuManifest.DotNet.1.0.1-alpha\lib\net45\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.DependencyResolver">
+      <HintPath>..\..\packages\NuGet.DependencyResolver.3.0.0\lib\net45\NuGet.DependencyResolver.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.DependencyResolver.Core">
+      <HintPath>..\..\packages\NuGet.DependencyResolver.Core.3.0.0\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Frameworks">
+      <HintPath>..\..\packages\NuGet.Frameworks.3.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.LibraryModel">
+      <HintPath>..\..\packages\NuGet.LibraryModel.3.0.0\lib\net45\NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.NuManifest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fde1dfc9ddcb8e3e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -58,12 +81,31 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.NuManifest.DotNet.1.0.1-alpha\lib\net45\NuGet.NuManifest.DotNet.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Packaging">
+      <HintPath>..\..\packages\NuGet.Packaging.3.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging.Core">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.3.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging.Core.Types">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.3.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.ProjectModel">
+      <HintPath>..\..\packages\NuGet.ProjectModel.3.0.0\lib\net45\NuGet.ProjectModel.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Repositories">
+      <HintPath>..\..\packages\NuGet.Repositories.3.0.0\lib\net45\NuGet.Repositories.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Versioning">
+      <HintPath>..\..\packages\NuGet.Versioning.3.0.0-beta4-10027\lib\net45\NuGet.Versioning.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Collections.Immutable">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>true</Private>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>

--- a/src/Microsoft.DotNet.Build.Tasks/PatternDefinitions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PatternDefinitions.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.ContentModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.NuGet.Build.Tasks
+{
+    internal class PatternDefinitions
+    {
+        public PropertyDefinitions Properties { get; private set; }
+        public ContentPatternDefinition CompileTimeAssemblies { get; private set; }
+        public ContentPatternDefinition ManagedAssemblies { get; private set; }
+        public ContentPatternDefinition AheadOfTimeAssemblies { get; private set; }
+        public ContentPatternDefinition ResourceAssemblies { get; private set; }
+        public ContentPatternDefinition NativeLibraries { get; private set; }
+
+        public PatternDefinitions()
+        {
+            Properties = new PropertyDefinitions();
+
+            ManagedAssemblies = new ContentPatternDefinition
+            {
+                GroupPatterns =
+                {
+                    "lib/{tfm}~{tpm}/{any?}",
+                    "lib/{tfm}/{any?}",
+                },
+                PathPatterns =
+                {
+                    "lib/{tfm}~{tpm}/{assembly}",
+                    "lib/{tfm}/{assembly}",
+                },
+                PropertyDefinitions = Properties.Definitions,
+            };
+
+            CompileTimeAssemblies = new ContentPatternDefinition
+            {
+                GroupPatterns =
+                {
+                    "ref/{tfm}~{tpm}/{any?}",
+                    "ref/{tfm}/{any?}",
+                },
+                PathPatterns =
+                {
+                    "ref/{tfm}~{tpm}/{assembly}",
+                    "ref/{tfm}/{assembly}",
+                },
+                PropertyDefinitions = Properties.Definitions,
+            };
+
+            AheadOfTimeAssemblies = new ContentPatternDefinition
+            {
+                GroupPatterns =
+                {
+                    "aot/{tfm}~{tpm}/{any?}",
+                    "aot/{tfm}/{any?}",
+                },
+                PathPatterns =
+                {
+                    "aot/{tfm}~{tpm}/{assembly}",
+                    "aot/{tfm}/{assembly}",
+                },
+                PropertyDefinitions = Properties.Definitions,
+            };
+
+            ResourceAssemblies = new ContentPatternDefinition
+            {
+                GroupPatterns =
+                {
+                    "lib/{tfm}~{tpm}/{locale?}/{resources?}",
+                    "lib/{tfm}/{locale?}/{resources?}",
+                },
+                PathPatterns =
+                {
+                    "lib/{tfm}.{tpm}/{locale}/{resources}",
+                    "lib/{tfm}/{locale}/{resources}",
+                },
+                PropertyDefinitions = Properties.Definitions,
+            };
+
+            NativeLibraries = new ContentPatternDefinition
+            {
+                GroupPatterns =
+                {
+                    "lib/{tfm}~{tpm}/{arch}/{any?}",
+                    "lib/{tpm}/{arch}/{any?}",
+                },
+                PathPatterns =
+                {
+                    "lib/{tfm}~{tpm}/{arch}/{dynamicLibrary}",
+                    "lib/{tpm}/{arch}/{dynamicLibrary}",
+                },
+                PropertyDefinitions = Properties.Definitions,
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PropertyDefinitions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PropertyDefinitions.cs
@@ -57,6 +57,7 @@ namespace Microsoft.NuGet.Build.Tasks
                 {
                     { "aspnet50", new NuGetFramework("ASP.NET", new Version(5, 0)) },
                     { "aspnetcore50", new NuGetFramework("ASP.NETCore", new Version(5, 0)) },
+                    { "dnxcore50", new NuGetFramework("DNXCore", new Version(5, 0)) },
                     { "any", NuGetFramework.AnyFramework },
                     { "monoandroid", new NuGetFramework("MonoAndroid",new Version()) },
                     { "monotouch", new NuGetFramework("MonoTouch",new Version()) },

--- a/src/Microsoft.DotNet.Build.Tasks/PropertyDefinitions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PropertyDefinitions.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.ContentModel;
+using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Versioning;
+
+namespace Microsoft.NuGet.Build.Tasks
+{
+    public class PropertyDefinitions
+    {
+        public PropertyDefinitions()
+        {
+            Definitions = new Dictionary<string, ContentPropertyDefinition>
+                {
+                    { "arch", _arch },
+                    { "language", _language },
+                    { "tfm", _targetFramework },
+                    { "tpm", _targetPlatform },
+                    { "assembly", _assembly },
+                    { "dynamicLibrary", _dynamicLibrary },
+                    { "resources", _resources },
+                    { "locale", _locale },
+                    { "any", _any },
+                };
+        }
+
+        public IDictionary<string, ContentPropertyDefinition> Definitions { get; private set; }
+
+        private readonly ContentPropertyDefinition _arch = new ContentPropertyDefinition
+        {
+            Table =
+                {
+                    { "x86", "x86" },
+                    { "x64", "amd64" },
+                    { "amd64", "amd64" },
+                    { "arm64", "arm64" },
+                    { "universal","anyCpu" },
+                }
+        };
+
+        private readonly ContentPropertyDefinition _language = new ContentPropertyDefinition
+        {
+            Table =
+                {
+                    { "cs", "CSharp" },
+                    { "vb", "Visual Basic" },
+                    { "fs", "FSharp" },
+                }
+        };
+
+        private readonly ContentPropertyDefinition _targetFramework = new ContentPropertyDefinition
+        {
+            Table =
+                {
+                    { "aspnet50", new NuGetFramework("ASP.NET", new Version(5, 0)) },
+                    { "aspnetcore50", new NuGetFramework("ASP.NETCore", new Version(5, 0)) },
+                    { "any", NuGetFramework.AnyFramework },
+                    { "monoandroid", new NuGetFramework("MonoAndroid",new Version()) },
+                    { "monotouch", new NuGetFramework("MonoTouch",new Version()) },
+                    { "monomac", new NuGetFramework("MonoMac", new Version()) },
+                    { "netcore50", new NuGetFramework(".NETCore", new Version(5, 0)) },
+                },
+            Parser = TargetFrameworkName_Parser,
+            OnIsCriteriaSatisfied = TargetFrameworkName_IsCriteriaSatisfied
+        };
+
+        private readonly ContentPropertyDefinition _targetPlatform = new ContentPropertyDefinition
+        {
+            Table =
+                {
+                    { "win81", new FrameworkName("Windows", new Version(8, 1)) },
+                    { "win8", new FrameworkName("Windows", new Version(8, 0)) },
+                    { "win7", new FrameworkName("Windows", new Version(7, 0)) },
+                    { "windows", new FrameworkName("Windows", new Version(0, 0)) },
+                    { "wp8", new FrameworkName("WindowsPhone", new Version(8, 0)) },
+                    { "wp81", new FrameworkName("WindowsPhone", new Version(8, 1)) },
+                    { "uap10", new FrameworkName("UAP", new Version(10, 0)) },
+                    { "darwin", new FrameworkName("Darwin", new Version(0, 0)) },
+                },
+            OnIsCriteriaSatisfied = TargetPlatformName_IsCriteriaSatisfied,
+        };
+
+        private readonly ContentPropertyDefinition _assembly = new ContentPropertyDefinition
+        {
+            FileExtensions = { ".dll" }
+        };
+
+        private readonly ContentPropertyDefinition _dynamicLibrary = new ContentPropertyDefinition
+        {
+            FileExtensions = { ".dll", ".dylib", ".so" }
+        };
+
+        private readonly ContentPropertyDefinition _resources = new ContentPropertyDefinition
+        {
+            FileExtensions = { ".resources.dll" }
+        };
+
+        private readonly ContentPropertyDefinition _locale = new ContentPropertyDefinition
+        {
+            Parser = Locale_Parser,
+        };
+
+        private readonly ContentPropertyDefinition _any = new ContentPropertyDefinition
+        {
+            Parser = name => name
+        };
+
+
+        internal static object Locale_Parser(string name)
+        {
+            if (name.Length == 2)
+            {
+                return name;
+            }
+            else if (name.Length >= 4 && name[2] == '-')
+            {
+                return name;
+            }
+
+            return null;
+        }
+
+        internal static object TargetFrameworkName_Parser(string name)
+        {
+            if (name.Contains("/"))
+            {
+                return null;
+            }
+
+            var result = NuGetFramework.Parse(name);
+
+            if (result != NuGetFramework.UnsupportedFramework)
+            {
+                return result;
+            }
+
+            return null;
+        }
+
+        internal static bool TargetFrameworkName_IsCriteriaSatisfied(object criteria, object available)
+        {
+            var criteriaFrameworkName = criteria as NuGetFramework;
+            var availableFrameworkName = available as NuGetFramework;
+
+            if (criteriaFrameworkName != null && availableFrameworkName != null)
+            {
+                return DefaultCompatibilityProvider.Instance.IsCompatible(criteriaFrameworkName, availableFrameworkName);
+            }
+
+            return false;
+        }
+
+        internal static bool TargetPlatformName_IsCriteriaSatisfied(object criteria, object available)
+        {
+            var criteriaFrameworkName = criteria as FrameworkName;
+            var availableFrameworkName = available as FrameworkName;
+
+            if (criteriaFrameworkName != null && availableFrameworkName != null)
+            {
+                if (!string.Equals(criteriaFrameworkName.Identifier, availableFrameworkName.Identifier, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                // HACK: UAP is windows
+                if (criteriaFrameworkName.Identifier == "UAP" && availableFrameworkName.Identifier == "Windows")
+                {
+                    return true;
+                }
+
+                if (NormalizeVersion(criteriaFrameworkName.Version) < NormalizeVersion(availableFrameworkName.Version))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        internal static Version NormalizeVersion(Version version)
+        {
+            return new Version(version.Major,
+                               version.Minor,
+                               Math.Max(version.Build, 0),
+                               Math.Max(version.Revision, 0));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -147,6 +147,15 @@ namespace Microsoft.NuGet.Build.Tasks
         }
 
         /// <summary>
+        /// True to ignore the lock file even when present
+        /// </summary>
+        public bool IngoreLockFile
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Performs the NuGet package resolution.
         /// </summary>
         public override bool Execute()
@@ -161,7 +170,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
             var lockFilePath = Path.Combine(Path.GetDirectoryName(ProjectFile), LockFileFormat.LockFileName);
 
-            if (File.Exists(lockFilePath))
+            if (File.Exists(lockFilePath) && !IngoreLockFile)
             {
                 var lockFile = LockFileFormat.Read(lockFilePath);
 

--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -108,6 +108,12 @@ namespace Microsoft.NuGet.Build.Tasks
             get; set;
         }
 
+        public string[] AdditonalProjectJsonFiles
+        {
+            get;
+            set;
+        }
+
         public bool UseDotNetNativeToolchain
         {
             get; set;
@@ -159,7 +165,7 @@ namespace Microsoft.NuGet.Build.Tasks
                 providers.Add(new NuGetDependencyResolver(GetSystemWidePackagesPath()));
             }
 
-            providers.Add(new MSBuildDependencyProvider(ProjectFile));
+            providers.Add(new MSBuildDependencyProvider(ProjectFile, AdditonalProjectJsonFiles));
 
             var walker = new DependencyWalker(providers);
             var root = walker.Walk(ProjectFile, new NuGetVersion(new Version()), NuGetFramework.Parse(TargetFrameworkMonikers.First()));

--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -114,6 +114,15 @@ namespace Microsoft.NuGet.Build.Tasks
             set;
         }
 
+        /// <summary>
+        /// The path to the downloaded nuget package dependencies.
+        /// </summary>
+        public string PackageRoot
+        {
+            get;
+            set;
+        }
+
         public bool UseDotNetNativeToolchain
         {
             get; set;
@@ -158,6 +167,11 @@ namespace Microsoft.NuGet.Build.Tasks
 
                 // Handle dependencies from the lock file
                 providers.Add(new LockFileDependencyProvider(lockFile));
+            }
+            else if (!String.IsNullOrEmpty(PackageRoot))
+            {
+                // use the passed in package root
+                providers.Add(new NuGetDependencyResolver(Path.GetFullPath(PackageRoot)));
             }
             else
             {

--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -1,0 +1,343 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.ContentModel;
+using NuGet.DependencyResolver;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Repositories;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.NuGet.Build.Tasks
+{
+    /// <summary>
+    /// Resolves the assets out of packages in the project.json.
+    /// </summary>
+    public sealed class ResolveNuGetPackageAssets : Task
+    {
+        /// <summary>
+        /// Creates a new <see cref="ResolveNuGetPackageAssets"/>.
+        /// </summary>
+        public ResolveNuGetPackageAssets()
+        {
+            ResolvedAnalyzers = new ITaskItem[0];
+            ResolvedCopyLocalItems = new ITaskItem[0];
+            ResolvedReferences = new ITaskItem[0];
+        }
+
+        /// <summary>
+        /// The full paths to resolved analyzers.
+        /// </summary>
+        [Output]
+        public ITaskItem[] ResolvedAnalyzers
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The full paths to resolved run-time resources.
+        /// </summary>
+        [Output]
+        public ITaskItem[] ResolvedCopyLocalItems
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The full paths to resolved build-time dependencies. Contains standard metadata for Reference items.
+        /// </summary>
+        [Output]
+        public ITaskItem[] ResolvedReferences
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The name of the architecture of binaries to choose. Examples include 'AnyCPU', 'x86', etc.
+        /// </summary>
+        [Required]
+        public string Architecture
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The name (Debug or Release) of the configuration to choose.
+        /// </summary>
+        [Required]
+        public string Configuration
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The target framework monikers to use when selecting assets from packages.
+        /// </summary>
+        [Required]
+        public string[] TargetFrameworkMonikers
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The target platform monikers to use when selecting assets from packages.
+        /// </summary>
+        [Required]
+        public string[] TargetPlatformMonikers
+        {
+            get; set;
+        }
+
+        [Required]
+        public ITaskItem[] TransitiveProjectReferences
+        {
+            get; set;
+        }
+
+        [Required]
+        public string ProjectFile
+        {
+            get; set;
+        }
+
+        public bool UseDotNetNativeToolchain
+        {
+            get; set;
+        }
+
+        public string IlcTargetFrameworkPath
+        {
+            get; set;
+        }
+
+        public string IlcTargetFrameworkFacadesPath
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The language of the source files in the project.
+        /// </summary>
+        public string Language
+        {
+            get; private set;
+        }
+
+        /// <summary>
+        /// Performs the NuGet package resolution.
+        /// </summary>
+        public override bool Execute()
+        {
+            Log.LogMessage(MessageImportance.High, "Running NuGet package resolution with TFM " + TargetFrameworkMonikers.First());
+
+            var analyzers = new List<ITaskItem>();
+            var copyLocalItems = new List<ITaskItem>();
+            var references = new List<ITaskItem>();
+
+            var providers = new List<IDependencyProvider>();
+
+            var lockFilePath = Path.Combine(Path.GetDirectoryName(ProjectFile), LockFileFormat.LockFileName);
+
+            if (File.Exists(lockFilePath))
+            {
+                var lockFile = LockFileFormat.Read(lockFilePath);
+
+                // Handle dependencies from the lock file
+                providers.Add(new LockFileDependencyProvider(lockFile));
+            }
+            else
+            {
+                // Use the global packages folder if available
+                providers.Add(new NuGetDependencyResolver(GetSystemWidePackagesPath()));
+            }
+
+            providers.Add(new MSBuildDependencyProvider(ProjectFile));
+
+            var walker = new DependencyWalker(providers);
+            var root = walker.Walk(ProjectFile, new NuGetVersion(new Version()), NuGetFramework.Parse(TargetFrameworkMonikers.First()));
+            root.TryResolveConflicts();
+
+            var resolvedItems = new Dictionary<string, Library>();
+
+            // Pick the relevant versions of the package after conflict
+            // resolution
+            root.ForEach(true, (node, state) =>
+            {
+                if (node.Disposition != Disposition.Accepted ||
+                    node.Item == null)
+                {
+                    return false;
+                }
+
+                if (!resolvedItems.ContainsKey(node.Key.Name))
+                {
+                    resolvedItems[node.Key.Name] = node.Item.Data;
+                }
+
+                return true;
+            });
+
+            var patternDefinitions = new PatternDefinitions();
+
+            if (UseDotNetNativeToolchain)
+            {
+                var directoriesToPrep = new[] { IlcTargetFrameworkPath, IlcTargetFrameworkFacadesPath };
+                foreach (var directoryToPrep in directoriesToPrep)
+                {
+                    var directoryInfoToPrep = new DirectoryInfo(directoryToPrep);
+                    directoryInfoToPrep.Create();
+                    foreach (var file in directoryInfoToPrep.GetFiles())
+                    {
+                        file.Delete();
+                    }
+                }
+            }
+
+            foreach (var library in resolvedItems.Values)
+            {
+                if (library.Identity.Type != LibraryTypes.Package)
+                {
+                    continue;
+                }
+
+                LoadContents(library);
+
+                var itemsInRef = GetTaskItemsFromLibrary(library, patternDefinitions.CompileTimeAssemblies);
+                var itemsInLib = GetTaskItemsFromLibrary(library, patternDefinitions.ManagedAssemblies);
+                var itemsInLibArchitectureSpecific = GetTaskItemsFromLibrary(library, patternDefinitions.NativeLibraries);
+                var itemsInAot = GetTaskItemsFromLibrary(library, patternDefinitions.AheadOfTimeAssemblies);
+
+                ApplyCompileTimeReferenceMetadata(itemsInRef, library);
+                references.AddRange(itemsInRef);
+
+                if (UseDotNetNativeToolchain)
+                {
+                    var frameworkAotItems = itemsInAot.Any() ? itemsInAot : itemsInLib;
+                    foreach (var frameworkAotItem in frameworkAotItems)
+                    {
+                        File.Copy(frameworkAotItem.ItemSpec, Path.Combine(IlcTargetFrameworkFacadesPath, Path.GetFileName(frameworkAotItem.ItemSpec)), overwrite: true);
+                    }
+
+                    foreach (var referenceItem in itemsInRef)
+                    {
+                        File.Copy(referenceItem.ItemSpec, Path.Combine(IlcTargetFrameworkPath, Path.GetFileName(referenceItem.ItemSpec)), overwrite: true);
+                    }
+                }
+                else
+                {
+                    copyLocalItems.AddRange(itemsInLib);
+                    copyLocalItems.AddRange(itemsInLibArchitectureSpecific);
+                }
+            }
+
+            ResolvedAnalyzers = analyzers.ToArray();
+            ResolvedCopyLocalItems = copyLocalItems.ToArray();
+            ResolvedReferences = references.ToArray();
+
+            return true;
+        }
+
+        private IList<ITaskItem> GetTaskItemsFromLibrary(Library library, ContentPatternDefinition definition)
+        {
+            var taskItems = new List<ITaskItem>();
+            var contents = library.GetItem<ContentItemCollection>("contents");
+
+            if (contents == null)
+            {
+                return taskItems;
+            }
+
+            var group = contents.FindBestItemGroup(GetSelectionCriteria(), definition);
+
+            if (group == null)
+            {
+                return taskItems;
+            }
+
+            foreach (var item in group.Items)
+            {
+                var taskItem = new TaskItem(Path.Combine(Path.GetDirectoryName(library.Path), item.Path.Replace('/', '\\')));
+
+                taskItem.SetMetadata("NuGetPackageName", library.Identity.Name);
+                taskItem.SetMetadata("NuGetPackageVersion", library.Identity.Version.ToString());
+
+                taskItems.Add(taskItem);
+            }
+
+            return taskItems;
+        }
+
+        private void ApplyCompileTimeReferenceMetadata(IList<ITaskItem> items, Library library)
+        {
+            foreach (var item in items)
+            {
+                item.SetMetadata("ReferenceGrouping", library.Identity.Name + ",Version=" + library.Identity.Version.Version);
+                item.SetMetadata("ReferenceGroupingDisplayName", library.Identity.Name + " (Package)");
+                item.SetMetadata("Private", "false");
+            }
+        }
+
+        private void LoadContents(Library library)
+        {
+            var contents = new ContentItemCollection();
+            var files = library.GetItem<IEnumerable<string>>("files");
+
+            if (files != null)
+            {
+                contents.Load(files);
+            }
+            else
+            {
+                var packageInfo = library.GetItem<LocalPackageInfo>("package");
+
+                if (packageInfo == null)
+                {
+                    return;
+                }
+
+                contents.Load(packageInfo.ExpandedPath);
+            }
+
+            library.Items["contents"] = contents;
+        }
+
+        private SelectionCriteria GetSelectionCriteria()
+        {
+            var criteria = new SelectionCriteria();
+
+            criteria.Entries.Add(new SelectionCriteriaEntry
+            {
+                Properties = new Dictionary<string, object>
+                {
+                    {"tpm" , NuGetFramework.Parse(TargetPlatformMonikers.First())},
+                    {"tfm" , NuGetFramework.Parse(TargetFrameworkMonikers.First())}
+                }
+            });
+
+            criteria.Entries.Add(new SelectionCriteriaEntry
+            {
+                Properties = new Dictionary<string, object>
+                {
+                    {"tfm", NuGetFramework.Parse(TargetFrameworkMonikers.First())}
+                }
+            });
+
+            return criteria;
+        }
+
+        private string GetSystemWidePackagesPath()
+        {
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Reference Assemblies", "Packages");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -65,7 +65,6 @@ namespace Microsoft.NuGet.Build.Tasks
         /// <summary>
         /// The name of the architecture of binaries to choose. Examples include 'AnyCPU', 'x86', etc.
         /// </summary>
-        [Required]
         public string Architecture
         {
             get; set;
@@ -74,7 +73,6 @@ namespace Microsoft.NuGet.Build.Tasks
         /// <summary>
         /// The name (Debug or Release) of the configuration to choose.
         /// </summary>
-        [Required]
         public string Configuration
         {
             get; set;

--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -243,6 +243,20 @@ namespace Microsoft.NuGet.Build.Tasks
                 var itemsInLib = GetTaskItemsFromLibrary(library, patternDefinitions.ManagedAssemblies);
                 var itemsInLibArchitectureSpecific = GetTaskItemsFromLibrary(library, patternDefinitions.NativeLibraries);
                 var itemsInAot = GetTaskItemsFromLibrary(library, patternDefinitions.AheadOfTimeAssemblies);
+                
+                Log.LogMessage(MessageImportance.Low, "Library {0}", library.Identity);
+                Log.LogMessage(MessageImportance.Low, "  Ref:");
+                Log.LogMessage(MessageImportance.Low, "    " + String.Join("    \r\n", itemsInRef));
+                Log.LogMessage(MessageImportance.Low, "  Lib:");
+                Log.LogMessage(MessageImportance.Low, "    " + String.Join("    \r\n", itemsInLib));
+
+
+                // workaround due to lack of distinction between ref with placeholder and no ref
+                if (itemsInRef.Count == 0 && !library.Identity.Name.StartsWith("System.Private")  && !library.Identity.Name.StartsWith("Microsoft.NETCore"))
+                {
+                    // use lib in absence of ref.
+                    itemsInRef = itemsInLib;
+                }
 
                 ApplyCompileTimeReferenceMetadata(itemsInRef, library);
                 references.AddRange(itemsInRef);

--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackages.cs
@@ -154,6 +154,12 @@ namespace Microsoft.Build.Tasks
             var targetFrameworks = new List<FrameworkName>();
             var targetFramework = new FrameworkName(TargetFramework);
 
+            if (targetFramework.Identifier == "DNXCore")
+            {
+                // We're still using a version of nuget.core that doesn't understand DNXCore.
+                targetFramework = new FrameworkName("ASP.NetCore", targetFramework.Version);
+            }
+
             if (targetFramework.Identifier == ".NETPortable")
             {
                 // Let's convert

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
@@ -26,12 +26,14 @@
     Import the default package restore and resolve targets 
   
       Inputs:
+        ProjectJson - If not set defaults to $(MSBuildProjectDirectory)\project.json
         ProjectPackagesConfigFile - If not set defaults to $(MSBuildProjectDirectory)\packages.config
-        RestorePackages - If not set defaults to the existence of the file $(ProjectPackagesConfigFile)
-        ResolveNuGetPackages - If not set defaults to to the existence of the file $(ProjectPackagesConfigFile)
+        RestorePackages - If not set defaults to the existence of the file $(ProjectPackagesConfigFile) or $(ProjectJson)
+        ResolveNuGetPackages - If not set defaults to to the existence of the file $(ProjectPackagesConfigFile) or $(ProjectJson)
       
       Depends on properties:
-        NugetRestoreCommand - Used to restore the project packages
+        NugetRestoreCommand - Used to restore the project packages from packages.config
+        DnuRestoreCommand - Used to restore the project packages from project.json
         PackagesDir - Packages are restored to and resolved from this location
 
       Depends on properties set by csharp/visualbasic.targets so needs to be imported after.
@@ -82,12 +84,14 @@
         RunTestsForProject - Usually set at the project level to disable the tests for a single project.
         CoverageEnabledForProject - Usually set at the project level to disable code coverage for a single project. 
         SkipTests - Usually set at the root level for builds that want to disable all the tests.
+        ProjectJson - If not set defaults to $(MSBuildProjectDirectory)\project.json
         ProjectPackagesConfigFile - Test publishing depends on this to be able to copy the dependencies to the test output
         CopyTestToTestDirectory - If not set defaults to $(IsTestProject)
 
       Depends on Properties:
         TestPath - Controls the root path from where the test assets are published and run from.
         NugetRestoreCommand - Used to restore the test runtime package
+        DnuRestoreCommand - Used to restore the project packages from project.json
         PackagesDir - Packages are restored to and resolved from this location    
    -->
   <Import Project="$(MSBuildThisFileDirectory)tests.targets" Condition="'$(IsTestProject)'=='true' and '$(ExcldueTestsImport)'!='true'"/> 

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/FrameworkTargeting.targets
@@ -44,10 +44,14 @@
       BeforeTargets="ResolveReferences"
       DependsOnTargets="GetReferenceAssemblyPaths"
   >
+    <PropertyGroup>
+      <_resolvedMscorlib Condition="'%(ReferencePath.FileName)' == 'mscorlib'">true</_resolvedMscorlib>
+    </PropertyGroup>
+
     <ItemGroup>
       <PossibleTargetFrameworks Include="$(_TargetFrameworkDirectories)" />
       <ReferencePath Include="%(PossibleTargetFrameworks.Identity)mscorlib.dll" 
-                     Condition="'%(PossibleTargetFrameworks.Identity)' != '' and Exists('%(PossibleTargetFrameworks.Identity)mscorlib.dll')" />
+                     Condition="'$(_resolvedMscorlib)' != 'true' and '%(PossibleTargetFrameworks.Identity)' != '' and Exists('%(PossibleTargetFrameworks.Identity)mscorlib.dll')" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -2,31 +2,39 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <UsingTask TaskName="ResolveNuGetPackages" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ProjectPackagesConfigFile Condition="'$(ProjectPackagesConfigFile)'=='' and Exists('$(MSBuildProjectDirectory)/packages.config')">$(MSBuildProjectDirectory)/packages.config</ProjectPackagesConfigFile>
+    <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>
+    <ProjectLockJson>$(MSBuildProjectDirectory)/project.lock.json</ProjectLockJson>
 
-    <RestorePackages Condition="'$(RestorePackages)'!='false' and Exists('$(ProjectPackagesConfigFile)')">true</RestorePackages>
-    <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)'!='false' and Exists('$(ProjectPackagesConfigFile)')">true</ResolveNuGetPackages>
+    <RestorePackages Condition="'$(RestorePackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</RestorePackages>
+    <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</ResolveNuGetPackages>
 
-    <RestorePackagesSemaphore>$(PackagesDir)$(MSBuildProjectFile)-packages.config</RestorePackagesSemaphore>
+    <RestorePackagesSemaphore Condition="Exists('$(ProjectPackagesConfigFile)')">$(PackagesDir)$(MSBuildProjectFile)-packages.config</RestorePackagesSemaphore>
+    <RestoreProjectJsonSemaphore Condition="Exists('$(ProjectJson)')">$(PackagesDir)$(MSBuildProjectFile)-project.json</RestoreProjectJsonSemaphore>
   </PropertyGroup>
 
   <Target Name="RestorePackages" 
           BeforeTargets="ResolveNuGetPackages"
-          Inputs="$(ProjectPackagesConfigFile)"
-          Outputs="$(RestorePackagesSemaphore)"
+          Inputs="$(ProjectPackagesConfigFile);$(ProjectJson)"
+          Outputs="$(RestorePackagesSemaphore);$(RestoreProjectJsonSemaphore)"
           Condition="'$(RestorePackages)'=='true'">
 
-    <Error Condition="'$(NugetRestoreCommand)'==''" Text="RestorePackages target needs a predefined NugetRestoreCommand property set in order to restore $(ProjectPackagesConfigFile)" /> 
+    <Error Condition="'$(NugetRestoreCommand)'=='' and Exists('$(ProjectPackagesConfigFile)')" Text="RestorePackages target needs a predefined NugetRestoreCommand property set in order to restore $(ProjectPackagesConfigFile)" /> 
+    <Error Condition="'$(DnuRestoreCommand)'=='' and Exists('$(ProjectJson)')" Text="RestorePackages target needs a predefined DnuRestoreCommand property set in order to restore $(ProjectJson)" /> 
+    
+    <Exec Condition="Exists('$(ProjectPackagesConfigFile)')" Command="$(NugetRestoreCommand) &quot;$(ProjectPackagesConfigFile)&quot;" StandardOutputImportance="Low" />
+    <Exec Condition="Exists('$(ProjectJson)')" Command="$(DnuRestoreCommand) &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
 
-    <Exec Command="$(NugetRestoreCommand) &quot;$(ProjectPackagesConfigFile)&quot;" StandardOutputImportance="Low" />
-
-    <Copy SourceFiles="$(ProjectPackagesConfigFile)" DestinationFiles="$(RestorePackagesSemaphore)" ContinueOnError="true" SkipUnchangedFiles="true" />
+    <Copy Condition="Exists('$(ProjectPackagesConfigFile)')" SourceFiles="$(ProjectPackagesConfigFile)" DestinationFiles="$(RestorePackagesSemaphore)" ContinueOnError="true" SkipUnchangedFiles="true" />
+    <Copy Condition="Exists('$(ProjectJson)')" SourceFiles="$(ProjectJson)" DestinationFiles="$(RestoreProjectJsonSemaphore)" ContinueOnError="true" SkipUnchangedFiles="true" />
   </Target>
 
-  <ItemGroup>
-    <CustomAdditionalCompileInputs Include="$(ProjectPackagesConfigFile)" Condition="'$(ResolvePackages)'=='true' or '$(ResolveNuGetPackages)'=='true'" />
+  <ItemGroup Condition="'$(ResolvePackages)'=='true' or '$(ResolveNuGetPackages)'=='true'">
+    <CustomAdditionalCompileInputs Condition="Exists('$(ProjectPackagesConfigFile)')" Include="$(ProjectPackagesConfigFile)" />
+    <CustomAdditionalCompileInputs Condition="Exists('$(ProjectJson)')" Include="$(ProjectJson)" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -34,23 +42,47 @@
       $(ResolveAssemblyReferencesDependsOn);
       ResolveNuGetPackages;
     </ResolveAssemblyReferencesDependsOn>
+    <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</NugetTargetFrameworkMoniker>
   </PropertyGroup>
 
   <Target Name="ResolveNuGetPackages" 
           Condition="'$(ResolveNuGetPackages)'=='true'">
 
-    <ResolveNuGetPackages PackagesConfigs="$(ProjectPackagesConfigFile)"
+    <!-- Use old task for packages.config -->
+    <ResolveNuGetPackages Condition="'$(ProjectPackagesConfigFile)' != ''"
+                          PackagesConfigs="$(ProjectPackagesConfigFile)"
                           PackageRoot="$(PackagesDir)"
                           Platform="$(PlatformTarget)"
                           Configuration="$(Configuration)"
                           Language="$(Language)"
-                          TargetFramework="$(TargetFrameworkMoniker)"
+                          TargetFramework="$(NugetTargetFrameworkMoniker)"
                           TargetPlatformMoniker="$(TargetPlatformMoniker)">
 
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
       <Output TaskParameter="ResolvedCopyLocal" ItemName="None" />
     </ResolveNuGetPackages>
+
+    <PropertyGroup>
+      <!-- Temporary workaround -->
+      <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == '.NETPortable,Version=v4.5,Profile=Profile7'">DNXCore,Version=v5.0</NugetTargetFrameworkMoniker>
+    </PropertyGroup>
+    
+    <!-- Use new task for project.json -->
+    <ResolveNuGetPackageAssets Condition="'$(ProjectJson)' != ''"
+                               Architecture="$(PlatformTarget)"
+                               Configuration="$(Configuration)"
+                               Language="$(Language)"
+                               IngoreLockFile="$(NuGetIngoreLockFile)"
+                               PackageRoot="$(PackagesDir)"
+                               ProjectFile="$(MSBuildProjectFullPath)"
+                               TargetFrameworkMonikers="$(NugetTargetFrameworkMoniker)"
+                               TargetPlatformMonikers="$(TargetPlatformMoniker)"
+                               TransitiveProjectReferences="">
+      <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
+      <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="None" />
+    </ResolveNuGetPackageAssets>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -83,6 +83,32 @@
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="None" />
     </ResolveNuGetPackageAssets>
+
+    <!-- We may have an indirect package reference that we want to replace with a project reference -->
+    <ItemGroup>
+      <!-- Convert to filenames so that we can intersect -->
+      <_ProjectReferenceFilenames Include="@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </_ProjectReferenceFilenames>
+
+      <_ReferencesFileNames Include="@(Reference->'%(FileName)%(Extension)')">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </_ReferencesFileNames>
+
+      <_NoneFileNames Include="@(None->'%(FileName)%(Extension)')">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </_NoneFileNames>
+      
+      <!-- Intersect project-refs with package-refs -->
+      <_ReferenceFileNamesToRemove Include="@(_ReferencesFileNames->'%(OriginalIdentity)')" Condition="'@(_ProjectReferenceFilenames)' == '@(_ReferencesFileNames)' and '%(Identity)' != ''"/>
+      <_NoneFileNamesToRemove Include="@(_NoneFileNames->'%(OriginalIdentity)')" Condition="'@(_ProjectReferenceFilenames)' == '@(_NoneFileNames)' and '%(Identity)' != ''"/>
+
+      <Reference Remove="@(_ReferenceFileNamesToRemove)" />
+      <None Remove="@(_NoneFileNamesToRemove)"/>
+    </ItemGroup>
+    
+    <Message Text="Excluding @(_ReferenceFileNamesToRemove);@(_NoneFileNamesToRemove) from package references since the same file is provided by a project refrence."
+             Condition="'@(_ReferenceFileNamesToRemove)' != '' AND '@(_NoneFileNamesToRemove)' != ''"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -66,6 +66,26 @@
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </ResolveNuGetPackageAssets>
 
+    <!-- We may have an indirect package reference that we want to replace with a project reference -->
+    <ItemGroup>
+      <!-- Convert to filenames so that we can intersect -->
+      <_ProjectReferenceFilenames Include="@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </_ProjectReferenceFilenames>
+
+      <_TestCopyLocalFileNames Include="@(Reference->'%(FileName)%(Extension)')">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </_TestCopyLocalFileNames>
+
+      <!-- Intersect project-refs with package-refs -->
+      <_TestCopyLocalFileNamesToRemove Include="@(_ReferencesFileNames->'%(OriginalIdentity)')" Condition="'@(_ProjectReferenceFilenames)' == '@(_ReferencesFileNames)' and '%(Identity)' != ''"/>
+
+      <TestCopyLocal Remove="@(_TestCopyLocalFileNamesToRemove)" />
+    </ItemGroup>
+
+    <Message Text="Excluding @(_TestCopyLocalFileNamesToRemove) from package references since the same file is provided by a project refrence."
+             Condition="'@(_TestCopyLocalFileNamesToRemove)' != ''"/>
+
     <ItemGroup>
       <TestCopyLocal Include="@(RunTestsForProjectInputs)" Exclude="@(PackagesConfigs)" />
     </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -2,22 +2,36 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <UsingTask TaskName="ResolveNuGetPackages" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
   <PropertyGroup>
     <TestRuntimePackageConfig>$(MSBuildThisFileDirectory)test-runtime\packages.config</TestRuntimePackageConfig>
     <TestRuntimePackageSemaphore>$(PackagesDir)test-runtime-packages.config</TestRuntimePackageSemaphore>
+
+    <TestRuntimeProjectJson>$(MSBuildThisFileDirectory)test-runtime\project.json</TestRuntimeProjectJson>
+    <TestRuntimeProjectJsonSemaphore>$(PackagesDir)test-runtime-project.json</TestRuntimeProjectJsonSemaphore>
   </PropertyGroup>
 
   <Target Name="RestoreTestRuntimePackage"
           BeforeTargets="ResolveNuGetPackages"
-          Inputs="$(TestRuntimePackageConfig)"
-          Outputs="$(TestRuntimePackageSemaphore)"
+          Inputs="$(TestRuntimePackageConfig);$(TestRuntimeProjectJson)"
+          Outputs="$(TestRuntimePackageSemaphore);$(TestRuntimeProjectJsonSemaphore)"
           Condition="'$(IsTestProject)' == 'true'">
 
     <Exec Command="$(NugetRestoreCommand) &quot;$(TestRuntimePackageConfig)&quot;" StandardOutputImportance="Low" />
 
-    <Copy SourceFiles="$(TestRuntimePackageConfig)" DestinationFiles="$(TestRuntimePackageSemaphore)" ContinueOnError="true" SkipUnchangedFiles="true" />
-    
+    <!-- DNU will emit a project.lock.json.  When multiple tests are building for the first time they may race on 
+         running this target and generating the lock.json.  This is causing IOExceptions in dnu for writing lock.json.
+         We should really be handling these test dependencies in a different way (as a package themselves) but for now
+         just restore the project.json from intermediate to avoid the race.  -->
+    <Copy SourceFiles="$(TestRuntimeProjectJson)" DestinationFolder="$(IntermediateOutputPath)">
+      <Output TaskParameter="CopiedFiles" PropertyName="TempTestRuntimeProjectJson"/>
+    </Copy>
+    <Exec Command="$(DnuRestoreCommand) &quot;$(TempTestRuntimeProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
+
+    <!-- Always copy since we need to force a timestamp update for inputs/outputs-->
+    <Copy SourceFiles="$(TestRuntimePackageConfig)" DestinationFiles="$(TestRuntimePackageSemaphore)" ContinueOnError="true" SkipUnchangedFiles="false" />
+    <Copy SourceFiles="$(TestRuntimeProjectJson)" DestinationFiles="$(TestRuntimeProjectJsonSemaphore)" ContinueOnError="true" SkipUnchangedFiles="false" />
   </Target>
 
   <PropertyGroup>
@@ -37,6 +51,20 @@
 
       <Output TaskParameter="ResolvedCopyLocal" ItemName="TestCopyLocal" />
     </ResolveNuGetPackages>
+
+    <ResolveNuGetPackageAssets AdditonalProjectJsonFiles="@(ProjectJsons)"
+                               Architecture="$(PlatformTarget)"
+                               Configuration="$(NuGetConfiguration)"
+                               IngoreLockFile="$(NuGetIngoreLockFile)"
+                               Language="$(Language)"
+                               PackageRoot="$(PackagesDir)"
+                               ProjectFile="$(MSBuildProjectFullPath)"
+                               TargetFrameworkMonikers="@(TestTargetFramework)"
+                               TargetPlatformMonikers="$(TargetPlatformMoniker)"
+                               TransitiveProjectReferences="">
+
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
+    </ResolveNuGetPackageAssets>
 
     <ItemGroup>
       <TestCopyLocal Include="@(RunTestsForProjectInputs)" Exclude="@(PackagesConfigs)" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -6,34 +6,6 @@
   <package id="Microsoft.DotNet.CoreCLR" version="1.0.3-prerelease" />
   <package id="Microsoft.DotNet.PerfTools" version="0.0.1-prerelease-00022" />
 
-  <package id="System.Collections" version="4.0.10-beta-22703" />
-  <package id="System.Collections.Concurrent" version="4.0.10-beta-22703" />
-  <package id="System.Console" version="4.0.0-beta-22703" />
-  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" />
-  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
-  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22703" />
-  <package id="System.Diagnostics.Tracing" version="4.0.20-beta-22703" />
-  <package id="System.Globalization" version="4.0.10-beta-22703" />
-  <package id="System.IO" version="4.0.10-beta-22703" />
-  <package id="System.IO.FileSystem" version="4.0.0-beta-22703" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
-  <package id="System.Linq" version="4.0.0-beta-22703" />
-  <package id="System.Reflection" version="4.0.10-beta-22703" />
-  <package id="System.Reflection.Extensions" version="4.0.0-beta-22703" />
-  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />
-  <package id="System.Runtime" version="4.0.20-beta-22703" />
-  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
-  <package id="System.Runtime.Handles" version="4.0.0-beta-22703" />
-  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
-  <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
-  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22703" />
-  <package id="System.Text.RegularExpressions" version="4.0.10-beta-22703" />
-  <package id="System.Threading" version="4.0.10-beta-22703" />
-  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
-  <package id="System.Threading.ThreadPool" version="4.0.10-beta-22703" />
-  <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22703" />
-  <package id="System.Xml.XDocument" version="4.0.10-beta-22703" />
-
   <package id="OpenCover" version="4.5.3809-rc94" />
   <package id="coveralls.io" version="1.4" />
   <package id="ReportGenerator" version="2.0.4.0" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-project.json
@@ -1,0 +1,31 @@
+{
+    "dependencies": {
+       "System.Collections": "4.0.10-beta-22809",
+       "System.Collections.Concurrent": "4.0.10-beta-22809",
+       "System.Console": "4.0.0-beta-22809",
+       "System.Diagnostics.Contracts": "4.0.0-beta-22809",
+       "System.Diagnostics.Debug": "4.0.10-beta-22809",
+       "System.Diagnostics.Tools": "4.0.0-beta-22809",
+       "System.Diagnostics.Tracing": "4.0.20-beta-22809",
+       "System.Globalization": "4.0.10-beta-22809",
+       "System.IO": "4.0.10-beta-22809",
+       "System.IO.FileSystem": "4.0.0-beta-22809",
+       "System.IO.FileSystem.Primitives": "4.0.0-beta-22809",
+       "System.Linq": "4.0.0-beta-22809",
+       "System.Reflection": "4.0.10-beta-22809",
+       "System.Reflection.Extensions": "4.0.0-beta-22809",
+       "System.Resources.ResourceManager": "4.0.0-beta-22809",
+       "System.Runtime": "4.0.20-beta-22809",
+       "System.Runtime.Extensions": "4.0.10-beta-22809",
+       "System.Runtime.Handles": "4.0.0-beta-22809",
+       "System.Runtime.InteropServices": "4.0.20-beta-22809",
+       "System.Text.Encoding": "4.0.10-beta-22809",
+       "System.Text.Encoding.Extensions": "4.0.10-beta-22809",
+       "System.Text.RegularExpressions": "4.0.10-beta-22809",
+       "System.Threading": "4.0.10-beta-22809",
+       "System.Threading.Tasks": "4.0.10-beta-22809",
+       "System.Threading.ThreadPool": "4.0.10-beta-22809",
+       "System.Xml.ReaderWriter": "4.0.10-beta-22809",
+       "System.Xml.XDocument": "4.0.10-beta-22809"
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -46,7 +46,7 @@
 
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">
-    <DebugTestFrameworkFolder>aspnetcore50</DebugTestFrameworkFolder>
+    <DebugTestFrameworkFolder>dnxcore50</DebugTestFrameworkFolder>
     <StartWorkingDirectory Condition="'$(StartWorkingDirectory)'==''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
     <StartAction Condition="'$(StartAction)'==''">Program</StartAction>
     <StartProgram Condition="'$(StartProgram)'==''">$(StartWorkingDirectory)\$(TestHost)</StartProgram>
@@ -55,14 +55,18 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <TestTargetFramework Include="ASP.NetCore, version=v5.0">
-      <Folder>aspnetcore50</Folder>
+    <TestTargetFramework Include="DNXCore, version=v5.0">
+      <Folder>dnxcore50</Folder>
     </TestTargetFramework>
   </ItemGroup>
 
   <ItemGroup>
     <PackagesConfigs Include="$(ProjectPackagesConfigFile)" />
     <PackagesConfigs Include="$(TestRuntimePackageConfig)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectJsons Include="$(TestRuntimeProjectJson)" />
   </ItemGroup>
 
   <Target Name="DiscoverTestInputs" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences;GetCopyToOutputDirectoryItems">

--- a/src/Microsoft.DotNet.Build.Tasks/packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/packages.config
@@ -2,9 +2,21 @@
 <packages>
   <package id="LibGit2Sharp" version="0.19.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
+  <package id="NuGet.ContentModel" version="3.0.0" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.3" targetFramework="net45" />
+  <package id="NuGet.DependencyResolver" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.DependencyResolver.Core" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.Frameworks" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.LibraryModel" version="3.0.0" targetFramework="net45" />
   <package id="NuGet.NuManifest" version="1.0.1-alpha" targetFramework="net45" />
   <package id="NuGet.NuManifest.DotNet" version="1.0.1-alpha" targetFramework="net45" />
+  <package id="NuGet.Packaging" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.Packaging.Core" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.Packaging.Core.Types" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.ProjectModel" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.Repositories" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.Versioning" version="3.0.0-beta4-10027" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" targetFramework="net45" />

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -7,6 +7,7 @@
     <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
     <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
+    <add key="myget.org aspnetvnext" value="https://www.myget.org/F/aspnetvnext/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
   <activePackageSource>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -26,11 +26,11 @@
     <file src="Microsoft.DotNet.Build.Tasks\PriConfig.xml" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\*.targets" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\test-runtime-packages.config" target="lib\test-runtime\packages.config" />
+    <file src="Microsoft.DotNet.Build.Tasks\test-runtime-project.json" target="lib\test-runtime\project.json" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks\NuGet.Core.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\NuGet.*.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\Newtonsoft.Json.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.Web.XmlTransform.dll" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks\NuGet.NuManifest.dll" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks\NuGet.NuManifest.DotNet.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\NativeVersion.rc" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\LibGit2Sharp.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\System.Collections.Immutable.dll" target="lib" />


### PR DESCRIPTION
This change enables buildtools to restore packages referenced by project.json.  New "nuget v3" style packages must be referenced via project.json. /cc @mellinoe @weshaggard @jasonmalinowski @JeremyKuhne 