### PR TITLE
Use locked dependencies for test-runtime.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -82,16 +82,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="Targets\*.*" />
+    <None Include="Targets\**\*.*" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">
     <ItemGroup>
-      <PackageFiles Include="$(MSBuildThisProjectDirectory)Targets\*.*" />
+      <PackageFiles Include="$(MSBuildThisProjectDirectory)Targets\**\*.*" />
       <NativeBinariesx86 Include="$(PackagesDir)LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\*.*" />
       <NativeBinariesamd64 Include="$(PackagesDir)LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(OutputPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(NativeBinariesx86)" DestinationFolder="$(OutputPath)NativeBinaries\x86" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(NativeBinariesamd64)" DestinationFolder="$(OutputPath)NativeBinaries\amd64" SkipUnchangedFiles="true" />
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -1,25 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="ExecWithMutex" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
   <PropertyGroup>
-    <TestRuntimeProjectJson>$(MSBuildThisFileDirectory)test-runtime\project.json</TestRuntimeProjectJson>
-    <TestRuntimeProjectLockJson>$(PackagesDir)test-runtime-project.lock.json</TestRuntimeProjectLockJson>
+    <TestRuntimeProjectJson Condition="'$(TestRuntimeProjectJson)' == ''">$(MSBuildThisFileDirectory)test-runtime\project.json</TestRuntimeProjectJson>
+    <TestRuntimeProjectLockJson Condition="'$(TestRuntimeProjectLockJson)' == ''">$(MSBuildThisFileDirectory)test-runtime\project.lock.json</TestRuntimeProjectLockJson>
     <SerializeProjects Condition="'$(TestWithLocalLibraries)'=='true'">true</SerializeProjects>
   </PropertyGroup>
 
   <Target Name="RestoreTestRuntimePackage"
           BeforeTargets="ResolveNuGetPackages"
-          Inputs="$(TestRuntimeProjectJson)"
-          Outputs="$(TestRuntimeProjectLockJson)"
           Condition="'$(IsTestProject)' == 'true'">
-
-    <ExecWithMutex Command="$(DnuRestoreCommand) &quot;$(TestRuntimeProjectJson)&quot;" MutexName="$(TestRuntimeProjectJson)" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
-
-    <!-- Always copy since we need to force a timestamp update for inputs/outputs-->
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)test-runtime\project.lock.json" DestinationFiles="$(TestRuntimeProjectLockJson)" ContinueOnError="true" SkipUnchangedFiles="false" />
+    <Exec Command="$(DnuRestoreCommand) &quot;$(TestRuntimeProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
   </Target>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
@@ -1,8 +1,8 @@
 {
     "dependencies": {
        "coveralls.io": "1.4",
-       "Microsoft.NETCore.Runtime.ApiSets-x86": "1.0.0-beta-*",
-       "Microsoft.NETCore.Runtime.CoreCLR.TestHost-x86": "1.0.0-beta-*",
+       "Microsoft.NETCore.Windows.ApiSets-x86": "1.0.0-beta-*",
+       "Microsoft.NETCore.TestHost-x86": "1.0.0-beta-*",
        "Microsoft.NETCore.Runtime.CoreCLR-x86": "1.0.0-beta-*",
        "Microsoft.DotNet.PerfTools": "0.0.1-prerelease-00022",
        "OpenCover": "4.5.4107-rc122",

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.lock.json
@@ -1,0 +1,2083 @@
+{
+  "locked": true,
+  "version": -9997,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "coveralls.io/1.4": {},
+      "Microsoft.Diagnostics.Tracing.TraceEvent/1.0.25": {},
+      "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00022": {
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.25",
+          "PowerArgs": "2.6.0.1"
+        }
+      },
+      "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0-beta-22927": {
+        "dependencies": {
+          "System.Collections": "[4.0.10-beta-22927]",
+          "System.Diagnostics.Debug": "[4.0.10-beta-22927]",
+          "System.Globalization": "[4.0.10-beta-22927]",
+          "System.IO": "[4.0.10-beta-22927]",
+          "System.ObjectModel": "[4.0.10-beta-22927]",
+          "System.Reflection": "[4.0.10-beta-22927]",
+          "System.Runtime.Extensions": "[4.0.10-beta-22927]",
+          "System.Text.Encoding": "[4.0.10-beta-22927]",
+          "System.Text.Encoding.Extensions": "[4.0.10-beta-22927]",
+          "System.Threading": "[4.0.10-beta-22927]",
+          "System.Threading.Tasks": "[4.0.10-beta-22927]",
+          "System.Diagnostics.Contracts": "[4.0.0-beta-22927]",
+          "System.Diagnostics.StackTrace": "[4.0.0-beta-22927]",
+          "System.Diagnostics.Tools": "[4.0.0-beta-22927]",
+          "System.Globalization.Calendars": "[4.0.0-beta-22927]",
+          "System.Reflection.Extensions": "[4.0.0-beta-22927]",
+          "System.Reflection.Primitives": "[4.0.0-beta-22927]",
+          "System.Resources.ResourceManager": "[4.0.0-beta-22927]",
+          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0-beta-22927]",
+          "System.Runtime.Handles": "[4.0.0-beta-22927]",
+          "System.Threading.Timer": "[4.0.0-beta-22927]",
+          "System.Private.Uri": "[4.0.0-beta-22927]",
+          "System.Diagnostics.Tracing": "[4.0.20-beta-22927]",
+          "System.Runtime": "[4.0.20-beta-22927]",
+          "System.Runtime.InteropServices": "[4.0.20-beta-22927]"
+        },
+        "runtime": [
+          "runtimes/win7-x86/lib/any/mscorlib.ni.dll"
+        ]
+      },
+      "Microsoft.NETCore.TestHost-x86/1.0.0-beta-22927": {},
+      "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0-beta-22927": {},
+      "OpenCover/4.5.4107-rc122": {},
+      "PowerArgs/2.6.0.1": {},
+      "ReportGenerator/2.1.5.0": {},
+      "System.Collections/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Collections.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Collections.dll"
+        ]
+      },
+      "System.Collections.Concurrent/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Diagnostics.Tracing": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Collections.Concurrent.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Collections.Concurrent.dll"
+        ]
+      },
+      "System.Console/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Runtime.InteropServices": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Console.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Console.dll"
+        ]
+      },
+      "System.Diagnostics.Contracts/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Contracts.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Contracts.dll"
+        ]
+      },
+      "System.Diagnostics.Debug/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Debug.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Debug.dll"
+        ]
+      },
+      "System.Diagnostics.StackTrace/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.StackTrace.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.StackTrace.dll"
+        ]
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Tools.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Tools.dll"
+        ]
+      },
+      "System.Diagnostics.Tracing/4.0.20-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Tracing.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll"
+        ]
+      },
+      "System.Globalization/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Globalization.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Globalization.dll"
+        ]
+      },
+      "System.Globalization.Calendars/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Globalization": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Globalization.Calendars.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Globalization.Calendars.dll"
+        ]
+      },
+      "System.IO/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Text.Encoding": "4.0.0-beta-22927",
+          "System.Threading.Tasks": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.IO.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.IO.dll"
+        ]
+      },
+      "System.IO.FileSystem/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Runtime.InteropServices": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22927",
+          "System.Runtime.Handles": "4.0.0-beta-22927",
+          "System.Threading.Overlapped": "4.0.0-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.IO.FileSystem.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.IO.FileSystem.dll"
+        ]
+      },
+      "System.IO.FileSystem.Primitives/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.IO.FileSystem.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/any/System.IO.FileSystem.Primitives.dll"
+        ]
+      },
+      "System.Linq/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Linq.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Linq.dll"
+        ]
+      },
+      "System.ObjectModel/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.ObjectModel.dll"
+        ],
+        "runtime": [
+          "lib/any/System.ObjectModel.dll"
+        ]
+      },
+      "System.Private.Uri/4.0.0-beta-22927": {
+        "runtime": [
+          "lib/DNXCore50/System.Private.Uri.dll"
+        ]
+      },
+      "System.Reflection/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.IO": "4.0.0-beta-22927",
+          "System.Reflection.Primitives": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Reflection.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.dll"
+        ]
+      },
+      "System.Reflection.Extensions/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.Extensions.dll"
+        ]
+      },
+      "System.Reflection.Primitives/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.Primitives.dll"
+        ]
+      },
+      "System.Resources.ResourceManager/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927",
+          "System.Globalization": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Resources.ResourceManager.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Resources.ResourceManager.dll"
+        ]
+      },
+      "System.Runtime/4.0.20-beta-22927": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.dll"
+        ]
+      },
+      "System.Runtime.Extensions/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.Extensions.dll"
+        ]
+      },
+      "System.Runtime.Handles/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Handles.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.Handles.dll"
+        ]
+      },
+      "System.Runtime.InteropServices/4.0.20-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927",
+          "System.Reflection.Primitives": "4.0.0-beta-22927",
+          "System.Runtime.Handles": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.InteropServices.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.InteropServices.dll"
+        ]
+      },
+      "System.Runtime.InteropServices.WindowsRuntime/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.InteropServices.WindowsRuntime.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.InteropServices.WindowsRuntime.dll"
+        ]
+      },
+      "System.Text.Encoding/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Text.Encoding.dll"
+        ]
+      },
+      "System.Text.Encoding.Extensions/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll"
+        ]
+      },
+      "System.Text.RegularExpressions/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "lib/any/System.Text.RegularExpressions.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Text.RegularExpressions.dll"
+        ]
+      },
+      "System.Threading/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Threading.Tasks": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.dll"
+        ]
+      },
+      "System.Threading.Overlapped/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Runtime.Handles": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.Overlapped.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.Overlapped.dll"
+        ]
+      },
+      "System.Threading.Tasks/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.Tasks.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.Tasks.dll"
+        ]
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Runtime.InteropServices": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.ThreadPool.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.ThreadPool.dll"
+        ]
+      },
+      "System.Threading.Timer/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.Timer.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.Timer.dll"
+        ]
+      },
+      "System.Xml.ReaderWriter/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Runtime.InteropServices": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.IO.FileSystem": "4.0.0-beta-22927",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Text.RegularExpressions": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Xml.ReaderWriter.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Xml.ReaderWriter.dll"
+        ]
+      },
+      "System.Xml.XDocument/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Xml.ReaderWriter": "4.0.10-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.Reflection": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Xml.XDocument.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Xml.XDocument.dll"
+        ]
+      },
+      "xunit.console.netcore/1.0.2-prerelease-00036": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-22703",
+          "System.Collections.Concurrent": "4.0.10-beta-22703",
+          "System.Console": "4.0.0-beta-22703",
+          "System.Diagnostics.Tools": "4.0.0-beta-22703",
+          "System.IO": "4.0.10-beta-22703",
+          "System.IO.FileSystem": "4.0.0-beta-22703",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22703",
+          "System.Linq": "4.0.0-beta-22703",
+          "System.Reflection": "4.0.10-beta-22703",
+          "System.Runtime": "4.0.20-beta-22703",
+          "System.Runtime.Extensions": "4.0.10-beta-22703",
+          "System.Runtime.Handles": "4.0.0-beta-22703",
+          "System.Text.RegularExpressions": "4.0.10-beta-22703",
+          "System.Threading": "4.0.0-beta-22703",
+          "System.Threading.Tasks": "4.0.10-beta-22703",
+          "System.Threading.ThreadPool": "4.0.10-beta-22703",
+          "System.Xml.ReaderWriter": "4.0.10-beta-22703",
+          "System.Xml.XDocument": "4.0.0-beta-22703"
+        }
+      },
+      "xunit.runner.dependencies.netcore/1.0.1-prerelease": {
+        "compile": [
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.abstractions.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.execution.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.runner.utility.dll"
+        ],
+        "runtime": [
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.abstractions.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.execution.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.runner.utility.dll"
+        ]
+      }
+    },
+    "DNXCore,Version=v5.0/win7-x86": {
+      "coveralls.io/1.4": {},
+      "Microsoft.Diagnostics.Tracing.TraceEvent/1.0.25": {},
+      "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00022": {
+        "dependencies": {
+          "Microsoft.Diagnostics.Tracing.TraceEvent": "1.0.25",
+          "PowerArgs": "2.6.0.1"
+        }
+      },
+      "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0-beta-22927": {
+        "dependencies": {
+          "System.Collections": "[4.0.10-beta-22927]",
+          "System.Diagnostics.Debug": "[4.0.10-beta-22927]",
+          "System.Globalization": "[4.0.10-beta-22927]",
+          "System.IO": "[4.0.10-beta-22927]",
+          "System.ObjectModel": "[4.0.10-beta-22927]",
+          "System.Reflection": "[4.0.10-beta-22927]",
+          "System.Runtime.Extensions": "[4.0.10-beta-22927]",
+          "System.Text.Encoding": "[4.0.10-beta-22927]",
+          "System.Text.Encoding.Extensions": "[4.0.10-beta-22927]",
+          "System.Threading": "[4.0.10-beta-22927]",
+          "System.Threading.Tasks": "[4.0.10-beta-22927]",
+          "System.Diagnostics.Contracts": "[4.0.0-beta-22927]",
+          "System.Diagnostics.StackTrace": "[4.0.0-beta-22927]",
+          "System.Diagnostics.Tools": "[4.0.0-beta-22927]",
+          "System.Globalization.Calendars": "[4.0.0-beta-22927]",
+          "System.Reflection.Extensions": "[4.0.0-beta-22927]",
+          "System.Reflection.Primitives": "[4.0.0-beta-22927]",
+          "System.Resources.ResourceManager": "[4.0.0-beta-22927]",
+          "System.Runtime.InteropServices.WindowsRuntime": "[4.0.0-beta-22927]",
+          "System.Runtime.Handles": "[4.0.0-beta-22927]",
+          "System.Threading.Timer": "[4.0.0-beta-22927]",
+          "System.Private.Uri": "[4.0.0-beta-22927]",
+          "System.Diagnostics.Tracing": "[4.0.20-beta-22927]",
+          "System.Runtime": "[4.0.20-beta-22927]",
+          "System.Runtime.InteropServices": "[4.0.20-beta-22927]"
+        },
+        "runtime": [
+          "runtimes/win7-x86/lib/any/mscorlib.ni.dll"
+        ],
+        "native": [
+          "runtimes/win7-x86/native/clretwrc.dll",
+          "runtimes/win7-x86/native/coreclr.dll",
+          "runtimes/win7-x86/native/dbgshim.dll",
+          "runtimes/win7-x86/native/mscordaccore.dll",
+          "runtimes/win7-x86/native/mscordbi.dll",
+          "runtimes/win7-x86/native/mscorrc.debug.dll",
+          "runtimes/win7-x86/native/mscorrc.dll"
+        ]
+      },
+      "Microsoft.NETCore.TestHost-x86/1.0.0-beta-22927": {
+        "native": [
+          "runtimes/win7-x86/native/CoreRun.exe"
+        ]
+      },
+      "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0-beta-22927": {
+        "native": [
+          "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-debug-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-debug-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-delayload-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-errorhandling-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-errorhandling-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-fibers-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-fibers-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-file-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-file-l1-2-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-file-l1-2-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-file-l2-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-file-l2-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-handle-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-heap-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-heap-obsolete-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-interlocked-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-io-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-io-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-localization-l2-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-2.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-normalization-l1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-2-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-processsecurity-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-profile-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-psapi-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-psapi-obsolete-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-realtime-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-registry-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-registry-l2-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-rtlsupport-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-shlwapi-legacy-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-threadpool-l1-2-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-threadpool-legacy-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-threadpool-private-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-timezone-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-url-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-util-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-version-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-winrt-error-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-winrt-error-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-winrt-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-winrt-registration-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-winrt-robuffer-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-winrt-string-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-wow64-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-xstate-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+          "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-security-base-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
+          "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-security-provider-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-security-sddl-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-service-management-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-service-management-l2-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-0.dll",
+          "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
+          "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
+          "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll"
+        ]
+      },
+      "OpenCover/4.5.4107-rc122": {},
+      "PowerArgs/2.6.0.1": {},
+      "ReportGenerator/2.1.5.0": {},
+      "System.Collections/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Collections.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Collections.dll"
+        ]
+      },
+      "System.Collections.Concurrent/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Diagnostics.Tracing": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Collections.Concurrent.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Collections.Concurrent.dll"
+        ]
+      },
+      "System.Console/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Runtime.InteropServices": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Console.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Console.dll"
+        ]
+      },
+      "System.Diagnostics.Contracts/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Contracts.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Contracts.dll"
+        ]
+      },
+      "System.Diagnostics.Debug/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Debug.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Debug.dll"
+        ]
+      },
+      "System.Diagnostics.StackTrace/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.StackTrace.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.StackTrace.dll"
+        ]
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Tools.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Tools.dll"
+        ]
+      },
+      "System.Diagnostics.Tracing/4.0.20-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Diagnostics.Tracing.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll"
+        ]
+      },
+      "System.Globalization/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Globalization.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Globalization.dll"
+        ]
+      },
+      "System.Globalization.Calendars/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Globalization": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Globalization.Calendars.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Globalization.Calendars.dll"
+        ]
+      },
+      "System.IO/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Text.Encoding": "4.0.0-beta-22927",
+          "System.Threading.Tasks": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.IO.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.IO.dll"
+        ]
+      },
+      "System.IO.FileSystem/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Runtime.InteropServices": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22927",
+          "System.Runtime.Handles": "4.0.0-beta-22927",
+          "System.Threading.Overlapped": "4.0.0-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.IO.FileSystem.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.IO.FileSystem.dll"
+        ]
+      },
+      "System.IO.FileSystem.Primitives/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.IO.FileSystem.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/any/System.IO.FileSystem.Primitives.dll"
+        ]
+      },
+      "System.Linq/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Linq.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Linq.dll"
+        ]
+      },
+      "System.ObjectModel/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.ObjectModel.dll"
+        ],
+        "runtime": [
+          "lib/any/System.ObjectModel.dll"
+        ]
+      },
+      "System.Private.Uri/4.0.0-beta-22927": {
+        "runtime": [
+          "lib/DNXCore50/System.Private.Uri.dll"
+        ]
+      },
+      "System.Reflection/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.IO": "4.0.0-beta-22927",
+          "System.Reflection.Primitives": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Reflection.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.dll"
+        ]
+      },
+      "System.Reflection.Extensions/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.Extensions.dll"
+        ]
+      },
+      "System.Reflection.Primitives/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Reflection.Primitives.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Reflection.Primitives.dll"
+        ]
+      },
+      "System.Resources.ResourceManager/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927",
+          "System.Globalization": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Resources.ResourceManager.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Resources.ResourceManager.dll"
+        ]
+      },
+      "System.Runtime/4.0.20-beta-22927": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.dll"
+        ]
+      },
+      "System.Runtime.Extensions/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.Extensions.dll"
+        ]
+      },
+      "System.Runtime.Handles/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.Handles.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.Handles.dll"
+        ]
+      },
+      "System.Runtime.InteropServices/4.0.20-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Reflection": "4.0.0-beta-22927",
+          "System.Reflection.Primitives": "4.0.0-beta-22927",
+          "System.Runtime.Handles": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.InteropServices.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.InteropServices.dll"
+        ]
+      },
+      "System.Runtime.InteropServices.WindowsRuntime/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Runtime.InteropServices.WindowsRuntime.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Runtime.InteropServices.WindowsRuntime.dll"
+        ]
+      },
+      "System.Text.Encoding/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Text.Encoding.dll"
+        ]
+      },
+      "System.Text.Encoding.Extensions/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Text.Encoding.Extensions.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll"
+        ]
+      },
+      "System.Text.RegularExpressions/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "lib/any/System.Text.RegularExpressions.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Text.RegularExpressions.dll"
+        ]
+      },
+      "System.Threading/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Threading.Tasks": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.dll"
+        ]
+      },
+      "System.Threading.Overlapped/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Runtime.Handles": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.Overlapped.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.Overlapped.dll"
+        ]
+      },
+      "System.Threading.Tasks/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.Tasks.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.Tasks.dll"
+        ]
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927",
+          "System.Runtime.InteropServices": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.ThreadPool.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.ThreadPool.dll"
+        ]
+      },
+      "System.Threading.Timer/4.0.0-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Threading.Timer.dll"
+        ],
+        "runtime": [
+          "lib/DNXCore50/System.Threading.Timer.dll"
+        ]
+      },
+      "System.Xml.ReaderWriter/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Threading.Tasks": "4.0.10-beta-22927",
+          "System.Runtime.InteropServices": "4.0.20-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.IO.FileSystem": "4.0.0-beta-22927",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Text.RegularExpressions": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Xml.ReaderWriter.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Xml.ReaderWriter.dll"
+        ]
+      },
+      "System.Xml.XDocument/4.0.10-beta-22927": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22927",
+          "System.IO": "4.0.10-beta-22927",
+          "System.Xml.ReaderWriter": "4.0.10-beta-22927",
+          "System.Resources.ResourceManager": "4.0.0-beta-22927",
+          "System.Diagnostics.Debug": "4.0.10-beta-22927",
+          "System.Collections": "4.0.10-beta-22927",
+          "System.Globalization": "4.0.10-beta-22927",
+          "System.Threading": "4.0.10-beta-22927",
+          "System.Text.Encoding": "4.0.10-beta-22927",
+          "System.Reflection": "4.0.10-beta-22927",
+          "System.Runtime.Extensions": "4.0.10-beta-22927"
+        },
+        "compile": [
+          "ref/any/System.Xml.XDocument.dll"
+        ],
+        "runtime": [
+          "lib/any/System.Xml.XDocument.dll"
+        ]
+      },
+      "xunit.console.netcore/1.0.2-prerelease-00036": {
+        "dependencies": {
+          "System.Collections": "4.0.10-beta-22703",
+          "System.Collections.Concurrent": "4.0.10-beta-22703",
+          "System.Console": "4.0.0-beta-22703",
+          "System.Diagnostics.Tools": "4.0.0-beta-22703",
+          "System.IO": "4.0.10-beta-22703",
+          "System.IO.FileSystem": "4.0.0-beta-22703",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22703",
+          "System.Linq": "4.0.0-beta-22703",
+          "System.Reflection": "4.0.10-beta-22703",
+          "System.Runtime": "4.0.20-beta-22703",
+          "System.Runtime.Extensions": "4.0.10-beta-22703",
+          "System.Runtime.Handles": "4.0.0-beta-22703",
+          "System.Text.RegularExpressions": "4.0.10-beta-22703",
+          "System.Threading": "4.0.0-beta-22703",
+          "System.Threading.Tasks": "4.0.10-beta-22703",
+          "System.Threading.ThreadPool": "4.0.10-beta-22703",
+          "System.Xml.ReaderWriter": "4.0.10-beta-22703",
+          "System.Xml.XDocument": "4.0.0-beta-22703"
+        }
+      },
+      "xunit.runner.dependencies.netcore/1.0.1-prerelease": {
+        "compile": [
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.abstractions.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.execution.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.runner.utility.dll"
+        ],
+        "runtime": [
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.abstractions.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.execution.dll",
+          "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.runner.utility.dll"
+        ]
+      }
+    }
+  },
+  "libraries": {
+    "coveralls.io/1.4": {
+      "sha512": "QJLuUzAD50drCp5P+PiWHh/TKcNBbsgnnZiN600YtRPx5DP4aY4MpVeY1oYs8eOnuhCZW+5TqcpUct3oHJigIQ==",
+      "files": [
+        "coveralls.io.1.4.nupkg",
+        "coveralls.io.1.4.nupkg.sha512",
+        "coveralls.io.nuspec",
+        "tools/CommandLine.dll",
+        "tools/CommandLine.xml",
+        "tools/Coveralls.dll",
+        "tools/coveralls.net.exe",
+        "tools/coveralls.net.exe.config",
+        "tools/coveralls.net.pdb",
+        "tools/Coveralls.pdb",
+        "tools/LibGit2Sharp.dll",
+        "tools/LibGit2Sharp.xml",
+        "tools/Newtonsoft.Json.dll",
+        "tools/Newtonsoft.Json.xml",
+        "tools/NativeBinaries/amd64/git2-e0902fb.dll",
+        "tools/NativeBinaries/amd64/git2-e0902fb.pdb",
+        "tools/NativeBinaries/x86/git2-e0902fb.dll",
+        "tools/NativeBinaries/x86/git2-e0902fb.pdb"
+      ]
+    },
+    "Microsoft.Diagnostics.Tracing.TraceEvent/1.0.25": {
+      "serviceable": true,
+      "sha512": "TExhCD70Js4OB1H+T6B4Fb5D3/wqtrZ67sHX1K5h9R8DpUIgQFZmH72aYzGk4Z8TsaV6NyX0e9x9Yh9/78JBhA==",
+      "files": [
+        "License-Stable.rtf",
+        "Microsoft.Diagnostics.Tracing.TraceEvent.1.0.25.nupkg",
+        "Microsoft.Diagnostics.Tracing.TraceEvent.1.0.25.nupkg.sha512",
+        "Microsoft.Diagnostics.Tracing.TraceEvent.nuspec",
+        "ReadMe.txt",
+        "ReleaseNotes.txt",
+        "build/Microsoft.Diagnostics.Tracing.TraceEvent.targets",
+        "content/TraceEvent.ReadMe.txt",
+        "content/TraceEvent.ReleaseNotes.txt",
+        "content/_TraceEventProgrammersGuide.docx",
+        "lib/native/amd64/KernelTraceControl.dll",
+        "lib/native/amd64/msdia120.dll",
+        "lib/native/x86/KernelTraceControl.dll",
+        "lib/native/x86/msdia120.dll",
+        "lib/net35/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
+        "lib/net35/Microsoft.Diagnostics.Tracing.TraceEvent.xml",
+        "lib/net40/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
+        "lib/net40/Microsoft.Diagnostics.Tracing.TraceEvent.xml"
+      ]
+    },
+    "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00022": {
+      "serviceable": true,
+      "sha512": "mF5PukcXYjvs//VDaTxd8XKik0zg+GPUXvYVYcsSWIRq5aqB8ajW9SWykd4e6RCwgO923y28fBw+/w+ioKOUvA==",
+      "files": [
+        "Microsoft.DotNet.PerfTools.0.0.1-prerelease-00022.nupkg",
+        "Microsoft.DotNet.PerfTools.0.0.1-prerelease-00022.nupkg.sha512",
+        "Microsoft.DotNet.PerfTools.nuspec",
+        "tools/ComparePerfEventsData.exe",
+        "tools/EventTracer.exe",
+        "tools/GenPerfBaseline.exe",
+        "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
+        "tools/PerfEventsData.dll",
+        "tools/PowerArgs.dll"
+      ]
+    },
+    "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0-beta-22927": {
+      "sha512": "fyKcNI0vsjTExWeHop7CU1fczzfwmjZQhgz9n5guCIPxMRY/qbU+lCOIHPINIpe+wGS49PzL4lV1nlSjhYwWIA==",
+      "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR-x86.1.0.0-beta-22927.nupkg",
+        "Microsoft.NETCore.Runtime.CoreCLR-x86.1.0.0-beta-22927.nupkg.sha512",
+        "Microsoft.NETCore.Runtime.CoreCLR-x86.nuspec",
+        "ref/any/_._",
+        "runtimes/win7-x86/lib/any/mscorlib.ni.dll",
+        "runtimes/win7-x86/native/clretwrc.dll",
+        "runtimes/win7-x86/native/coreclr.dll",
+        "runtimes/win7-x86/native/dbgshim.dll",
+        "runtimes/win7-x86/native/mscordaccore.dll",
+        "runtimes/win7-x86/native/mscordbi.dll",
+        "runtimes/win7-x86/native/mscorrc.debug.dll",
+        "runtimes/win7-x86/native/mscorrc.dll"
+      ]
+    },
+    "Microsoft.NETCore.TestHost-x86/1.0.0-beta-22927": {
+      "sha512": "j+jtwQlFAASz+b4AMwH4LqlRV0HR6fuJr6uaeWgXKVMYsjQixFhZCvt9arFdSVe/l3BeB57Dp0NGUYsdAgv37A==",
+      "files": [
+        "Microsoft.NETCore.TestHost-x86.1.0.0-beta-22927.nupkg",
+        "Microsoft.NETCore.TestHost-x86.1.0.0-beta-22927.nupkg.sha512",
+        "Microsoft.NETCore.TestHost-x86.nuspec",
+        "runtimes/win7-x86/native/CoreRun.exe"
+      ]
+    },
+    "Microsoft.NETCore.Windows.ApiSets-x86/1.0.0-beta-22927": {
+      "sha512": "8YYhHQ4fimX0LzD5mXTWh3HpJaHkf8CyC4FxvXFXVjdz9Jh9cWkoMJbi6lhcnj+rnUd8FEcT1sjGqd7oDtGPbA==",
+      "files": [
+        "Microsoft.NETCore.Windows.ApiSets-x86.1.0.0-beta-22927.nupkg",
+        "Microsoft.NETCore.Windows.ApiSets-x86.1.0.0-beta-22927.nupkg.sha512",
+        "Microsoft.NETCore.Windows.ApiSets-x86.nuspec",
+        "runtimes/win10-x86/native/_._",
+        "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-debug-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-debug-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-delayload-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-errorhandling-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-errorhandling-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-fibers-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-fibers-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-file-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-file-l1-2-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-file-l1-2-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-file-l2-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-file-l2-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-handle-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-heap-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-heap-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-interlocked-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-io-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-io-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-libraryloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-localization-l1-2-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-localization-l2-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-2.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-normalization-l1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-processenvironment-l1-2-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-processsecurity-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-profile-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-psapi-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-psapi-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-realtime-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-registry-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-registry-l2-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-rtlsupport-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-shlwapi-legacy-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-threadpool-l1-2-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-threadpool-legacy-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-threadpool-private-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-timezone-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-url-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-util-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-version-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-winrt-error-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-winrt-error-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-winrt-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-winrt-registration-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-winrt-robuffer-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-winrt-string-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-wow64-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-xstate-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x86/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-security-base-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-security-provider-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-security-sddl-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-service-core-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-service-management-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-service-management-l2-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
+        "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win8-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-localization-l1-2-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-memory-l1-1-2.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-winrt-error-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-xstate-l2-1-0.dll",
+        "runtimes/win8-x86/native/API-MS-Win-devices-config-L1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
+        "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll"
+      ]
+    },
+    "OpenCover/4.5.4107-rc122": {
+      "sha512": "PUTiqRj1GYDSPk9Q0hyZttdernkUlmitMbVbyLQ8QuocEPY74oS1NBqC91KSdzbtq6IPPlMI59F14irCOx28hw==",
+      "files": [
+        "Autofac.Configuration.dll",
+        "Autofac.dll",
+        "Gendarme.Framework.dll",
+        "Gendarme.Rules.Maintainability.dll",
+        "License.rtf",
+        "log4net.config",
+        "log4net.dll",
+        "Mono.Cecil.dll",
+        "Mono.Cecil.Mdb.dll",
+        "Mono.Cecil.Pdb.dll",
+        "OpenCover.4.5.4107-rc122.nupkg",
+        "OpenCover.4.5.4107-rc122.nupkg.sha512",
+        "OpenCover.Console.exe",
+        "OpenCover.Console.exe.config",
+        "OpenCover.Console.pdb",
+        "OpenCover.Extensions.dll",
+        "OpenCover.Extensions.pdb",
+        "OpenCover.Framework.dll",
+        "OpenCover.Framework.pdb",
+        "OpenCover.nuspec",
+        "readme.txt",
+        "docs/ReleaseNotes.txt",
+        "docs/Usage.rtf",
+        "MSBuild/OpenCover.MSBuild.dll",
+        "MSBuild/OpenCover.targets",
+        "Samples/x64/OpenCover.Simple.Target.exe",
+        "Samples/x64/OpenCover.Simple.Target.pdb",
+        "Samples/x86/OpenCover.Simple.Target.exe",
+        "Samples/x86/OpenCover.Simple.Target.pdb",
+        "SampleSln/BomSample.sln",
+        "SampleSln/coverage.bat",
+        "SampleSln/.nuget/packages.config",
+        "SampleSln/Bom/Bom.csproj",
+        "SampleSln/Bom/BomManager.cs",
+        "SampleSln/Bom/Properties/AssemblyInfo.cs",
+        "SampleSln/BomTest/BomManagerTests.cs",
+        "SampleSln/BomTest/BomTest.csproj",
+        "SampleSln/BomTest/packages.config",
+        "SampleSln/BomTest/Properties/AssemblyInfo.cs",
+        "SampleSln/packages/repositories.config",
+        "transform/simple_report.xslt",
+        "transform/transform.ps1",
+        "x64/OpenCover.Profiler.dll",
+        "x86/OpenCover.Profiler.dll"
+      ]
+    },
+    "PowerArgs/2.6.0.1": {
+      "sha512": "o44xzWjmJ0YmIhb3VLU9B6KUQ+vE5qWCilpaSVvy3qvmUT6Ki02uzajvCQtELjRZaqThEv6mOqm5uQjBUhrNEg==",
+      "files": [
+        "PowerArgs.2.6.0.1.nupkg",
+        "PowerArgs.2.6.0.1.nupkg.sha512",
+        "PowerArgs.nuspec",
+        "lib/net40/PowerArgs.dll",
+        "lib/net40/PowerArgs.XML"
+      ]
+    },
+    "ReportGenerator/2.1.5.0": {
+      "sha512": "afQRxdYh+HKzprA2MbInvXcfN3djGP3mAGLlGKlHv7O31TlhTEcT3awSnzWwSUkkOEz2/Y/FtkkKmrQ3PumJ7g==",
+      "files": [
+        "ICSharpCode.NRefactory.CSharp.dll",
+        "ICSharpCode.NRefactory.dll",
+        "LICENSE.txt",
+        "log4net.dll",
+        "Readme.txt",
+        "ReportGenerator.2.1.5.0.nupkg",
+        "ReportGenerator.2.1.5.0.nupkg.sha512",
+        "ReportGenerator.exe",
+        "ReportGenerator.nuspec",
+        "ReportGenerator.Reporting.dll",
+        "ReportGenerator.Reporting.XML",
+        "ReportGenerator.XML"
+      ]
+    },
+    "System.Collections/4.0.10-beta-22927": {
+      "sha512": "2revXdMTcGJAJlSRfeczJ+1P8Y6UIUub8oiIt9t4rS8yN0yyCDjc4lscORcZB9SaW/CoO/c7IB7PRAjxULvTAA==",
+      "files": [
+        "System.Collections.4.0.10-beta-22927.nupkg",
+        "System.Collections.4.0.10-beta-22927.nupkg.sha512",
+        "System.Collections.nuspec",
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/net46/System.Collections.dll",
+        "lib/netcore50/System.Collections.dll",
+        "ref/any/System.Collections.dll",
+        "ref/net46/System.Collections.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
+      ]
+    },
+    "System.Collections.Concurrent/4.0.10-beta-22927": {
+      "sha512": "+Wm0UdWs9+i7Kcs+x2/cctuH+y9fW4uO5KmJkbOOfpYiVhbxyP0YQikgtjcYlup0Xp3C+rSCKcwvvGVYT9qstg==",
+      "files": [
+        "System.Collections.Concurrent.4.0.10-beta-22927.nupkg",
+        "System.Collections.Concurrent.4.0.10-beta-22927.nupkg.sha512",
+        "System.Collections.Concurrent.nuspec",
+        "lib/any/System.Collections.Concurrent.dll",
+        "lib/net46/System.Collections.Concurrent.dll",
+        "ref/any/System.Collections.Concurrent.dll",
+        "ref/net46/System.Collections.Concurrent.dll"
+      ]
+    },
+    "System.Console/4.0.0-beta-22927": {
+      "sha512": "KZRrlvSx0nqsWaUlVhA79tt3RsDl2KuCJoy1vti55Az6QT24Uni/NedtZFrMaKtn90fWvT5hmT7cGQwgUJZ/OQ==",
+      "files": [
+        "System.Console.4.0.0-beta-22927.nupkg",
+        "System.Console.4.0.0-beta-22927.nupkg.sha512",
+        "System.Console.nuspec",
+        "lib/DNXCore50/System.Console.dll",
+        "lib/net46/System.Console.dll",
+        "ref/any/System.Console.dll",
+        "ref/net46/System.Console.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Console.dll"
+      ]
+    },
+    "System.Diagnostics.Contracts/4.0.0-beta-22927": {
+      "sha512": "z4Jqz+UtuqLGygscHG365n9frqOiJi7+oSJmJtfgrI2D7XAN+aNsI2WrcaFciIlgDo9rPq3mTye8E5reWA4Ofg==",
+      "files": [
+        "System.Diagnostics.Contracts.4.0.0-beta-22927.nupkg",
+        "System.Diagnostics.Contracts.4.0.0-beta-22927.nupkg.sha512",
+        "System.Diagnostics.Contracts.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Contracts.dll",
+        "lib/net46/System.Diagnostics.Contracts.dll",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/any/System.Diagnostics.Contracts.dll",
+        "ref/net46/System.Diagnostics.Contracts.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10-beta-22927": {
+      "sha512": "uhcpTHJXFOXz1BHrZ2I37p28nW+HkWEYssFDQ3I6Jvt/OrMHOOZ7un1ANIICBnKjH3IM2LAznyvEZDJ9DourSw==",
+      "files": [
+        "System.Diagnostics.Debug.4.0.10-beta-22927.nupkg",
+        "System.Diagnostics.Debug.4.0.10-beta-22927.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/net46/System.Diagnostics.Debug.dll",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/any/System.Diagnostics.Debug.dll",
+        "ref/net46/System.Diagnostics.Debug.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
+      ]
+    },
+    "System.Diagnostics.StackTrace/4.0.0-beta-22927": {
+      "sha512": "Rd9rxG5+d4Dpi8RjQ9/AstaCLGlJpaMMQYM/FloH8ZYliqavmECsrnHggSS6Z5egaq9iamIGi/I7a7w+Jd5q+w==",
+      "files": [
+        "System.Diagnostics.StackTrace.4.0.0-beta-22927.nupkg",
+        "System.Diagnostics.StackTrace.4.0.0-beta-22927.nupkg.sha512",
+        "System.Diagnostics.StackTrace.nuspec",
+        "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "ref/any/System.Diagnostics.StackTrace.dll",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll"
+      ]
+    },
+    "System.Diagnostics.Tools/4.0.0-beta-22927": {
+      "sha512": "M4cVyhcHCxnq29YPcTnz03dekf+iGO/z3HjjHME01si0EFdVGaJ/G46ZVrpCqrPED4i2Kc7+g5T24BLLm2obzA==",
+      "files": [
+        "System.Diagnostics.Tools.4.0.0-beta-22927.nupkg",
+        "System.Diagnostics.Tools.4.0.0-beta-22927.nupkg.sha512",
+        "System.Diagnostics.Tools.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/net46/System.Diagnostics.Tools.dll",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
+        "ref/any/System.Diagnostics.Tools.dll",
+        "ref/net46/System.Diagnostics.Tools.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.20-beta-22927": {
+      "sha512": "ipM2BR5+CHCKOPcPYnVhyrutBhvRZQd7kI8T+DCdhYVKueQc9f+Fs+vOZW2I/sucTfCvWicJSWCwuOD/MnSE4w==",
+      "files": [
+        "System.Diagnostics.Tracing.4.0.20-beta-22927.nupkg",
+        "System.Diagnostics.Tracing.4.0.20-beta-22927.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Tracing.dll",
+        "lib/net46/System.Diagnostics.Tracing.dll",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/any/System.Diagnostics.Tracing.dll",
+        "ref/net46/System.Diagnostics.Tracing.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
+      ]
+    },
+    "System.Globalization/4.0.10-beta-22927": {
+      "sha512": "rbmDPmDERoBkhUzJl7R9U9lWBmw7CjbF4e9u3idmekXXrSEoAMQpjU5YlRsFjG81q1CUBaGHDGnl5XYaVPKpsg==",
+      "files": [
+        "System.Globalization.4.0.10-beta-22927.nupkg",
+        "System.Globalization.4.0.10-beta-22927.nupkg.sha512",
+        "System.Globalization.nuspec",
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/net46/System.Globalization.dll",
+        "lib/netcore50/System.Globalization.dll",
+        "ref/any/System.Globalization.dll",
+        "ref/net46/System.Globalization.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
+      ]
+    },
+    "System.Globalization.Calendars/4.0.0-beta-22927": {
+      "sha512": "4BqjFoGyGLaRYJxZYl654d5FMEpu5dDR7dFACYBqtNytcHy0e7ICG+s90Kmv0geruO81I4vHyKFFhhRIoYb+Gw==",
+      "files": [
+        "System.Globalization.Calendars.4.0.0-beta-22927.nupkg",
+        "System.Globalization.Calendars.4.0.0-beta-22927.nupkg.sha512",
+        "System.Globalization.Calendars.nuspec",
+        "lib/DNXCore50/System.Globalization.Calendars.dll",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
+        "ref/any/System.Globalization.Calendars.dll",
+        "ref/net46/System.Globalization.Calendars.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
+      ]
+    },
+    "System.IO/4.0.10-beta-22927": {
+      "sha512": "JgzGZPdtw13JXMqWHj/8eQZinBMGUYlRTwvayr9MUFuj2nUIHXFEvWnimuct7gmnMFFxRONjPlSl4uKE4BUq4g==",
+      "files": [
+        "System.IO.4.0.10-beta-22927.nupkg",
+        "System.IO.4.0.10-beta-22927.nupkg.sha512",
+        "System.IO.nuspec",
+        "lib/DNXCore50/System.IO.dll",
+        "lib/net46/System.IO.dll",
+        "lib/netcore50/System.IO.dll",
+        "ref/any/System.IO.dll",
+        "ref/net46/System.IO.dll",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
+      ]
+    },
+    "System.IO.FileSystem/4.0.0-beta-22927": {
+      "sha512": "EHBlOg0b1jhXdX8JbPZm8OptfCiVPlL1+i62wiVRjbdyYlTszIl0MEfSLaHDhlIWaVUGOovDo93tGtSuhVj1zA==",
+      "files": [
+        "System.IO.FileSystem.4.0.0-beta-22927.nupkg",
+        "System.IO.FileSystem.4.0.0-beta-22927.nupkg.sha512",
+        "System.IO.FileSystem.nuspec",
+        "lib/DNXCore50/System.IO.FileSystem.dll",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
+        "ref/any/System.IO.FileSystem.dll",
+        "ref/net46/System.IO.FileSystem.dll"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.0-beta-22927": {
+      "sha512": "yoAg/I9mjJpnfikY09QTrpX355YBDzK+74Z3KnnTXUTvAAaquXDVtouEMib+pUi0ppFPD4Cp5exO9dWa89p7Zw==",
+      "files": [
+        "System.IO.FileSystem.Primitives.4.0.0-beta-22927.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.0-beta-22927.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec",
+        "lib/any/System.IO.FileSystem.Primitives.dll",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/any/System.IO.FileSystem.Primitives.dll",
+        "ref/net46/System.IO.FileSystem.Primitives.dll"
+      ]
+    },
+    "System.Linq/4.0.0-beta-22927": {
+      "sha512": "eVlTn053TNQ7pipRD4fpKlQ8XagjnYEVfHY6asnJOnmo3kXDK84xRZIfTESQHUtlplcL5EYGyF/n5uIraIeKgw==",
+      "files": [
+        "System.Linq.4.0.0-beta-22927.nupkg",
+        "System.Linq.4.0.0-beta-22927.nupkg.sha512",
+        "System.Linq.nuspec",
+        "lib/any/System.Linq.dll",
+        "lib/net46/System.Linq.dll",
+        "ref/any/System.Linq.dll",
+        "ref/net46/System.Linq.dll"
+      ]
+    },
+    "System.ObjectModel/4.0.10-beta-22927": {
+      "sha512": "D2oOxAARKU3gC0JdlOnOQfVaM4S/F4zjaq0r0WrXs96piya+i5HHb08RiKiO0bE2Kh0TMb8BYZETL8BLm4onXg==",
+      "files": [
+        "System.ObjectModel.4.0.10-beta-22927.nupkg",
+        "System.ObjectModel.4.0.10-beta-22927.nupkg.sha512",
+        "System.ObjectModel.nuspec",
+        "lib/any/System.ObjectModel.dll",
+        "lib/net46/System.ObjectModel.dll",
+        "ref/any/System.ObjectModel.dll",
+        "ref/net46/System.ObjectModel.dll"
+      ]
+    },
+    "System.Private.Uri/4.0.0-beta-22927": {
+      "sha512": "iugPtkQOqHeCuyvBsQ3Z8vc+4YgL1ySVhe5IiMYIJ5J9kVqMGC9/9tb7SNd80nVSMYIOV/L/SPI1dTDYC+FOvA==",
+      "files": [
+        "System.Private.Uri.4.0.0-beta-22927.nupkg",
+        "System.Private.Uri.4.0.0-beta-22927.nupkg.sha512",
+        "System.Private.Uri.nuspec",
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
+      ]
+    },
+    "System.Reflection/4.0.10-beta-22927": {
+      "sha512": "aodFUDKmBP9Xr1q7y3esjPeNht8KoY1URbvOe2o/Zvv08qW0zNXRv06u5/loWy3tUT4cXs+qIFKDjYNWgyT9XQ==",
+      "files": [
+        "System.Reflection.4.0.10-beta-22927.nupkg",
+        "System.Reflection.4.0.10-beta-22927.nupkg.sha512",
+        "System.Reflection.nuspec",
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/net46/System.Reflection.dll",
+        "lib/netcore50/System.Reflection.dll",
+        "ref/any/System.Reflection.dll",
+        "ref/net46/System.Reflection.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
+      ]
+    },
+    "System.Reflection.Extensions/4.0.0-beta-22927": {
+      "sha512": "J2sYoBGl5kfGaJ94WKamhfHqPf4gDTitZtZS1g+lBBVT4J6/lJLj878X77c1+/MWj9uyO7BKjIJh+SX0uj96kQ==",
+      "files": [
+        "System.Reflection.Extensions.4.0.0-beta-22927.nupkg",
+        "System.Reflection.Extensions.4.0.0-beta-22927.nupkg.sha512",
+        "System.Reflection.Extensions.nuspec",
+        "lib/DNXCore50/System.Reflection.Extensions.dll",
+        "lib/net46/System.Reflection.Extensions.dll",
+        "lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/any/System.Reflection.Extensions.dll",
+        "ref/net46/System.Reflection.Extensions.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0-beta-22927": {
+      "sha512": "C3+Wx4snFHYvOncOW7slXJV1UTSSsREllmhJKXn+Ud5rC1UXut218w5ULD41ltV4TQxyH5nY/pkrhysVUU7etA==",
+      "files": [
+        "System.Reflection.Primitives.4.0.0-beta-22927.nupkg",
+        "System.Reflection.Primitives.4.0.0-beta-22927.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec",
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net46/System.Reflection.Primitives.dll",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/any/System.Reflection.Primitives.dll",
+        "ref/net46/System.Reflection.Primitives.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0-beta-22927": {
+      "sha512": "YQIec/RtRVNVl8IrNhJIrpQOGDkCp11PRy4CHzpE9Fg3Ywo/rrV8w9aZWA//lbzU0QaJ0QZc8V8AFR+PMdHKug==",
+      "files": [
+        "System.Resources.ResourceManager.4.0.0-beta-22927.nupkg",
+        "System.Resources.ResourceManager.4.0.0-beta-22927.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec",
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net46/System.Resources.ResourceManager.dll",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/any/System.Resources.ResourceManager.dll",
+        "ref/net46/System.Resources.ResourceManager.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
+      ]
+    },
+    "System.Runtime/4.0.20-beta-22927": {
+      "sha512": "W8n/HCb4n/qKmWohYKmCQa9PN91T92zBxkT1H+kK8OlM6BvKmlTs9XUA56em0sCF/h3wvJUXzLI0k7aBv2JgDw==",
+      "files": [
+        "System.Runtime.4.0.20-beta-22927.nupkg",
+        "System.Runtime.4.0.20-beta-22927.nupkg.sha512",
+        "System.Runtime.nuspec",
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/net46/System.Runtime.dll",
+        "lib/netcore50/System.Runtime.dll",
+        "ref/any/System.Runtime.dll",
+        "ref/net46/System.Runtime.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10-beta-22927": {
+      "sha512": "8OW2hPfDCo7ASSLjVvgV7hnOKl67K4EFG/JD/Jjv5zi0rZezneJnYGiPRE4KgXNjsxFmJT8NjPrKSDCWZvb2xw==",
+      "files": [
+        "System.Runtime.Extensions.4.0.10-beta-22927.nupkg",
+        "System.Runtime.Extensions.4.0.10-beta-22927.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/net46/System.Runtime.Extensions.dll",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/any/System.Runtime.Extensions.dll",
+        "ref/net46/System.Runtime.Extensions.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0-beta-22927": {
+      "sha512": "fALM0oSPlQjwxgXZG7K0m3IahgNDXIDT6Rk/VSiovrrRjtHTSe3HxKcRwe0oOYdp0URoT/13TH35J/Bg+fHbKw==",
+      "files": [
+        "System.Runtime.Handles.4.0.0-beta-22927.nupkg",
+        "System.Runtime.Handles.4.0.0-beta-22927.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/net46/System.Runtime.Handles.dll",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "ref/any/System.Runtime.Handles.dll",
+        "ref/net46/System.Runtime.Handles.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20-beta-22927": {
+      "sha512": "Xw3SfbkoTPBybCQ/aBTN2L7tU4ixXjAg1eBRycFW47hpYTbPjxM6UxlP354RCX0g4DAgOOZ78586/15NKJkykw==",
+      "files": [
+        "System.Runtime.InteropServices.4.0.20-beta-22927.nupkg",
+        "System.Runtime.InteropServices.4.0.20-beta-22927.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec",
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/net46/System.Runtime.InteropServices.dll",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/any/System.Runtime.InteropServices.dll",
+        "ref/net46/System.Runtime.InteropServices.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
+      ]
+    },
+    "System.Runtime.InteropServices.WindowsRuntime/4.0.0-beta-22927": {
+      "sha512": "a8cNOh3yf3+6pwPM7+6Eb5VuGCZkuW27VIPBu3GzHObN59y4zdwByw5f3uC85VELuhOBNRa/TfAHOog+5U/ynQ==",
+      "files": [
+        "System.Runtime.InteropServices.WindowsRuntime.4.0.0-beta-22927.nupkg",
+        "System.Runtime.InteropServices.WindowsRuntime.4.0.0-beta-22927.nupkg.sha512",
+        "System.Runtime.InteropServices.WindowsRuntime.nuspec",
+        "lib/DNXCore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "lib/net46/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "ref/any/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "ref/net46/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.WindowsRuntime.dll"
+      ]
+    },
+    "System.Text.Encoding/4.0.10-beta-22927": {
+      "sha512": "ZtyyVxaz9Z0zJrA8dwGCpnqdbg/CO5L4OH1dmLIC18ZKJScRXFJhBPbcj+l8uDDCo0grBLbQpbh6OQ5jgmcfqw==",
+      "files": [
+        "System.Text.Encoding.4.0.10-beta-22927.nupkg",
+        "System.Text.Encoding.4.0.10-beta-22927.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/net46/System.Text.Encoding.dll",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "ref/any/System.Text.Encoding.dll",
+        "ref/net46/System.Text.Encoding.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.10-beta-22927": {
+      "sha512": "rE1UW93KdxW2XAuNT+sWzYgK1RHopQI+Xv/WychMg0ITTI3l5m98NeRYllYObEj6bbkOp6i/TYQXxOX/ygsr3Q==",
+      "files": [
+        "System.Text.Encoding.Extensions.4.0.10-beta-22927.nupkg",
+        "System.Text.Encoding.Extensions.4.0.10-beta-22927.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
+        "lib/net46/System.Text.Encoding.Extensions.dll",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/any/System.Text.Encoding.Extensions.dll",
+        "ref/net46/System.Text.Encoding.Extensions.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
+      ]
+    },
+    "System.Text.RegularExpressions/4.0.10-beta-22927": {
+      "sha512": "8Eh4O42HsmeWDSsySLDovn/cILI61dDi/yGptfx1IrfoHLAIsoF1HMcBnJb4DfnQbXkfFOcT+VWA8VHzDEMAmA==",
+      "files": [
+        "System.Text.RegularExpressions.4.0.10-beta-22927.nupkg",
+        "System.Text.RegularExpressions.4.0.10-beta-22927.nupkg.sha512",
+        "System.Text.RegularExpressions.nuspec",
+        "lib/any/System.Text.RegularExpressions.dll"
+      ]
+    },
+    "System.Threading/4.0.10-beta-22927": {
+      "sha512": "WQHiDnaGlg07qiI09vvY/G/jjax4IyTBstRQFBQrcQm2ZHv8CtdoJnN3WshOUHaK8xcJL5x6/K5S9BZzCeOn2g==",
+      "files": [
+        "System.Threading.4.0.10-beta-22927.nupkg",
+        "System.Threading.4.0.10-beta-22927.nupkg.sha512",
+        "System.Threading.nuspec",
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/net46/System.Threading.dll",
+        "lib/netcore50/System.Threading.dll",
+        "ref/any/System.Threading.dll",
+        "ref/net46/System.Threading.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
+      ]
+    },
+    "System.Threading.Overlapped/4.0.0-beta-22927": {
+      "sha512": "Oc4KXDlynLlrdcGkWXFkxx9Cl+WT/EW4Ye1Garefpcqeoxz5QZAj+nSaIF5m9ifBBRZHyGSiUbyrgnyqPDPrdg==",
+      "files": [
+        "System.Threading.Overlapped.4.0.0-beta-22927.nupkg",
+        "System.Threading.Overlapped.4.0.0-beta-22927.nupkg.sha512",
+        "System.Threading.Overlapped.nuspec",
+        "lib/DNXCore50/System.Threading.Overlapped.dll",
+        "lib/net46/System.Threading.Overlapped.dll",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "ref/any/System.Threading.Overlapped.dll",
+        "ref/net46/System.Threading.Overlapped.dll"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10-beta-22927": {
+      "sha512": "SeUpExzifr3zENWz5oMF1M0niHwo8c3xKx3k/p5yBZnvmw7Uxrfgj/Pf5kyD50JB48EdqVJ43IhSml6tOX2ZzA==",
+      "files": [
+        "System.Threading.Tasks.4.0.10-beta-22927.nupkg",
+        "System.Threading.Tasks.4.0.10-beta-22927.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/net46/System.Threading.Tasks.dll",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "ref/any/System.Threading.Tasks.dll",
+        "ref/net46/System.Threading.Tasks.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
+      ]
+    },
+    "System.Threading.ThreadPool/4.0.10-beta-22927": {
+      "sha512": "kq7puy/cjwwktXc5Vyk8bLHyvaLBmWX0bfs2EvYRVoHhA5cYPrG0jpttFd/jOdlQ7EnHo2wxn2HwuqEHBs/Rsw==",
+      "files": [
+        "System.Threading.ThreadPool.4.0.10-beta-22927.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-22927.nupkg.sha512",
+        "System.Threading.ThreadPool.nuspec",
+        "lib/DNXCore50/System.Threading.ThreadPool.dll",
+        "lib/net46/System.Threading.ThreadPool.dll",
+        "ref/any/System.Threading.ThreadPool.dll",
+        "ref/net46/System.Threading.ThreadPool.dll"
+      ]
+    },
+    "System.Threading.Timer/4.0.0-beta-22927": {
+      "sha512": "G+kuKHI78dewlORKn80K2uauwsRlb4C5Bc2sSP6HqHOEhLJjDB1MHazahej6oC+Q5qKUD2iQ+rC5fP0KBNRcnQ==",
+      "files": [
+        "System.Threading.Timer.4.0.0-beta-22927.nupkg",
+        "System.Threading.Timer.4.0.0-beta-22927.nupkg.sha512",
+        "System.Threading.Timer.nuspec",
+        "lib/DNXCore50/System.Threading.Timer.dll",
+        "lib/net46/System.Threading.Timer.dll",
+        "lib/netcore50/System.Threading.Timer.dll",
+        "ref/any/System.Threading.Timer.dll",
+        "ref/net46/System.Threading.Timer.dll",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
+      ]
+    },
+    "System.Xml.ReaderWriter/4.0.10-beta-22927": {
+      "sha512": "paHPGM2oSj2dyFOKe65lGGhJKQ+gv3mXoIJT6vTxY9VLF/xgy+rgnxu6U/GhKeR+pTDX3eukHoqm8w/bQgu0jQ==",
+      "files": [
+        "System.Xml.ReaderWriter.4.0.10-beta-22927.nupkg",
+        "System.Xml.ReaderWriter.4.0.10-beta-22927.nupkg.sha512",
+        "System.Xml.ReaderWriter.nuspec",
+        "lib/any/System.Xml.ReaderWriter.dll",
+        "lib/net46/System.Xml.ReaderWriter.dll",
+        "ref/any/System.Xml.ReaderWriter.dll",
+        "ref/net46/System.Xml.ReaderWriter.dll"
+      ]
+    },
+    "System.Xml.XDocument/4.0.10-beta-22927": {
+      "sha512": "lofZsitiv7f8LlylK1SKFbCMBjf+7kgphHh/JKGWJRCB30nV5ql6EWJOpk9Ksedfq486qfjTWkhoEyvQZTEhJw==",
+      "files": [
+        "System.Xml.XDocument.4.0.10-beta-22927.nupkg",
+        "System.Xml.XDocument.4.0.10-beta-22927.nupkg.sha512",
+        "System.Xml.XDocument.nuspec",
+        "lib/any/System.Xml.XDocument.dll",
+        "lib/net46/System.Xml.XDocument.dll",
+        "ref/any/System.Xml.XDocument.dll",
+        "ref/net46/System.Xml.XDocument.dll"
+      ]
+    },
+    "xunit.console.netcore/1.0.2-prerelease-00036": {
+      "sha512": "NVuZktvD1o4GZNPcQRqQGBz4R4vT9kWLYwNs1Il4FELmAUahxG9rz/VNlAQ45huf4wT5zjez4eg5XtbuOcBj6Q==",
+      "files": [
+        "xunit.console.netcore.1.0.2-prerelease-00036.nupkg",
+        "xunit.console.netcore.1.0.2-prerelease-00036.nupkg.sha512",
+        "xunit.console.netcore.nuspec",
+        "lib/aspnetcore50/xunit.console.netcore.exe"
+      ]
+    },
+    "xunit.runner.dependencies.netcore/1.0.1-prerelease": {
+      "sha512": "iXWBtOaQXWyG0xwMR/tsHC2Aa9fDjEKo1pNgzhH+gAvNENFrUqar+ZNW9Ysyrvyu2o7sLtFwDlnsHfrr1Aqj0g==",
+      "files": [
+        "xunit.runner.dependencies.netcore.1.0.1-prerelease.nupkg",
+        "xunit.runner.dependencies.netcore.1.0.1-prerelease.nupkg.sha512",
+        "xunit.runner.dependencies.netcore.nuspec",
+        "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.abstractions.dll",
+        "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.execution.dll",
+        "lib/portable-wpa80+win8+net45+aspnetcore50/xunit.runner.utility.dll"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "coveralls.io >= 1.4",
+      "Microsoft.NETCore.Windows.ApiSets-x86 >= 1.0.0-beta-*",
+      "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-*",
+      "Microsoft.NETCore.Runtime.CoreCLR-x86 >= 1.0.0-beta-*",
+      "Microsoft.DotNet.PerfTools >= 0.0.1-prerelease-00022",
+      "OpenCover >= 4.5.4107-rc122",
+      "ReportGenerator >= 2.1.5.0",
+      "System.Collections >= 4.0.10-beta-*",
+      "System.Collections.Concurrent >= 4.0.10-beta-*",
+      "System.Console >= 4.0.0-beta-*",
+      "System.Diagnostics.Contracts >= 4.0.0-beta-*",
+      "System.Diagnostics.Debug >= 4.0.10-beta-*",
+      "System.Diagnostics.Tools >= 4.0.0-beta-*",
+      "System.Diagnostics.Tracing >= 4.0.20-beta-*",
+      "System.Globalization >= 4.0.10-beta-*",
+      "System.IO >= 4.0.10-beta-*",
+      "System.IO.FileSystem >= 4.0.0-beta-*",
+      "System.IO.FileSystem.Primitives >= 4.0.0-beta-*",
+      "System.Linq >= 4.0.0-beta-*",
+      "System.Reflection >= 4.0.10-beta-*",
+      "System.Reflection.Extensions >= 4.0.0-beta-*",
+      "System.Resources.ResourceManager >= 4.0.0-beta-*",
+      "System.Runtime >= 4.0.20-beta-*",
+      "System.Runtime.Extensions >= 4.0.10-beta-*",
+      "System.Runtime.Handles >= 4.0.0-beta-*",
+      "System.Runtime.InteropServices >= 4.0.20-beta-*",
+      "System.Text.Encoding >= 4.0.10-beta-*",
+      "System.Text.Encoding.Extensions >= 4.0.10-beta-*",
+      "System.Text.RegularExpressions >= 4.0.10-beta-*",
+      "System.Threading >= 4.0.10-beta-*",
+      "System.Threading.Tasks >= 4.0.10-beta-*",
+      "System.Threading.ThreadPool >= 4.0.10-beta-*",
+      "System.Xml.ReaderWriter >= 4.0.10-beta-*",
+      "System.Xml.XDocument >= 4.0.10-beta-*",
+      "xunit.console.netcore >= 1.0.2-prerelease-00036",
+      "xunit.runner.dependencies.netcore >= 1.0.1-prerelease"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/readme.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/readme.txt
@@ -1,0 +1,3 @@
+To regenerate project.lock.json after updating project.json please run dnu.cmd restore project.json --lock.
+
+DNU can be obtained at http://github.com/aspnet/home.

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -27,7 +27,8 @@
     <file src="Microsoft.DotNet.Build.Tasks\MSFT.snk" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\PriConfig.xml" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\*.targets" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks\test-runtime-project.json" target="lib\test-runtime\project.json" />
+    <file src="Microsoft.DotNet.Build.Tasks\test-runtime\project.json" target="lib\test-runtime\project.json" />
+    <file src="Microsoft.DotNet.Build.Tasks\test-runtime\project.lock.json" target="lib\test-runtime\project.lock.json" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\NuGet.*.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Newtonsoft.Json.dll" target="lib" />


### PR DESCRIPTION
I previously moved test-runtime project.json to using * dependencies.  Doing so without checking in a locked lock file causes the dependencies to float to the highest version.  This change adds a lock file with the same versions as are currently used by corefx.  I also added conditions on TestRuntimeProjectJson and TestRuntimeProjectLockJson to permit overriding them.