### PR TITLE
Two improvements to xunit.console.netcore

### DIFF
--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -39,6 +39,7 @@ namespace Xunit.ConsoleClient
 
 #if !NETCORE
                 AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+#endif
                 Console.CancelKeyPress += (sender, e) =>
                 {
                     if (!cancel)
@@ -48,9 +49,6 @@ namespace Xunit.ConsoleClient
                         e.Cancel = true;
                     }
                 };
-#else
-                cancel = false;
-#endif
 
                 var defaultDirectory = Directory.GetCurrentDirectory();
                 if (!defaultDirectory.EndsWith(new String(new[] { Path.DirectorySeparatorChar })))
@@ -263,6 +261,9 @@ namespace Xunit.ConsoleClient
             {
                 if (!ValidateFileExists(consoleLock, assembly.AssemblyFilename) || !ValidateFileExists(consoleLock, assembly.ConfigFilename))
                     return null;
+
+                // Turn off pre-enumeration of theories, since there is no theory selection UI in this runner
+                assembly.Configuration.PreEnumerateTheories = false;
 
                 var discoveryOptions = TestFrameworkOptions.ForDiscovery(assembly.Configuration);
                 var executionOptions = TestFrameworkOptions.ForExecution(assembly.Configuration);


### PR DESCRIPTION
1. Console.CancelKeyPress is now exposed from the Console contract, so we no longer have to exclude ctrl-C behavior.
2. Brad added the ability to disable discovery enumeration of theories, which is only necessary when there's UI associated with showing test cases (https://github.com/xunit/xunit/commit/07178782a6ea455ae42f1fa6f4b3bfec935cd587).  Just as in xunit.console, I'm disabling such preenumeration of theories as it's unnecessary overhead.

Note that I've not yet tested this against corefx; I'll do so once @mellinoe's xunit changes in corefx go in.