### PR TITLE
Fix tests running under code coverage

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -26,7 +26,12 @@
   <PropertyGroup Condition="'$(TestWithCore)' == 'true'">
     <TestRuntimeProjectJson Condition="'$(TestRuntimeProjectJson)' == ''">$(MSBuildThisFileDirectory)test-runtime\project.json</TestRuntimeProjectJson>
     <TestRuntimeProjectLockJson Condition="'$(TestRuntimeProjectLockJson)' == ''">$(MSBuildThisFileDirectory)test-runtime\project.lock.json</TestRuntimeProjectLockJson>
-    <TestHost>corerun.exe</TestHost>
+    <!-- Invoke with the correct casing of corerun per-OS.  There are some process tests
+         that check the invoked process name against known casing which fail under code coverage.
+         This is probably because the code coverage target invocation does not canonicalize the
+         process name. -->
+    <TestHost Condition="'$(OS)' == 'Windows_NT'">CoreRun.exe</TestHost>
+    <TestHost Condition="'$(OS)' != 'Windows_NT'">corerun</TestHost>
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.netcore.exe</XunitExecutable>
     <DebugTestFrameworkFolder>dnxcore50</DebugTestFrameworkFolder>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
@@ -111,7 +116,7 @@
 
     <!-- Replace the {XunitTraitOptions} place holder with the actual traits.  We use the place holder
          because code coverage needs to have a bit of the test command line after the traits (it adds ending quotes
-		 to one of its options).  Simply appending the traits would break code coverage. -->
+         to one of its options).  Simply appending the traits would break code coverage. -->
     <PropertyGroup>
       <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
     </PropertyGroup>
@@ -162,8 +167,8 @@
   </Target>
 
   <Target Name="CheckTestPlatforms"
-  		  AfterTargets="Test"
-  		  Condition="'$(TestDisabled)'!='true'">
+          AfterTargets="Test"
+          Condition="'$(TestDisabled)'!='true'">
     <PropertyGroup>
       <IsWindowsAssembly Condition="'$(OS)'=='Windows_NT' And '%(UnsupportedPlatformsItems.Identity)'=='Windows_NT'">false</IsWindowsAssembly>
       <TestDisabled Condition="'$(IsWindowsAssembly)'=='false'">true</TestDisabled>


### PR DESCRIPTION
Under code coverage, a System.Diagnostics.Process test was failing because the invoked process name did not match in casing to the expected value.  The expected value matches with the casing of CoreRun.exe, while the test was seeing corerun.exe on Windows.  The issue here appears to be that under OpenCover, the invoked target process (corerun) doesn't have its name canonicalized vs. the file system.  Fix this by setting the test host for Windows and Linux with the correct casing.

Fixes dotnet/corefx#2570