### PR TITLE
Support partial facade generation on X-Plat

### DIFF
--- a/src/GenFacades/Program.cs
+++ b/src/GenFacades/Program.cs
@@ -32,6 +32,7 @@ namespace GenFacades
             ErrorTreatment contractLoadErrorTreatment = ErrorTreatment.Default;
             string[] seedTypePreferencesUnsplit = null;
             bool forceZeroVersionSeeds = false;
+            bool producePdb = true;
             string partialFacadeAssemblyPath = null;
 
             bool parsingSucceeded = CommandLineParser.ParseForConsoleApplication((parser) =>
@@ -49,6 +50,7 @@ namespace GenFacades
                 parser.DefineOptionalQualifier("preferSeedType", ref seedTypePreferencesUnsplit, "Set which seed assembly to choose for a given type when it is defined in more than one assembly. Format: FullTypeName=PreferredSeedAssemblyName");
                 parser.DefineOptionalQualifier("forceZeroVersionSeeds", ref forceZeroVersionSeeds, "Forces all seed assembly versions to 0.0.0.0, regardless of their true version.");
                 parser.DefineOptionalQualifier("partialFacadeAssemblyPath", ref partialFacadeAssemblyPath, "Specifies the path to a single partial facade assembly, into which appropriate type forwards will be added to satisfy the given contract. If this option is specified, only a single partial assembly and a single contract may be given.");
+                parser.DefineOptionalQualifier("producePdb", ref producePdb, "Specifices if a PDB file should be produced for the resulting partial facade.");
             }, args);
 
             if (!parsingSucceeded)
@@ -127,12 +129,15 @@ namespace GenFacades
 
                         string pdbLocation = null;
 
-                        string pdbFolder = Path.GetDirectoryName(partialFacadeAssemblyPath);
-                        pdbLocation = Path.Combine(pdbFolder, contractAssembly.Name + ".pdb");
-                        if (!File.Exists(pdbLocation))
+                        if (producePdb)
                         {
-                            pdbLocation = null;
-                            Trace.TraceWarning("No PDB file present for un-transformed partial facade. No PDB will be generated.");
+                            string pdbFolder = Path.GetDirectoryName(partialFacadeAssemblyPath);
+                            pdbLocation = Path.Combine(pdbFolder, contractAssembly.Name + ".pdb");
+                            if (producePdb && !File.Exists(pdbLocation))
+                            {
+                                pdbLocation = null;
+                                Trace.TraceWarning("No PDB file present for un-transformed partial facade. No PDB will be generated.");
+                            }
                         }
 
                         OutputFacadeToFile(facadePath, seedHost, filledPartialFacade, contractAssembly, pdbLocation);

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -41,6 +41,7 @@
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
     <Compile Include="ResolveNuGetPackages.cs" />
+    <Compile Include="UpdateBuildVersionTargets.cs" />
     <Compile Include="Strings.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildValues.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/UpdateBuildValues.targets
@@ -1,18 +1,26 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="GetNextRevisionNumber" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdateBuildVersionTargets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <GitWorkingBranch Condition="'$(GitWorkingBranch)' == ''">master</GitWorkingBranch>
   </PropertyGroup>
 
-  <Target Name="GetNextRevisionNumber"
+  <Target Name="UpdateBuildValues"
     BeforeTargets="Build;BuildAllProjects"
     Condition="'$(UpdateBuildValues)' == 'true'"
     >
+
     <GetNextRevisionNumber
       VersionPropsFile="$(SourceDir)BuildValues.props">
       <Output PropertyName="RevisionNumber" TaskParameter="RevisionNumber" />
     </GetNextRevisionNumber>
+
+    <UpdateBuildVersionTargets
+      BuildVersionTargetsFile="$(SourceDir)Microsoft.DotNet.Build.Tasks\Targets\buildtoolsversion.targets"
+      RevisionNumber="$(RevisionNumber)"
+    />
+
   </Target>
 
   <Target Name="CommitBuildValues"
@@ -39,7 +47,7 @@
     <Exec
       WorkingDirectory="$(SourceDir)"
       StandardOutputImportance="Low"
-      Command="git commit -m &quot;Automated commit of revision number value $(RevisionNumber).&quot; $(SourceDir)BuildValues.props" />
+      Command="git commit -m &quot;Automated commit of revision number value $(RevisionNumber).&quot; $(SourceDir)BuildValues.props $(SourceDir)Microsoft.DotNet.Build.Tasks\Targets\buildtoolsversion.targets" />
 
     <Exec
       WorkingDirectory="$(SourceDir)"

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/buildtoolsversion.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/buildtoolsversion.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildToolsRevisionNumber>00085</BuildToolsRevisionNumber>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="$(MSBuildThisFileDirectory)buildtoolsversion.targets" />
+
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
-    <GenFacadesNuGetName>Microsoft.DotNet.BuildTools.ApiTools.1.0.0-prerelease</GenFacadesNuGetName>
+    <GenFacadesNuGetName>GenFacades.Desktop.1.0.0-experimental-$(BuildToolsRevisionNumber)</GenFacadesNuGetName>
     <GenFacadesPath>$(PackagesDir)$(GenFacadesNuGetName)\tools\GenFacades.exe</GenFacadesPath>
   </PropertyGroup>
 
@@ -163,12 +165,19 @@
       <GenFacadesArgs>$(GenFacadesArgs) -contracts:"%(ResolvedMatchingContract.Identity)"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -seeds:"@(GenFacadesSeeds, ';')"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -facadePath:"$(GenFacadesOutputPath.TrimEnd('\'))"</GenFacadesArgs>
+      <GenFacadesArgs Condition="'$(DebugSymbols)' == 'false'">$(GenFacadesArgs) -producePdb:false</GenFacadesArgs>
       <GenFacadesArgs Condition="'@(SeedTypePreference)' != ''">$(GenFacadesArgs) -preferSeedType:"@(SeedTypePreference->'%(Identity)=%(Assembly)', ',')"</GenFacadesArgs>
     </PropertyGroup>
 
     <!-- Move the assembly into a subdirectory for GenFacades -->
-    <Move SourceFiles="$(PartialFacadeAssemblyPath);$(PartialFacadeSymbols)"
+    <Move SourceFiles="$(PartialFacadeAssemblyPath)"
           DestinationFolder="$(GenFacadesInputPath)"
+    />
+
+    <!-- Move the PDB into a subdirectory for GenFacades if we are producing PDBs -->
+    <Move SourceFiles="$(PartialFacadeSymbols)"
+          DestinationFolder="$(GenFacadesInputPath)"
+          Condition="'$(DebugSymbols)' != 'false'"
     />
 
     <Exec Command="&quot;$(GenFacadesPath)&quot; $(GenFacadesArgs)" />

--- a/src/Microsoft.DotNet.Build.Tasks/UpdateBuildVersionTargets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdateBuildVersionTargets.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class UpdateBuildVersionTargets : Task
+    {
+        [Required]
+        public string BuildVersionTargetsFile { get; set; }
+
+        [Required]
+        public string RevisionNumber { get; set; }
+
+        public override bool Execute()
+        {
+            Log.LogMessage("Starting UpdateBuildVersionTargets");
+
+            XDocument versionProps = XDocument.Load(BuildVersionTargetsFile);
+            var defaultNS = versionProps.Root.GetDefaultNamespace();
+
+            var buildNode =
+                (from el in versionProps.Descendants(defaultNS + "BuildToolsRevisionNumber")
+                 select el).FirstOrDefault();
+
+            buildNode.Value = RevisionNumber;
+            versionProps.Save(BuildVersionTargetsFile);
+
+            Log.LogMessage(string.Format("UpdateBuildVersionTargets completed successfully - the revision number is now {0}", RevisionNumber));
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This change does the minimial amount of work to get partial facade
generation into a state where it can be run as part of the build when
running on Linux or OSX.

The major problem was that since we don't produce PDBs when building
with Roslyn on Linux or OSX, GenFacades needs to be able to handle the
case where PDBs are missing.  The version of GenFacades that we had in
build tools can handle this (it issues a warning when doing so) but we
actually don't consume this version from BuildTools today. This change
addresses that issue.

 - Update partialfacades.targets to consume the GenFacades.Desktop
   pacakge.  In doing so, I have introduced a new targets file that
   ships as part of build tools that has version number information
   about the revision of build tools in question so we don't have to
   hardcode the ever changing revision into the targets.  This does
   require that folks that restore the build tools and want to use
   partial facades need to now start restoring the GenFacades.Desktop
   pacakge as well.

 - Fix up some logic in the targets to not try to move PDBs if
   DebugSymbols is false, as it is on Linux and OSX.

 - Add a way to supress the warning to GenFacades for the case where the
   PDB is known not to exist

With these changes, GenFacades can run and fill partial facades on Linux
when running on a custom version of Mono (Mono is missing
Array.Empty<T>() and some StringBuilder overloads which
Microsoft.Cci.dll depends on, these will be added when Mono consumes an
updated reference assembly drop, for now it is easy enough to add them
and then build locally if you really want this to work, which I do.
Longer term we should just move to running GenFacades.exe on top of
CoreCLR, once we have cross platform coreclr runtime packages we can
consume.)