### PR TITLE
Update to ReportGenerator v2.1.6

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
@@ -6,7 +6,7 @@
   -->
   <PropertyGroup>
     <OpenCoverVersion>4.5.4107-rc122</OpenCoverVersion>
-    <ReportGeneratorVersion>2.1.5.0</ReportGeneratorVersion>
+    <ReportGeneratorVersion>2.1.6.0</ReportGeneratorVersion>
     <CoverallsUploaderVersion>1.4</CoverallsUploaderVersion>
   </PropertyGroup>
   

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
@@ -6,7 +6,7 @@
        "Microsoft.NETCore.Runtime.CoreCLR-x86": "1.0.0-beta-*",
        "Microsoft.DotNet.PerfTools": "0.0.1-prerelease-00022",
        "OpenCover": "4.5.4107-rc122",
-       "ReportGenerator": "2.1.5.0",
+       "ReportGenerator": "2.1.6.0",
        "System.Collections": "4.0.10-beta-*",
        "System.Collections.Concurrent": "4.0.10-beta-*",
        "System.Console": "4.0.0-beta-*",


### PR DESCRIPTION
Fixes a bug in the report generation that's causing some of our Interop types to be left out of the reports.