### PR TITLE
Update to latest copy of ResolveNuGetPackageAssets.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/MSBuildDependencyResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/MSBuildDependencyResolver.cs
@@ -1,30 +1,38 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Build.Framework;
 using NuGet.DependencyResolver;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
-using NuGet.ProjectModel;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.NuGet.Build.Tasks
 {
     internal sealed class MSBuildDependencyProvider : IDependencyProvider
     {
+        private readonly IList<LibraryDependency> _dependencies;
         private readonly string _msbuildProjectFilePath;
-        private readonly string[] _additionalProjectJsonPaths;
-        
 
-        public MSBuildDependencyProvider(string projectFilePath, IEnumerable<string> additionalProjectJsonPaths)
+        public MSBuildDependencyProvider(string projectFilePath, IEnumerable<ITaskItem> nugetPackageReferences)
         {
+            _dependencies = new List<LibraryDependency>();
+
+            foreach (var nugetPackageReference in nugetPackageReferences)
+            {
+                _dependencies.Add(new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = nugetPackageReference.ItemSpec,
+                        VersionRange = VersionRange.Parse(nugetPackageReference.GetMetadata("VersionRange"))
+                    },
+                });
+            }
+
             _msbuildProjectFilePath = projectFilePath;
-            _additionalProjectJsonPaths = additionalProjectJsonPaths == null ? new string[0] : additionalProjectJsonPaths.ToArray();
         }
 
         public Library GetDescription(LibraryRange libraryRange, NuGetFramework targetFramework)
@@ -32,21 +40,6 @@ namespace Microsoft.NuGet.Build.Tasks
             if (libraryRange.Name != _msbuildProjectFilePath)
             {
                 return null;
-            }
-
-            var dependencies = new List<LibraryDependency>();
-
-            var projectJsonPath = Path.Combine(Path.GetDirectoryName(_msbuildProjectFilePath), "project.json");
-
-            if (File.Exists(projectJsonPath))
-            {
-                // may be running against a project with only a packages.config
-                AddFromProjectJsonFile(dependencies, projectJsonPath, targetFramework);
-            }
-
-            foreach(string additionalProjectJsonPath in _additionalProjectJsonPaths)
-            {
-                AddFromProjectJsonFile(dependencies, additionalProjectJsonPath, targetFramework);
             }
 
             var description = new Library
@@ -59,24 +52,10 @@ namespace Microsoft.NuGet.Build.Tasks
                     Type = LibraryTypes.MSBuild,
                 },
                 Path = _msbuildProjectFilePath,
-                Dependencies = dependencies
+                Dependencies = _dependencies
             };
 
             return description;
-        }
-
-        private void AddFromProjectJsonFile(List<LibraryDependency> dependencies, string projectJsonPath, NuGetFramework targetFramework)
-        {
-            using (var fileStream = new FileStream(projectJsonPath, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                var packageSpec = JsonPackageSpecReader.GetPackageSpec(fileStream, projectJsonPath, projectJsonPath);
-
-                // Grab dependencies from here too
-                var targetFrameworkInfo = packageSpec.GetTargetFramework(targetFramework);
-
-                dependencies.AddRange(packageSpec.Dependencies);
-                dependencies.AddRange(targetFrameworkInfo.Dependencies);
-            }
         }
 
         public bool SupportsType(string libraryType)

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -36,6 +36,7 @@
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="PatternDefinitions.cs" />
     <Compile Include="PropertyDefinitions.cs" />
+    <Compile Include="ReadNuGetPackageReferences.cs" />
     <Compile Include="ResolveNuGetPackageAssets.cs" />
     <Compile Include="ResolveNuGetPackages.cs" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PatternDefinitions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PatternDefinitions.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using NuGet.ContentModel;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.NuGet.Build.Tasks
 {
@@ -77,7 +72,7 @@ namespace Microsoft.NuGet.Build.Tasks
                 },
                 PathPatterns =
                 {
-                    "lib/{tfm}.{tpm}/{locale}/{resources}",
+                    "lib/{tfm}~{tpm}/{locale}/{resources}",
                     "lib/{tfm}/{locale}/{resources}",
                 },
                 PropertyDefinitions = Properties.Definitions,

--- a/src/Microsoft.DotNet.Build.Tasks/PropertyDefinitions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PropertyDefinitions.cs
@@ -86,12 +86,12 @@ namespace Microsoft.NuGet.Build.Tasks
 
         private readonly ContentPropertyDefinition _assembly = new ContentPropertyDefinition
         {
-            FileExtensions = { ".dll" }
+            FileExtensions = { ".dll", "_._" }
         };
 
         private readonly ContentPropertyDefinition _dynamicLibrary = new ContentPropertyDefinition
         {
-            FileExtensions = { ".dll", ".dylib", ".so" }
+            FileExtensions = { ".dll", ".dylib", ".so", "_._" }
         };
 
         private readonly ContentPropertyDefinition _resources = new ContentPropertyDefinition

--- a/src/Microsoft.DotNet.Build.Tasks/ReadNuGetPackageReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ReadNuGetPackageReferences.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.NuGet.Build.Tasks
+{
+    public sealed class ReadNuGetPackageReferences : Task
+    {
+        private readonly List<ITaskItem> _nuGetPackageReferences = new List<ITaskItem>();
+
+        /// <summary>
+        /// The target framework monikers to use when selecting assets from packages.
+        /// </summary>
+        [Required]
+        public string[] TargetFrameworkMonikers
+        {
+            get; set;
+        }
+
+        [Required]
+        public string ProjectLockJsonFile
+        {
+            get; set;
+        }
+
+        [Output]
+        public ITaskItem[] NuGetPackageReferences
+        {
+            get { return _nuGetPackageReferences.ToArray(); }
+        }
+
+        public override bool Execute()
+        {
+            using (var streamReader = new StreamReader(ProjectLockJsonFile))
+            {
+                var lockFile = JObject.Load(new JsonTextReader(streamReader));
+                var libraries = (JObject)lockFile["libraries"];
+                foreach (var library in libraries)
+                {
+                    var nameParts = library.Key.Split('/');
+                    var taskItem = new TaskItem(nameParts[0]);
+                    taskItem.SetMetadata("VersionRange", nameParts[1]);
+                    _nuGetPackageReferences.Add(taskItem);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <UsingTask TaskName="ReadNuGetPackageReferences" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ResolveNuGetPackages" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ProjectPackagesConfigFile Condition="'$(ProjectPackagesConfigFile)'=='' and Exists('$(MSBuildProjectDirectory)/packages.config')">$(MSBuildProjectDirectory)/packages.config</ProjectPackagesConfigFile>
     <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>
+    <ProjectLockJson Condition="Exists('$(ProjectJson)') and '$(ProjectLockJson)'==''">$(MSBuildProjectDirectory)/project.lock.json</ProjectLockJson>
     <ResolveNugetProjectFile Condition="'$(ResolveNugetProjectFile)' == ''">$(MSBuildProjectFullPath)</ResolveNugetProjectFile>
 
     <RestorePackages Condition="'$(RestorePackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</RestorePackages>
     <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</ResolveNuGetPackages>
 
     <RestorePackagesSemaphore Condition="Exists('$(ProjectPackagesConfigFile)')">$(PackagesDir)$(MSBuildProjectFile)-packages.config</RestorePackagesSemaphore>
-    <RestoreProjectJsonSemaphore Condition="Exists('$(ProjectJson)')">$(PackagesDir)$(MSBuildProjectFile)-project.json</RestoreProjectJsonSemaphore>
+    <RestoreProjectLockJson Condition="Exists('$(ProjectJson)')">$(PackagesDir)$(MSBuildProjectFile)-project.lock.json</RestoreProjectLockJson>
   </PropertyGroup>
 
   <Target Name="RestorePackages" 
           BeforeTargets="ResolveNuGetPackages"
           Inputs="$(ProjectPackagesConfigFile);$(ProjectJson)"
-          Outputs="$(RestorePackagesSemaphore);$(RestoreProjectJsonSemaphore)"
+          Outputs="$(RestorePackagesSemaphore);$(RestoreProjectLockJson)"
           Condition="'$(RestorePackages)'=='true'">
 
     <Error Condition="'$(NugetRestoreCommand)'=='' and Exists('$(ProjectPackagesConfigFile)')" Text="RestorePackages target needs a predefined NugetRestoreCommand property set in order to restore $(ProjectPackagesConfigFile)" /> 
@@ -29,7 +31,8 @@
     <Exec Condition="Exists('$(ProjectJson)')" Command="$(DnuRestoreCommand) &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
 
     <Copy Condition="Exists('$(ProjectPackagesConfigFile)')" SourceFiles="$(ProjectPackagesConfigFile)" DestinationFiles="$(RestorePackagesSemaphore)" ContinueOnError="true" SkipUnchangedFiles="true" />
-    <Copy Condition="Exists('$(ProjectJson)')" SourceFiles="$(ProjectJson)" DestinationFiles="$(RestoreProjectJsonSemaphore)" ContinueOnError="true" SkipUnchangedFiles="true" />
+    <!-- Project.lock.json is created if we ran restore-->
+    <Copy Condition="Exists('$(ProjectJson)')" SourceFiles="$(ProjectLockJson)" DestinationFiles="$(RestoreProjectLockJson)" ContinueOnError="true" SkipUnchangedFiles="true" />
   </Target>
 
   <ItemGroup Condition="'$(ResolvePackages)'=='true' or '$(ResolveNuGetPackages)'=='true'">
@@ -45,7 +48,7 @@
     <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</NugetTargetFrameworkMoniker>
   </PropertyGroup>
 
-  <Target Name="ResolveNuGetPackages" 
+  <Target Name="ResolveNuGetPackages"
           Condition="'$(ResolveNuGetPackages)'=='true'">
 
     <!-- Use old task for packages.config -->
@@ -69,16 +72,21 @@
     </PropertyGroup>
     
     <!-- Use new task for project.json -->
-    <ResolveNuGetPackageAssets Condition="'$(ProjectJson)' != ''"
+    <ReadNuGetPackageReferences ProjectLockJsonFile="$(RestoreProjectLockJson)"
+                                TargetFrameworkMonikers="$(NugetTargetFrameworkMoniker)"
+                                Condition="Exists($(RestoreProjectLockJson))">
+      <Output TaskParameter="NuGetPackageReferences" ItemName="NuGetPackageReference" />
+    </ReadNuGetPackageReferences>
+
+    <ResolveNuGetPackageAssets Condition="'@(NuGetPackageReference)' != ''"
                                Architecture="$(PlatformTarget)"
                                Configuration="$(Configuration)"
                                Language="$(Language)"
-                               IngoreLockFile="$(NuGetIngoreLockFile)"
+                               NuGetPackageReferences="@(NuGetPackageReference)"
                                PackageRoot="$(PackagesDir)"
                                ProjectFile="$(ResolveNugetProjectFile)"
                                TargetFrameworkMonikers="$(NugetTargetFrameworkMoniker)"
-                               TargetPlatformMonikers="$(TargetPlatformMoniker)"
-                               TransitiveProjectReferences="">
+                               TargetPlatformMonikers="$(TargetPlatformMoniker)">
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="None" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
@@ -78,17 +78,21 @@
     <!-- Restore the special partial facade json file, which must contain the contract package to use in GenFacades -->
     <Exec Command="$(DnuRestoreCommand) &quot;$(CustomPartialFacadeJsonFile)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
 
-      <!-- Resolve the references using this task, store them in @(PossibleContractRefs) -->
-    <ResolveNuGetPackageAssets AdditonalProjectJsonFiles="$(CustomPartialFacadeJsonFile)"
-                               Architecture="$(PlatformTarget)"
+    <!-- Read out the restored packages -->
+    <ReadNuGetPackageReferences ProjectLockJsonFile="$(CustomPartialFacadeLockJsonFile)"
+                                TargetFrameworkMonikers="$(NugetTargetFrameworkMoniker)">
+      <Output TaskParameter="NuGetPackageReferences" ItemName="CustomPartialFacadePackageReference" />
+    </ReadNuGetPackageReferences>
+    
+    <!-- Resolve the references using this task, store them in @(PossibleContractRefs) -->
+    <ResolveNuGetPackageAssets Architecture="$(PlatformTarget)"
                                Configuration="$(Configuration)"
                                Language="$(Language)"
-                               IngoreLockFile="$(NuGetIngoreLockFile)"
+                               NugetPackageReferences="@(CustomPartialFacadePackageReference)"
                                PackageRoot="$(PackagesDir)"
                                ProjectFile="$(MSBuildProjectFullPath)"
                                TargetFrameworkMonikers="$(NugetTargetFrameworkMoniker)"
-                               TargetPlatformMonikers="$(TargetPlatformMoniker)"
-                               TransitiveProjectReferences="">
+                               TargetPlatformMonikers="$(TargetPlatformMoniker)">
       <Output TaskParameter="ResolvedReferences" ItemName="PossibleContractRefs" />
     </ResolveNuGetPackageAssets>
 

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -8,14 +8,14 @@
     <TestRuntimePackageConfig>$(MSBuildThisFileDirectory)test-runtime\packages.config</TestRuntimePackageConfig>
     <TestRuntimePackageSemaphore>$(PackagesDir)test-runtime-packages.config</TestRuntimePackageSemaphore>
     <TestRuntimeProjectJson>$(MSBuildThisFileDirectory)test-runtime\project.json</TestRuntimeProjectJson>
-    <TestRuntimeProjectJsonSemaphore>$(PackagesDir)test-runtime-project.json</TestRuntimeProjectJsonSemaphore>
+    <TestRuntimeProjectLockJson>$(PackagesDir)test-runtime-project.lock.json</TestRuntimeProjectLockJson>
     <SerializeProjects Condition="'$(TestWithLocalLibraries)'=='true'">true</SerializeProjects>
   </PropertyGroup>
 
   <Target Name="RestoreTestRuntimePackage"
           BeforeTargets="ResolveNuGetPackages"
           Inputs="$(TestRuntimePackageConfig);$(TestRuntimeProjectJson)"
-          Outputs="$(TestRuntimePackageSemaphore);$(TestRuntimeProjectJsonSemaphore)"
+          Outputs="$(TestRuntimePackageSemaphore);$(TestRuntimeProjectLockJson)"
           Condition="'$(IsTestProject)' == 'true'">
 
     <Exec Command="$(NugetRestoreCommand) &quot;$(TestRuntimePackageConfig)&quot;" StandardOutputImportance="Low" />
@@ -31,7 +31,24 @@
 
     <!-- Always copy since we need to force a timestamp update for inputs/outputs-->
     <Copy SourceFiles="$(TestRuntimePackageConfig)" DestinationFiles="$(TestRuntimePackageSemaphore)" ContinueOnError="true" SkipUnchangedFiles="false" />
-    <Copy SourceFiles="$(TestRuntimeProjectJson)" DestinationFiles="$(TestRuntimeProjectJsonSemaphore)" ContinueOnError="true" SkipUnchangedFiles="false" />
+    <Copy SourceFiles="$(IntermediateOutputPath)/project.lock.json" DestinationFiles="$(TestRuntimeProjectLockJson)" ContinueOnError="true" SkipUnchangedFiles="false" />
+  </Target>
+
+  <Target Name="GetTestNugetPackageReferences"
+          DependsOnTargets="RestorePackages;RestoreTestRuntimePackage">
+    <ReadNuGetPackageReferences ProjectLockJsonFile="$(TestRuntimeProjectLockJson)"
+                                TargetFrameworkMonikers="@(TestTargetFramework)" 
+                                Condition="Exists($(TestRuntimeProjectLockJson))">
+      <Output TaskParameter="NuGetPackageReferences" ItemName="TestNuGetPackageReference" />
+    </ReadNuGetPackageReferences>
+
+    <!-- Re-evaluate the project's package dependencies since TestTargetFramework may be 
+         different than NugetTargetFramework -->
+    <ReadNuGetPackageReferences ProjectLockJsonFile="$(RestoreProjectLockJson)"
+                                TargetFrameworkMonikers="@(TestTargetFramework)" 
+                                Condition="Exists($(RestoreProjectLockJson))">
+      <Output TaskParameter="NuGetPackageReferences" ItemName="TestNuGetPackageReference" />
+    </ReadNuGetPackageReferences>
   </Target>
 
   <PropertyGroup>
@@ -39,7 +56,8 @@
   </PropertyGroup>
 
   <Target Name="CopyTestToTestDirectory"
-    Condition="'$(CopyTestToTestDirectory)'=='true'">
+          DependsOnTargets="GetTestNugetPackageReferences"
+          Condition="'$(CopyTestToTestDirectory)'=='true'">
 
     <ResolveNuGetPackages PackagesConfigs="@(PackagesConfigs)"
                           PackageRoot="$(PackagesDir)"
@@ -52,16 +70,15 @@
       <Output TaskParameter="ResolvedCopyLocal" ItemName="TestCopyLocal" />
     </ResolveNuGetPackages>
 
-    <ResolveNuGetPackageAssets AdditonalProjectJsonFiles="@(ProjectJsons)"
+    <ResolveNuGetPackageAssets Condition="'@(TestNuGetPackageReference)' != ''"
                                Architecture="$(PlatformTarget)"
                                Configuration="$(NuGetConfiguration)"
-                               IngoreLockFile="$(NuGetIngoreLockFile)"
                                Language="$(Language)"
+                               NuGetPackageReferences="@(TestNuGetPackageReference)"
                                PackageRoot="$(PackagesDir)"
                                ProjectFile="$(MSBuildProjectFullPath)"
                                TargetFrameworkMonikers="@(TestTargetFramework)"
-                               TargetPlatformMonikers="$(TargetPlatformMoniker)"
-                               TransitiveProjectReferences="">
+                               TargetPlatformMonikers="$(TargetPlatformMoniker)">
 
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </ResolveNuGetPackageAssets>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -66,10 +66,6 @@
     <PackagesConfigs Include="$(TestRuntimePackageConfig)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectJsons Include="$(TestRuntimeProjectJson)" />
-  </ItemGroup>
-
   <Target Name="DiscoverTestInputs" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences;GetCopyToOutputDirectoryItems">
     <ItemGroup>
       <RunTestsForProjectInputs Include="@(PackagesConfigs)" />


### PR DESCRIPTION
This version handles transitive dependencies via the .lock.json.  We aren't yet using the .lock.json for asset selection. /cc @weshaggard @jasonmalinowski 