### PR TITLE
Expose DefaultNoCategories property to enable specifying the categories(like perf) that are not in innerloop.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -15,6 +15,7 @@
     <!-- Split semicolon separated lists -->
     <WithCategoriesItems Include="$(WithCategories)" />
     <WithoutCategoriesItems Include="$(WithoutCategories)" />
+    <DefaultNoCategories Include="$(DefaultNoCategories)" />
     <UnsupportedPlatformsItems Include="$(UnsupportedPlatforms)"/>
   </ItemGroup>
 


### PR DESCRIPTION
This feature will enable extensibility as more categories are added, and need to be excluded from a dev test run (plain build.cmd). So if there are more categories in future, like perf, stress, etc, these can be excluded by specifying <DefaultNoCategories>Perf;Stress</DefaultNoCategories> or /p:DefaultNoCategories=Perf;Stress

CC @krwq 