### PR TITLE
Disable "warning" for no tests in assembly

### DIFF
--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -299,8 +299,8 @@ namespace Xunit.ConsoleClient
                     {
                         lock (consoleLock)
                         {
-                            Console.ForegroundColor = ConsoleColor.Yellow;
-                            Console.WriteLine("Warning:       {0} has no tests to run", Path.GetFileNameWithoutExtension(assembly.AssemblyFilename));
+                            Console.ForegroundColor = ConsoleColor.DarkYellow;
+                            Console.WriteLine("Info:        {0} has no tests to run", Path.GetFileNameWithoutExtension(assembly.AssemblyFilename));
                             Console.ForegroundColor = ConsoleColor.Gray;
                         }
                     }


### PR DESCRIPTION
The xunit.console.netcore runner is printing out "Warning: " when there are no tests to run in the specified assembly.  This causes msbuild to treat that as a warning, which gets flagged and accumulated in the warnings statistics when doing a full build.  That results in 17 warnings when building corefx today, which is very noisy and ends up making it difficult to spot real warnings that should be fixed.

This commit simply changes the string to be "Info" instead of "Warning", and also uses a slightly different shade of yellow in order to differentiate it from more important warnings.  This brings the number of warnings generated during a full corefx build back down to 0.