### PR TITLE
Always run the package restore step

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -13,15 +13,10 @@
 
     <RestorePackages Condition="'$(RestorePackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</RestorePackages>
     <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</ResolveNuGetPackages>
-
-    <RestorePackagesSemaphore Condition="Exists('$(ProjectPackagesConfigFile)')">$(PackagesDir)$(MSBuildProjectFile)-packages.config</RestorePackagesSemaphore>
-    <RestoreProjectLockJson Condition="Exists('$(ProjectJson)')">$(PackagesDir)$(MSBuildProjectFile)-project.lock.json</RestoreProjectLockJson>
   </PropertyGroup>
 
   <Target Name="RestorePackages" 
           BeforeTargets="ResolveNuGetPackages"
-          Inputs="$(ProjectPackagesConfigFile);$(ProjectJson)"
-          Outputs="$(RestorePackagesSemaphore);$(RestoreProjectLockJson)"
           Condition="'$(RestorePackages)'=='true'">
 
     <Error Condition="'$(NugetRestoreCommand)'=='' and Exists('$(ProjectPackagesConfigFile)')" Text="RestorePackages target needs a predefined NugetRestoreCommand property set in order to restore $(ProjectPackagesConfigFile)" /> 
@@ -29,10 +24,6 @@
     
     <Exec Condition="Exists('$(ProjectPackagesConfigFile)')" Command="$(NugetRestoreCommand) &quot;$(ProjectPackagesConfigFile)&quot;" StandardOutputImportance="Low" />
     <Exec Condition="Exists('$(ProjectJson)')" Command="$(DnuRestoreCommand) &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
-
-    <Copy Condition="Exists('$(ProjectPackagesConfigFile)')" SourceFiles="$(ProjectPackagesConfigFile)" DestinationFiles="$(RestorePackagesSemaphore)" ContinueOnError="true" SkipUnchangedFiles="true" />
-    <!-- Project.lock.json is created if we ran restore-->
-    <Copy Condition="Exists('$(ProjectJson)')" SourceFiles="$(ProjectLockJson)" DestinationFiles="$(RestoreProjectLockJson)" ContinueOnError="true" SkipUnchangedFiles="true" />
   </Target>
 
   <ItemGroup Condition="'$(ResolvePackages)'=='true' or '$(ResolveNuGetPackages)'=='true'">
@@ -71,12 +62,12 @@
       <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == '.NETPortable,Version=v4.5,Profile=Profile7'">DNXCore,Version=v5.0</NugetTargetFrameworkMoniker>
     </PropertyGroup>
 
-    <ResolveNuGetPackageAssets Condition="Exists($(RestoreProjectLockJson))"
+    <ResolveNuGetPackageAssets Condition="Exists($(ProjectLockJson))"
                                Architecture="$(PlatformTarget)"
                                Configuration="$(Configuration)"
                                Language="$(Language)"
                                PackageRoot="$(PackagesDir)"
-                               ProjectLockFile="$(RestoreProjectLockJson)"
+                               ProjectLockFile="$(ProjectLockJson)"
                                TargetFrameworkMonikers="$(NugetTargetFrameworkMoniker)"
                                TargetPlatformMonikers="$(TargetPlatformMoniker)">
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />


### PR DESCRIPTION
This is specifically targeted toward the new json package format.  The issue we have is that the coreclr tests have project names that sometimes non-unique in the tests (there are template projects).  This causes locking issues when restoring packages, or occasionally packages do not get restored at all.  This is because the semaphore file is based off of the project name.  This implicitly adds a restriction that project file names must be unique within an msbuild invocation.  The semaphore file was an attempt to have incremental package restore.  Under  dnx, the lock files dramatically speed up restore and so always restoring is okay.

This changes removes the incremental restore and unblocks coreclr's move to dnx.

/cc @ericstj 