### PR TITLE
Fix issue introduced by removal of lock semaphore files

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -30,7 +30,7 @@
   <Target Name="CopyTestToTestDirectory"
           Condition="'$(CopyTestToTestDirectory)'=='true'">
     <ItemGroup>
-      <TestNugetProjectLockFile Include="$(RestoreProjectLockJson)" Condition="Exists($(RestoreProjectLockJson))"/>
+      <TestNugetProjectLockFile Include="$(ProjectLockJson)" Condition="Exists($(ProjectLockJson))"/>
       <TestNugetProjectLockFile Include="$(TestRuntimeProjectLockJson)" Condition="Exists($(TestRuntimeProjectLockJson))"/>
     </ItemGroup>
 


### PR DESCRIPTION
Missed a spot where the lock semaphore files were being referenced, causing corefx not to copy all dependencies to test directories