### PR TITLE
Allow OuterLoop on a class

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/OuterLoopAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/OuterLoopAttribute.cs
@@ -10,7 +10,7 @@ namespace Xunit
     /// Apply this attribute to your test method to specify a outer-loop category.
     /// </summary>
     [TraitDiscoverer("Xunit.NetCore.Extensions.OuterLoopTestsDiscoverer", "Xunit.NetCore.Extensions")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
     public class OuterLoopAttribute : Attribute, ITraitAttribute
     {
         public OuterLoopAttribute() { }

--- a/src/xunit.netcore.extensions/Attributes/PlatformSpecificAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/PlatformSpecificAttribute.cs
@@ -10,7 +10,7 @@ namespace Xunit
     /// Apply this attribute to your test method to specify this is a platform specific test.
     /// </summary>
     [TraitDiscoverer("Xunit.NetCore.Extensions.PlatformSpecificDiscoverer", "Xunit.NetCore.Extensions")]
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
     public class PlatformSpecificAttribute : Attribute, ITraitAttribute
     {
         public PlatformSpecificAttribute(PlatformID platform) { }


### PR DESCRIPTION
Technically, a trait can be applied to a class in addition to a method. This would let us mark a whole class as OuterLoop, something I might be interested in doing if I were to re-organize some of the Tasks tests.