### PR TITLE
Allow override of reference assembly output path

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/ReferenceAssemblies.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/ReferenceAssemblies.targets
@@ -15,7 +15,8 @@
 
   <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
     <AssemblyName Condition="'$(AssemblyName)' == ''">$(MSBuildProjectName)</AssemblyName>
-    <OutputPath>$(BaseOutputPath)ref\$(AssemblyName)\$(AssemblyVersion)</OutputPath>
+    <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(BaseOutputPath)ref\</ReferenceAssemblyOutputPath>
+    <OutputPath>$(ReferenceAssemblyOutputPath)$(AssemblyName)\$(AssemblyVersion)</OutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)ref\$(AssemblyName)\$(AssemblyVersion)</IntermediateOutputPath>
     
     <!-- ensure a unique path to assemblyinfo -->


### PR DESCRIPTION
This enables us to have the reference assemblies built to the contracts folder for internal builds.