### PR TITLE
Fix VS debugging iteration experience

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -35,6 +35,7 @@
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
+    <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="ResolveNuGetPackageAssets.cs" />
     <Compile Include="ResolveNuGetPackages.cs" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/RemoveDuplicatesWithLastOneWinsPolicy.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/RemoveDuplicatesWithLastOneWinsPolicy.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Given a list of items, remove duplicate items. Metadata is not considered. Case insensitive.
+    /// Unlike <see cref="RemoveDuplicates"/>, the last item in the list wins rather than the first.
+    /// That distinction is important when the items have different metadata.
+    /// </summary>
+    public class RemoveDuplicatesWithLastOneWinsPolicy : Task
+    {
+        /// <summary>
+        /// The list of items from which to remove duplicates.
+        /// </summary>
+        public ITaskItem[] Inputs
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The list of items with duplicates removed.
+        /// </summary>
+        [Output]
+        public ITaskItem[] Filtered
+        {
+            get;
+            set;
+        }
+
+        public override bool Execute()
+        {
+            var existingIndexMap = new Dictionary<string, int>(Inputs.Length, StringComparer.OrdinalIgnoreCase);
+            var filteredList = new List<ITaskItem>(Inputs.Length);
+
+            foreach (ITaskItem item in Inputs)
+            {
+                int existingIndex;
+                if (existingIndexMap.TryGetValue(item.ItemSpec, out existingIndex))
+                {
+                    filteredList[existingIndex] = item;
+                }
+                else
+                {
+                    filteredList.Add(item);
+                    existingIndexMap.Add(item.ItemSpec, filteredList.Count - 1);
+                }
+            }
+
+            Filtered = filteredList.ToArray();
+            return true;
+        }
+    }
+}
+
+

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="RemoveDuplicatesWithLastOneWinsPolicy" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
   <PropertyGroup>
     <TestRuntimeProjectJson Condition="'$(TestRuntimeProjectJson)' == ''">$(MSBuildThisFileDirectory)test-runtime\project.json</TestRuntimeProjectJson>
@@ -16,12 +17,12 @@
   </Target>
 
   <PropertyGroup>
-    <CopyTestToTestDirectory Condition="'$(CopyTestToTestDirectory)'==''">$(IsTestProject)</CopyTestToTestDirectory>
+    <PrepareForRunDependsOn Condition="'$(IsTestProject)'=='true'">$(PrepareForRunDependsOn);CopyTestToTestDirectory</PrepareForRunDependsOn>
     <TestArchitecture Condition="'$(TestArchitecture)' == ''">x86</TestArchitecture>
   </PropertyGroup>
 
-  <Target Name="CopyTestToTestDirectory"
-          Condition="'$(CopyTestToTestDirectory)'=='true'">
+  <Target Name="CopyTestToTestDirectory" 
+          DependsOnTargets="DiscoverTestInputs">
     <ItemGroup>
       <TestNugetProjectLockFile Include="$(ProjectLockJson)" Condition="Exists($(ProjectLockJson))"/>
       <TestNugetProjectLockFile Include="$(TestRuntimeProjectLockJson)" Condition="Exists($(TestRuntimeProjectLockJson))"/>
@@ -39,62 +40,49 @@
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </ResolveNuGetPackageAssets>
 
-    <!-- We may have an indirect package reference that we want to replace with a project reference -->
-    <ItemGroup>
-      <!-- Convert to filenames so that we can intersect -->
-      <_ProjectReferenceFilenames Include="@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')">
-        <OriginalIdentity>%(Identity)</OriginalIdentity>
-      </_ProjectReferenceFilenames>
-
-      <_TestCopyLocalFileNames Include="@(Reference->'%(FileName)%(Extension)')">
-        <OriginalIdentity>%(Identity)</OriginalIdentity>
-      </_TestCopyLocalFileNames>
-
-      <!-- Intersect project-refs with package-refs -->
-      <_TestCopyLocalFileNamesToRemove Include="@(_TestCopyLocalFileNames->'%(OriginalIdentity)')" Condition="'@(_ProjectReferenceFilenames)' == '@(_TestCopyLocalFileNames)' and '%(Identity)' != ''"/>
-
-      <TestCopyLocal Remove="@(_TestCopyLocalFileNamesToRemove)" />
-    </ItemGroup>
-
-    <Message Text="Excluding @(_TestCopyLocalFileNamesToRemove) from package references since the same file is provided by a project refrence."
-             Condition="'@(_TestCopyLocalFileNamesToRemove)' != ''"/>
-
+     <!-- We may have an indirect package reference that we want to replace with a project reference.
+          Those are part of RunTestsForProjectInputs. The order that we append to TestCopyLocal is
+          significant, later entries override earlier entries. -->
     <ItemGroup>
       <TestCopyLocal Include="@(RunTestsForProjectInputs)" Exclude="@(PackagesConfigs)" />
     </ItemGroup>
     
-    <!-- Test using locally built libraries -->
+    <!-- Test using locally built libraries if requested. Again, later entries override earlier
+         entries. -->
     <ItemGroup Condition="'$(TestWithLocalLibraries)'=='true'">
       <!-- Replace some of the resolved libraries that came from nuget by exploring the list of files that we are going to copy
            and replacing them with local copies that were just built -->
       <_ReplacementCandidates Include="@(TestCopyLocal -> '$(BaseOutputPath)$(OSPlatformConfig)\%(filename)\%(filename).dll')" />
       <_ReplacementCandidates Include="@(TestCopyLocal -> '$(BaseOutputPath)$(OSPlatformConfig)\%(filename)\%(filename).pdb')" />
-      <_ExistingReplacementCandidate Include="@(_ReplacementCandidates)" Condition="Exists('%(_ReplacementCandidates.FullPath)')" />
-      
-      <!-- Convert to filenames so that we can intersect -->
-      <_ReplacementFilenames Include="@(_ExistingReplacementCandidate->'%(FileName)%(Extension)')">
-        <OriginalIdentity>%(Identity)</OriginalIdentity>
-      </_ReplacementFilenames>
-      
-      <_TestCopyLocalFileNamesToRemove Include="@(_ReplacementFilenames->'%(OriginalIdentity)')" Condition="'@(_ReplacementFilenames)' == '@(_TestCopyLocalFileNames)' and '%(Identity)' != ''"/>
-      
-      <TestCopyLocal Remove="@(_TestCopyLocalFileNamesToRemove)" />
-      
+      <_ExistingReplacementCandidate Include="@(_ReplacementCandidates)" Condition="Exists('%(_ReplacementCandidates.FullPath)')" />      
       <TestCopyLocal Include="@(_ExistingReplacementCandidate)" />
     </ItemGroup>
 
+    <!-- Remove duplicates. Note that we musn't just copy in sequence and let 
+         the last one win that way because it will cause copies to occur on 
+         every incremental build. -->
+    <ItemGroup>
+      <_TestCopyLocalByFileName Include="@(TestCopyLocal->'%(FileName)%(Extension)')">
+        <SourcePath>%(Identity)</SourcePath>
+      </_TestCopyLocalByFileName>
+    </ItemGroup>      
+    <RemoveDuplicatesWithLastOneWinsPolicy Inputs="@(_TestCopyLocalByFileName)">
+      <Output TaskParameter="Filtered" ItemName="_TestCopyLocalByFileNameWithoutDuplicates" />
+    </RemoveDuplicatesWithLastOneWinsPolicy>
+
+    <!-- NOTE: UseHardLinksIfPossible is hard-coded to true because we copy tons of the 
+         same files for every single test project here. -->
     <Copy
-      SourceFiles="@(TestCopyLocal)"
+      SourceFiles="@(_TestCopyLocalByFileNameWithoutDuplicates->'%(SourcePath)')"
       DestinationFolder="$(TestPath)%(TestTargetFramework.Folder)"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"
       RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+      UseHardlinksIfPossible="true">
       
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
-      
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -81,8 +81,6 @@
           Outputs="$(TestPath)%(TestTargetFramework.Folder)\$(TestsSuccessfulSemaphore);$(TestPath)%(TestTargetFramework.Folder)\$(XunitResultsFileName);$(CoverageOutputFilePath)"
           Condition="'$(TestDisabled)'!='true'">
 
-    <CallTarget Targets="CopyTestToTestDirectory"/>
-
     <PropertyGroup>
       <XunitTraitOptions Condition="'@(RunWithTraits)'!=''">$(XunitTraitOptions) -trait category=@(RunWithTraits, ' -trait category=') </XunitTraitOptions>
       <XunitTraitOptions Condition="'@(RunWithoutTraits)'!=''">$(XunitTraitOptions) -notrait category=@(RunWithoutTraits, ' -notrait category=') </XunitTraitOptions>


### PR DESCRIPTION
Move test deployment to build phase and speed it up

The experience around building and running tests in VS got broken by a
change to only copy tests when they're run from msbuild. Move them back
to PrepareForRun to bring back the VS workflow.

In doing so, it became apparent that the test deployment step was
copying files on every invocation regardless of whether there were any
changes. That turned out to be because there are different versions of
files with the same simple name destind for the same output folder. As
such, every iteration would swap them back and forth. The fix here is
too trim out the duplicates before invoking the Copy task. Some of the
duplication is by design (e.g. to override nuget assets with local
assets), but we are also getting multiple nuget package versions out
of the nuget asset resolution, which seems like a bug, which is now filed
as #182.

To further speed things up, using hard-links is now always on for the
test deployment step, which currently copies tons of the same files
to each test folder.

Fix #181