### PR TITLE
Fix code coverage traits

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/CodeCoverage.targets
@@ -40,7 +40,7 @@
     <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user -target:$(TestProgram) -output:$(CoverageOutputFilePath)</CoverageCommandLine>
     <TestHost>$(CoverageHost)</TestHost>
     <XunitOptions>$(XunitOptions) -parallel none</XunitOptions>
-    <TestCommandLine>$(TestHost) $(CoverageCommandLine) -targetargs:"$(TestArguments)"</TestCommandLine>
+    <TestCommandLine>$(TestHost) $(CoverageCommandLine) -targetargs:"$(TestArguments) {XunitTraitOptions}"</TestCommandLine>
   </PropertyGroup>
 
   <!-- Report Generator Properties -->


### PR DESCRIPTION
The last change to avoid setting {XunitTraitOptions} on TestArguments broke setting of xunit traits on code coverage.