### PR TITLE
Pushing automated build changes doesn't work for tracking branches.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildValues.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildValues.targets
@@ -34,6 +34,11 @@
     <Exec
       WorkingDirectory="$(SourceDir)"
       StandardOutputImportance="Low"
+      Command="git checkout $(GitWorkingBranch)" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
       Command="git commit -m &quot;Automated commit of revision number value $(RevisionNumber).&quot; $(SourceDir)BuildValues.props" />
 
     <Exec


### PR DESCRIPTION
When Team Build enlists in tracking branches it puts them into a
detached head state (see https://github.com/dotnet/corefx/issues/1791).

Check out the working branch before committing and pushing changes.