### PR TITLE
Fix typo in publishtest.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -78,7 +78,7 @@
       </_TestCopyLocalFileNames>
 
       <!-- Intersect project-refs with package-refs -->
-      <_TestCopyLocalFileNamesToRemove Include="@(_ReferencesFileNames->'%(OriginalIdentity)')" Condition="'@(_ProjectReferenceFilenames)' == '@(_ReferencesFileNames)' and '%(Identity)' != ''"/>
+      <_TestCopyLocalFileNamesToRemove Include="@(_ReferencesFileNames->'%(OriginalIdentity)')" Condition="'@(_ProjectReferenceFilenames)' == '@(_TestCopyLocalFileNames)' and '%(Identity)' != ''"/>
 
       <TestCopyLocal Remove="@(_TestCopyLocalFileNamesToRemove)" />
     </ItemGroup>


### PR DESCRIPTION
Copy-paste error when replicating the logic from packageresolve.targets.