### PR TITLE
Fix path combine on Unix.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ResolveNuGetPackageAssets.cs
@@ -209,7 +209,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
             foreach (string value in values)
             {
-                var item = new TaskItem(Path.Combine(dnxPackage, value.Replace('/', '\\')));
+                var item = new TaskItem(Path.Combine(dnxPackage, value.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
 
                 item.SetMetadata("NuGetPackageName", packageName);
                 item.SetMetadata("NuGetPackageVersion", packageVersion);
@@ -237,7 +237,7 @@ namespace Microsoft.NuGet.Build.Tasks
 
                 foreach (string exe in Directory.GetFiles(exeSearchPath, "*.exe", SearchOption.AllDirectories))
                 {
-                    var item = new TaskItem(Path.Combine(dnxPackage, exe.Replace('/', '\\')));
+                    var item = new TaskItem(Path.Combine(dnxPackage, exe.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
 
                     item.SetMetadata("NuGetPackageName", packageName);
                     item.SetMetadata("NuGetPackageVersion", packageVersion);


### PR DESCRIPTION
If a path starts with '\' on Unix it isn't considered rooted. This causes Path.Combine to not take just the second argument because we've converted it from rooted to unrooted.

@ericstj; @weshaggard 