### PR TITLE
Skip restoring packages in VS2015 background build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"  InitialTargets="CheckDesignTime">
 
   <PropertyGroup>
     <!-- A number of the imports below depend on these default properties -->
@@ -105,6 +105,19 @@
         DnuRestoreCommand - Used to restore the project packages from project.json
         PackagesDir - Packages are restored to and resolved from this location    
    -->
-  <Import Project="$(MSBuildThisFileDirectory)tests.targets" Condition="'$(IsTestProject)'=='true' and '$(ExcldueTestsImport)'!='true'"/> 
+  <Import Project="$(MSBuildThisFileDirectory)tests.targets" Condition="'$(IsTestProject)'=='true' and '$(ExcldueTestsImport)'!='true'"/>
 
+  <Target Name="CheckDesignTime">
+    <!--
+      Visual Studio does a number of background builds to do a variety of tasks such as resolving references and preparing for intellisense.
+      These are called "design time" builds. You can only determine this state within a target as the properties VS sets are added at build time.
+
+      To see design time logs set TRACEDESIGNTIME=true before launching Visual Studio. Logs will go to %TEMP%.
+
+      Note that the existing $(DesignTimeBuild) is not set for all background builds.
+    -->
+    <PropertyGroup>
+      <VSDesignTimeBuild Condition="'$(BuildingInsideVisualStudio)'=='true' and '$(BuildingOutOfProcess)'=='false'">true</VSDesignTimeBuild>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -10,7 +10,6 @@
     <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>
     <ProjectLockJson Condition="Exists('$(ProjectJson)') and '$(ProjectLockJson)'==''">$(MSBuildProjectDirectory)/project.lock.json</ProjectLockJson>
     <ResolveNugetProjectFile Condition="'$(ResolveNugetProjectFile)' == ''">$(MSBuildProjectFullPath)</ResolveNugetProjectFile>
-
     <RestorePackages Condition="'$(RestorePackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)')) and '$(DesignTimeBuild)' != 'true'">true</RestorePackages>
     <PrereleaseResolveNuGetPackages Condition="'$(PrereleaseResolveNuGetPackages)'!='false' and (Exists('$(ProjectPackagesConfigFile)') or Exists('$(ProjectJson)'))">true</PrereleaseResolveNuGetPackages>
 
@@ -23,9 +22,10 @@
     <ResolveNugetPackages>false</ResolveNugetPackages>
   </PropertyGroup>
 
-  <Target Name="RestorePackages" 
+  <!-- Restoring packages during a background (designtime) build will cause VS 2015 (v14) to get into an endless loop of resolving references. -->
+  <Target Name="RestorePackages"
           BeforeTargets="ResolveNuGetPackages"
-          Condition="'$(RestorePackages)'=='true'">
+          Condition="'$(RestorePackages)'=='true' and !('$(VSDesignTimeBuild)'=='true' and '$(VisualStudioVersion)' >= '14.0')">
 
     <Error Condition="'$(NugetRestoreCommand)'=='' and Exists('$(ProjectPackagesConfigFile)')" Text="RestorePackages target needs a predefined NugetRestoreCommand property set in order to restore $(ProjectPackagesConfigFile)" /> 
     <Error Condition="'$(DnuRestoreCommand)'=='' and Exists('$(ProjectJson)')" Text="RestorePackages target needs a predefined DnuRestoreCommand property set in order to restore $(ProjectJson)" /> 
@@ -105,9 +105,8 @@
       <Reference Remove="@(_ReferenceFileNamesToRemove)" />
       <None Remove="@(_NoneFileNamesToRemove)"/>
     </ItemGroup>
-    
+
     <Message Text="Excluding @(_ReferenceFileNamesToRemove);@(_NoneFileNamesToRemove) from package references since the same file is provided by a project refrence."
              Condition="'@(_ReferenceFileNamesToRemove)' != '' or '@(_NoneFileNamesToRemove)' != ''"/>
   </Target>
-
 </Project>


### PR DESCRIPTION
This avoids a deadlock with VS endlessly resolving references. Fixes #191. @weshaggard, @nguerrera 