### PR TITLE
InnerLoop support is added to xunit.

### DIFF
--- a/src/common/TestDiscoveryVisitor.cs
+++ b/src/common/TestDiscoveryVisitor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Xunit.Abstractions;
 
 #if XUNIT_CORE_DLL
@@ -18,6 +19,10 @@ namespace Xunit
 
         protected override bool Visit(ITestCaseDiscoveryMessage discovery)
         {
+            List<string> value = new List<string>();
+            if (!discovery.TestCase.Traits.TryGetValue("innerloop", out value) || !value.Contains("false"))
+                discovery.TestCase.Traits.Add("category", "innerloop");
+
             TestCases.Add(discovery.TestCase);
 
             return true;

--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -297,11 +297,7 @@ namespace Xunit.ConsoleClient
                     if (filteredTestCases.Count == 0)
                     {
                         lock (consoleLock)
-                        {
-                            Console.ForegroundColor = ConsoleColor.Yellow;
-                            Console.WriteLine("Warning:       {0} has no tests to run", Path.GetFileNameWithoutExtension(assembly.AssemblyFilename));
-                            Console.ForegroundColor = ConsoleColor.Gray;
-                        }
+                            Console.WriteLine("{0} has no tests to run", Path.GetFileNameWithoutExtension(assembly.AssemblyFilename));
                     }
                     else
                     {

--- a/src/xunit.netcore.extensions/Attributes/PerfAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/PerfAttribute.cs
@@ -9,12 +9,12 @@ using Xunit.NetCore.Extensions;
 namespace Xunit
 {
     /// <summary>
-    /// Apply this attribute to your test method to specify a outer-loop category.
+    /// Apply this attribute to your test method to specify perf category.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    [TraitDiscoverer("Xunit.NetCore.Extensions.OuterLoopDiscoverer", "Xunit.NetCore.Extensions")]
-    public class OuterLoopAttribute : Attribute, ITraitAttribute
+    [TraitDiscoverer("Xunit.NetCore.Extensions.PerfDiscoverer", "Xunit.NetCore.Extensions")]
+    public class PerfAttribute : Attribute, ITraitAttribute
     {
-        public OuterLoopAttribute() { }
+        public PerfAttribute() { }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/StressAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/StressAttribute.cs
@@ -9,12 +9,12 @@ using Xunit.NetCore.Extensions;
 namespace Xunit
 {
     /// <summary>
-    /// Apply this attribute to your test method to specify a outer-loop category.
+    /// Apply this attribute to your test method to specify Stress category.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    [TraitDiscoverer("Xunit.NetCore.Extensions.OuterLoopDiscoverer", "Xunit.NetCore.Extensions")]
-    public class OuterLoopAttribute : Attribute, ITraitAttribute
+    [TraitDiscoverer("Xunit.NetCore.Extensions.StressDiscoverer", "Xunit.NetCore.Extensions")]
+    public class StressAttribute : Attribute, ITraitAttribute
     {
-        public OuterLoopAttribute() { }
+        public StressAttribute() { }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -23,7 +23,7 @@ namespace Xunit.NetCore.Extensions
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             IEnumerable<object> ctorArgs = traitAttribute.GetConstructorArguments();
-            Debug.Assert(ctorArgs.Count() >= 2);
+            Debug.Assert(ctorArgs.Count() == 2);
 
             string issue = ctorArgs.First().ToString();
             PlatformID platforms = (PlatformID)ctorArgs.Last();
@@ -34,7 +34,6 @@ namespace Xunit.NetCore.Extensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
                 yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
             }
-
         }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/OuterLoopDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/OuterLoopDiscoverer.cs
@@ -1,7 +1,9 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -11,7 +13,7 @@ namespace Xunit.NetCore.Extensions
     /// This class discovers all of the tests and test classes that have
     /// applied the OuterLoop attribute
     /// </summary>
-    public class OuterLoopTestsDiscoverer : ITraitDiscoverer
+    public class OuterLoopDiscoverer : ITraitDiscoverer
     {
         /// <summary>
         /// Gets the trait values from the Category attribute.
@@ -21,6 +23,9 @@ namespace Xunit.NetCore.Extensions
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
             yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.OuterLoop);
+            // Pass (innerloop, false) to exclude this test from innerloop.
+            yield return new KeyValuePair<string, string>(XunitConstants.InnerLoop, XunitConstants.False);
         }
     }
 }
+

--- a/src/xunit.netcore.extensions/Discoverers/PerfDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/PerfDiscoverer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.NetCore.Extensions
+{
+    /// <summary>
+    /// This class discovers all of the tests and test classes that have
+    /// applied the Perf attribute
+    /// </summary>
+    public class PerfDiscoverer : ITraitDiscoverer
+    {
+        /// <summary>
+        /// Gets the trait values from the Category attribute.
+        /// </summary>
+        /// <param name="traitAttribute">The trait attribute containing the trait values.</param>
+        /// <returns>The trait values.</returns>
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Perf);
+            // Pass (innerloop, false) to exclude this test from innerloop.
+            yield return new KeyValuePair<string, string>(XunitConstants.InnerLoop, XunitConstants.False);
+        }
+    }
+}
+

--- a/src/xunit.netcore.extensions/Discoverers/StressDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/StressDiscoverer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.NetCore.Extensions
+{
+    /// <summary>
+    /// This class discovers all of the tests and test classes that have
+    /// applied the Stress attribute
+    /// </summary>
+    public class StressDiscoverer : ITraitDiscoverer
+    {
+        /// <summary>
+        /// Gets the trait values from the Category attribute.
+        /// </summary>
+        /// <param name="traitAttribute">The trait attribute containing the trait values.</param>
+        /// <returns>The trait values.</returns>
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Stress);
+            // Pass (innerloop, false) to exclude this test from innerloop.
+            yield return new KeyValuePair<string, string>(XunitConstants.InnerLoop, XunitConstants.False);
+        }
+    }
+}
+

--- a/src/xunit.netcore.extensions/XunitConstants.cs
+++ b/src/xunit.netcore.extensions/XunitConstants.cs
@@ -8,12 +8,17 @@ namespace Xunit.NetCore.Extensions
 {
     internal struct XunitConstants
     {
+        public const string True = "true";
+        public const string Category = "category";
         public const string NonWindowsTest = "nonwindowstests";
         public const string NonLinuxTest = "nonlinuxtests";
         public const string NonOSXTest = "nonosxtests";
-        public const string Category = "category";
         public const string Failing = "failing";
         public const string ActiveIssue = "activeissue";
         public const string OuterLoop = "outerloop";
+        public const string InnerLoop = "innerloop";
+        public const string Perf = "perf";
+        public const string Stress = "stress";
+        public const string False = "false";
     }
 }

--- a/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
+++ b/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
@@ -18,11 +18,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Attributes\ActiveIssueAttribute.cs" />
-    <Compile Include="Attributes\PlatformSpecificAttribute.cs" />
-    <Compile Include="Discoverers\ActiveIssueDiscoverer.cs" />
     <Compile Include="Attributes\OuterLoopAttribute.cs" />
-    <Compile Include="Discoverers\OuterLoopTestsDiscoverer.cs" />
+    <Compile Include="Attributes\PerfAttribute.cs" />
+    <Compile Include="Attributes\PlatformSpecificAttribute.cs" />
+    <Compile Include="Attributes\StressAttribute.cs" />
+    <Compile Include="Discoverers\ActiveIssueDiscoverer.cs" />
+    <Compile Include="Discoverers\OuterLoopDiscoverer.cs" />
+    <Compile Include="Discoverers\PerfDiscoverer.cs" />
     <Compile Include="Discoverers\PlatformSpecificDiscoverer.cs" />
+    <Compile Include="Discoverers\StressDiscoverer.cs" />
     <Compile Include="Interop.PlatformDetection.cs" />
     <Compile Include="PlatformID.cs" />
     <Compile Include="XunitConstants.cs" />


### PR DESCRIPTION
This enables user to pass innerloop as a valid value to xunit trait
category. Warnings are no longer reported if there are no tests found in
the test project.
With plain msbuild, does not run categories mentioned in
{DefaultNoCategories} property. To exclude categories from plain msbuild,
specify them in DefaultNoCategories property. Hardcoded values in build
script for DefaultNoCategories: outerloop;failing.
/p:WithCategories="innerloop;outerloop" runs all innerloop and outerloop
tests.
/p:WithCategories="innerloop;outerloop;perf" runs all innerloop, outerloop
and perf tests.
/p:WithCategories="failing" runs all failing tests that are not outerloop.
/p:WithCategories="outerloop;failing" runs all outerloop and failing
tests.
/p:WithCategories="outerloop;failing" /p:WithoutCategories="innerloop"
runs all outerloop tests that are failing.

cc @weshaggard @krwq @Chrisboh @iamjasonp @roncain 

Note: This change enables running innerloop and outerloop tests together, to unblock this scenario for CI builds. This does not cover all the scenarios being discussed in issue dotnet\corefx#1477