### PR TITLE
Shorten semaphore path

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <TestDisabled>false</TestDisabled>
     <TestDisabled Condition="'$(IsTestProject)'!='true' Or '$(SkipTests)'=='true' Or '$(RunTestsForProject)'=='false'">true</TestDisabled>
-    <TestsSuccessfulSemaphore>$(MSBuildProjectFile).tests.lastsucceeded</TestsSuccessfulSemaphore>
+    <TestsSuccessfulSemaphore>tests.passed</TestsSuccessfulSemaphore>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Shorten the test succeeded semaphore file to avoid cases where we might create a path that is too long for some tools on Windows.

dotnet/corefx#1701