### PR TITLE
Add AssemblyInfoPartial to BuildTools NuGet package

### DIFF
--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -40,6 +40,7 @@
     <file src="Microsoft.DotNet.Build.Tasks\System.Reflection.Metadata.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\NativeBinaries\amd64\git2-69db893.dll" target="lib\NativeBinaries\amd64" />
     <file src="Microsoft.DotNet.Build.Tasks\NativeBinaries\x86\git2-69db893.dll" target="lib\NativeBinaries\x86" />
+    <file src="Microsoft.DotNet.Build.Tasks\AssemblyInfoPartial.*" target="lib" />
   </files>
   
 </package>


### PR DESCRIPTION
This change adds the AssemblyInfoPartial files to the BuildTools NuGet
package; these files are required by the build (see https://github.com/dotnet/buildtools/pull/251)