### PR TITLE
Fix build break when spaces in path

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
@@ -134,11 +134,11 @@
     <Error Text="No single matching contract found." Condition="'@(ResolvedMatchingContract->Count())' != '1'" />
 
     <PropertyGroup>
-      <GenFacadesArgs>-partialFacadeAssemblyPath:$(GenFacadesInputAssembly)</GenFacadesArgs>
-      <GenFacadesArgs>$(GenFacadesArgs) -contracts:%(ResolvedMatchingContract.Identity)</GenFacadesArgs>
-      <GenFacadesArgs>$(GenFacadesArgs) -seeds:@(GenFacadesSeeds, ';')</GenFacadesArgs>
-      <GenFacadesArgs>$(GenFacadesArgs) -facadePath:$(GenFacadesOutputPath)</GenFacadesArgs>
-      <GenFacadesArgs Condition="'@(SeedTypePreference)' != ''">$(GenFacadesArgs) -preferSeedType:@(SeedTypePreference->'%(Identity)=%(Assembly)', ',')</GenFacadesArgs>
+      <GenFacadesArgs>-partialFacadeAssemblyPath:"$(GenFacadesInputAssembly)"</GenFacadesArgs>
+      <GenFacadesArgs>$(GenFacadesArgs) -contracts:"%(ResolvedMatchingContract.Identity)"</GenFacadesArgs>
+      <GenFacadesArgs>$(GenFacadesArgs) -seeds:"@(GenFacadesSeeds, ';')"</GenFacadesArgs>
+      <GenFacadesArgs>$(GenFacadesArgs) -facadePath:"$(GenFacadesOutputPath.TrimEnd('\'))"</GenFacadesArgs>
+      <GenFacadesArgs Condition="'@(SeedTypePreference)' != ''">$(GenFacadesArgs) -preferSeedType:"@(SeedTypePreference->'%(Identity)=%(Assembly)', ',')"</GenFacadesArgs>
     </PropertyGroup>
 
     <!-- Move the assembly into a subdirectory for GenFacades -->
@@ -146,7 +146,7 @@
           DestinationFolder="$(GenFacadesInputPath)"
     />
 
-    <Exec Command="$(GenFacadesPath) $(GenFacadesArgs)" />
+    <Exec Command="&quot;$(GenFacadesPath)&quot; $(GenFacadesArgs)" />
 
     <ItemGroup>
       <FileWrites Include="$(GenFacadesInputAssembly)" />


### PR DESCRIPTION
If there are spaces in the path to the repository that we are building
in, the partialfacade targets fail, because the exec command and
argument parsing logic gets confused.

Wrap invocations with quotes, so this doesn't happen.