### PR TITLE
Add the AssemblyMetadataAttribute to the framework assemblies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/versioning.targets
@@ -55,6 +55,8 @@
       <AssemblyInfoLines Condition="'$(StringResourcesPath)' != ''" Include="[assembly:System.Resources.NeutralResourcesLanguage(&quot;en-US&quot;)]" />
       <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="[assembly:CLSCompliant(true)]" />
       <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="[assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))]" />
+      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'" 
+        Include="[assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)]" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.vbproj'">
@@ -72,6 +74,8 @@
       <AssemblyInfoLines Condition="'$(StringResourcesPath)' != ''" Include="&lt;Assembly:System.Resources.NeutralResourcesLanguage(&quot;en-US&quot;)&gt;" />
       <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="&lt;Assembly:CLSCompliant(True)&gt;" />
       <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="&lt;Assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))&gt;" />
+      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'" 
+          Include="&lt;assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)&gt;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' And '$(GenerateThisAssemblyClass)' == 'true'">


### PR DESCRIPTION
Tagging the framework assemblies with the metadata attribute to identify
the framework assemblies .
This attribute will be used during the app compilation to special handle
any framework assembly as needed.