### PR TITLE
Changes to use xUnit.net 2.1.0-beta2-build2981 with xunit.console.netcore...

### DIFF
--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -155,7 +155,7 @@ namespace Xunit.ConsoleClient
             var consoleLock = new object();
 
             if (!parallelizeAssemblies.HasValue)
-                parallelizeAssemblies = project.All(assembly => assembly.Configuration.ParallelizeAssembly);
+                parallelizeAssemblies = project.All(assembly => assembly.Configuration.ParallelizeAssembly ?? false); 
 
             if (needsXml)
                 assembliesElement = new XElement("assemblies");
@@ -273,7 +273,7 @@ namespace Xunit.ConsoleClient
 
                 lock (consoleLock)
                 {
-                    if (assembly.Configuration.DiagnosticMessages)
+                    if (assembly.Configuration.DiagnosticMessages ?? false)
                         Console.WriteLine("Discovering: {0} (method display = {1}, parallel test collections = {2}, max threads = {3})",
                                           Path.GetFileNameWithoutExtension(assembly.AssemblyFilename),
                                           discoveryOptions.GetMethodDisplay(),

--- a/src/xunit.console.netcore/packages.config
+++ b/src/xunit.console.netcore/packages.config
@@ -22,5 +22,7 @@
   <package id="System.Threading.ThreadPool" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Xml.ReaderWriter" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
   <package id="System.Xml.XDocument" version="4.0.10-beta-22703" targetFramework="portable-net45+win" />
-  <package id="xunit.runner.dependencies.netcore" version="1.0.1-prerelease" targetFramework="portable-net45+win" />
+  <package id="xunit.abstractions" version="2.0.0.0" targetFramework="portable-net45+win" />
+  <package id="xunit.extensibility.execution" version="2.1.0-beta2-build2981" targetFramework="dnxcore50" />
+  <package id="xunit.runner.utility" version="2.1.0-beta2-build2981" targetFramework="dnxcore50" />
 </packages>

--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -15,6 +15,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
+    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -110,15 +111,15 @@
     </Reference>
     <Reference Include="xunit.abstractions">
       <Private>True</Private>
-      <HintPath>..\..\packages\xunit.runner.dependencies.netcore.1.0.1-prerelease\lib\portable-wpa80+win8+net45+aspnetcore50\xunit.abstractions.dll</HintPath>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution">
+    <Reference Include="xunit.execution.dnx">
       <Private>True</Private>
-      <HintPath>..\..\packages\xunit.runner.dependencies.netcore.1.0.1-prerelease\lib\portable-wpa80+win8+net45+aspnetcore50\xunit.execution.dll</HintPath>
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0-beta2-build2981\lib\dnxcore50\xunit.execution.dnx.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.runner.utility">
+    <Reference Include="xunit.runner.utility.dnx">
       <Private>True</Private>
-      <HintPath>..\..\packages\xunit.runner.dependencies.netcore.1.0.1-prerelease\lib\portable-wpa80+win8+net45+aspnetcore50\xunit.runner.utility.dll</HintPath>
+      <HintPath>..\..\packages\xunit.runner.utility.2.1.0-beta2-build2981\lib\dnxcore50\xunit.runner.utility.dnx.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
An updated xunit.console.netcore is needed for testing Roslyn portable-pdb and compilers.  Can we move xunit.console.netcore forward to this public version of xUnit?