### PR TITLE
Prevent concurrent restore of same project.json

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExecWithMutex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExecWithMutex.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class ExecWithMutex : Exec
+    {
+        [Required]
+        public string MutexName
+        {
+            get;
+            set;
+        }
+
+        protected override int ExecuteTool(string pathToTool, string responseFileCommands, string commandLineCommands)
+        {
+            string actualMutexName = MutexName.Replace(Path.DirectorySeparatorChar, '_');
+            bool created = false;
+
+            using (Mutex mutex = new Mutex(true, actualMutexName, out created))
+            {
+                try
+                {
+                    if (!created)
+                    {
+                        mutex.WaitOne();
+                    }
+                    return base.ExecuteTool(pathToTool, responseFileCommands, commandLineCommands);
+                }
+                finally
+                {
+                    mutex.ReleaseMutex();
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/MSBuildDependencyResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/MSBuildDependencyResolver.cs
@@ -8,6 +8,7 @@ using NuGet.LibraryModel;
 using NuGet.Versioning;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.NuGet.Build.Tasks
 {
@@ -33,6 +34,11 @@ namespace Microsoft.NuGet.Build.Tasks
             }
 
             _msbuildProjectFilePath = projectFilePath;
+        }
+
+        public IEnumerable<string> GetAttemptedPaths(NuGetFramework targetFramework)
+        {
+            return Enumerable.Empty<string>();
         }
 
         public Library GetDescription(LibraryRange libraryRange, NuGetFramework targetFramework)

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -57,24 +57,29 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ContentModel">
-      <HintPath>..\..\packages\NuGet.ContentModel.3.0.0\lib\net45\NuGet.ContentModel.dll</HintPath>
+    <Reference Include="NuGet.ContentModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.ContentModel.3.0.0-beta20150421-212839\lib\net45\NuGet.ContentModel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.NuManifest.DotNet.1.0.1-alpha\lib\net45\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.DependencyResolver">
-      <HintPath>..\..\packages\NuGet.DependencyResolver.3.0.0\lib\net45\NuGet.DependencyResolver.dll</HintPath>
+    <Reference Include="NuGet.DependencyResolver, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.DependencyResolver.3.0.0-beta20150421-212843\lib\net45\NuGet.DependencyResolver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.DependencyResolver.Core">
-      <HintPath>..\..\packages\NuGet.DependencyResolver.Core.3.0.0\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
+    <Reference Include="NuGet.DependencyResolver.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.DependencyResolver.Core.3.0.0-beta20150421-212848\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Frameworks">
-      <HintPath>..\..\packages\NuGet.Frameworks.3.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+    <Reference Include="NuGet.Frameworks, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Frameworks.3.0.0-beta20150421-212851\lib\net45\NuGet.Frameworks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.LibraryModel">
-      <HintPath>..\..\packages\NuGet.LibraryModel.3.0.0\lib\net45\NuGet.LibraryModel.dll</HintPath>
+    <Reference Include="NuGet.LibraryModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.LibraryModel.3.0.0-beta20150421-212856\lib\net45\NuGet.LibraryModel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NuGet.NuManifest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fde1dfc9ddcb8e3e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -84,23 +89,29 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.NuManifest.DotNet.1.0.1-alpha\lib\net45\NuGet.NuManifest.DotNet.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging">
-      <HintPath>..\..\packages\NuGet.Packaging.3.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
+    <Reference Include="NuGet.Packaging, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.3.0.0-beta20150421-212900\lib\net45\NuGet.Packaging.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.3.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.3.0.0-beta20150421-212907\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types">
-      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.3.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+    <Reference Include="NuGet.Packaging.Core.Types, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Packaging.Core.Types.3.0.0-beta20150421-212910\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.ProjectModel">
-      <HintPath>..\..\packages\NuGet.ProjectModel.3.0.0\lib\net45\NuGet.ProjectModel.dll</HintPath>
+    <Reference Include="NuGet.ProjectModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.ProjectModel.3.0.0-beta20150421-212916\lib\net45\NuGet.ProjectModel.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Repositories">
-      <HintPath>..\..\packages\NuGet.Repositories.3.0.0\lib\net45\NuGet.Repositories.dll</HintPath>
+    <Reference Include="NuGet.Repositories, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Repositories.3.0.0-beta20150421-212919\lib\net45\NuGet.Repositories.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.Versioning">
-      <HintPath>..\..\packages\NuGet.Versioning.3.0.0-beta4-10027\lib\net45\NuGet.Versioning.dll</HintPath>
+    <Reference Include="NuGet.Versioning, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NuGet.Versioning.3.0.0-beta20150421-212538\lib\net45\NuGet.Versioning.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ExecWithMutex.cs" />
     <Compile Include="GenerateResourcesCode.cs" />
     <Compile Include="GetWorkspaceBranch.cs" />
     <Compile Include="GitTag.cs" />
@@ -41,6 +42,7 @@
     <Compile Include="ResolveNuGetPackages.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="mscorlib" />
     <Reference Include="LibGit2Sharp">

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <UsingTask TaskName="ExecWithMutex" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ResolveNuGetPackages" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
@@ -20,18 +21,11 @@
 
     <Exec Command="$(NugetRestoreCommand) &quot;$(TestRuntimePackageConfig)&quot;" StandardOutputImportance="Low" />
 
-    <!-- DNU will emit a project.lock.json.  When multiple tests are building for the first time they may race on 
-         running this target and generating the lock.json.  This is causing IOExceptions in dnu for writing lock.json.
-         We should really be handling these test dependencies in a different way (as a package themselves) but for now
-         just restore the project.json from intermediate to avoid the race.  -->
-    <Copy SourceFiles="$(TestRuntimeProjectJson)" DestinationFolder="$(IntermediateOutputPath)">
-      <Output TaskParameter="CopiedFiles" PropertyName="TempTestRuntimeProjectJson"/>
-    </Copy>
-    <Exec Command="$(DnuRestoreCommand) &quot;$(TempTestRuntimeProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
+    <ExecWithMutex Command="$(DnuRestoreCommand) &quot;$(TestRuntimeProjectJson)&quot;" MutexName="$(TestRuntimeProjectJson)" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
 
     <!-- Always copy since we need to force a timestamp update for inputs/outputs-->
     <Copy SourceFiles="$(TestRuntimePackageConfig)" DestinationFiles="$(TestRuntimePackageSemaphore)" ContinueOnError="true" SkipUnchangedFiles="false" />
-    <Copy SourceFiles="$(IntermediateOutputPath)/project.lock.json" DestinationFiles="$(TestRuntimeProjectLockJson)" ContinueOnError="true" SkipUnchangedFiles="false" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)test-runtime\project.lock.json" DestinationFiles="$(TestRuntimeProjectLockJson)" ContinueOnError="true" SkipUnchangedFiles="false" />
   </Target>
 
   <Target Name="GetTestNugetPackageReferences"

--- a/src/Microsoft.DotNet.Build.Tasks/packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/packages.config
@@ -3,20 +3,20 @@
   <package id="LibGit2Sharp" version="0.19.0.0" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
-  <package id="NuGet.ContentModel" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.ContentModel" version="3.0.0-beta20150421-212839" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.3" targetFramework="net45" />
-  <package id="NuGet.DependencyResolver" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.DependencyResolver.Core" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.Frameworks" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.LibraryModel" version="3.0.0" targetFramework="net45" />
+  <package id="NuGet.DependencyResolver" version="3.0.0-beta20150421-212843" targetFramework="net45" />
+  <package id="NuGet.DependencyResolver.Core" version="3.0.0-beta20150421-212848" targetFramework="net45" />
+  <package id="NuGet.Frameworks" version="3.0.0-beta20150421-212851" targetFramework="net45" />
+  <package id="NuGet.LibraryModel" version="3.0.0-beta20150421-212856" targetFramework="net45" />
   <package id="NuGet.NuManifest" version="1.0.1-alpha" targetFramework="net45" />
   <package id="NuGet.NuManifest.DotNet" version="1.0.1-alpha" targetFramework="net45" />
-  <package id="NuGet.Packaging" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.Packaging.Core" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.Packaging.Core.Types" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.ProjectModel" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.Repositories" version="3.0.0" targetFramework="net45" />
-  <package id="NuGet.Versioning" version="3.0.0-beta4-10027" targetFramework="net45" />
+  <package id="NuGet.Packaging" version="3.0.0-beta20150421-212900" targetFramework="net45" />
+  <package id="NuGet.Packaging.Core" version="3.0.0-beta20150421-212907" targetFramework="net45" />
+  <package id="NuGet.Packaging.Core.Types" version="3.0.0-beta20150421-212910" targetFramework="net45" />
+  <package id="NuGet.ProjectModel" version="3.0.0-beta20150421-212916" targetFramework="net45" />
+  <package id="NuGet.Repositories" version="3.0.0-beta20150421-212919" targetFramework="net45" />
+  <package id="NuGet.Versioning" version="3.0.0-beta20150421-212538" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />
   <package id="xunit.runners" version="2.0.0-beta5-build2785" targetFramework="net45" />

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -7,7 +7,7 @@
     <add key="myget.org dotnet-coreclr" value="https://www.myget.org/F/dotnet-coreclr/" />
     <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
-    <add key="myget.org aspnetvnext" value="https://www.myget.org/F/aspnetvnext/" />
+    <add key="myget.org nugetbuild" value="https://www.myget.org/F/nugetbuild/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
   <activePackageSource>


### PR DESCRIPTION
DNX has an issue with concurrent restore: https://github.com/aspnet/dnx/issues/1682

Previously I would workaround by copying to intermediate, but this breaks in official build where intermediate is not under the scope of our nuget.config, so custom package sources are ignored.

Fix this instead by wrapping the call to dnu restore with a mutex unique to the project.json name.  We only need to do this for the test project.json because that is the only one we'll restore concurrently.