### PR TITLE
Add option to change number of threads that xunit uses

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -27,6 +27,7 @@
     <XunitCommandLine>xunit.console.netcore.exe $(TargetFileName)</XunitCommandLine>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
     <XunitOptions Condition="'$(OS)'=='Windows_NT'">$(XunitOptions) -notrait category=nonwindowstests</XunitOptions>
+    <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
 
     <!-- We need to exclude xunit traits and add wait option for VS -->
     <VSStartArguments>$(XunitCommandLine) $(XunitOptions) -wait</VSStartArguments>


### PR DESCRIPTION
This was useful in detecting issues in test concurrency.  A high number of threads appears to expose problems