### PR TITLE
Avoid conflict with built-in nuget targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -36,7 +36,7 @@
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
-    <Compile Include="ResolveNuGetPackageAssets.cs" />
+    <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
     <Compile Include="ResolveNuGetPackages.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
@@ -15,16 +15,16 @@ namespace Microsoft.NuGet.Build.Tasks
     /// <summary>
     /// Resolves the assets out of packages in the project.json.
     /// </summary>
-    public sealed class ResolveNuGetPackageAssets : Task
+    public sealed class PrereleaseResolveNuGetPackageAssets : Task
     {
         private readonly List<ITaskItem> _analyzers = new List<ITaskItem>();
         private readonly List<ITaskItem> _copyLocalItems = new List<ITaskItem>();
         private readonly List<ITaskItem> _references = new List<ITaskItem>();
 
         /// <summary>
-        /// Creates a new <see cref="ResolveNuGetPackageAssets"/>.
+        /// Creates a new <see cref="PrereleaseResolveNuGetPackageAssets"/>.
         /// </summary>
-        public ResolveNuGetPackageAssets()
+        public PrereleaseResolveNuGetPackageAssets()
         { }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -3,7 +3,7 @@
 
   <UsingTask TaskName="ReadNuGetPackageReferences" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ResolveNuGetPackages" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ProjectPackagesConfigFile Condition="'$(ProjectPackagesConfigFile)'=='' and Exists('$(MSBuildProjectDirectory)/packages.config')">$(MSBuildProjectDirectory)/packages.config</ProjectPackagesConfigFile>
@@ -11,8 +11,16 @@
     <ProjectLockJson Condition="Exists('$(ProjectJson)') and '$(ProjectLockJson)'==''">$(MSBuildProjectDirectory)/project.lock.json</ProjectLockJson>
     <ResolveNugetProjectFile Condition="'$(ResolveNugetProjectFile)' == ''">$(MSBuildProjectFullPath)</ResolveNugetProjectFile>
 
-    <RestorePackages Condition="'$(RestorePackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</RestorePackages>
-    <ResolveNuGetPackages Condition="'$(ResolveNuGetPackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</ResolveNuGetPackages>
+    <RestorePackages Condition="'$(RestorePackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)')) and '$(DesignTimeBuild)' != 'true'">true</RestorePackages>
+    <PrereleaseResolveNuGetPackages Condition="'$(PrereleaseResolveNuGetPackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</PrereleaseResolveNuGetPackages>
+
+    <!-- 
+        For now, prevent built-in task (if available) from running.
+        More changes are needed to light up on their availability
+        and use them instead of what we have here. See buildtools
+        issue #192.
+     -->
+    <ResolveNugetPackages>false</ResolveNugetPackages>
   </PropertyGroup>
 
   <Target Name="RestorePackages" 
@@ -26,7 +34,7 @@
     <Exec Condition="Exists('$(ProjectJson)')" Command="$(DnuRestoreCommand) &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
   </Target>
 
-  <ItemGroup Condition="'$(ResolvePackages)'=='true' or '$(ResolveNuGetPackages)'=='true'">
+  <ItemGroup Condition="'$(ResolvePackages)'=='true' or '$(PrereleaseResolveNuGetPackages)'=='true'">
     <CustomAdditionalCompileInputs Condition="Exists('$(ProjectPackagesConfigFile)')" Include="$(ProjectPackagesConfigFile)" />
     <CustomAdditionalCompileInputs Condition="Exists('$(ProjectJson)')" Include="$(ProjectJson)" />
   </ItemGroup>
@@ -40,7 +48,7 @@
   </PropertyGroup>
 
   <Target Name="ResolveNuGetPackages"
-          Condition="'$(ResolveNuGetPackages)'=='true'">
+          Condition="'$(PrereleaseResolveNuGetPackages)'=='true'">
 
     <!-- Use old task for packages.config -->
     <ResolveNuGetPackages Condition="'$(ProjectPackagesConfigFile)' != ''"
@@ -62,7 +70,7 @@
       <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == '.NETPortable,Version=v4.5,Profile=Profile7'">DNXCore,Version=v5.0</NugetTargetFrameworkMoniker>
     </PropertyGroup>
 
-    <ResolveNuGetPackageAssets Condition="Exists($(ProjectLockJson))"
+    <PrereleaseResolveNuGetPackageAssets Condition="Exists($(ProjectLockJson))"
                                Architecture="$(PlatformTarget)"
                                Configuration="$(Configuration)"
                                Language="$(Language)"
@@ -73,7 +81,7 @@
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="None" />
-    </ResolveNuGetPackageAssets>
+    </PrereleaseResolveNuGetPackageAssets>
 
     <!-- We may have an indirect package reference that we want to replace with a project reference -->
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <GenFacadesNuGetName>Microsoft.DotNet.BuildTools.ApiTools.1.0.0-prerelease</GenFacadesNuGetName>
@@ -55,7 +55,7 @@
 
   <!-- FindPartialFacadeContractReference
          Generates a special project.json file to restore the NuGet package containing the partial facade's contract assembly.
-         Filters the list of references returned by the ResolveNuGetPackageAssets task to just the contract assembly and stores it.
+         Filters the list of references returned by the PrereleaseResolveNuGetPackageAssets task to just the contract assembly and stores it.
          The identity of the NuGet package is constructed from the assembly's name and version number.
   -->
   <Target Name="FindPartialFacadeContractReference">
@@ -79,7 +79,7 @@
     <Exec Command="$(DnuRestoreCommand) &quot;$(CustomPartialFacadeJsonFile)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
     
     <!-- Resolve the references using this task, store them in @(PossibleContractRefs) -->
-    <ResolveNuGetPackageAssets Architecture="$(PlatformTarget)"
+    <PrereleaseResolveNuGetPackageAssets Architecture="$(PlatformTarget)"
                                Configuration="$(Configuration)"
                                Language="$(Language)"
                                PackageRoot="$(PackagesDir)"
@@ -87,7 +87,7 @@
                                TargetFrameworkMonikers="$(NugetTargetFrameworkMoniker)"
                                TargetPlatformMonikers="$(TargetPlatformMoniker)">
       <Output TaskParameter="ResolvedReferences" ItemName="PossibleContractRefs" />
-    </ResolveNuGetPackageAssets>
+    </PrereleaseResolveNuGetPackageAssets>
 
     <ItemGroup>
       <!-- Match the contract by assembly name -->

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/publishtest.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="ResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="RemoveDuplicatesWithLastOneWinsPolicy" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
   <PropertyGroup>
@@ -26,7 +26,7 @@
       <TestNugetProjectLockFile Include="$(TestRuntimeProjectLockJson)" Condition="Exists($(TestRuntimeProjectLockJson))"/>
     </ItemGroup>
 
-    <ResolveNuGetPackageAssets Condition="'@(TestNugetProjectLockFile)' != ''"
+    <PrereleaseResolveNuGetPackageAssets Condition="'@(TestNugetProjectLockFile)' != ''"
                                Architecture="$(TestArchitecture)"
                                Configuration="$(NuGetConfiguration)"
                                Language="$(Language)"
@@ -36,7 +36,7 @@
                                TargetPlatformMonikers="$(TargetPlatformMoniker)">
 
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
-    </ResolveNuGetPackageAssets>
+    </PrereleaseResolveNuGetPackageAssets>
 
      <!-- We may have an indirect package reference that we want to replace with a project reference.
           Those are part of RunTestsForProjectInputs. The order that we append to TestCopyLocal is


### PR DESCRIPTION
This is a quick change to avoid naming collision and always disable
the built-in nuget resolution targets in favor of what we've used
in buildtools to bootstrap building against the .NET Core packages.

#192 tracks getting things fixed so that we actually consume the
built-in targets when they're available.

cc @ericstj @ljw1004 