### PR TITLE
Fix the perf tools version mentioned in the targets file

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
@@ -11,7 +11,7 @@
     Perf tools package versions go here and in the test-runtime-packages.config
   -->
   <PropertyGroup>
-    <PerfToolsVersion>0.0.1-prerelease-00022</PerfToolsVersion>
+    <PerfToolsVersion>0.0.1-prerelease-00077</PerfToolsVersion>
     <PerfToolsDir Condition="'$(PerfToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.PerfTools\$(PerfToolsVersion)\tools\</PerfToolsDir>
     <EventTracer>"$(PerfToolsDir)EventTracer.exe"</EventTracer>
     <!-- by default delete the trace files after consumption -->


### PR DESCRIPTION
Was causing the consumptive metrics to not find EventTracer.