### PR TITLE
Update Microsoft.DotNet.TestHost package version.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime-packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="xunit.console.netcore" version="1.0.2-prerelease-00036" />
   <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" />
-  <package id="Microsoft.DotNet.TestHost" version="1.0.4-prerelease" />
+  <package id="Microsoft.DotNet.TestHost" version="1.0.5-prerelease" />
   <package id="Microsoft.DotNet.CoreCLR" version="1.0.3-prerelease" />
   <package id="Microsoft.DotNet.PerfTools" version="0.0.1-prerelease-00022" />
 


### PR DESCRIPTION
TestHost package has been updated to include a new APISet. This change updates the BuildTools to reference the new package.