### PR TITLE
Re-lock test-runtime dependencies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.lock.json
@@ -4,7 +4,7 @@
   "targets": {
     "DNXCore,Version=v5.0": {
       "coveralls.io/1.4": {},
-      "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00067": {},
+      "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00068": {},
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0-beta-23127": {
         "dependencies": {
           "System.Collections": "[4.0.10-beta-23127]",
@@ -521,7 +521,7 @@
           "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
         }
       },
-      "xunit.console.netcore/1.0.2-prerelease-00067": {
+      "xunit.console.netcore/1.0.2-prerelease-00068": {
         "dependencies": {
           "System.Collections": "4.0.10-beta-22703",
           "System.Collections.Concurrent": "4.0.10-beta-22703",
@@ -591,7 +591,7 @@
     },
     "DNXCore,Version=v5.0/win7-x86": {
       "coveralls.io/1.4": {},
-      "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00067": {},
+      "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00068": {},
       "Microsoft.NETCore.Runtime.CoreCLR-x86/1.0.0-beta-23127": {
         "dependencies": {
           "System.Collections": "[4.0.10-beta-23127]",
@@ -1246,7 +1246,7 @@
           "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
         }
       },
-      "xunit.console.netcore/1.0.2-prerelease-00067": {
+      "xunit.console.netcore/1.0.2-prerelease-00068": {
         "dependencies": {
           "System.Collections": "4.0.10-beta-22703",
           "System.Collections.Concurrent": "4.0.10-beta-22703",
@@ -1339,12 +1339,12 @@
         "tools/NativeBinaries/x86/git2-e0902fb.pdb"
       ]
     },
-    "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00067": {
+    "Microsoft.DotNet.PerfTools/0.0.1-prerelease-00068": {
       "serviceable": true,
-      "sha512": "so2nlAV8Bm8DXhfFS08C00P635GNr09NvzwwlOaxqNX5KgVZhh73ey9oAsoaSOCgxmExz7vEXFTUhmsUtNg0Aw==",
+      "sha512": "rTTK7vkpyF72rxJnlrWytv6mEera3rRusNEK6aVADj5Uspu7sLmNBvLQ7XiOERB5bOcNIqYXS6VbYaWE5Cx65Q==",
       "files": [
-        "Microsoft.DotNet.PerfTools.0.0.1-prerelease-00067.nupkg",
-        "Microsoft.DotNet.PerfTools.0.0.1-prerelease-00067.nupkg.sha512",
+        "Microsoft.DotNet.PerfTools.0.0.1-prerelease-00068.nupkg",
+        "Microsoft.DotNet.PerfTools.0.0.1-prerelease-00068.nupkg.sha512",
         "Microsoft.DotNet.PerfTools.nuspec",
         "tools/ComparePerfEventsData.exe",
         "tools/EventTracer.exe",
@@ -2738,11 +2738,11 @@
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.xml"
       ]
     },
-    "xunit.console.netcore/1.0.2-prerelease-00067": {
-      "sha512": "hqSO24TU/Ng1UrBB2ShLFGi8EQv39c8QGCQmFFvZTRzKS4B0M9EX96TULmKpXQSL+pVMFamiUCWHkHds/sBBVw==",
+    "xunit.console.netcore/1.0.2-prerelease-00068": {
+      "sha512": "Szkni9yJfdxphJ3jPSYhG6YVQkAiXGsPt2dOHWbGoK1O3rkXKX3bO/CsW+L+UfuDPH3PnwIUZ5bw+SRLGtel8A==",
       "files": [
-        "xunit.console.netcore.1.0.2-prerelease-00067.nupkg",
-        "xunit.console.netcore.1.0.2-prerelease-00067.nupkg.sha512",
+        "xunit.console.netcore.1.0.2-prerelease-00068.nupkg",
+        "xunit.console.netcore.1.0.2-prerelease-00068.nupkg.sha512",
         "xunit.console.netcore.nuspec",
         "lib/aspnetcore50/xunit.console.netcore.exe"
       ]

--- a/src/nuget/xunit.netcore.extensions.nuspec
+++ b/src/nuget/xunit.netcore.extensions.nuspec
@@ -14,18 +14,18 @@
     <description>This package provides things like various traits and discovers like OuterLoop/ActiveIssue that are used by .NET Core framework test projects.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <dependency id="System.Diagnostics.Debug" version="4.0.10-beta-23121" />
-      <dependency id="System.IO" version="4.0.10-beta-23121" />
-      <dependency id="System.Linq" version="4.0.0-beta-23121" />
-      <dependency id="System.Reflection" version="4.0.10-beta-23121" />
-      <dependency id="System.Reflection.Primitives" version="4.0.0-beta-23121" />
-      <dependency id="System.Runtime" version="4.0.20-beta-23121" />
-      <dependency id="System.Runtime.Extensions" version="4.0.10-beta-23121" />
-      <dependency id="System.Runtime.Handles" version="4.0.0-beta-23121" />
-      <dependency id="System.Runtime.InteropServices" version="4.0.20-beta-23121" />
-      <dependency id="System.Text.Encoding" version="4.0.10-beta-23121" />
-      <dependency id="System.Threading" version="4.0.10-beta-23121" />
-      <dependency id="System.Threading.Tasks" version="4.0.10-beta-23121" />
+      <dependency id="System.Diagnostics.Debug" version="4.0.10-beta-23127" />
+      <dependency id="System.IO" version="4.0.10-beta-23127" />
+      <dependency id="System.Linq" version="4.0.0-beta-23127" />
+      <dependency id="System.Reflection" version="4.0.10-beta-23127" />
+      <dependency id="System.Reflection.Primitives" version="4.0.0-beta-23127" />
+      <dependency id="System.Runtime" version="4.0.20-beta-23127" />
+      <dependency id="System.Runtime.Extensions" version="4.0.10-beta-23127" />
+      <dependency id="System.Runtime.Handles" version="4.0.0-beta-23127" />
+      <dependency id="System.Runtime.InteropServices" version="4.0.20-beta-23127" />
+      <dependency id="System.Text.Encoding" version="4.0.10-beta-23127" />
+      <dependency id="System.Threading" version="4.0.10-beta-23127" />
+      <dependency id="System.Threading.Tasks" version="4.0.10-beta-23127" />
       <dependency id="xunit" version="2.1.0-beta3-build3029" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Second half of the buildtools changes needed to move to the latest xUnit beta.

This change just re-locks the dependencies of the test-runtime package, which brings us to the version of the packages built from the last official build of this repo. The next official build should give us a package with version prerelease-00069 which is what my corefx PR is set up to consume.