### PR TITLE
Add common localization code

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
@@ -8,6 +8,12 @@
     <AssemblyVersion Condition="'$(AssemblyVersion)'==''">999.999.999.999</AssemblyVersion>
     <CLSCompliant Condition="'$(CLSCompliant)'=='' and '$(IsTestProject)'=='true'">false</CLSCompliant>
     <CLSCompliant Condition="'$(CLSCompliant)'==''">true</CLSCompliant>
+
+    <!--
+      Check if the project has been localized by looking for the existence of the .de.xlf file.  By convention, we assume that if 
+      a project is localized in German, then it is localized in all languages.
+    -->
+    <ExcludeLocalizationImport Condition="'$(ExcludeLocalizationImport)'=='' And !Exists('$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).de.xlf')">true</ExcludeLocalizationImport>
   </PropertyGroup>
   
   <!--
@@ -83,6 +89,11 @@
       BuildNumberTarget - If this property is set it will try to import the file which allows for it to override the properties above.
   -->
   <Import Project="$(MSBuildThisFileDirectory)versioning.targets" Condition="'$(ExcludeVersioningImport)'!='true'" />
+
+  <!--
+    Import the localization target
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)localization.targets" Condition="'$(ExcludeLocalizationImport)'!='true'" />
 
   <!-- 
     Import the partial facade generation targets

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/localization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/localization.targets
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="MultilingualAppToolkit">
+    <MultilingualAppToolkitVersion>4.0</MultilingualAppToolkitVersion>
+    <MultilingualFallbackLanguage>en-US</MultilingualFallbackLanguage>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.de.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.es.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.fr.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.it.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.ja.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.ko.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.ru.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.zh-Hans.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)\Resources\Strings.zh-Hant.resx">
+      <Visible>True</Visible>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).de.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).es.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).fr.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).it.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).ja.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).ko.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).ru.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).zh-Hans.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+    <XliffResource Include="$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).zh-Hant.xlf">
+      <Visible>True</Visible>
+    </XliffResource>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets" Label="MultilingualAppToolkit" Condition="Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" />
+  <Target Name="MATPrerequisite" BeforeTargets="PrepareForBuild" Condition="!Exists('$(MSBuildExtensionsPath)\Microsoft\Multilingual App Toolkit\Microsoft.Multilingual.ResxResources.targets')" Label="MultilingualAppToolkit">
+    <Message Text="$(MSBuildProjectFile) is Multilingual build enabled, but the Multilingual App Toolkit is unavailable during the build. If building with Visual Studio and you wish to work with localization files, please ensure that the toolkit is properly installed." />
+  </Target>
+</Project>


### PR DESCRIPTION
This localization code is common to all C# projects, and is the code
added by the Multilingual App Toolkit (MAT) for maintaining localization
in a project.

When building a project on a machine with MAT installed, MAT
synchronizes the .xlf files in the project with the Strings.resx, and
synchronizes the localized Strings.resx files with the .xlf files.  If
MAT is not installed on the machine, the loc file synchronization is
skipped and a message is written to the log file.

For the files to show up in Solution Explorer, it is necessary to set
Visible to True.