### PR TITLE
Exclude injected SR.cs/vb file from code coverage

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
@@ -36,7 +36,7 @@
   <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true'">
     <CoverageHost>$(PackagesDir)OpenCover\$(OpenCoverVersion)\OpenCover.Console.exe</CoverageHost>
     <CoverageOutputFilePath>$(CoverageReportDir)$(MSBuildProjectName).coverage.xml</CoverageOutputFilePath>
-    <CoverageOptions>-filter:"+[*]* -[*.Tests]*" -nodefaultfilters -excludebyattribute:*.ExcludeFromCodeCoverage* -skipautoprops -hideskipped:All -threshold:1</CoverageOptions>
+    <CoverageOptions>-filter:"+[*]* -[*.Tests]*" -excludebyfile:"*\Common\src\System\SR.*" -nodefaultfilters -excludebyattribute:*.ExcludeFromCodeCoverage* -skipautoprops -hideskipped:All -threshold:1</CoverageOptions>
     <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user -target:$(XunitHost) -output:$(CoverageOutputFilePath)</CoverageCommandLine>
     <TestHost>$(CoverageHost)</TestHost>
     <XunitOptions>$(XunitOptions) -parallel none</XunitOptions>


### PR DESCRIPTION
This avoids any additional custom attributes in corefx and avoids churning the SR.cs/vb files.  We'll just need to remember to update build tools if we ever move those files to a different location or otherwise rename them, or if we put additional code into those files that for some reason shouldn't be excluded.