### PR TITLE
Fix code coverage build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
@@ -5,7 +5,7 @@
     Code coverage package versions go here and in the test-runtime-packages.config
   -->
   <PropertyGroup>
-    <OpenCoverVersion>4.5.4107-rc122</OpenCoverVersion>
+    <OpenCoverVersion>4.6.166</OpenCoverVersion>
     <ReportGeneratorVersion>2.1.6.0</ReportGeneratorVersion>
     <CoverallsUploaderVersion>1.4</CoverallsUploaderVersion>
   </PropertyGroup>
@@ -34,13 +34,13 @@
 
   <!-- xUnit command line with coverage enabled -->
   <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true'">
-    <CoverageHost>$(PackagesDir)OpenCover\$(OpenCoverVersion)\OpenCover.Console.exe</CoverageHost>
+    <CoverageHost>$(PackagesDir)OpenCover\$(OpenCoverVersion)\tools\OpenCover.Console.exe</CoverageHost>
     <CoverageOutputFilePath>$(CoverageReportDir)$(MSBuildProjectName).coverage.xml</CoverageOutputFilePath>
     <CoverageOptions>-filter:"+[*]* -[*.Tests]*" -excludebyfile:"*\Common\src\System\SR.*" -nodefaultfilters -excludebyattribute:*.ExcludeFromCodeCoverage* -skipautoprops -hideskipped:All -threshold:1</CoverageOptions>
-    <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user -target:$(XunitHost) -output:$(CoverageOutputFilePath)</CoverageCommandLine>
+    <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user -target:$(TestProgram) -output:$(CoverageOutputFilePath)</CoverageCommandLine>
     <TestHost>$(CoverageHost)</TestHost>
     <XunitOptions>$(XunitOptions) -parallel none</XunitOptions>
-    <TestCommandLine>$(CoverageCommandLine) -targetargs:"$(XunitCommandLine) $(XunitOptions)"</TestCommandLine>
+    <TestCommandLine>$(TestHost) $(CoverageCommandLine) -targetargs:"$(TestArguments)"</TestCommandLine>
   </PropertyGroup>
 
   <!-- Report Generator Properties -->

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
@@ -5,7 +5,7 @@
        "Microsoft.NETCore.TestHost-x86": "1.0.0-beta-*",
        "Microsoft.NETCore.Runtime.CoreCLR-x86": "1.0.0-beta-*",
        "Microsoft.DotNet.PerfTools": "0.0.1-prerelease-00022",
-       "OpenCover": "4.5.4107-rc122",
+       "OpenCover": "4.6.166",
        "ReportGenerator": "2.1.6.0",
        "System.Collections": "4.0.10-beta-*",
        "System.Collections.Concurrent": "4.0.10-beta-*",

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -58,12 +58,12 @@
     <XunitArguments>$(TargetFileName) $(XunitOptions)</XunitArguments>
 
     <TestProgram Condition="'$(TestHost)'!=''">$(TestHost)</TestProgram>
-    <TestArguments Condition="'$(TestHost)'!=''">$(XunitExecutable) $(XunitArguments)</TestArguments>
+    <TestArguments Condition="'$(TestHost)'!=''">$(XunitExecutable) $(XunitArguments) {XunitTraitOptions}</TestArguments>
 
     <TestProgram Condition="'$(TestHost)'==''">$(XunitExecutable)</TestProgram>
-    <TestArguments Condition="'$(TestHost)'==''">$(XunitArguments)</TestArguments>
+    <TestArguments Condition="'$(TestHost)'==''">$(XunitArguments) {XunitTraitOptions}</TestArguments>
 
-    <TestCommandLine>$(TestProgram) $(TestArguments) $(XunitTraitOptions)</TestCommandLine>
+    <TestCommandLine>$(TestProgram) $(TestArguments)</TestCommandLine>
   </PropertyGroup>
 
   <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
@@ -109,9 +109,11 @@
       <XunitTraitOptions Condition="'@(RunWithoutTraits)'!=''">$(XunitTraitOptions) -notrait category=@(RunWithoutTraits, ' -notrait category=') </XunitTraitOptions>
     </PropertyGroup>
 
-    <!-- Append the xunit trait options to the end of the TestCommandLine -->
+    <!-- Replace the {XunitTraitOptions} place holder with the actual traits.  We use the place holder
+         because code coverage needs to have a bit of the test command line after the traits (it adds ending quotes
+		 to one of its options).  Simply appending the traits would break code coverage. -->
     <PropertyGroup>
-      <TestCommandLine>$(TestCommandLine) $(XunitTraitOptions)</TestCommandLine>
+      <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
     </PropertyGroup>
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />


### PR DESCRIPTION
    Recent changes to enable overriding of test run properties broke the code coverage build.  There were two issues.  CodeCoverage needed to be updated to use the new property names, and we need to revert to the way we were passing in the Xunit trait options before.  The complication around code coverage is that the coverage line isn't just a simple wrapper around the original command line.  It needs to know the host as well as the full set of arguments passed to that host.

    In addition, this change updates the code coverage version