### PR TITLE
Tool runtime support

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/Build.Common.targets
@@ -15,6 +15,14 @@
     -->
     <ExcludeLocalizationImport Condition="'$(ExcludeLocalizationImport)'=='' And !Exists('$(MSBuildProjectDirectory)\MultilingualResources\$(MSBuildProjectName).de.xlf')">true</ExcludeLocalizationImport>
   </PropertyGroup>
+
+  <!--
+    Import the provides support for EnsureBuildToolsRuntime target which will restore a .NET Core based 
+    runtime and setup a $(ToolRuntimePath) and $(ToolHost) for others to consume.
+    
+    This must be imported before any tools that need to use it are imported.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)toolruntime.targets" Condition="'$(ExcludeToolRuntimeImport)' != 'true'"/>
   
   <!--
     Import the reference assembly targets

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
@@ -3,11 +3,6 @@
 
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
-  <PropertyGroup>
-    <GenFacadesNuGetName>Microsoft.DotNet.BuildTools.ApiTools.1.0.0-prerelease</GenFacadesNuGetName>
-    <GenFacadesPath>$(PackagesDir)$(GenFacadesNuGetName)\tools\GenFacades.exe</GenFacadesPath>
-  </PropertyGroup>
-
   <!-- Default properties for partial facade projects -->
   <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
     <PostFilterNugetReferences>true</PostFilterNugetReferences>
@@ -149,7 +144,7 @@
        Fills the "input assembly" by finding types in the contract assembly that are missing from it, and adding type-forwards
          to those matching types in the seed assemblies.
   -->
-  <Target Name="FillPartialFacade">
+  <Target Name="FillPartialFacade" DependsOnTargets="EnsureBuildToolsRuntime">
 
     <ItemGroup>
       <!-- References used for compilation are automatically included as seed assemblies -->
@@ -178,7 +173,11 @@
           Condition="'$(DebugSymbols)' != 'false'"
     />
 
-    <Exec Command="&quot;$(GenFacadesPath)&quot; $(GenFacadesArgs)" />
+    <PropertyGroup>
+      <GenFacadesCmd>"$(ToolRuntimePath)$(ToolHost)" "$(ToolsDir)GenFacades.dll"</GenFacadesCmd>
+    </PropertyGroup>
+
+    <Exec Command="$(GenFacadesCmd) $(GenFacadesArgs)" WorkingDirectory="$(ToolRuntimePath)" />
 
     <ItemGroup>
       <FileWrites Include="$(GenFacadesInputAssembly)" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tool-runtime/project.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-beta-*",
+    "Microsoft.NETCore.TestHost-x64": "1.0.0-beta-*",
+    "Microsoft.NETCore.Console": "1.0.0-beta-*",
+    "Microsoft.Cci": "4.0.0-beta-*",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-*",
+    "System.Diagnostics.TraceSource": "4.0.0-beta-*",
+  },
+  "frameworks": {
+    "dnxcore50": { }
+  },
+  "runtimes": {
+    "win7-x64": { }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tool-runtime/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tool-runtime/project.lock.json
@@ -1,0 +1,7938 @@
+{
+  "locked": true,
+  "version": -9996,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "Microsoft.Cci/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/Microsoft.Cci.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Cci.dll": {}
+        }
+      },
+      "Microsoft.CSharp/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.ObjectModel": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.CSharp.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.CSharp.dll": {}
+        }
+      },
+      "Microsoft.NETCore/5.0.1-beta-23311": {
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1-beta-23311",
+          "Microsoft.VisualBasic": "10.0.1-beta-23311",
+          "System.AppContext": "4.0.1-beta-23311",
+          "System.Collections": "4.0.11-beta-23311",
+          "System.Collections.Concurrent": "4.0.11-beta-23311",
+          "System.Collections.Immutable": "1.1.38-beta-23311",
+          "System.ComponentModel": "4.0.1-beta-23311",
+          "System.ComponentModel.Annotations": "4.0.11-beta-23311",
+          "System.Diagnostics.Debug": "4.0.11-beta-23311",
+          "System.Diagnostics.Tools": "4.0.1-beta-23311",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23311",
+          "System.Dynamic.Runtime": "4.0.11-beta-23311",
+          "System.Globalization": "4.0.11-beta-23311",
+          "System.Globalization.Calendars": "4.0.1-beta-23311",
+          "System.Globalization.Extensions": "4.0.1-beta-23311",
+          "System.IO": "4.0.11-beta-23311",
+          "System.IO.Compression": "4.0.1-beta-23311",
+          "System.IO.Compression.ZipFile": "4.0.1-beta-23311",
+          "System.IO.FileSystem": "4.0.1-beta-23311",
+          "System.IO.FileSystem.Primitives": "4.0.1-beta-23311",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23311",
+          "System.Linq": "4.0.1-beta-23311",
+          "System.Linq.Expressions": "4.0.11-beta-23311",
+          "System.Linq.Parallel": "4.0.1-beta-23311",
+          "System.Linq.Queryable": "4.0.1-beta-23311",
+          "System.Net.NetworkInformation": "4.0.1-beta-23311",
+          "System.Net.Http": "4.0.1-beta-23311",
+          "System.Net.Primitives": "4.0.11-beta-23311",
+          "System.Numerics.Vectors": "4.1.1-beta-23311",
+          "System.ObjectModel": "4.0.11-beta-23311",
+          "System.Reflection": "4.1.0-beta-23311",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23311",
+          "System.Reflection.Extensions": "4.0.1-beta-23311",
+          "System.Reflection.Metadata": "1.0.23-beta-23311",
+          "System.Reflection.Primitives": "4.0.1-beta-23311",
+          "System.Reflection.TypeExtensions": "4.0.1-beta-23311",
+          "System.Resources.ResourceManager": "4.0.1-beta-23311",
+          "System.Runtime": "4.0.21-beta-23311",
+          "System.Runtime.Extensions": "4.0.11-beta-23311",
+          "System.Runtime.Handles": "4.0.1-beta-23311",
+          "System.Runtime.InteropServices": "4.0.21-beta-23311",
+          "System.Runtime.Numerics": "4.0.1-beta-23311",
+          "System.Security.Claims": "4.0.1-beta-23311",
+          "System.Security.Principal": "4.0.1-beta-23311",
+          "System.Text.Encoding": "4.0.11-beta-23311",
+          "System.Text.Encoding.Extensions": "4.0.11-beta-23311",
+          "System.Text.RegularExpressions": "4.0.11-beta-23311",
+          "System.Threading": "4.0.11-beta-23311",
+          "System.Threading.Tasks": "4.0.11-beta-23311",
+          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23311",
+          "System.Threading.Tasks.Parallel": "4.0.1-beta-23311",
+          "System.Threading.Timer": "4.0.1-beta-23311",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23311",
+          "System.Xml.XDocument": "4.0.11-beta-23311",
+          "Microsoft.NETCore.Targets": "1.0.1-beta-23311"
+        }
+      },
+      "Microsoft.NETCore.Console/1.0.0-beta-23311": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23311",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23311",
+          "Microsoft.NETCore": "5.0.1-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.1-beta-23311",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23311",
+          "System.Console": "4.0.0-beta-23311",
+          "System.Data.Common": "4.0.1-beta-23311",
+          "System.Data.SqlClient": "4.0.0-beta-23311",
+          "System.Diagnostics.Contracts": "4.0.1-beta-23311",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23311",
+          "System.Diagnostics.Process": "4.1.0-beta-23311",
+          "System.Diagnostics.StackTrace": "4.0.1-beta-23311",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23311",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23311",
+          "System.IO.MemoryMappedFiles": "4.0.0-beta-23311",
+          "System.IO.Pipes": "4.0.0-beta-23311",
+          "System.Net.NetworkInformation": "4.1.0-beta-23311",
+          "System.Net.NameResolution": "4.0.0-beta-23311",
+          "System.Net.Requests": "4.0.11-beta-23311",
+          "System.Net.Security": "4.0.0-beta-23311",
+          "System.Net.Sockets": "4.1.0-beta-23311",
+          "System.Net.Utilities": "4.0.0-beta-23311",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23311",
+          "System.Net.WebSockets": "4.0.0-beta-23311",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23311",
+          "System.Reflection.Emit": "4.0.1-beta-23311",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23311",
+          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23311",
+          "System.Resources.ReaderWriter": "4.0.0-beta-23311",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23311",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23311",
+          "System.Runtime.Loader": "4.0.0-beta-23311",
+          "System.Runtime.Serialization.Json": "4.0.1-beta-23311",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23311",
+          "System.Runtime.Serialization.Xml": "4.0.11-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Security.Cryptography.DeriveBytes": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encryption.Aes": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Security.Cryptography.RandomNumberGenerator": "4.0.0-beta-23311",
+          "System.Security.Cryptography.RSA": "4.0.0-beta-23311",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Security.SecureString": "4.0.0-beta-23311",
+          "System.ServiceModel.Duplex": "4.0.1-beta-23311",
+          "System.ServiceModel.Http": "4.0.11-beta-23311",
+          "System.ServiceModel.NetTcp": "4.0.1-beta-23311",
+          "System.ServiceModel.Primitives": "4.0.1-beta-23311",
+          "System.ServiceModel.Security": "4.0.1-beta-23311",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23311"
+        }
+      },
+      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23311": {},
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23311": {},
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+        "dependencies": {
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23311",
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
+        }
+      },
+      "Microsoft.NETCore.Targets/1.0.1-beta-23311": {
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23311",
+          "Microsoft.NETCore.Platforms": "1.0.1-beta-23311"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23311": {},
+      "Microsoft.NETCore.TestHost-x64/1.0.0-beta-23225": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {},
+      "Microsoft.VisualBasic/10.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.ObjectModel": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.VisualBasic.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.VisualBasic.dll": {}
+        }
+      },
+      "Microsoft.Win32.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
+        }
+      },
+      "System.AppContext/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.AppContext.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.AppContext.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.21-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.38-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.ComponentModel.Annotations/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.ComponentModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.Annotations.dll": {}
+        }
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Console.dll": {}
+        }
+      },
+      "System.Data.Common/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Data.Common.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Data.Common.dll": {}
+        }
+      },
+      "System.Data.SqlClient/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.0",
+          "System.Data.Common": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Data.SqlClient.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.FileVersionInfo.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.FileVersionInfo.dll": {}
+        }
+      },
+      "System.Diagnostics.Process/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Threading.Thread": "4.0.0-beta-23311",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading.ThreadPool": "4.0.10-beta-23311",
+          "System.Globalization": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.StackTrace/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
+        }
+      },
+      "System.Diagnostics.TextWriterTraceListener/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.TraceSource": "4.0.0-beta-23311",
+          "System.IO": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.TextWriterTraceListener.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.TextWriterTraceListener.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.TraceSource/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.TraceSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.21-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Dynamic.Runtime/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Globalization": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "System.IO/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Text.Encoding": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO.Compression": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.DriveInfo.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.DriveInfo.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Watcher.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.Watcher.dll": {}
+        }
+      },
+      "System.IO.MemoryMappedFiles/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.MemoryMappedFiles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.MemoryMappedFiles.dll": {}
+        }
+      },
+      "System.IO.Pipes/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Pipes.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.Pipes.dll": {}
+        }
+      },
+      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+        }
+      },
+      "System.Linq/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Parallel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.Parallel.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Collections": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.IO.Compression": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Http.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.NameResolution.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.NetworkInformation/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.NetworkInformation.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.NetworkInformation.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Requests/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Requests.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Security/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Security.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Sockets.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.Utilities/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Utilities.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Utilities.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Collections": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
+        }
+      },
+      "System.Numerics.Vectors/4.1.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Numerics.Vectors.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Numerics.Vectors.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.DataContractSerialization/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23311"
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "System.Private.Networking/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Security.SecureString": "4.0.0-beta-23311",
+          "System.Security.Principal.Windows": "4.0.0-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading.ThreadPool": "4.0.10-beta-23311",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Networking.dll": {}
+        }
+      },
+      "System.Private.ServiceModel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Security.Principal.Windows": "4.0.0-beta-23311",
+          "System.Security.Claims": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Net.Security": "4.0.0-beta-23311",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NameResolution": "4.0.0-beta-23311",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.IO.Compression": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.Sockets": "4.0.10-beta-23311",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Linq.Expressions": "4.0.10"
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.ServiceModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-beta-23311": {
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.DispatchProxy/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.0.23-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Collections.Immutable": "1.1.37"
+        },
+        "compile": {
+          "lib/dotnet/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ReaderWriter/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Globalization": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.21-beta-23311": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.CompilerServices.VisualC.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.21-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Loader/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.IO": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Json/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.DataContractSerialization": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Json.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Xml/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23311",
+          "System.Private.DataContractSerialization": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
+        }
+      },
+      "System.Security.Claims/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Security.Principal": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Claims.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Reflection": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.DeriveBytes/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.DeriveBytes.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.DeriveBytes.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Diagnostics.Debug": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encryption/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encryption.Aes/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.Aes.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.Aes.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Hashing/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll": {}
+        }
+      },
+      "System.Security.Cryptography.RSA/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Csp": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.RSA.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.RSA.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Csp": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Security.Cryptography.Cng": "4.0.0-beta-23311",
+          "System.Globalization": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Principal.dll": {}
+        }
+      },
+      "System.Security.Principal.Windows/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.Windows.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Security.SecureString/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.SecureString.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.SecureString.dll": {}
+        }
+      },
+      "System.ServiceModel.Duplex/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Duplex.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
+        }
+      },
+      "System.ServiceModel.Http/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Http.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Http.dll": {}
+        }
+      },
+      "System.ServiceModel.NetTcp/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
+        }
+      },
+      "System.ServiceModel.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
+        }
+      },
+      "System.ServiceModel.Security/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Security.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Dataflow/4.5.26-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlDocument/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
+        }
+      }
+    },
+    "DNXCore,Version=v5.0/win7-x64": {
+      "Microsoft.Cci/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/Microsoft.Cci.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Cci.dll": {}
+        }
+      },
+      "Microsoft.CSharp/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.ObjectModel": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.CSharp.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.CSharp.dll": {}
+        }
+      },
+      "Microsoft.NETCore/5.0.1-beta-23311": {
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1-beta-23311",
+          "Microsoft.VisualBasic": "10.0.1-beta-23311",
+          "System.AppContext": "4.0.1-beta-23311",
+          "System.Collections": "4.0.11-beta-23311",
+          "System.Collections.Concurrent": "4.0.11-beta-23311",
+          "System.Collections.Immutable": "1.1.38-beta-23311",
+          "System.ComponentModel": "4.0.1-beta-23311",
+          "System.ComponentModel.Annotations": "4.0.11-beta-23311",
+          "System.Diagnostics.Debug": "4.0.11-beta-23311",
+          "System.Diagnostics.Tools": "4.0.1-beta-23311",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23311",
+          "System.Dynamic.Runtime": "4.0.11-beta-23311",
+          "System.Globalization": "4.0.11-beta-23311",
+          "System.Globalization.Calendars": "4.0.1-beta-23311",
+          "System.Globalization.Extensions": "4.0.1-beta-23311",
+          "System.IO": "4.0.11-beta-23311",
+          "System.IO.Compression": "4.0.1-beta-23311",
+          "System.IO.Compression.ZipFile": "4.0.1-beta-23311",
+          "System.IO.FileSystem": "4.0.1-beta-23311",
+          "System.IO.FileSystem.Primitives": "4.0.1-beta-23311",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23311",
+          "System.Linq": "4.0.1-beta-23311",
+          "System.Linq.Expressions": "4.0.11-beta-23311",
+          "System.Linq.Parallel": "4.0.1-beta-23311",
+          "System.Linq.Queryable": "4.0.1-beta-23311",
+          "System.Net.NetworkInformation": "4.0.1-beta-23311",
+          "System.Net.Http": "4.0.1-beta-23311",
+          "System.Net.Primitives": "4.0.11-beta-23311",
+          "System.Numerics.Vectors": "4.1.1-beta-23311",
+          "System.ObjectModel": "4.0.11-beta-23311",
+          "System.Reflection": "4.1.0-beta-23311",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23311",
+          "System.Reflection.Extensions": "4.0.1-beta-23311",
+          "System.Reflection.Metadata": "1.0.23-beta-23311",
+          "System.Reflection.Primitives": "4.0.1-beta-23311",
+          "System.Reflection.TypeExtensions": "4.0.1-beta-23311",
+          "System.Resources.ResourceManager": "4.0.1-beta-23311",
+          "System.Runtime": "4.0.21-beta-23311",
+          "System.Runtime.Extensions": "4.0.11-beta-23311",
+          "System.Runtime.Handles": "4.0.1-beta-23311",
+          "System.Runtime.InteropServices": "4.0.21-beta-23311",
+          "System.Runtime.Numerics": "4.0.1-beta-23311",
+          "System.Security.Claims": "4.0.1-beta-23311",
+          "System.Security.Principal": "4.0.1-beta-23311",
+          "System.Text.Encoding": "4.0.11-beta-23311",
+          "System.Text.Encoding.Extensions": "4.0.11-beta-23311",
+          "System.Text.RegularExpressions": "4.0.11-beta-23311",
+          "System.Threading": "4.0.11-beta-23311",
+          "System.Threading.Tasks": "4.0.11-beta-23311",
+          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23311",
+          "System.Threading.Tasks.Parallel": "4.0.1-beta-23311",
+          "System.Threading.Timer": "4.0.1-beta-23311",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23311",
+          "System.Xml.XDocument": "4.0.11-beta-23311",
+          "Microsoft.NETCore.Targets": "1.0.1-beta-23311"
+        }
+      },
+      "Microsoft.NETCore.Console/1.0.0-beta-23311": {
+        "dependencies": {
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23311",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23311",
+          "Microsoft.NETCore": "5.0.1-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.1-beta-23311",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23311",
+          "System.Console": "4.0.0-beta-23311",
+          "System.Data.Common": "4.0.1-beta-23311",
+          "System.Data.SqlClient": "4.0.0-beta-23311",
+          "System.Diagnostics.Contracts": "4.0.1-beta-23311",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23311",
+          "System.Diagnostics.Process": "4.1.0-beta-23311",
+          "System.Diagnostics.StackTrace": "4.0.1-beta-23311",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23311",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23311",
+          "System.IO.MemoryMappedFiles": "4.0.0-beta-23311",
+          "System.IO.Pipes": "4.0.0-beta-23311",
+          "System.Net.NetworkInformation": "4.1.0-beta-23311",
+          "System.Net.NameResolution": "4.0.0-beta-23311",
+          "System.Net.Requests": "4.0.11-beta-23311",
+          "System.Net.Security": "4.0.0-beta-23311",
+          "System.Net.Sockets": "4.1.0-beta-23311",
+          "System.Net.Utilities": "4.0.0-beta-23311",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23311",
+          "System.Net.WebSockets": "4.0.0-beta-23311",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23311",
+          "System.Reflection.Emit": "4.0.1-beta-23311",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23311",
+          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23311",
+          "System.Resources.ReaderWriter": "4.0.0-beta-23311",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23311",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23311",
+          "System.Runtime.Loader": "4.0.0-beta-23311",
+          "System.Runtime.Serialization.Json": "4.0.1-beta-23311",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23311",
+          "System.Runtime.Serialization.Xml": "4.0.11-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Security.Cryptography.DeriveBytes": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encryption": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encryption.Aes": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Hashing": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Hashing.Algorithms": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Security.Cryptography.RandomNumberGenerator": "4.0.0-beta-23311",
+          "System.Security.Cryptography.RSA": "4.0.0-beta-23311",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Security.SecureString": "4.0.0-beta-23311",
+          "System.ServiceModel.Duplex": "4.0.1-beta-23311",
+          "System.ServiceModel.Http": "4.0.11-beta-23311",
+          "System.ServiceModel.NetTcp": "4.0.1-beta-23311",
+          "System.ServiceModel.Primitives": "4.0.1-beta-23311",
+          "System.ServiceModel.Security": "4.0.1-beta-23311",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23311"
+        }
+      },
+      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23311": {},
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23311": {},
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+        "dependencies": {
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23311",
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
+        }
+      },
+      "Microsoft.NETCore.Targets/1.0.1-beta-23311": {
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23311",
+          "Microsoft.NETCore.Platforms": "1.0.1-beta-23311"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23311": {},
+      "Microsoft.NETCore.TestHost-x64/1.0.0-beta-23225": {
+        "native": {
+          "runtimes/win7-x64/native/CoreRun.exe": {}
+        }
+      },
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {},
+      "Microsoft.VisualBasic/10.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Dynamic.Runtime": "4.0.10",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.ObjectModel": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.VisualBasic.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.VisualBasic.dll": {}
+        }
+      },
+      "Microsoft.Win32.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
+        }
+      },
+      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "runtime.win7.System.Console/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10"
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Console.dll": {}
+        }
+      },
+      "runtime.win7.System.Data.SqlClient/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Data.Common": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Threading.ThreadPool": "4.0.0-beta-23311",
+          "System.Security.Principal.Windows": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Text.Encoding.CodePages": "4.0.0",
+          "System.Threading.Thread": "4.0.0-beta-23311",
+          "System.Reflection": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10"
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Data.SqlClient.dll": {}
+        }
+      },
+      "runtime.win7.System.IO.FileSystem/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.IO.FileSystem.dll": {}
+        }
+      },
+      "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23311": {
+        "native": {
+          "runtimes/win7-x64/native/CoreConsole.exe": {}
+        }
+      },
+      "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+        "runtime": {
+          "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll": {}
+        },
+        "native": {
+          "runtimes/win7-x64/native/clretwrc.dll": {},
+          "runtimes/win7-x64/native/coreclr.dll": {},
+          "runtimes/win7-x64/native/dbgshim.dll": {},
+          "runtimes/win7-x64/native/mscordaccore.dll": {},
+          "runtimes/win7-x64/native/mscordbi.dll": {},
+          "runtimes/win7-x64/native/mscorrc.debug.dll": {},
+          "runtimes/win7-x64/native/mscorrc.dll": {}
+        }
+      },
+      "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
+        "native": {
+          "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-debug-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-debug-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-delayload-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-errorhandling-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-errorhandling-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-fibers-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-fibers-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-file-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-file-l1-2-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-file-l1-2-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-file-l2-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-file-l2-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-handle-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-heap-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-heap-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-interlocked-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-io-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-io-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-localization-l2-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-localization-obsolete-l1-2-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-2.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-3.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-normalization-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-2-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-processsecurity-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-2.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-profile-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-psapi-ansi-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-psapi-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-psapi-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-realtime-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-registry-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-registry-l2-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-rtlsupport-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-shlwapi-legacy-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-threadpool-l1-2-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-threadpool-legacy-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-threadpool-private-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-timezone-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-url-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-util-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-version-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-winrt-error-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-winrt-error-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-winrt-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-winrt-registration-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-winrt-robuffer-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-winrt-string-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-wow64-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-xstate-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-xstate-l2-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-ro-typeresolution-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-security-base-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-security-cpwl-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-security-provider-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-security-sddl-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-service-management-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-service-management-l2-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-service-winsvc-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll": {}
+        }
+      },
+      "System.AppContext/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.AppContext.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.AppContext.dll": {}
+        }
+      },
+      "System.Collections/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.21-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.38-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.ComponentModel.Annotations/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.ComponentModel": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.Annotations.dll": {}
+        }
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Console.dll": {}
+        }
+      },
+      "System.Data.Common/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Threading.Tasks": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Data.Common.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Data.Common.dll": {}
+        }
+      },
+      "System.Data.SqlClient/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.0",
+          "System.Data.Common": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Data.SqlClient.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.FileVersionInfo.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.FileVersionInfo.dll": {}
+        }
+      },
+      "System.Diagnostics.Process/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Threading.Thread": "4.0.0-beta-23311",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading.ThreadPool": "4.0.10-beta-23311",
+          "System.Globalization": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.StackTrace/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.StackTrace.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
+        }
+      },
+      "System.Diagnostics.TextWriterTraceListener/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.TraceSource": "4.0.0-beta-23311",
+          "System.IO": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.TextWriterTraceListener.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.TextWriterTraceListener.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.TraceSource/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.TraceSource.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.TraceSource.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.21-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Dynamic.Runtime/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
+        }
+      },
+      "System.Globalization/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Globalization": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "System.IO/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Text.Encoding": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.clrcompression-x64/4.0.0": {
+        "native": {
+          "runtimes/win7-x64/native/clrcompression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO.Compression": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.DriveInfo.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.DriveInfo.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Watcher.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.Watcher.dll": {}
+        }
+      },
+      "System.IO.MemoryMappedFiles/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.UnmanagedMemoryStream": "4.0.0",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.MemoryMappedFiles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.MemoryMappedFiles.dll": {}
+        }
+      },
+      "System.IO.Pipes/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Pipes.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.Pipes.dll": {}
+        }
+      },
+      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+        }
+      },
+      "System.Linq/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.ObjectModel": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Parallel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.Parallel.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Collections": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.IO.Compression": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Http.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.NameResolution.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.NameResolution.dll": {}
+        }
+      },
+      "System.Net.NetworkInformation/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.NetworkInformation.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.NetworkInformation.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Net.Requests/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Requests.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.Requests.dll": {}
+        }
+      },
+      "System.Net.Security/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Security.dll": {}
+        }
+      },
+      "System.Net.Sockets/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Sockets.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Sockets.dll": {}
+        }
+      },
+      "System.Net.Utilities/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Utilities.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Utilities.dll": {}
+        }
+      },
+      "System.Net.WebHeaderCollection/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebHeaderCollection.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Net.WebHeaderCollection.dll": {}
+        }
+      },
+      "System.Net.WebSockets/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "Microsoft.Win32.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.dll": {}
+        }
+      },
+      "System.Net.WebSockets.Client/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Net.WebSockets": "4.0.0-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Collections": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.WebSockets.Client.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.WebSockets.Client.dll": {}
+        }
+      },
+      "System.Numerics.Vectors/4.1.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Numerics.Vectors.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Numerics.Vectors.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.DataContractSerialization/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23311"
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "System.Private.Networking/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Security.SecureString": "4.0.0-beta-23311",
+          "System.Security.Principal.Windows": "4.0.0-beta-23311",
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading.ThreadPool": "4.0.10-beta-23311",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10"
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Networking.dll": {}
+        }
+      },
+      "System.Private.ServiceModel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23311",
+          "System.Security.Principal.Windows": "4.0.0-beta-23311",
+          "System.Security.Claims": "4.0.0",
+          "System.Threading.Timer": "4.0.0",
+          "System.Collections.Specialized": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Net.Security": "4.0.0-beta-23311",
+          "System.Net.Http": "4.0.0",
+          "System.Net.NameResolution": "4.0.0-beta-23311",
+          "System.Net.WebHeaderCollection": "4.0.0",
+          "System.Reflection.DispatchProxy": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Queryable": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.IO.Compression": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Serialization.Xml": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Net.Primitives": "4.0.10",
+          "System.Net.Sockets": "4.0.10-beta-23311",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Linq.Expressions": "4.0.10"
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.ServiceModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.1-beta-23311": {
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.1.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.DispatchProxy/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.0.23-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Collections.Immutable": "1.1.37"
+        },
+        "compile": {
+          "lib/dotnet/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ReaderWriter/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Globalization": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.21-beta-23311": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.CompilerServices.VisualC.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.21-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Loader/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.IO": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Json/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.DataContractSerialization": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Json.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Serialization.Primitives.dll": {}
+        }
+      },
+      "System.Runtime.Serialization.Xml/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime.Serialization.Primitives": "4.0.11-beta-23311",
+          "System.Private.DataContractSerialization": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Serialization.Xml.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
+        }
+      },
+      "System.Security.Claims/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Security.Principal": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Claims.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Cng/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Cng.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Cng.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Reflection": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.DeriveBytes/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.DeriveBytes.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.DeriveBytes.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Diagnostics.Debug": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encryption/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encryption.Aes/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.Aes.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encryption.Aes.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Hashing/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll": {}
+        }
+      },
+      "System.Security.Cryptography.RSA/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Csp": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311"
+        },
+        "compile": {
+          "lib/DNXCore50/System.Security.Cryptography.RSA.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.RSA.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Csp": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23311",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23311",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Globalization.Calendars": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.Security.Cryptography.Cng": "4.0.0-beta-23311",
+          "System.Globalization": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Principal.dll": {}
+        }
+      },
+      "System.Security.Principal.Windows/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Security.Claims": "4.0.0",
+          "System.Security.Principal": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.Windows.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Security.SecureString/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23311",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.SecureString.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.SecureString.dll": {}
+        }
+      },
+      "System.ServiceModel.Duplex/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Duplex.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
+        }
+      },
+      "System.ServiceModel.Http/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Http.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Http.dll": {}
+        }
+      },
+      "System.ServiceModel.NetTcp/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.NetTcp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
+        }
+      },
+      "System.ServiceModel.Primitives/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
+        }
+      },
+      "System.ServiceModel.Security/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Private.ServiceModel": "4.0.1-beta-23311"
+        },
+        "compile": {
+          "ref/dotnet/System.ServiceModel.Security.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.ServiceModel.Security.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.CodePages/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Dataflow/4.5.26-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Collections": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "System.Dynamic.Runtime": "4.0.0",
+          "System.Diagnostics.Tracing": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections.Concurrent": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.1-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Tools": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlDocument/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Xml.XmlDocument": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Microsoft.Cci/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "ey2amcfzfdQqDQvVCJnVUw4M4c09bQD1CpW15OA5YW43SkMwVZs4qXpF/7ZUBlM1sVYX0tsz5Mt/Pe77mgMD6A==",
+      "files": [
+        "Microsoft.Cci.4.0.0-beta-23311.nupkg",
+        "Microsoft.Cci.4.0.0-beta-23311.nupkg.sha512",
+        "Microsoft.Cci.nuspec",
+        "lib/dotnet/Microsoft.Cci.dll"
+      ]
+    },
+    "Microsoft.CSharp/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "RgWT7bEdc5FvkuV6BmKNY89wjKVkGhCUuwRhrQR1m1IyY1p3sf51jFtf7yCOFxKioH5TCTQ/KAuOKCEbYaKhfQ==",
+      "files": [
+        "Microsoft.CSharp.4.0.1-beta-23311.nupkg",
+        "Microsoft.CSharp.4.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.CSharp.nuspec",
+        "Microsoft.CSharp.xml",
+        "de/Microsoft.CSharp.xml",
+        "es/Microsoft.CSharp.xml",
+        "fr/Microsoft.CSharp.xml",
+        "it/Microsoft.CSharp.xml",
+        "ja/Microsoft.CSharp.xml",
+        "ko/Microsoft.CSharp.xml",
+        "lib/dotnet/Microsoft.CSharp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/Microsoft.CSharp.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/Microsoft.CSharp.xml",
+        "zh-hans/Microsoft.CSharp.xml",
+        "zh-hant/Microsoft.CSharp.xml"
+      ]
+    },
+    "Microsoft.NETCore/5.0.1-beta-23311": {
+      "sha512": "aiL05E0OJ6YM8cH+WYnHExLpaFCPW7PgK0hshoh+dB85HN/0HQLcKJBe4R4qbCtV+vuTv4+vyB6qyzKkCEZjtw==",
+      "files": [
+        "Microsoft.NETCore.5.0.1-beta-23311.nupkg",
+        "Microsoft.NETCore.5.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.nuspec",
+        "_._"
+      ]
+    },
+    "Microsoft.NETCore.Console/1.0.0-beta-23311": {
+      "sha512": "5yBRTNyA60RL52bx0MUOEtyyZHXbDhr7SU9dg6tiABNDt7aXA0sXAtZUbZnS5D/LLgHosDXXwzgdbfMOtwWZEA==",
+      "files": [
+        "Microsoft.NETCore.Console.1.0.0-beta-23311.nupkg",
+        "Microsoft.NETCore.Console.1.0.0-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.Console.nuspec",
+        "_._"
+      ]
+    },
+    "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23311": {
+      "sha512": "juwLUDf+mAi/O+IJ/vAD2Onsqh6pwIVWGPNHPxH/Jx2FjGm1sV3hcSpSE1HQJG1Ad9qs89SCCj5HyMWD6qkihg==",
+      "files": [
+        "Microsoft.NETCore.ConsoleHost.1.0.0-beta-23311.nupkg",
+        "Microsoft.NETCore.ConsoleHost.1.0.0-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.ConsoleHost.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Platforms/1.0.1-beta-23311": {
+      "sha512": "dHNQXYEiFTPiUQoMI0bOnRKLN/NI5yQwqZ/Ncn5EomAPYFbtxBTQwDtipbWM1hcfnFhLwgf/q8BzS9fqJfxeTA==",
+      "files": [
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23311.nupkg",
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.Platforms.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+      "sha512": "/VCAiycb0NrigRzRTJE+E0nlS23Jt9CWAsvWU+jDHYRbnp3N7wy3WE+lliWsroLDg+/84b7na9vjGr02UO3oFg==",
+      "files": [
+        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23311.nupkg",
+        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Targets/1.0.1-beta-23311": {
+      "sha512": "/+wAXXutnnBdwsJGolZCMuAqxEoIg9yh31ibdFAcwTjyR3r7+P6uYW4ybkitOIXaSH2a8QlRfuitzHl1OQcpsA==",
+      "files": [
+        "Microsoft.NETCore.Targets.1.0.1-beta-23311.nupkg",
+        "Microsoft.NETCore.Targets.1.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.Targets.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23311": {
+      "sha512": "VlzepJd19u3K2XdPEHD36yNswgxhNGo/qd4Rr92JPL1kgPkt3hvJQNTO6efdS8JV1sNfTrABgpJzNv84D0rwvA==",
+      "files": [
+        "Microsoft.NETCore.Targets.DNXCore.5.0.0-beta-23311.nupkg",
+        "Microsoft.NETCore.Targets.DNXCore.5.0.0-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.Targets.DNXCore.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.TestHost-x64/1.0.0-beta-23225": {
+      "sha512": "D+OrRHthQ/ViCNveXP8ClxEVKJdDTFwp4s9ubLhagMPTWsJKh3NWmUw35sGEXzZcRNAKAEDjaH8iybD7T285QQ==",
+      "files": [
+        "Microsoft.NETCore.TestHost-x64.1.0.0-beta-23225.nupkg",
+        "Microsoft.NETCore.TestHost-x64.1.0.0-beta-23225.nupkg.sha512",
+        "Microsoft.NETCore.TestHost-x64.nuspec",
+        "runtimes/win7-x64/native/CoreRun.exe"
+      ]
+    },
+    "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
+      "sha512": "SV5WFOHAXEJABi9OaikQWLHpuDHriGxTNvt6QIvVmDw25vEWlIwhu1LIA2+jrlpTZZTiJLBrZzydvkHVGGpncg==",
+      "files": [
+        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23311.nupkg",
+        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.Windows.ApiSets.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.VisualBasic/10.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "GTfy3jeUn8jNpqMvd154gxAVmFJVwiiKcbYAO9d10g0Awv+0h4OZ9g3xyONLelhaRSIQd6BmoAH1VFQ8qkb6ZA==",
+      "files": [
+        "Microsoft.VisualBasic.10.0.1-beta-23311.nupkg",
+        "Microsoft.VisualBasic.10.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.VisualBasic.nuspec",
+        "Microsoft.VisualBasic.xml",
+        "de/Microsoft.VisualBasic.xml",
+        "es/Microsoft.VisualBasic.xml",
+        "fr/Microsoft.VisualBasic.xml",
+        "it/Microsoft.VisualBasic.xml",
+        "ja/Microsoft.VisualBasic.xml",
+        "ko/Microsoft.VisualBasic.xml",
+        "lib/dotnet/Microsoft.VisualBasic.dll",
+        "lib/net45/_._",
+        "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/net45/_._",
+        "ref/netcore50/Microsoft.VisualBasic.dll",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ru/Microsoft.VisualBasic.xml",
+        "zh-hans/Microsoft.VisualBasic.xml",
+        "zh-hant/Microsoft.VisualBasic.xml"
+      ]
+    },
+    "Microsoft.Win32.Primitives/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "jmRHZb7Wk8CNvInMiPCoE9vm3itZbyKBKgHAnxm4bFf69FqArBRVf82QUjooobhdbhlprYoiOYR+PAq/iSkFPg==",
+      "files": [
+        "Microsoft.Win32.Primitives.4.0.1-beta-23311.nupkg",
+        "Microsoft.Win32.Primitives.4.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
+        "runtime.json",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "Microsoft.Win32.Registry/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "W3zUZ8Fb00S5qqWie6K9PAJ9jRsYxz2xSQPL2Kvn1/7gBuqRpsZjBZV8AWGD7e6IPn9t+W6StmoXyK5BqczmXw==",
+      "files": [
+        "Microsoft.Win32.Registry.4.0.0-beta-23311.nupkg",
+        "Microsoft.Win32.Registry.4.0.0-beta-23311.nupkg.sha512",
+        "Microsoft.Win32.Registry.nuspec",
+        "Microsoft.Win32.Registry.xml",
+        "de/Microsoft.Win32.Registry.xml",
+        "es/Microsoft.Win32.Registry.xml",
+        "fr/Microsoft.Win32.Registry.xml",
+        "it/Microsoft.Win32.Registry.xml",
+        "ja/Microsoft.Win32.Registry.xml",
+        "ko/Microsoft.Win32.Registry.xml",
+        "lib/DNXCore50/Microsoft.Win32.Registry.dll",
+        "lib/net46/Microsoft.Win32.Registry.dll",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/net46/Microsoft.Win32.Registry.dll",
+        "ru/Microsoft.Win32.Registry.xml",
+        "zh-hans/Microsoft.Win32.Registry.xml",
+        "zh-hant/Microsoft.Win32.Registry.xml"
+      ]
+    },
+    "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "YF0QmE5C6gj6cc5gmxF+GTryBlTdmUFiM7Wrk3uwh3Fm6h5PWAV1RE7Ag/plpZY7/RyKpC2hGFnIWNr/A90Uiw==",
+      "files": [
+        "Microsoft.Win32.Primitives.xml",
+        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-beta-23311.nupkg",
+        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-beta-23311.nupkg.sha512",
+        "runtime.win7.Microsoft.Win32.Primitives.nuspec",
+        "de/Microsoft.Win32.Primitives.xml",
+        "es/Microsoft.Win32.Primitives.xml",
+        "fr/Microsoft.Win32.Primitives.xml",
+        "it/Microsoft.Win32.Primitives.xml",
+        "ja/Microsoft.Win32.Primitives.xml",
+        "ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/_._",
+        "ru/Microsoft.Win32.Primitives.xml",
+        "runtimes/win7/lib/dotnet/Microsoft.Win32.Primitives.dll",
+        "zh-hans/Microsoft.Win32.Primitives.xml",
+        "zh-hant/Microsoft.Win32.Primitives.xml"
+      ]
+    },
+    "runtime.win7.System.Console/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "z3nkl8x0HvPR4VP0dOZk7sm+wDHGP1gAk/18mQ/05MbJHuHl1InE6hfDYQ0XI2vQlg9atU4knUaHTAymW9iOSA==",
+      "files": [
+        "runtime.win7.System.Console.4.0.0-beta-23311.nupkg",
+        "runtime.win7.System.Console.4.0.0-beta-23311.nupkg.sha512",
+        "runtime.win7.System.Console.nuspec",
+        "System.Console.xml",
+        "de/System.Console.xml",
+        "es/System.Console.xml",
+        "fr/System.Console.xml",
+        "it/System.Console.xml",
+        "ja/System.Console.xml",
+        "ko/System.Console.xml",
+        "lib/win8/_._",
+        "lib/wp8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/_._",
+        "ru/System.Console.xml",
+        "runtimes/win7/lib/dotnet/System.Console.dll",
+        "zh-hans/System.Console.xml",
+        "zh-hant/System.Console.xml"
+      ]
+    },
+    "runtime.win7.System.Data.SqlClient/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "sAOHbHkoUoy+ILlgixSvdBrLZXuzTgVWbGOP4OGiyNmbjst6+WqVjtjeotVmYhOJLCIW7u4oTc3SsQYTTeE6Aw==",
+      "files": [
+        "runtime.win7.System.Data.SqlClient.4.0.0-beta-23311.nupkg",
+        "runtime.win7.System.Data.SqlClient.4.0.0-beta-23311.nupkg.sha512",
+        "runtime.win7.System.Data.SqlClient.nuspec",
+        "System.Data.SqlClient.xml",
+        "de/System.Data.SqlClient.xml",
+        "es/System.Data.SqlClient.xml",
+        "fr/System.Data.SqlClient.xml",
+        "it/System.Data.SqlClient.xml",
+        "ja/System.Data.SqlClient.xml",
+        "ko/System.Data.SqlClient.xml",
+        "lib/net/_._",
+        "lib/win8/_._",
+        "lib/wp8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/_._",
+        "ref/netcore50/_._",
+        "ru/System.Data.SqlClient.xml",
+        "runtimes/win7/lib/dotnet/System.Data.SqlClient.dll",
+        "zh-hans/System.Data.SqlClient.xml",
+        "zh-hant/System.Data.SqlClient.xml"
+      ]
+    },
+    "runtime.win7.System.IO.FileSystem/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "ozoKTszj7NM9piPEgFlyS6JEJDG4lEE5+/lOYsyzNVw/iOM0k5Z+/HSdFEc9Rya7mLJfxtdpMOD9P2+tUfHHUQ==",
+      "files": [
+        "runtime.win7.System.IO.FileSystem.4.0.1-beta-23311.nupkg",
+        "runtime.win7.System.IO.FileSystem.4.0.1-beta-23311.nupkg.sha512",
+        "runtime.win7.System.IO.FileSystem.nuspec",
+        "System.IO.FileSystem.xml",
+        "de/System.IO.FileSystem.xml",
+        "es/System.IO.FileSystem.xml",
+        "fr/System.IO.FileSystem.xml",
+        "it/System.IO.FileSystem.xml",
+        "ja/System.IO.FileSystem.xml",
+        "ko/System.IO.FileSystem.xml",
+        "lib/net/_._",
+        "lib/win8/_._",
+        "lib/wp8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/_._",
+        "ref/netcore50/_._",
+        "ru/System.IO.FileSystem.xml",
+        "runtimes/win7/lib/dotnet/System.IO.FileSystem.dll",
+        "runtimes/win7/lib/netcore50/System.IO.FileSystem.dll",
+        "zh-hans/System.IO.FileSystem.xml",
+        "zh-hant/System.IO.FileSystem.xml"
+      ]
+    },
+    "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23311": {
+      "sha512": "NNNYcPQjrqTby9jyiWSVO3ZAEcZS1Oibu+a5QF6+IWkK8vgkJpoOHvNKnvxDMDfrOv7YBUtvHVHVFbcr5MAbqA==",
+      "files": [
+        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23311.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23311.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.nuspec",
+        "runtimes/win7-x64/native/CoreConsole.exe"
+      ]
+    },
+    "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+      "sha512": "nMRY83TeOv6w4w4lmEn1/RL44os+5s8ciyUyYeS2r9fTP680SBfMFWmMvn7v2fU9YW6UNQj/oZaF2I5BBK37PQ==",
+      "files": [
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23311.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23311.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "ref/dotnet/_._",
+        "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
+        "runtimes/win7-x64/native/clretwrc.dll",
+        "runtimes/win7-x64/native/coreclr.dll",
+        "runtimes/win7-x64/native/dbgshim.dll",
+        "runtimes/win7-x64/native/mscordaccore.dll",
+        "runtimes/win7-x64/native/mscordbi.dll",
+        "runtimes/win7-x64/native/mscorrc.debug.dll",
+        "runtimes/win7-x64/native/mscorrc.dll"
+      ]
+    },
+    "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
+      "sha512": "EUGN4DCOJZGlyzC+r7rU9GiblXMSwVL0anF3b2k4HvUWHG05Nntkw36qRbY+sLDpP3pgO+c1UNbdA4zOXbq+sg==",
+      "files": [
+        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23311.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23311.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.nuspec",
+        "runtimes/win10-x64/native/_._",
+        "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-debug-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-debug-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-delayload-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-errorhandling-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-errorhandling-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-fibers-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-fibers-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-file-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-file-l1-2-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-file-l1-2-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-file-l2-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-file-l2-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-handle-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-heap-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-heap-obsolete-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-interlocked-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-io-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-io-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-libraryloader-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-localization-l1-2-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-localization-l2-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-2.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-normalization-l1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-PrivateProfile-L1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-processenvironment-l1-2-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-processsecurity-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-ProcessTopology-Obsolete-L1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-profile-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-psapi-ansi-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-psapi-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-psapi-obsolete-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-realtime-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-registry-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-registry-l2-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-rtlsupport-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-shlwapi-legacy-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-threadpool-l1-2-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-threadpool-legacy-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-threadpool-private-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-timezone-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-url-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-util-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-version-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-winrt-error-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-winrt-error-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-winrt-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-winrt-registration-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-winrt-robuffer-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-winrt-roparameterizediid-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-winrt-string-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-wow64-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-xstate-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-xstate-l2-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-ClassicProvider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Consumer-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Controller-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Eventing-Provider-L1-1-0.dll",
+        "runtimes/win7-x64/native/API-MS-Win-EventLog-Legacy-L1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-ro-typeresolution-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-security-base-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Security-LsaPolicy-L1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-security-provider-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-security-sddl-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-service-core-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-service-management-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-service-management-l2-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-service-winsvc-l1-1-0.dll",
+        "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-file-l1-2-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-file-l2-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-1.dll",
+        "runtimes/win8-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-localization-l1-2-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-localization-obsolete-l1-2-0.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-memory-l1-1-2.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-winrt-error-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-xstate-l2-1-0.dll",
+        "runtimes/win8-x64/native/API-MS-Win-devices-config-L1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
+        "runtimes/win8-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
+        "runtimes/win8-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll"
+      ]
+    },
+    "System.AppContext/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "ZtKgsW5DxzEpM7obCA2z8VPuP48g36L7giMJ8H9io4vOSTci1+PFt07OHCT7ahE19Zlh3yJCpkVbBbOVP878qQ==",
+      "files": [
+        "System.AppContext.4.0.1-beta-23311.nupkg",
+        "System.AppContext.4.0.1-beta-23311.nupkg.sha512",
+        "System.AppContext.nuspec",
+        "System.AppContext.xml",
+        "de/System.AppContext.xml",
+        "es/System.AppContext.xml",
+        "fr/System.AppContext.xml",
+        "it/System.AppContext.xml",
+        "ja/System.AppContext.xml",
+        "ko/System.AppContext.xml",
+        "lib/DNXCore50/System.AppContext.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.AppContext.xml",
+        "zh-hans/System.AppContext.xml",
+        "zh-hant/System.AppContext.xml"
+      ]
+    },
+    "System.Collections/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "rQ4wFxL3RaxsuAjXe8JV4dwidyaEiBit4Flq9KXFJJdQi81iAEXGTgWw+XYZWN2Oo+HPyTpZPL1JP3RAkNsbmQ==",
+      "files": [
+        "System.Collections.4.0.11-beta-23311.nupkg",
+        "System.Collections.4.0.11-beta-23311.nupkg.sha512",
+        "System.Collections.nuspec",
+        "System.Collections.xml",
+        "de/System.Collections.xml",
+        "es/System.Collections.xml",
+        "fr/System.Collections.xml",
+        "it/System.Collections.xml",
+        "ja/System.Collections.xml",
+        "ko/System.Collections.xml",
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Collections.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "zh-hans/System.Collections.xml",
+        "zh-hant/System.Collections.xml"
+      ]
+    },
+    "System.Collections.Concurrent/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "csWD44xP4WMi8X0PTz6KkGi1V9vdqIQJyDWF6E95qxNJbW+r5HM5kORECTcHnYV33dD4Oy2cro5xMJ3HKyDQqA==",
+      "files": [
+        "System.Collections.Concurrent.4.0.11-beta-23311.nupkg",
+        "System.Collections.Concurrent.4.0.11-beta-23311.nupkg.sha512",
+        "System.Collections.Concurrent.nuspec",
+        "System.Collections.Concurrent.xml",
+        "de/System.Collections.Concurrent.xml",
+        "es/System.Collections.Concurrent.xml",
+        "fr/System.Collections.Concurrent.xml",
+        "it/System.Collections.Concurrent.xml",
+        "ja/System.Collections.Concurrent.xml",
+        "ko/System.Collections.Concurrent.xml",
+        "lib/dotnet/System.Collections.Concurrent.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Collections.Concurrent.xml",
+        "zh-hans/System.Collections.Concurrent.xml",
+        "zh-hant/System.Collections.Concurrent.xml"
+      ]
+    },
+    "System.Collections.Immutable/1.1.38-beta-23311": {
+      "serviceable": true,
+      "sha512": "ADu1JwbQrL6VeWsnASaPLqSrdkv2dbiB6HZp3fzDgqLwDKuiLMY5f/ZKipCTVo146KFwa16bZPKx6joYzVyixg==",
+      "files": [
+        "System.Collections.Immutable.1.1.38-beta-23311.nupkg",
+        "System.Collections.Immutable.1.1.38-beta-23311.nupkg.sha512",
+        "System.Collections.Immutable.nuspec",
+        "lib/dotnet/System.Collections.Immutable.dll",
+        "lib/dotnet/System.Collections.Immutable.xml",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml"
+      ]
+    },
+    "System.Collections.NonGeneric/4.0.0": {
+      "serviceable": true,
+      "sha512": "rVgwrFBMkmp8LI6GhAYd6Bx+2uLIXjRfNg6Ie+ASfX8ESuh9e2HNxFy2yh1MPIXZq3OAYa+0mmULVwpnEC6UDA==",
+      "files": [
+        "System.Collections.NonGeneric.4.0.0.nupkg",
+        "System.Collections.NonGeneric.4.0.0.nupkg.sha512",
+        "System.Collections.NonGeneric.nuspec",
+        "lib/dotnet/System.Collections.NonGeneric.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
+        "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
+        "ref/dotnet/fr/System.Collections.NonGeneric.xml",
+        "ref/dotnet/it/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ja/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ko/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Collections.Specialized/4.0.0": {
+      "serviceable": true,
+      "sha512": "poJFwQCUOoXqvdoGxx+3p8Z63yawcYKPBSFP67Z2jICeOINvEIQZN7mVOAnC7gsVF0WU+A2wtVwfhagC7UCgAg==",
+      "files": [
+        "System.Collections.Specialized.4.0.0.nupkg",
+        "System.Collections.Specialized.4.0.0.nupkg.sha512",
+        "System.Collections.Specialized.nuspec",
+        "lib/dotnet/System.Collections.Specialized.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.Specialized.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/dotnet/System.Collections.Specialized.xml",
+        "ref/dotnet/de/System.Collections.Specialized.xml",
+        "ref/dotnet/es/System.Collections.Specialized.xml",
+        "ref/dotnet/fr/System.Collections.Specialized.xml",
+        "ref/dotnet/it/System.Collections.Specialized.xml",
+        "ref/dotnet/ja/System.Collections.Specialized.xml",
+        "ref/dotnet/ko/System.Collections.Specialized.xml",
+        "ref/dotnet/ru/System.Collections.Specialized.xml",
+        "ref/dotnet/zh-hans/System.Collections.Specialized.xml",
+        "ref/dotnet/zh-hant/System.Collections.Specialized.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.Specialized.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.ComponentModel/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "0Mks9e3aTrh1SKotisb+N50skI3R+IN/qyYHgiJNrjvzRbv3FW9kyqeIXhMN2AG33bjdZJh2qwuKjfKuA9oTxQ==",
+      "files": [
+        "System.ComponentModel.4.0.1-beta-23311.nupkg",
+        "System.ComponentModel.4.0.1-beta-23311.nupkg.sha512",
+        "System.ComponentModel.nuspec",
+        "System.ComponentModel.xml",
+        "de/System.ComponentModel.xml",
+        "es/System.ComponentModel.xml",
+        "fr/System.ComponentModel.xml",
+        "it/System.ComponentModel.xml",
+        "ja/System.ComponentModel.xml",
+        "ko/System.ComponentModel.xml",
+        "lib/dotnet/System.ComponentModel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.ComponentModel.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.ComponentModel.xml",
+        "zh-hans/System.ComponentModel.xml",
+        "zh-hant/System.ComponentModel.xml"
+      ]
+    },
+    "System.ComponentModel.Annotations/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "af2i2SJUzuafGgGOItPtEpz1V1ndVynlriTL/GgIdkEOjSSAU8ZrEhoCPMjcRXrm/GKisGbXLwrX00fEIpYX/Q==",
+      "files": [
+        "System.ComponentModel.Annotations.4.0.11-beta-23311.nupkg",
+        "System.ComponentModel.Annotations.4.0.11-beta-23311.nupkg.sha512",
+        "System.ComponentModel.Annotations.nuspec",
+        "System.ComponentModel.Annotations.xml",
+        "de/System.ComponentModel.Annotations.xml",
+        "es/System.ComponentModel.Annotations.xml",
+        "fr/System.ComponentModel.Annotations.xml",
+        "it/System.ComponentModel.Annotations.xml",
+        "ja/System.ComponentModel.Annotations.xml",
+        "ko/System.ComponentModel.Annotations.xml",
+        "lib/dotnet/System.ComponentModel.Annotations.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.ComponentModel.Annotations.xml",
+        "zh-hans/System.ComponentModel.Annotations.xml",
+        "zh-hant/System.ComponentModel.Annotations.xml"
+      ]
+    },
+    "System.ComponentModel.EventBasedAsync/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "pfx20JPFdxAtSkf2vgrBNXaCsNv5+NRhDnh8qyala1N/UTPianCiwoaMO+l8MVS1QAN3hVMPWc30M6ErFrNQXw==",
+      "files": [
+        "System.ComponentModel.EventBasedAsync.4.0.11-beta-23311.nupkg",
+        "System.ComponentModel.EventBasedAsync.4.0.11-beta-23311.nupkg.sha512",
+        "System.ComponentModel.EventBasedAsync.nuspec",
+        "System.ComponentModel.EventBasedAsync.xml",
+        "de/System.ComponentModel.EventBasedAsync.xml",
+        "es/System.ComponentModel.EventBasedAsync.xml",
+        "fr/System.ComponentModel.EventBasedAsync.xml",
+        "it/System.ComponentModel.EventBasedAsync.xml",
+        "ja/System.ComponentModel.EventBasedAsync.xml",
+        "ko/System.ComponentModel.EventBasedAsync.xml",
+        "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.ComponentModel.EventBasedAsync.xml",
+        "zh-hans/System.ComponentModel.EventBasedAsync.xml",
+        "zh-hant/System.ComponentModel.EventBasedAsync.xml"
+      ]
+    },
+    "System.Console/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "aCYId/+628/CuOEBKx7sGxQ9fpqvLDqkOMuc0rqWRUCAIgNLtLd5htaQo58aXjzrP8D4/X35xVC+PQoHHis4Mg==",
+      "files": [
+        "runtime.json",
+        "System.Console.4.0.0-beta-23311.nupkg",
+        "System.Console.4.0.0-beta-23311.nupkg.sha512",
+        "System.Console.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Console.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Data.Common/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "aUkSDNaUWKZu1mE5TgHoPNXJidarzu9X6c+xC67tlaCAA7o/bXAaIFQeFIiflYJG+FNU98O90k+AKcSBtsAILA==",
+      "files": [
+        "System.Data.Common.4.0.1-beta-23311.nupkg",
+        "System.Data.Common.4.0.1-beta-23311.nupkg.sha512",
+        "System.Data.Common.nuspec",
+        "System.Data.Common.xml",
+        "de/System.Data.Common.xml",
+        "es/System.Data.Common.xml",
+        "fr/System.Data.Common.xml",
+        "it/System.Data.Common.xml",
+        "ja/System.Data.Common.xml",
+        "ko/System.Data.Common.xml",
+        "lib/dotnet/System.Data.Common.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Data.Common.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Data.Common.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Data.Common.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Data.Common.xml",
+        "zh-hans/System.Data.Common.xml",
+        "zh-hant/System.Data.Common.xml"
+      ]
+    },
+    "System.Data.SqlClient/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "8JymhYjgXZw6RtpA+r/eWMcx9oVh2RAsT70d+InQf8djh/rftUyXyUvi/tOc1tqrTX5FIcAJyFffQokD55f4SA==",
+      "files": [
+        "runtime.json",
+        "System.Data.SqlClient.4.0.0-beta-23311.nupkg",
+        "System.Data.SqlClient.4.0.0-beta-23311.nupkg.sha512",
+        "System.Data.SqlClient.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Data.SqlClient.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Data.SqlClient.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Data.SqlClient.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Diagnostics.Contracts/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "q2lECCuvYJMqahWmraVnJ9BZJfFRxJLPjYYWkVn/FsWaspTJZohdow/TFlKK0Rj4iDgaPXG+Y9PGv7lyxdjVEg==",
+      "files": [
+        "System.Diagnostics.Contracts.4.0.1-beta-23311.nupkg",
+        "System.Diagnostics.Contracts.4.0.1-beta-23311.nupkg.sha512",
+        "System.Diagnostics.Contracts.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Contracts.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "n7u7E8qdkPLrDHcvPvEaxGoHmv+G2l3tQDKS7bPyOocvB2Fr0kzEE+Uwp7k0SDl7s/kqe9bc9O6KxZhdp6ADgQ==",
+      "files": [
+        "System.Diagnostics.Debug.4.0.11-beta-23311.nupkg",
+        "System.Diagnostics.Debug.4.0.11-beta-23311.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec",
+        "System.Diagnostics.Debug.xml",
+        "de/System.Diagnostics.Debug.xml",
+        "es/System.Diagnostics.Debug.xml",
+        "fr/System.Diagnostics.Debug.xml",
+        "it/System.Diagnostics.Debug.xml",
+        "ja/System.Diagnostics.Debug.xml",
+        "ko/System.Diagnostics.Debug.xml",
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Diagnostics.Debug.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "zh-hans/System.Diagnostics.Debug.xml",
+        "zh-hant/System.Diagnostics.Debug.xml"
+      ]
+    },
+    "System.Diagnostics.FileVersionInfo/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "h0JpJlsCsWpOc9VRFDlymqc1yGkjedyXukRgLhvG9hX15e/2GUqRb0borh924qgiEjMD+B6BAu/odZspFhgwYQ==",
+      "files": [
+        "System.Diagnostics.FileVersionInfo.4.0.0-beta-23311.nupkg",
+        "System.Diagnostics.FileVersionInfo.4.0.0-beta-23311.nupkg.sha512",
+        "System.Diagnostics.FileVersionInfo.nuspec",
+        "System.Diagnostics.FileVersionInfo.xml",
+        "de/System.Diagnostics.FileVersionInfo.xml",
+        "es/System.Diagnostics.FileVersionInfo.xml",
+        "fr/System.Diagnostics.FileVersionInfo.xml",
+        "it/System.Diagnostics.FileVersionInfo.xml",
+        "ja/System.Diagnostics.FileVersionInfo.xml",
+        "ko/System.Diagnostics.FileVersionInfo.xml",
+        "lib/DNXCore50/System.Diagnostics.FileVersionInfo.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.FileVersionInfo.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.FileVersionInfo.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.FileVersionInfo.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Diagnostics.FileVersionInfo.xml",
+        "zh-hans/System.Diagnostics.FileVersionInfo.xml",
+        "zh-hant/System.Diagnostics.FileVersionInfo.xml"
+      ]
+    },
+    "System.Diagnostics.Process/4.1.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "g/39xOnF7aCzougGX1ezkFV/VeVFlS6/64LxY8Zs/82rGDKAu0P8+uAs68JnMNCj9zNJIN8gG/E4Ke8rmI2lDg==",
+      "files": [
+        "System.Diagnostics.Process.4.1.0-beta-23311.nupkg",
+        "System.Diagnostics.Process.4.1.0-beta-23311.nupkg.sha512",
+        "System.Diagnostics.Process.nuspec",
+        "System.Diagnostics.Process.xml",
+        "de/System.Diagnostics.Process.xml",
+        "es/System.Diagnostics.Process.xml",
+        "fr/System.Diagnostics.Process.xml",
+        "it/System.Diagnostics.Process.xml",
+        "ja/System.Diagnostics.Process.xml",
+        "ko/System.Diagnostics.Process.xml",
+        "lib/DNXCore50/System.Diagnostics.Process.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.Process.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Process.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Diagnostics.Process.xml",
+        "zh-hans/System.Diagnostics.Process.xml",
+        "zh-hant/System.Diagnostics.Process.xml"
+      ]
+    },
+    "System.Diagnostics.StackTrace/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "jZ3+0apsOdgdtB1RjnVq2AgCRgt2abCVUYHrZKENw52K7nZbE74SpxfbUb2bHLs/2rqS/Hxtsn66Ltjl6AJvmw==",
+      "files": [
+        "System.Diagnostics.StackTrace.4.0.1-beta-23311.nupkg",
+        "System.Diagnostics.StackTrace.4.0.1-beta-23311.nupkg.sha512",
+        "System.Diagnostics.StackTrace.nuspec",
+        "System.Diagnostics.StackTrace.xml",
+        "de/System.Diagnostics.StackTrace.xml",
+        "es/System.Diagnostics.StackTrace.xml",
+        "fr/System.Diagnostics.StackTrace.xml",
+        "it/System.Diagnostics.StackTrace.xml",
+        "ja/System.Diagnostics.StackTrace.xml",
+        "ko/System.Diagnostics.StackTrace.xml",
+        "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.StackTrace.dll",
+        "lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.StackTrace.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.StackTrace.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Diagnostics.StackTrace.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "zh-hans/System.Diagnostics.StackTrace.xml",
+        "zh-hant/System.Diagnostics.StackTrace.xml"
+      ]
+    },
+    "System.Diagnostics.TextWriterTraceListener/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "4w7WKRZU7IljZE+pw6hcnZ6ZTwsyFWlSPQbwf7CObov9E+j3/si/FQhBOYHDx6+PlmoccANNmDKsl76RFGDJVA==",
+      "files": [
+        "System.Diagnostics.TextWriterTraceListener.4.0.0-beta-23311.nupkg",
+        "System.Diagnostics.TextWriterTraceListener.4.0.0-beta-23311.nupkg.sha512",
+        "System.Diagnostics.TextWriterTraceListener.nuspec",
+        "System.Diagnostics.TextWriterTraceListener.xml",
+        "de/System.Diagnostics.TextWriterTraceListener.xml",
+        "es/System.Diagnostics.TextWriterTraceListener.xml",
+        "fr/System.Diagnostics.TextWriterTraceListener.xml",
+        "it/System.Diagnostics.TextWriterTraceListener.xml",
+        "ja/System.Diagnostics.TextWriterTraceListener.xml",
+        "ko/System.Diagnostics.TextWriterTraceListener.xml",
+        "lib/DNXCore50/System.Diagnostics.TextWriterTraceListener.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.TextWriterTraceListener.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.TextWriterTraceListener.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.TextWriterTraceListener.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Diagnostics.TextWriterTraceListener.xml",
+        "zh-hans/System.Diagnostics.TextWriterTraceListener.xml",
+        "zh-hant/System.Diagnostics.TextWriterTraceListener.xml"
+      ]
+    },
+    "System.Diagnostics.Tools/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "xk3go6oEZ9M5ZdVYlPooNL0nOz8rqbQIRUesgpz7WtYb5UrW25+x0sUUEWZlPGep4nCaIb5MSy8fFeBV0sKnPw==",
+      "files": [
+        "System.Diagnostics.Tools.4.0.1-beta-23311.nupkg",
+        "System.Diagnostics.Tools.4.0.1-beta-23311.nupkg.sha512",
+        "System.Diagnostics.Tools.nuspec",
+        "System.Diagnostics.Tools.xml",
+        "de/System.Diagnostics.Tools.xml",
+        "es/System.Diagnostics.Tools.xml",
+        "fr/System.Diagnostics.Tools.xml",
+        "it/System.Diagnostics.Tools.xml",
+        "ja/System.Diagnostics.Tools.xml",
+        "ko/System.Diagnostics.Tools.xml",
+        "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.Diagnostics.Tools.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "zh-hans/System.Diagnostics.Tools.xml",
+        "zh-hant/System.Diagnostics.Tools.xml"
+      ]
+    },
+    "System.Diagnostics.TraceSource/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "DImRs9P3eJD21ZZtty5bWo4htuT+jA7e+v7tf1DM4vkhB0zOtIFFWWw+nnQeQ9x6vFo7xxKBWeC7m6sBQEBt1g==",
+      "files": [
+        "System.Diagnostics.TraceSource.4.0.0-beta-23311.nupkg",
+        "System.Diagnostics.TraceSource.4.0.0-beta-23311.nupkg.sha512",
+        "System.Diagnostics.TraceSource.nuspec",
+        "System.Diagnostics.TraceSource.xml",
+        "de/System.Diagnostics.TraceSource.xml",
+        "es/System.Diagnostics.TraceSource.xml",
+        "fr/System.Diagnostics.TraceSource.xml",
+        "it/System.Diagnostics.TraceSource.xml",
+        "ja/System.Diagnostics.TraceSource.xml",
+        "ko/System.Diagnostics.TraceSource.xml",
+        "lib/DNXCore50/System.Diagnostics.TraceSource.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.TraceSource.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.TraceSource.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.TraceSource.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Diagnostics.TraceSource.xml",
+        "zh-hans/System.Diagnostics.TraceSource.xml",
+        "zh-hant/System.Diagnostics.TraceSource.xml"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.21-beta-23311": {
+      "serviceable": true,
+      "sha512": "JSFqSML/9N0CcZA1k3bW5CrHctHhxp7AbzEulNGOPdW+g/GdXXKrk7VZtEQjqjgGzUhFvC6djHQDu4QuBHy85Q==",
+      "files": [
+        "System.Diagnostics.Tracing.4.0.21-beta-23311.nupkg",
+        "System.Diagnostics.Tracing.4.0.21-beta-23311.nupkg.sha512",
+        "System.Diagnostics.Tracing.nuspec",
+        "System.Diagnostics.Tracing.xml",
+        "de/System.Diagnostics.Tracing.xml",
+        "es/System.Diagnostics.Tracing.xml",
+        "fr/System.Diagnostics.Tracing.xml",
+        "it/System.Diagnostics.Tracing.xml",
+        "ja/System.Diagnostics.Tracing.xml",
+        "ko/System.Diagnostics.Tracing.xml",
+        "lib/DNXCore50/System.Diagnostics.Tracing.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Diagnostics.Tracing.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "zh-hans/System.Diagnostics.Tracing.xml",
+        "zh-hant/System.Diagnostics.Tracing.xml"
+      ]
+    },
+    "System.Dynamic.Runtime/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "olmm4FUX8tT1eG/o7uIq7EeDuLAk3PR3toy2WBNHiIW2GQJgML9TiQJX+xR0LIjcKAI8BlCqZLO6RuiKwT8PiQ==",
+      "files": [
+        "System.Dynamic.Runtime.4.0.11-beta-23311.nupkg",
+        "System.Dynamic.Runtime.4.0.11-beta-23311.nupkg.sha512",
+        "System.Dynamic.Runtime.nuspec",
+        "System.Dynamic.Runtime.xml",
+        "de/System.Dynamic.Runtime.xml",
+        "es/System.Dynamic.Runtime.xml",
+        "fr/System.Dynamic.Runtime.xml",
+        "it/System.Dynamic.Runtime.xml",
+        "ja/System.Dynamic.Runtime.xml",
+        "ko/System.Dynamic.Runtime.xml",
+        "lib/DNXCore50/System.Dynamic.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Dynamic.Runtime.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
+        "zh-hans/System.Dynamic.Runtime.xml",
+        "zh-hant/System.Dynamic.Runtime.xml"
+      ]
+    },
+    "System.Globalization/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "R4V8zVZpPaYVdjnOy9PSAHtf+oHjHSf+bEUtP21OyqnlFc4ZvgVd1CTkOU8sU+62zJN/QbFTjVNQpiQtuXn2Ow==",
+      "files": [
+        "System.Globalization.4.0.11-beta-23311.nupkg",
+        "System.Globalization.4.0.11-beta-23311.nupkg.sha512",
+        "System.Globalization.nuspec",
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
+      ]
+    },
+    "System.Globalization.Calendars/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "kiFDf9I66eYQCJDV/W9H7uWevx6BHvgNJDsZmiEycEeuABj4+J7mLaI3EZ/goGzNGt+TFkmm2U26IvFyv1CTwQ==",
+      "files": [
+        "System.Globalization.Calendars.4.0.1-beta-23311.nupkg",
+        "System.Globalization.Calendars.4.0.1-beta-23311.nupkg.sha512",
+        "System.Globalization.Calendars.nuspec",
+        "lib/DNXCore50/System.Globalization.Calendars.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
+      ]
+    },
+    "System.Globalization.Extensions/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "VU+u5T5SKCcwL/mq62MWQDWFAvDkeH+k8YV0Ay3hOMeTscIzU/9yN+J+8iBhFbA4SNWXAQOLEYaPuIlIfW3tSw==",
+      "files": [
+        "System.Globalization.Extensions.4.0.1-beta-23311.nupkg",
+        "System.Globalization.Extensions.4.0.1-beta-23311.nupkg.sha512",
+        "System.Globalization.Extensions.nuspec",
+        "System.Globalization.Extensions.xml",
+        "de/System.Globalization.Extensions.xml",
+        "es/System.Globalization.Extensions.xml",
+        "fr/System.Globalization.Extensions.xml",
+        "it/System.Globalization.Extensions.xml",
+        "ja/System.Globalization.Extensions.xml",
+        "ko/System.Globalization.Extensions.xml",
+        "lib/dotnet/System.Globalization.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Globalization.Extensions.xml",
+        "zh-hans/System.Globalization.Extensions.xml",
+        "zh-hant/System.Globalization.Extensions.xml"
+      ]
+    },
+    "System.IO/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "F79g+V2p3HBXYu+2ozAu2C2B1SLs7A75g+8i2yFIGqCF4qnqGn1kduL9gAlpCxPIf0oA6Dq/QLO84gXT2QrnkQ==",
+      "files": [
+        "System.IO.4.0.11-beta-23311.nupkg",
+        "System.IO.4.0.11-beta-23311.nupkg.sha512",
+        "System.IO.nuspec",
+        "System.IO.xml",
+        "de/System.IO.xml",
+        "es/System.IO.xml",
+        "fr/System.IO.xml",
+        "it/System.IO.xml",
+        "ja/System.IO.xml",
+        "ko/System.IO.xml",
+        "lib/DNXCore50/System.IO.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.IO.xml",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "zh-hans/System.IO.xml",
+        "zh-hant/System.IO.xml"
+      ]
+    },
+    "System.IO.Compression/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "LYA4Yi4PpHdUOa8piIqGacGj3sVwFjfTd2JQUHG6G3XFFFv3G/hWoNqDFjaOpyrwanIPFWoC48YB3wA4nT3b2A==",
+      "files": [
+        "runtime.json",
+        "System.IO.Compression.4.0.1-beta-23311.nupkg",
+        "System.IO.Compression.4.0.1-beta-23311.nupkg.sha512",
+        "System.IO.Compression.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.IO.Compression.dll",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.IO.Compression.clrcompression-x64/4.0.0": {
+      "sha512": "Lqr+URMwKzf+8HJF6YrqEqzKzDzFJTE4OekaxqdIns71r8Ufbd8SbZa0LKl9q+7nu6Em4SkIEXVMB7plSXekOw==",
+      "files": [
+        "System.IO.Compression.clrcompression-x64.4.0.0.nupkg",
+        "System.IO.Compression.clrcompression-x64.4.0.0.nupkg.sha512",
+        "System.IO.Compression.clrcompression-x64.nuspec",
+        "runtimes/win10-x64/native/ClrCompression.dll",
+        "runtimes/win7-x64/native/clrcompression.dll"
+      ]
+    },
+    "System.IO.Compression.ZipFile/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "BuMq8Ofv5oICLAy+CYtKk0GeZwDxjj2CERw2apW4WzzWRCUqCQNdnjYD+fP6T48O8KJEG3A3ismUyAAOTZ5QJg==",
+      "files": [
+        "System.IO.Compression.ZipFile.4.0.1-beta-23311.nupkg",
+        "System.IO.Compression.ZipFile.4.0.1-beta-23311.nupkg.sha512",
+        "System.IO.Compression.ZipFile.nuspec",
+        "System.IO.Compression.ZipFile.xml",
+        "de/System.IO.Compression.ZipFile.xml",
+        "es/System.IO.Compression.ZipFile.xml",
+        "fr/System.IO.Compression.ZipFile.xml",
+        "it/System.IO.Compression.ZipFile.xml",
+        "ja/System.IO.Compression.ZipFile.xml",
+        "ko/System.IO.Compression.ZipFile.xml",
+        "lib/dotnet/System.IO.Compression.ZipFile.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.IO.Compression.ZipFile.xml",
+        "zh-hans/System.IO.Compression.ZipFile.xml",
+        "zh-hant/System.IO.Compression.ZipFile.xml"
+      ]
+    },
+    "System.IO.FileSystem/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "KLQFzD4yotNo34CIIqZgDMv6gsZgLHUPFjLXy+17f/bi3Q2QVwCAMvma4ufVrsipYpiOLC/3skTMCYZKit8nsQ==",
+      "files": [
+        "runtime.json",
+        "System.IO.FileSystem.4.0.1-beta-23311.nupkg",
+        "System.IO.FileSystem.4.0.1-beta-23311.nupkg.sha512",
+        "System.IO.FileSystem.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.IO.FileSystem.DriveInfo/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "o5iKAcojHRjzX7SX0LpIZJcTWOFVJGjb8QaJ7DhUQd/shjrPyrxWz/8dtqWeUp8nGBRoHJizYuQ6Srn2K+hrlQ==",
+      "files": [
+        "System.IO.FileSystem.DriveInfo.4.0.0-beta-23311.nupkg",
+        "System.IO.FileSystem.DriveInfo.4.0.0-beta-23311.nupkg.sha512",
+        "System.IO.FileSystem.DriveInfo.nuspec",
+        "System.IO.FileSystem.DriveInfo.xml",
+        "de/System.IO.FileSystem.DriveInfo.xml",
+        "es/System.IO.FileSystem.DriveInfo.xml",
+        "fr/System.IO.FileSystem.DriveInfo.xml",
+        "it/System.IO.FileSystem.DriveInfo.xml",
+        "ja/System.IO.FileSystem.DriveInfo.xml",
+        "ko/System.IO.FileSystem.DriveInfo.xml",
+        "lib/DNXCore50/System.IO.FileSystem.DriveInfo.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.DriveInfo.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.DriveInfo.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.DriveInfo.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.IO.FileSystem.DriveInfo.xml",
+        "zh-hans/System.IO.FileSystem.DriveInfo.xml",
+        "zh-hant/System.IO.FileSystem.DriveInfo.xml"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "c3J63Jzabn2rREdyyU2Ox5G+c0xI8ZJpl8yuDR5t5hsQJhSu6QkPnnUYNFOLq6kqWL2GkOfHTn8a5xYY/EU6aQ==",
+      "files": [
+        "System.IO.FileSystem.Primitives.4.0.1-beta-23311.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.1-beta-23311.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec",
+        "System.IO.FileSystem.Primitives.xml",
+        "de/System.IO.FileSystem.Primitives.xml",
+        "es/System.IO.FileSystem.Primitives.xml",
+        "fr/System.IO.FileSystem.Primitives.xml",
+        "it/System.IO.FileSystem.Primitives.xml",
+        "ja/System.IO.FileSystem.Primitives.xml",
+        "ko/System.IO.FileSystem.Primitives.xml",
+        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.IO.FileSystem.Primitives.xml",
+        "zh-hans/System.IO.FileSystem.Primitives.xml",
+        "zh-hant/System.IO.FileSystem.Primitives.xml"
+      ]
+    },
+    "System.IO.FileSystem.Watcher/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "rXhTrS2uvK/CI7efYngvRkIbMOone/1uB3+kdk0ooNZHCOnAWWTsUuRv9HDu/RA21BqG9e+tiZdGLj/zE9/6cA==",
+      "files": [
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23311.nupkg",
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23311.nupkg.sha512",
+        "System.IO.FileSystem.Watcher.nuspec",
+        "System.IO.FileSystem.Watcher.xml",
+        "de/System.IO.FileSystem.Watcher.xml",
+        "es/System.IO.FileSystem.Watcher.xml",
+        "fr/System.IO.FileSystem.Watcher.xml",
+        "it/System.IO.FileSystem.Watcher.xml",
+        "ja/System.IO.FileSystem.Watcher.xml",
+        "ko/System.IO.FileSystem.Watcher.xml",
+        "lib/DNXCore50/System.IO.FileSystem.Watcher.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Watcher.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.Watcher.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Watcher.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.IO.FileSystem.Watcher.xml",
+        "zh-hans/System.IO.FileSystem.Watcher.xml",
+        "zh-hant/System.IO.FileSystem.Watcher.xml"
+      ]
+    },
+    "System.IO.MemoryMappedFiles/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "7ggEpbHoxlE9rB4byck6VW53jmBoJnr9d8OgIoWM8llqnBIH0LLQMhbj12ejQs6vVFZ3fFnSc4Eo1SCSNXLiYg==",
+      "files": [
+        "System.IO.MemoryMappedFiles.4.0.0-beta-23311.nupkg",
+        "System.IO.MemoryMappedFiles.4.0.0-beta-23311.nupkg.sha512",
+        "System.IO.MemoryMappedFiles.nuspec",
+        "System.IO.MemoryMappedFiles.xml",
+        "de/System.IO.MemoryMappedFiles.xml",
+        "es/System.IO.MemoryMappedFiles.xml",
+        "fr/System.IO.MemoryMappedFiles.xml",
+        "it/System.IO.MemoryMappedFiles.xml",
+        "ja/System.IO.MemoryMappedFiles.xml",
+        "ko/System.IO.MemoryMappedFiles.xml",
+        "lib/DNXCore50/System.IO.MemoryMappedFiles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.MemoryMappedFiles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.MemoryMappedFiles.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.MemoryMappedFiles.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.IO.MemoryMappedFiles.xml",
+        "zh-hans/System.IO.MemoryMappedFiles.xml",
+        "zh-hant/System.IO.MemoryMappedFiles.xml"
+      ]
+    },
+    "System.IO.Pipes/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "5d6NEneBaLGfVsxqs4ijhKsH97pZGKQJtGqfLQXJ6pLo4YskfSZTv8fcmhp75phYecHPswWn1Z1O5c1jQHAOKA==",
+      "files": [
+        "System.IO.Pipes.4.0.0-beta-23311.nupkg",
+        "System.IO.Pipes.4.0.0-beta-23311.nupkg.sha512",
+        "System.IO.Pipes.nuspec",
+        "System.IO.Pipes.xml",
+        "de/System.IO.Pipes.xml",
+        "es/System.IO.Pipes.xml",
+        "fr/System.IO.Pipes.xml",
+        "it/System.IO.Pipes.xml",
+        "ja/System.IO.Pipes.xml",
+        "ko/System.IO.Pipes.xml",
+        "lib/DNXCore50/System.IO.Pipes.dll",
+        "lib/net46/System.IO.Pipes.dll",
+        "ref/dotnet/System.IO.Pipes.dll",
+        "ref/net46/System.IO.Pipes.dll",
+        "ru/System.IO.Pipes.xml",
+        "zh-hans/System.IO.Pipes.xml",
+        "zh-hant/System.IO.Pipes.xml"
+      ]
+    },
+    "System.IO.UnmanagedMemoryStream/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "3c0UjPutuzByOTb7JG1y8rIW2EwFG1x4fjL2Ba3Hz2Be/zgIqXVAmqCgGYQXvyv3GouI//3ofDcUBCkQZZljMQ==",
+      "files": [
+        "System.IO.UnmanagedMemoryStream.4.0.1-beta-23311.nupkg",
+        "System.IO.UnmanagedMemoryStream.4.0.1-beta-23311.nupkg.sha512",
+        "System.IO.UnmanagedMemoryStream.nuspec",
+        "System.IO.UnmanagedMemoryStream.xml",
+        "de/System.IO.UnmanagedMemoryStream.xml",
+        "es/System.IO.UnmanagedMemoryStream.xml",
+        "fr/System.IO.UnmanagedMemoryStream.xml",
+        "it/System.IO.UnmanagedMemoryStream.xml",
+        "ja/System.IO.UnmanagedMemoryStream.xml",
+        "ko/System.IO.UnmanagedMemoryStream.xml",
+        "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.IO.UnmanagedMemoryStream.xml",
+        "zh-hans/System.IO.UnmanagedMemoryStream.xml",
+        "zh-hant/System.IO.UnmanagedMemoryStream.xml"
+      ]
+    },
+    "System.Linq/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "VIF/qCCRSftjzoPq39i0v0yb4cUhfMBdqi82T+0L2Uwj1dGaiZ98Cdn4WJjVCRT4DSoTuEGj4ks6KgM0aH4CHw==",
+      "files": [
+        "System.Linq.4.0.1-beta-23311.nupkg",
+        "System.Linq.4.0.1-beta-23311.nupkg.sha512",
+        "System.Linq.nuspec",
+        "System.Linq.xml",
+        "de/System.Linq.xml",
+        "es/System.Linq.xml",
+        "fr/System.Linq.xml",
+        "it/System.Linq.xml",
+        "ja/System.Linq.xml",
+        "ko/System.Linq.xml",
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.Linq.xml",
+        "zh-hans/System.Linq.xml",
+        "zh-hant/System.Linq.xml"
+      ]
+    },
+    "System.Linq.Expressions/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "Mys/xNUD2sdtggvpCA2nT2t3JYZVryG6ycRhMdedwFo5SA3YGxedKDx8um/8hP7vib6WxpKUVDk6x35Wtbqeow==",
+      "files": [
+        "runtime.json",
+        "System.Linq.Expressions.4.0.11-beta-23311.nupkg",
+        "System.Linq.Expressions.4.0.11-beta-23311.nupkg.sha512",
+        "System.Linq.Expressions.nuspec",
+        "System.Linq.Expressions.xml",
+        "de/System.Linq.Expressions.xml",
+        "es/System.Linq.Expressions.xml",
+        "fr/System.Linq.Expressions.xml",
+        "it/System.Linq.Expressions.xml",
+        "ja/System.Linq.Expressions.xml",
+        "ko/System.Linq.Expressions.xml",
+        "lib/DNXCore50/System.Linq.Expressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Linq.Expressions.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "zh-hans/System.Linq.Expressions.xml",
+        "zh-hant/System.Linq.Expressions.xml"
+      ]
+    },
+    "System.Linq.Parallel/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "cfq2u8g15Y+KJOUXsYynvEWNVT9BLzrSzZP3SGDWR9fvMvpiHqhhJW4h4A3H7KPwCHkFEqepNvOt4vFXu6yl1A==",
+      "files": [
+        "System.Linq.Parallel.4.0.1-beta-23311.nupkg",
+        "System.Linq.Parallel.4.0.1-beta-23311.nupkg.sha512",
+        "System.Linq.Parallel.nuspec",
+        "System.Linq.Parallel.xml",
+        "de/System.Linq.Parallel.xml",
+        "es/System.Linq.Parallel.xml",
+        "fr/System.Linq.Parallel.xml",
+        "it/System.Linq.Parallel.xml",
+        "ja/System.Linq.Parallel.xml",
+        "ko/System.Linq.Parallel.xml",
+        "lib/dotnet/System.Linq.Parallel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.Parallel.dll",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ru/System.Linq.Parallel.xml",
+        "zh-hans/System.Linq.Parallel.xml",
+        "zh-hant/System.Linq.Parallel.xml"
+      ]
+    },
+    "System.Linq.Queryable/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "Y+1LySFDG0uDdtWEMvQhHGiLKiuNaBPIKi0XfLHwTTXmGA0prtjro6ohbXKAjdTMWzu/TuBncPBhGRwNhGT35Q==",
+      "files": [
+        "System.Linq.Queryable.4.0.1-beta-23311.nupkg",
+        "System.Linq.Queryable.4.0.1-beta-23311.nupkg.sha512",
+        "System.Linq.Queryable.nuspec",
+        "System.Linq.Queryable.xml",
+        "de/System.Linq.Queryable.xml",
+        "es/System.Linq.Queryable.xml",
+        "fr/System.Linq.Queryable.xml",
+        "it/System.Linq.Queryable.xml",
+        "ja/System.Linq.Queryable.xml",
+        "ko/System.Linq.Queryable.xml",
+        "lib/dotnet/System.Linq.Queryable.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.Queryable.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.Linq.Queryable.xml",
+        "zh-hans/System.Linq.Queryable.xml",
+        "zh-hant/System.Linq.Queryable.xml"
+      ]
+    },
+    "System.Net.Http/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "wl7ubSIcDcYOLR2pTprnbs0+p6JsDU91rbkUMmUeaaPhmjNZAJh2z6VBwRtr9toG07z9FQI1nl0W/3pJVTSilg==",
+      "files": [
+        "System.Net.Http.4.0.1-beta-23311.nupkg",
+        "System.Net.Http.4.0.1-beta-23311.nupkg.sha512",
+        "System.Net.Http.nuspec",
+        "System.Net.Http.xml",
+        "de/System.Net.Http.xml",
+        "es/System.Net.Http.xml",
+        "fr/System.Net.Http.xml",
+        "it/System.Net.Http.xml",
+        "ja/System.Net.Http.xml",
+        "ko/System.Net.Http.xml",
+        "lib/DNXCore50/System.Net.Http.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Net.Http.dll",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ru/System.Net.Http.xml",
+        "zh-hans/System.Net.Http.xml",
+        "zh-hant/System.Net.Http.xml"
+      ]
+    },
+    "System.Net.NameResolution/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "ua4poSvF1k3YigeS3MohCAxtZYYbApyDQAVaVC2i4CCwcBiEWREqSXwmW3jpWcj5BOxzkGN70EN42sWkZq7KhA==",
+      "files": [
+        "System.Net.NameResolution.4.0.0-beta-23311.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23311.nupkg.sha512",
+        "System.Net.NameResolution.nuspec",
+        "lib/DNXCore50/System.Net.NameResolution.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.NameResolution.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.NameResolution.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.NameResolution.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Net.NetworkInformation/4.1.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "S1PwOL+SYFLa0+WNIu6GwN03wm56/hITTSp8dYhdSYfIP/Ekj3b0xo1iawAR17eMkDJELWZwotKB5sOAhFPNkA==",
+      "files": [
+        "System.Net.NetworkInformation.4.1.0-beta-23311.nupkg",
+        "System.Net.NetworkInformation.4.1.0-beta-23311.nupkg.sha512",
+        "System.Net.NetworkInformation.nuspec",
+        "System.Net.NetworkInformation.xml",
+        "de/System.Net.NetworkInformation.xml",
+        "es/System.Net.NetworkInformation.xml",
+        "fr/System.Net.NetworkInformation.xml",
+        "it/System.Net.NetworkInformation.xml",
+        "ja/System.Net.NetworkInformation.xml",
+        "ko/System.Net.NetworkInformation.xml",
+        "lib/DNXCore50/System.Net.NetworkInformation.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.NetworkInformation.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.NetworkInformation.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Net.NetworkInformation.xml",
+        "zh-hans/System.Net.NetworkInformation.xml",
+        "zh-hant/System.Net.NetworkInformation.xml"
+      ]
+    },
+    "System.Net.Primitives/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "pyUL6rnfyj4WJy2tc63C575mJ3K3Zfyv7EjvGLcApJ2li5+NQMSLzbDvWF6H0MRT+M1PmyZkUcZ5XpaBtnFlbQ==",
+      "files": [
+        "System.Net.Primitives.4.0.11-beta-23311.nupkg",
+        "System.Net.Primitives.4.0.11-beta-23311.nupkg.sha512",
+        "System.Net.Primitives.nuspec",
+        "System.Net.Primitives.xml",
+        "de/System.Net.Primitives.xml",
+        "es/System.Net.Primitives.xml",
+        "fr/System.Net.Primitives.xml",
+        "it/System.Net.Primitives.xml",
+        "ja/System.Net.Primitives.xml",
+        "ko/System.Net.Primitives.xml",
+        "lib/DNXCore50/System.Net.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Net.Primitives.xml",
+        "zh-hans/System.Net.Primitives.xml",
+        "zh-hant/System.Net.Primitives.xml"
+      ]
+    },
+    "System.Net.Requests/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "XfOwQX7H9QPJKOg6iWXs8H0HOpXls3Nc2blq8dd/VMsPPYVwnl5e1DsOfSFw/RrmrZr2JcLrIbX3s9HqY3/5HA==",
+      "files": [
+        "System.Net.Requests.4.0.11-beta-23311.nupkg",
+        "System.Net.Requests.4.0.11-beta-23311.nupkg.sha512",
+        "System.Net.Requests.nuspec",
+        "System.Net.Requests.xml",
+        "de/System.Net.Requests.xml",
+        "es/System.Net.Requests.xml",
+        "fr/System.Net.Requests.xml",
+        "it/System.Net.Requests.xml",
+        "ja/System.Net.Requests.xml",
+        "ko/System.Net.Requests.xml",
+        "lib/dotnet/System.Net.Requests.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Requests.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Net.Requests.xml",
+        "zh-hans/System.Net.Requests.xml",
+        "zh-hant/System.Net.Requests.xml"
+      ]
+    },
+    "System.Net.Security/4.0.0-beta-23311": {
+      "sha512": "0tNm4Wodk091pBmOtoDK71lMzpjkcABUUpUu3Wj9Pv6LJfBXO6BZ8mmHShA2jqJraxVtyls3/v6GFcUi56Uerg==",
+      "files": [
+        "System.Net.Security.4.0.0-beta-23311.nupkg",
+        "System.Net.Security.4.0.0-beta-23311.nupkg.sha512",
+        "System.Net.Security.nuspec",
+        "lib/DNXCore50/System.Net.Security.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.Security.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Security.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.Security.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Net.Sockets/4.1.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "l9OuafxuR1K6xbktxd8eseRDX5lq/qekTMj9mgumR+xqF+Rowfho/EOgaZSehJzY3y5WmuyODbE/Iymdbv581g==",
+      "files": [
+        "System.Net.Sockets.4.1.0-beta-23311.nupkg",
+        "System.Net.Sockets.4.1.0-beta-23311.nupkg.sha512",
+        "System.Net.Sockets.nuspec",
+        "System.Net.Sockets.xml",
+        "de/System.Net.Sockets.xml",
+        "es/System.Net.Sockets.xml",
+        "fr/System.Net.Sockets.xml",
+        "it/System.Net.Sockets.xml",
+        "ja/System.Net.Sockets.xml",
+        "ko/System.Net.Sockets.xml",
+        "lib/DNXCore50/System.Net.Sockets.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.Sockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Sockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.Sockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Net.Sockets.xml",
+        "zh-hans/System.Net.Sockets.xml",
+        "zh-hant/System.Net.Sockets.xml"
+      ]
+    },
+    "System.Net.Utilities/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "Uy2KmNj9ZTRZNqci9LyYtujiLQhIheEq4QcebWxmZrqxm6VOH1m1jpKLsArk4MdxWH6IV7CPz/TzMOWsNqzBXQ==",
+      "files": [
+        "System.Net.Utilities.4.0.0-beta-23311.nupkg",
+        "System.Net.Utilities.4.0.0-beta-23311.nupkg.sha512",
+        "System.Net.Utilities.nuspec",
+        "lib/DNXCore50/System.Net.Utilities.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.Utilities.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Utilities.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.Utilities.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Net.WebHeaderCollection/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "NYGM2R3XISyZdC2dz4yU96Wz4qwdHFTPw94MJ9GjBY4er4KMGemSAFSMpm0PN2H0VUVb6+/s0zN/pYQHbc70xA==",
+      "files": [
+        "System.Net.WebHeaderCollection.4.0.1-beta-23311.nupkg",
+        "System.Net.WebHeaderCollection.4.0.1-beta-23311.nupkg.sha512",
+        "System.Net.WebHeaderCollection.nuspec",
+        "System.Net.WebHeaderCollection.xml",
+        "de/System.Net.WebHeaderCollection.xml",
+        "es/System.Net.WebHeaderCollection.xml",
+        "fr/System.Net.WebHeaderCollection.xml",
+        "it/System.Net.WebHeaderCollection.xml",
+        "ja/System.Net.WebHeaderCollection.xml",
+        "ko/System.Net.WebHeaderCollection.xml",
+        "lib/dotnet/System.Net.WebHeaderCollection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebHeaderCollection.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Net.WebHeaderCollection.xml",
+        "zh-hans/System.Net.WebHeaderCollection.xml",
+        "zh-hant/System.Net.WebHeaderCollection.xml"
+      ]
+    },
+    "System.Net.WebSockets/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "gt7nwSj87Xnx4kKAFXV1h0XzeP2VUXOTldob7lOXP0h4bEamxVGXxjv4f0DCaDUp1yZm0/qiWp963upMj0dSvA==",
+      "files": [
+        "System.Net.WebSockets.4.0.0-beta-23311.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23311.nupkg.sha512",
+        "System.Net.WebSockets.nuspec",
+        "System.Net.WebSockets.xml",
+        "de/System.Net.WebSockets.xml",
+        "es/System.Net.WebSockets.xml",
+        "fr/System.Net.WebSockets.xml",
+        "it/System.Net.WebSockets.xml",
+        "ja/System.Net.WebSockets.xml",
+        "ko/System.Net.WebSockets.xml",
+        "lib/DNXCore50/System.Net.WebSockets.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Net.WebSockets.xml",
+        "zh-hans/System.Net.WebSockets.xml",
+        "zh-hant/System.Net.WebSockets.xml"
+      ]
+    },
+    "System.Net.WebSockets.Client/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "oPVRLR5pe5hA7VWOe3w6R88sM91K+Dx4qzm4q4mttoUGu2jC14IpOlI4BvA0zyk6AUl769/MqvC1u24iCXVONQ==",
+      "files": [
+        "System.Net.WebSockets.Client.4.0.0-beta-23311.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23311.nupkg.sha512",
+        "System.Net.WebSockets.Client.nuspec",
+        "System.Net.WebSockets.Client.xml",
+        "de/System.Net.WebSockets.Client.xml",
+        "es/System.Net.WebSockets.Client.xml",
+        "fr/System.Net.WebSockets.Client.xml",
+        "it/System.Net.WebSockets.Client.xml",
+        "ja/System.Net.WebSockets.Client.xml",
+        "ko/System.Net.WebSockets.Client.xml",
+        "lib/DNXCore50/System.Net.WebSockets.Client.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Net.WebSockets.Client.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.WebSockets.Client.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Net.WebSockets.Client.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Net.WebSockets.Client.xml",
+        "zh-hans/System.Net.WebSockets.Client.xml",
+        "zh-hant/System.Net.WebSockets.Client.xml"
+      ]
+    },
+    "System.Numerics.Vectors/4.1.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "NpHd9XXlwdeAp8yd0sqwIU5fp6WH1r3bnQbsBShJzMgxWCfm0LloxblVWQYSXLJKA7vRl9z/zao1DVeXK7ubXg==",
+      "files": [
+        "System.Numerics.Vectors.4.1.1-beta-23311.nupkg",
+        "System.Numerics.Vectors.4.1.1-beta-23311.nupkg.sha512",
+        "System.Numerics.Vectors.nuspec",
+        "lib/dotnet/System.Numerics.Vectors.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
+        "lib/portable-net45+win8/System.Numerics.Vectors.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Numerics.Vectors.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.ObjectModel/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "w3KLOdj/MCNB3k53bhm5KW2UzOgTFZ71s/M5xzIQBUZEo0dM2/T3iWf6KnKy/mRz5YstFxZioyllc5VUDQZYPg==",
+      "files": [
+        "System.ObjectModel.4.0.11-beta-23311.nupkg",
+        "System.ObjectModel.4.0.11-beta-23311.nupkg.sha512",
+        "System.ObjectModel.nuspec",
+        "System.ObjectModel.xml",
+        "de/System.ObjectModel.xml",
+        "es/System.ObjectModel.xml",
+        "fr/System.ObjectModel.xml",
+        "it/System.ObjectModel.xml",
+        "ja/System.ObjectModel.xml",
+        "ko/System.ObjectModel.xml",
+        "lib/dotnet/System.ObjectModel.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.ObjectModel.xml",
+        "zh-hans/System.ObjectModel.xml",
+        "zh-hant/System.ObjectModel.xml"
+      ]
+    },
+    "System.Private.DataContractSerialization/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "rX9X083O4FvqVRdbsjtKni4ExZt8ywpJ28xJ8lQPKSvV3GzoAA2bvu5MGAUC+88RGidx5WIe4wtXXEpkxcKKew==",
+      "files": [
+        "runtime.json",
+        "System.Private.DataContractSerialization.4.0.1-beta-23311.nupkg",
+        "System.Private.DataContractSerialization.4.0.1-beta-23311.nupkg.sha512",
+        "System.Private.DataContractSerialization.nuspec",
+        "lib/DNXCore50/System.Private.DataContractSerialization.dll",
+        "lib/netcore50/System.Private.DataContractSerialization.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll"
+      ]
+    },
+    "System.Private.Networking/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "26SmurZIUMIWKmU0exNc14Efg9dDxPV0/eRuGPbbBUWiddmx4y4h1wj3OOQwtuWmVix9EnnYYGRShG0Mb6rYrg==",
+      "files": [
+        "System.Private.Networking.4.0.1-beta-23311.nupkg",
+        "System.Private.Networking.4.0.1-beta-23311.nupkg.sha512",
+        "System.Private.Networking.nuspec",
+        "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._"
+      ]
+    },
+    "System.Private.ServiceModel/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "WxhanhOvlyvtM3QiOdAxyEQFsoRR/uqVLeSBUuEDgYa7jlceVmiYQoNtnn0phcW8raEy8+XKSAja7K+ppG8PBQ==",
+      "files": [
+        "System.Private.ServiceModel.4.0.1-beta-23311.nupkg",
+        "System.Private.ServiceModel.4.0.1-beta-23311.nupkg.sha512",
+        "System.Private.ServiceModel.nuspec",
+        "lib/DNXCore50/System.Private.ServiceModel.dll",
+        "lib/netcore50/System.Private.ServiceModel.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._"
+      ]
+    },
+    "System.Private.Uri/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "LeCKGhHcwNQ/YHtIolX2pBVaRgWmrMpvX2bhuIz5HOmoFBYAhAsTgcAH/psj+xGFbBoBLzLGv+reuLo4R81ySg==",
+      "files": [
+        "System.Private.Uri.4.0.1-beta-23311.nupkg",
+        "System.Private.Uri.4.0.1-beta-23311.nupkg.sha512",
+        "System.Private.Uri.nuspec",
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
+      ]
+    },
+    "System.Reflection/4.1.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "mIq5fCrLhNf4DD261l09pozbft/bU7zhEPiVfw7GzMJQeac81TfSTxV0tsrO9BlWc25wcSvp5vHb+7aCS1nIAw==",
+      "files": [
+        "System.Reflection.4.1.0-beta-23311.nupkg",
+        "System.Reflection.4.1.0-beta-23311.nupkg.sha512",
+        "System.Reflection.nuspec",
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
+      ]
+    },
+    "System.Reflection.DispatchProxy/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "TvySGtUfjbAA5yBrTu41xDFDXGXP72kwBnSRS6a8GtuiB99MZxrsDN832JsGI/89q9eEzyIl+BGkyeheVmHAaQ==",
+      "files": [
+        "runtime.json",
+        "System.Reflection.DispatchProxy.4.0.1-beta-23311.nupkg",
+        "System.Reflection.DispatchProxy.4.0.1-beta-23311.nupkg.sha512",
+        "System.Reflection.DispatchProxy.nuspec",
+        "System.Reflection.DispatchProxy.xml",
+        "de/System.Reflection.DispatchProxy.xml",
+        "es/System.Reflection.DispatchProxy.xml",
+        "fr/System.Reflection.DispatchProxy.xml",
+        "it/System.Reflection.DispatchProxy.xml",
+        "ja/System.Reflection.DispatchProxy.xml",
+        "ko/System.Reflection.DispatchProxy.xml",
+        "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Reflection.DispatchProxy.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "zh-hans/System.Reflection.DispatchProxy.xml",
+        "zh-hant/System.Reflection.DispatchProxy.xml"
+      ]
+    },
+    "System.Reflection.Emit/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "zmk67Hss7xkr7MN65vG8X/VrmfE9Fsktad6nSrr4FAZIjUuxWq8rW53brBOEHfd4FWTE5pWmmm0AydozKOXj/Q==",
+      "files": [
+        "System.Reflection.Emit.4.0.1-beta-23311.nupkg",
+        "System.Reflection.Emit.4.0.1-beta-23311.nupkg.sha512",
+        "System.Reflection.Emit.nuspec",
+        "lib/DNXCore50/System.Reflection.Emit.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/net45/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "System.Reflection.Emit.ILGeneration/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "sPOasDtH9JXtyXqdXmEA/MD29Dgfr22ahrgPQa1sluMVfpSL+FTwJ0xBUHSmU3AEtzwFmgKYgk+jnVDjHDvCRQ==",
+      "files": [
+        "System.Reflection.Emit.ILGeneration.4.0.1-beta-23311.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.1-beta-23311.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec",
+        "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "System.Reflection.Emit.Lightweight/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "L2bJ+mcCLWRmq2WKbsc2CBPIsbIEcdu4hkHe74W6TxBNZukzSv4Ar8N6Uo+el9nzxLZxHVL/JCKySqqeDkqBfA==",
+      "files": [
+        "System.Reflection.Emit.Lightweight.4.0.1-beta-23311.nupkg",
+        "System.Reflection.Emit.Lightweight.4.0.1-beta-23311.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.nuspec",
+        "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "System.Reflection.Extensions/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "68FUrBOdFAMHgeRu0D+lx0pVo8eWsTl/bY0O688nQ4O9jJGoSuX3R+tl+N59lrfa7EO2nsnLc4EYlLipqlLDog==",
+      "files": [
+        "System.Reflection.Extensions.4.0.1-beta-23311.nupkg",
+        "System.Reflection.Extensions.4.0.1-beta-23311.nupkg.sha512",
+        "System.Reflection.Extensions.nuspec",
+        "System.Reflection.Extensions.xml",
+        "de/System.Reflection.Extensions.xml",
+        "es/System.Reflection.Extensions.xml",
+        "fr/System.Reflection.Extensions.xml",
+        "it/System.Reflection.Extensions.xml",
+        "ja/System.Reflection.Extensions.xml",
+        "ko/System.Reflection.Extensions.xml",
+        "lib/DNXCore50/System.Reflection.Extensions.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Extensions.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.Reflection.Extensions.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "zh-hans/System.Reflection.Extensions.xml",
+        "zh-hant/System.Reflection.Extensions.xml"
+      ]
+    },
+    "System.Reflection.Metadata/1.0.23-beta-23311": {
+      "serviceable": true,
+      "sha512": "UjlI7VszDenj+sGTreJWdafACi+UjrfDyYG5++ko9Bi7DKIN7HhNO7K7VSlS8pl8IaIeTc5HNIRww35wUxM+qA==",
+      "files": [
+        "System.Reflection.Metadata.1.0.23-beta-23311.nupkg",
+        "System.Reflection.Metadata.1.0.23-beta-23311.nupkg.sha512",
+        "System.Reflection.Metadata.nuspec",
+        "lib/dotnet/System.Reflection.Metadata.dll",
+        "lib/dotnet/System.Reflection.Metadata.xml",
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "NtBa8OyGPH5WISeOmbl4fHn5t4TmxmfERvmjRSnEharhSpXZjgYBPW5hPx0wdc+Cd6qCG4XYxlu3kXMScJEkcQ==",
+      "files": [
+        "System.Reflection.Primitives.4.0.1-beta-23311.nupkg",
+        "System.Reflection.Primitives.4.0.1-beta-23311.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec",
+        "System.Reflection.Primitives.xml",
+        "de/System.Reflection.Primitives.xml",
+        "es/System.Reflection.Primitives.xml",
+        "fr/System.Reflection.Primitives.xml",
+        "it/System.Reflection.Primitives.xml",
+        "ja/System.Reflection.Primitives.xml",
+        "ko/System.Reflection.Primitives.xml",
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.Reflection.Primitives.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "zh-hans/System.Reflection.Primitives.xml",
+        "zh-hant/System.Reflection.Primitives.xml"
+      ]
+    },
+    "System.Reflection.TypeExtensions/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "a1pn0TkzP9b3VwoWn7c0DoOKBmjQiOE18NbPMR3t7jL5wcCtOGzJ2nqk37zZ+Zj1wV/NaqR9jlTxsDQUH7tWlw==",
+      "files": [
+        "System.Reflection.TypeExtensions.4.0.1-beta-23311.nupkg",
+        "System.Reflection.TypeExtensions.4.0.1-beta-23311.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec",
+        "System.Reflection.TypeExtensions.xml",
+        "de/System.Reflection.TypeExtensions.xml",
+        "es/System.Reflection.TypeExtensions.xml",
+        "fr/System.Reflection.TypeExtensions.xml",
+        "it/System.Reflection.TypeExtensions.xml",
+        "ja/System.Reflection.TypeExtensions.xml",
+        "ko/System.Reflection.TypeExtensions.xml",
+        "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Reflection.TypeExtensions.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "zh-hans/System.Reflection.TypeExtensions.xml",
+        "zh-hant/System.Reflection.TypeExtensions.xml"
+      ]
+    },
+    "System.Resources.ReaderWriter/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "NuIGzHybTYRZ/wmyWTc75cMDSufMVXLlJDuWmEAov558qaAjUn7lxyvxpZaR4usk6X5XgpDysQi+8nidMPsa/g==",
+      "files": [
+        "System.Resources.ReaderWriter.4.0.0-beta-23311.nupkg",
+        "System.Resources.ReaderWriter.4.0.0-beta-23311.nupkg.sha512",
+        "System.Resources.ReaderWriter.nuspec",
+        "System.Resources.ReaderWriter.xml",
+        "de/System.Resources.ReaderWriter.xml",
+        "es/System.Resources.ReaderWriter.xml",
+        "fr/System.Resources.ReaderWriter.xml",
+        "it/System.Resources.ReaderWriter.xml",
+        "ja/System.Resources.ReaderWriter.xml",
+        "ko/System.Resources.ReaderWriter.xml",
+        "lib/DNXCore50/System.Resources.ReaderWriter.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Resources.ReaderWriter.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Resources.ReaderWriter.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Resources.ReaderWriter.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Resources.ReaderWriter.xml",
+        "zh-hans/System.Resources.ReaderWriter.xml",
+        "zh-hant/System.Resources.ReaderWriter.xml"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "sCmngpvZb/dP8JbxiS/tRySq1T/E2ZvByc2Rkl8qVfbErp5STkTpnq97gc3HIlSk2r2JJKs4PkkLShJ/A6+Kkw==",
+      "files": [
+        "System.Resources.ResourceManager.4.0.1-beta-23311.nupkg",
+        "System.Resources.ResourceManager.4.0.1-beta-23311.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec",
+        "System.Resources.ResourceManager.xml",
+        "de/System.Resources.ResourceManager.xml",
+        "es/System.Resources.ResourceManager.xml",
+        "fr/System.Resources.ResourceManager.xml",
+        "it/System.Resources.ResourceManager.xml",
+        "ja/System.Resources.ResourceManager.xml",
+        "ko/System.Resources.ResourceManager.xml",
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.Resources.ResourceManager.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "zh-hans/System.Resources.ResourceManager.xml",
+        "zh-hant/System.Resources.ResourceManager.xml"
+      ]
+    },
+    "System.Runtime/4.0.21-beta-23311": {
+      "serviceable": true,
+      "sha512": "Ds+6jLqn3wFWsTRRoJg0BlSA08PtXSzrB3QqRAc1r6v/Bk9jWcQNv0qdYVxgtnmH5elN5SuyzwNHR4ONqb6Yzg==",
+      "files": [
+        "System.Runtime.4.0.21-beta-23311.nupkg",
+        "System.Runtime.4.0.21-beta-23311.nupkg.sha512",
+        "System.Runtime.nuspec",
+        "System.Runtime.xml",
+        "de/System.Runtime.xml",
+        "es/System.Runtime.xml",
+        "fr/System.Runtime.xml",
+        "it/System.Runtime.xml",
+        "ja/System.Runtime.xml",
+        "ko/System.Runtime.xml",
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Runtime.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "zh-hans/System.Runtime.xml",
+        "zh-hant/System.Runtime.xml"
+      ]
+    },
+    "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "fbWT8GVNb43Mbo6QX+hOD39xIPr82Yjc2jtRzA7/djrMXQAktHioeJVB2YdILl4Y1La73euVYaVNSa60d4x7Nw==",
+      "files": [
+        "System.Runtime.CompilerServices.VisualC.4.0.0-beta-23311.nupkg",
+        "System.Runtime.CompilerServices.VisualC.4.0.0-beta-23311.nupkg.sha512",
+        "System.Runtime.CompilerServices.VisualC.nuspec",
+        "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Runtime.CompilerServices.VisualC.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.CompilerServices.VisualC.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Runtime.CompilerServices.VisualC.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "g0vhHxnlvPee50fLKK7Qperoz/DEoI1TJzsme+p+EXrZt/AwkykwwIMe+HJx6BjWC1gXtCSKi6fpOlO81P00nw==",
+      "files": [
+        "System.Runtime.Extensions.4.0.11-beta-23311.nupkg",
+        "System.Runtime.Extensions.4.0.11-beta-23311.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
+        "System.Runtime.Extensions.xml",
+        "de/System.Runtime.Extensions.xml",
+        "es/System.Runtime.Extensions.xml",
+        "fr/System.Runtime.Extensions.xml",
+        "it/System.Runtime.Extensions.xml",
+        "ja/System.Runtime.Extensions.xml",
+        "ko/System.Runtime.Extensions.xml",
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Runtime.Extensions.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "zh-hans/System.Runtime.Extensions.xml",
+        "zh-hant/System.Runtime.Extensions.xml"
+      ]
+    },
+    "System.Runtime.Handles/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "YDukEVbMY2SDx9novP8uqpbsA4ejYz1RR+AD9fa2X02DLEvnk17B4dRYMKCUUvbnL9Y1Jdumgaq67go61JS5lw==",
+      "files": [
+        "System.Runtime.Handles.4.0.1-beta-23311.nupkg",
+        "System.Runtime.Handles.4.0.1-beta-23311.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
+        "System.Runtime.Handles.xml",
+        "de/System.Runtime.Handles.xml",
+        "es/System.Runtime.Handles.xml",
+        "fr/System.Runtime.Handles.xml",
+        "it/System.Runtime.Handles.xml",
+        "ja/System.Runtime.Handles.xml",
+        "ko/System.Runtime.Handles.xml",
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Runtime.Handles.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "zh-hans/System.Runtime.Handles.xml",
+        "zh-hant/System.Runtime.Handles.xml"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.21-beta-23311": {
+      "serviceable": true,
+      "sha512": "GCbSxg1aN3FaNq52/YHaqpITjzPbN12hEE9jGyRetWhQEAZqlYkp8yN77itz3e4Q5HrQ5LrKoUkUO88Ep826Pg==",
+      "files": [
+        "System.Runtime.InteropServices.4.0.21-beta-23311.nupkg",
+        "System.Runtime.InteropServices.4.0.21-beta-23311.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec",
+        "System.Runtime.InteropServices.xml",
+        "de/System.Runtime.InteropServices.xml",
+        "es/System.Runtime.InteropServices.xml",
+        "fr/System.Runtime.InteropServices.xml",
+        "it/System.Runtime.InteropServices.xml",
+        "ja/System.Runtime.InteropServices.xml",
+        "ko/System.Runtime.InteropServices.xml",
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Runtime.InteropServices.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "zh-hans/System.Runtime.InteropServices.xml",
+        "zh-hant/System.Runtime.InteropServices.xml"
+      ]
+    },
+    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "76bBVSdeG3enYyNmibt8x85V2fHK8mRPlpz5cPdtl0QPj2A3Hyar+g+W5t9XSw5jPLwRB4tZn8a18bPRcCEiow==",
+      "files": [
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23311.nupkg",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23311.nupkg.sha512",
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
+        "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Runtime.Loader/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "pOrTQ3qJgnQp0AS3Oh56ow++83ZxCDLiU3HTJDZGrZHI3083P+qtsnWyJhb8GqBosq/Cb8ikjxRqI77tWBFfUQ==",
+      "files": [
+        "System.Runtime.Loader.4.0.0-beta-23311.nupkg",
+        "System.Runtime.Loader.4.0.0-beta-23311.nupkg.sha512",
+        "System.Runtime.Loader.nuspec",
+        "lib/DNXCore50/System.Runtime.Loader.dll",
+        "ref/dotnet/System.Runtime.Loader.dll"
+      ]
+    },
+    "System.Runtime.Numerics/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "HB1f1KvM4gm6pm/Ucbxrqi8UG8iKWXMl+27HDtr35i4hEDnuq6Q4f1nN0x5H6Iwl+7iBOKGjW8K/Yips4MKUqA==",
+      "files": [
+        "System.Runtime.Numerics.4.0.1-beta-23311.nupkg",
+        "System.Runtime.Numerics.4.0.1-beta-23311.nupkg.sha512",
+        "System.Runtime.Numerics.nuspec",
+        "System.Runtime.Numerics.xml",
+        "de/System.Runtime.Numerics.xml",
+        "es/System.Runtime.Numerics.xml",
+        "fr/System.Runtime.Numerics.xml",
+        "it/System.Runtime.Numerics.xml",
+        "ja/System.Runtime.Numerics.xml",
+        "ko/System.Runtime.Numerics.xml",
+        "lib/dotnet/System.Runtime.Numerics.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Runtime.Numerics.dll",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ru/System.Runtime.Numerics.xml",
+        "zh-hans/System.Runtime.Numerics.xml",
+        "zh-hant/System.Runtime.Numerics.xml"
+      ]
+    },
+    "System.Runtime.Serialization.Json/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "LDJg64agAUhDpti38MOwtGd9xWPCShyxiVT32Sfmhc2ZcmuTv7c2BpkCzycOZuppebglZsklVjkBtjwJJt+WIQ==",
+      "files": [
+        "System.Runtime.Serialization.Json.4.0.1-beta-23311.nupkg",
+        "System.Runtime.Serialization.Json.4.0.1-beta-23311.nupkg.sha512",
+        "System.Runtime.Serialization.Json.nuspec",
+        "lib/DNXCore50/System.Runtime.Serialization.Json.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Runtime.Serialization.Json.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Runtime.Serialization.Json.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Runtime.Serialization.Json.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll"
+      ]
+    },
+    "System.Runtime.Serialization.Primitives/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "tfTiWOaLLUWqJ+MaVN3XdP+PuvWycg+NucMupaQav4jbo+FV9V3F2anDY8sbp3zFKf3CKgz20PBQLMWPbqKNfw==",
+      "files": [
+        "System.Runtime.Serialization.Primitives.4.0.11-beta-23311.nupkg",
+        "System.Runtime.Serialization.Primitives.4.0.11-beta-23311.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.nuspec",
+        "System.Runtime.Serialization.Primitives.xml",
+        "de/System.Runtime.Serialization.Primitives.xml",
+        "es/System.Runtime.Serialization.Primitives.xml",
+        "fr/System.Runtime.Serialization.Primitives.xml",
+        "it/System.Runtime.Serialization.Primitives.xml",
+        "ja/System.Runtime.Serialization.Primitives.xml",
+        "ko/System.Runtime.Serialization.Primitives.xml",
+        "lib/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Serialization.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Runtime.Serialization.Primitives.xml",
+        "zh-hans/System.Runtime.Serialization.Primitives.xml",
+        "zh-hant/System.Runtime.Serialization.Primitives.xml"
+      ]
+    },
+    "System.Runtime.Serialization.Xml/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "NSEOlV9EFsoIt3Hk0Gh84kD08vnuXOiiz5eCgrezDBkHuI5GwgG/6C0kk+BKZJtg0Jy4U5HG6zQhaefFfmVvhA==",
+      "files": [
+        "System.Runtime.Serialization.Xml.4.0.11-beta-23311.nupkg",
+        "System.Runtime.Serialization.Xml.4.0.11-beta-23311.nupkg.sha512",
+        "System.Runtime.Serialization.Xml.nuspec",
+        "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Serialization.Xml.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Serialization.Xml.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll"
+      ]
+    },
+    "System.Security.Claims/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "jzgRhJwJnBG74/ooiopRA2zf5WB/0D0mWbd9nwQTkwrGQFy8a9vL4WKhrhmkIGUDUCqWgtgi3iSGMvjFMiH7IQ==",
+      "files": [
+        "System.Security.Claims.4.0.1-beta-23311.nupkg",
+        "System.Security.Claims.4.0.1-beta-23311.nupkg.sha512",
+        "System.Security.Claims.nuspec",
+        "System.Security.Claims.xml",
+        "de/System.Security.Claims.xml",
+        "es/System.Security.Claims.xml",
+        "fr/System.Security.Claims.xml",
+        "it/System.Security.Claims.xml",
+        "ja/System.Security.Claims.xml",
+        "ko/System.Security.Claims.xml",
+        "lib/dotnet/System.Security.Claims.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Security.Claims.xml",
+        "zh-hans/System.Security.Claims.xml",
+        "zh-hant/System.Security.Claims.xml"
+      ]
+    },
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "1l9b838cbDrV/KUwlnLmGTF2JbHBt7yJ0tw9mCl2LXZk31y+W0vzo0gA0RUfdr4ASvhF1dOzq6cUwolPScc7wQ==",
+      "files": [
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Algorithms.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Algorithms.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.Cng/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "T/vjQNnI4FSk1+faUCyVCS1pJzgGocBPRC1s/UhJltwyHB195pOmYLwJJBxwqBT85XaWl0Emb/XL/2TXnBMK+Q==",
+      "files": [
+        "System.Security.Cryptography.Cng.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Cng.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Cng.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Cng.dll",
+        "lib/net46/System.Security.Cryptography.Cng.dll",
+        "ref/dotnet/System.Security.Cryptography.Cng.dll",
+        "ref/net46/System.Security.Cryptography.Cng.dll"
+      ]
+    },
+    "System.Security.Cryptography.Csp/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "DHqs+RZcJgXgcOL/AOZJpOpJwpxK/9PJgg4b2h/M1VGl/MpT+jN1IE7ExVVT5OE/2lw3YZgg9DIV5HxQVQOKGQ==",
+      "files": [
+        "System.Security.Cryptography.Csp.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Csp.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Csp.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Csp.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Csp.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Csp.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.DeriveBytes/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "9/V/IwEV8JEj6ZK8SrJhqE+M7hel0K3v9NxRGivNHu1cKia8hdQWgtiXmQWA7MJRlGc1M/jdcuzJ5gZVaa3ivA==",
+      "files": [
+        "System.Security.Cryptography.DeriveBytes.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.DeriveBytes.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.DeriveBytes.nuspec",
+        "System.Security.Cryptography.DeriveBytes.xml",
+        "de/System.Security.Cryptography.DeriveBytes.xml",
+        "es/System.Security.Cryptography.DeriveBytes.xml",
+        "fr/System.Security.Cryptography.DeriveBytes.xml",
+        "it/System.Security.Cryptography.DeriveBytes.xml",
+        "ja/System.Security.Cryptography.DeriveBytes.xml",
+        "ko/System.Security.Cryptography.DeriveBytes.xml",
+        "lib/DNXCore50/System.Security.Cryptography.DeriveBytes.dll",
+        "ru/System.Security.Cryptography.DeriveBytes.xml",
+        "zh-hans/System.Security.Cryptography.DeriveBytes.xml",
+        "zh-hant/System.Security.Cryptography.DeriveBytes.xml"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "dtzZI2XMpdO7NuEaxib9QYJc7+zHcQoZiKjnah61fEj7MTbLyi4Bv6MD/phjM6Rq0gIq+tGwFOHzh7kcblTn+w==",
+      "files": [
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.nuspec",
+        "System.Security.Cryptography.Encoding.xml",
+        "de/System.Security.Cryptography.Encoding.xml",
+        "es/System.Security.Cryptography.Encoding.xml",
+        "fr/System.Security.Cryptography.Encoding.xml",
+        "it/System.Security.Cryptography.Encoding.xml",
+        "ja/System.Security.Cryptography.Encoding.xml",
+        "ko/System.Security.Cryptography.Encoding.xml",
+        "lib/DNXCore50/System.Security.Cryptography.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Security.Cryptography.Encoding.xml",
+        "zh-hans/System.Security.Cryptography.Encoding.xml",
+        "zh-hant/System.Security.Cryptography.Encoding.xml"
+      ]
+    },
+    "System.Security.Cryptography.Encryption/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "MFD9kFWRF8nFZmcuYeI0DKl3ftmxG+JFDbK3l6hZam2WSq9Dw/9RkK+vmZIOAgaJ8Ky69G+p2KrVrZ7w2nFU/Q==",
+      "files": [
+        "System.Security.Cryptography.Encryption.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Encryption.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Encryption.nuspec",
+        "System.Security.Cryptography.Encryption.xml",
+        "de/System.Security.Cryptography.Encryption.xml",
+        "es/System.Security.Cryptography.Encryption.xml",
+        "fr/System.Security.Cryptography.Encryption.xml",
+        "it/System.Security.Cryptography.Encryption.xml",
+        "ja/System.Security.Cryptography.Encryption.xml",
+        "ko/System.Security.Cryptography.Encryption.xml",
+        "lib/DNXCore50/System.Security.Cryptography.Encryption.dll",
+        "ru/System.Security.Cryptography.Encryption.xml",
+        "zh-hans/System.Security.Cryptography.Encryption.xml",
+        "zh-hant/System.Security.Cryptography.Encryption.xml"
+      ]
+    },
+    "System.Security.Cryptography.Encryption.Aes/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "f0jn9xjsNQg2XOPrhrYDbHvQueuiGfqiHuZQvPRjakc3+6SJqRQeAtRbfTw90O2wSGKUlahbje1WDKirY8bA9w==",
+      "files": [
+        "System.Security.Cryptography.Encryption.Aes.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Encryption.Aes.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Encryption.Aes.nuspec",
+        "System.Security.Cryptography.Encryption.Aes.xml",
+        "de/System.Security.Cryptography.Encryption.Aes.xml",
+        "es/System.Security.Cryptography.Encryption.Aes.xml",
+        "fr/System.Security.Cryptography.Encryption.Aes.xml",
+        "it/System.Security.Cryptography.Encryption.Aes.xml",
+        "ja/System.Security.Cryptography.Encryption.Aes.xml",
+        "ko/System.Security.Cryptography.Encryption.Aes.xml",
+        "lib/DNXCore50/System.Security.Cryptography.Encryption.Aes.dll",
+        "ru/System.Security.Cryptography.Encryption.Aes.xml",
+        "zh-hans/System.Security.Cryptography.Encryption.Aes.xml",
+        "zh-hant/System.Security.Cryptography.Encryption.Aes.xml"
+      ]
+    },
+    "System.Security.Cryptography.Hashing/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "Egx4uZpKeYVX/fFZqmnKrCiUdH5Qazu7A7oErRyNik/KKtdf2kGjNr8+8wbJIu3nBNxXpXxaHLoX/z9vB/C5aw==",
+      "files": [
+        "System.Security.Cryptography.Hashing.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Hashing.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Hashing.nuspec",
+        "System.Security.Cryptography.Hashing.xml",
+        "de/System.Security.Cryptography.Hashing.xml",
+        "es/System.Security.Cryptography.Hashing.xml",
+        "fr/System.Security.Cryptography.Hashing.xml",
+        "it/System.Security.Cryptography.Hashing.xml",
+        "ja/System.Security.Cryptography.Hashing.xml",
+        "ko/System.Security.Cryptography.Hashing.xml",
+        "lib/DNXCore50/System.Security.Cryptography.Hashing.dll",
+        "ru/System.Security.Cryptography.Hashing.xml",
+        "zh-hans/System.Security.Cryptography.Hashing.xml",
+        "zh-hant/System.Security.Cryptography.Hashing.xml"
+      ]
+    },
+    "System.Security.Cryptography.Hashing.Algorithms/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "OR5tGGelqx20MGQpWT3kMw1pDg/auXwevZ/SynUt6Dl0Ac2SQ38WEzqmBvovvoTH/sqlKQFvBhQ/0yd4F/b2Ag==",
+      "files": [
+        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Hashing.Algorithms.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Hashing.Algorithms.nuspec",
+        "System.Security.Cryptography.Hashing.Algorithms.xml",
+        "de/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "es/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "fr/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "it/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ja/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "ko/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "lib/DNXCore50/System.Security.Cryptography.Hashing.Algorithms.dll",
+        "ru/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "zh-hans/System.Security.Cryptography.Hashing.Algorithms.xml",
+        "zh-hant/System.Security.Cryptography.Hashing.Algorithms.xml"
+      ]
+    },
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "znDa+79gOts4Kgfvy/JmZ6m5xLE4q7CJSCxkPFl3t+BJE7IXwwkUQ489oc7E02YrIm1EpnYTcyUnnI0EqmgGXQ==",
+      "files": [
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.RandomNumberGenerator/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "y83t9Dtk9rLsbw4NBVolRmv9cqTNn51c0wfoMuG6oGjya/9YN8XmOR5knpo/PbmuoyGHJvuzT9EnsvFt+/YwfQ==",
+      "files": [
+        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.RandomNumberGenerator.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.RandomNumberGenerator.nuspec",
+        "System.Security.Cryptography.RandomNumberGenerator.xml",
+        "de/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "es/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "fr/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "it/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ja/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "ko/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "lib/DNXCore50/System.Security.Cryptography.RandomNumberGenerator.dll",
+        "ru/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "zh-hans/System.Security.Cryptography.RandomNumberGenerator.xml",
+        "zh-hant/System.Security.Cryptography.RandomNumberGenerator.xml"
+      ]
+    },
+    "System.Security.Cryptography.RSA/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "tz1LsB12Xnc8TVCisYDcqMyX+8Yep7XQmGARbPahLN79X3p5C4am2+20VU3Kq/x/EfNn5GmU9c0wtGOTvOM/2A==",
+      "files": [
+        "System.Security.Cryptography.RSA.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.RSA.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.RSA.nuspec",
+        "System.Security.Cryptography.RSA.xml",
+        "de/System.Security.Cryptography.RSA.xml",
+        "es/System.Security.Cryptography.RSA.xml",
+        "fr/System.Security.Cryptography.RSA.xml",
+        "it/System.Security.Cryptography.RSA.xml",
+        "ja/System.Security.Cryptography.RSA.xml",
+        "ko/System.Security.Cryptography.RSA.xml",
+        "lib/DNXCore50/System.Security.Cryptography.RSA.dll",
+        "ru/System.Security.Cryptography.RSA.xml",
+        "zh-hans/System.Security.Cryptography.RSA.xml",
+        "zh-hant/System.Security.Cryptography.RSA.xml"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "OdLrb0zAibmK8zzlyKPG+fUzxzkptgLlgYIMdP2+00348/mhmzX9ZcCtNsEvxJByN+TnJ8adCPJOcml5b/nYzQ==",
+      "files": [
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23311.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.nuspec",
+        "System.Security.Cryptography.X509Certificates.xml",
+        "de/System.Security.Cryptography.X509Certificates.xml",
+        "es/System.Security.Cryptography.X509Certificates.xml",
+        "fr/System.Security.Cryptography.X509Certificates.xml",
+        "it/System.Security.Cryptography.X509Certificates.xml",
+        "ja/System.Security.Cryptography.X509Certificates.xml",
+        "ko/System.Security.Cryptography.X509Certificates.xml",
+        "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Security.Cryptography.X509Certificates.xml",
+        "zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "zh-hant/System.Security.Cryptography.X509Certificates.xml"
+      ]
+    },
+    "System.Security.Principal/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "xL9ukP1bInwjlicifdmhm+dD8n1VHRY2jdDFisIWPWebx1JrWCTatRs5EuyUaK9XHZ7muqHJtHWT67g83Rumgw==",
+      "files": [
+        "System.Security.Principal.4.0.1-beta-23311.nupkg",
+        "System.Security.Principal.4.0.1-beta-23311.nupkg.sha512",
+        "System.Security.Principal.nuspec",
+        "System.Security.Principal.xml",
+        "de/System.Security.Principal.xml",
+        "es/System.Security.Principal.xml",
+        "fr/System.Security.Principal.xml",
+        "it/System.Security.Principal.xml",
+        "ja/System.Security.Principal.xml",
+        "ko/System.Security.Principal.xml",
+        "lib/dotnet/System.Security.Principal.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Security.Principal.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ru/System.Security.Principal.xml",
+        "zh-hans/System.Security.Principal.xml",
+        "zh-hant/System.Security.Principal.xml"
+      ]
+    },
+    "System.Security.Principal.Windows/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "6prP/ZgRLLvcAJyM0AqRHSmGGWuLJTnIB4aVw3f1ffM5L+m0G/5REKcLytubqOxIAAEy5kUPfKQaS+SQBdmtfg==",
+      "files": [
+        "System.Security.Principal.Windows.4.0.0-beta-23311.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.Principal.Windows.nuspec",
+        "System.Security.Principal.Windows.xml",
+        "de/System.Security.Principal.Windows.xml",
+        "es/System.Security.Principal.Windows.xml",
+        "fr/System.Security.Principal.Windows.xml",
+        "it/System.Security.Principal.Windows.xml",
+        "ja/System.Security.Principal.Windows.xml",
+        "ko/System.Security.Principal.Windows.xml",
+        "lib/DNXCore50/System.Security.Principal.Windows.dll",
+        "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/net46/System.Security.Principal.Windows.dll",
+        "ru/System.Security.Principal.Windows.xml",
+        "zh-hans/System.Security.Principal.Windows.xml",
+        "zh-hant/System.Security.Principal.Windows.xml"
+      ]
+    },
+    "System.Security.SecureString/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "izUtxnsuX6Qw91jPbOhlxP7lolyNHIeliBWUX2RWcTpmfZf3MnGLPsf2F66OjBnLv983D2Cf7MA3cLG8fveztQ==",
+      "files": [
+        "System.Security.SecureString.4.0.0-beta-23311.nupkg",
+        "System.Security.SecureString.4.0.0-beta-23311.nupkg.sha512",
+        "System.Security.SecureString.nuspec",
+        "System.Security.SecureString.xml",
+        "de/System.Security.SecureString.xml",
+        "es/System.Security.SecureString.xml",
+        "fr/System.Security.SecureString.xml",
+        "it/System.Security.SecureString.xml",
+        "ja/System.Security.SecureString.xml",
+        "ko/System.Security.SecureString.xml",
+        "lib/DNXCore50/System.Security.SecureString.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Security.SecureString.xml",
+        "zh-hans/System.Security.SecureString.xml",
+        "zh-hant/System.Security.SecureString.xml"
+      ]
+    },
+    "System.ServiceModel.Duplex/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "gaQG0amRMZUNe6Pl7YUiXvA3jvR82mlLk2nMXW3LjzDHh8mR6YbHcM8xV9GQWKGFLiW80GPxmE3QKK8X0bOuqw==",
+      "files": [
+        "System.ServiceModel.Duplex.4.0.1-beta-23311.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23311.nupkg.sha512",
+        "System.ServiceModel.Duplex.nuspec",
+        "System.ServiceModel.Duplex.xml",
+        "de/System.ServiceModel.Duplex.xml",
+        "es/System.ServiceModel.Duplex.xml",
+        "fr/System.ServiceModel.Duplex.xml",
+        "it/System.ServiceModel.Duplex.xml",
+        "ja/System.ServiceModel.Duplex.xml",
+        "ko/System.ServiceModel.Duplex.xml",
+        "lib/DNXCore50/System.ServiceModel.Duplex.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.Duplex.dll",
+        "lib/win8/_._",
+        "ref/dotnet/System.ServiceModel.Duplex.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.ServiceModel.Duplex.dll",
+        "ref/win8/_._",
+        "ru/System.ServiceModel.Duplex.xml",
+        "zh-hans/System.ServiceModel.Duplex.xml",
+        "zh-hant/System.ServiceModel.Duplex.xml"
+      ]
+    },
+    "System.ServiceModel.Http/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "jARk7q79LBPyMEtLzND6gFmZtgH87MG4m3MZaObtrZ7asqFv9nJdSqMCHV3MJg+JIqooCJg7P0Qio2O1dqLpXw==",
+      "files": [
+        "System.ServiceModel.Http.4.0.11-beta-23311.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23311.nupkg.sha512",
+        "System.ServiceModel.Http.nuspec",
+        "System.ServiceModel.Http.xml",
+        "de/System.ServiceModel.Http.xml",
+        "es/System.ServiceModel.Http.xml",
+        "fr/System.ServiceModel.Http.xml",
+        "it/System.ServiceModel.Http.xml",
+        "ja/System.ServiceModel.Http.xml",
+        "ko/System.ServiceModel.Http.xml",
+        "lib/DNXCore50/System.ServiceModel.Http.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.ServiceModel.Http.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ServiceModel.Http.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.ServiceModel.Http.xml",
+        "zh-hans/System.ServiceModel.Http.xml",
+        "zh-hant/System.ServiceModel.Http.xml"
+      ]
+    },
+    "System.ServiceModel.NetTcp/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "tmkGJozi9F46biphoDFXefFunWz/rtap143VvX2jOmyaxu75/gCZ7WxgKl7PfvQ4ORMjr5FFfz3Dr0Ff+NyX2w==",
+      "files": [
+        "System.ServiceModel.NetTcp.4.0.1-beta-23311.nupkg",
+        "System.ServiceModel.NetTcp.4.0.1-beta-23311.nupkg.sha512",
+        "System.ServiceModel.NetTcp.nuspec",
+        "System.ServiceModel.NetTcp.xml",
+        "de/System.ServiceModel.NetTcp.xml",
+        "es/System.ServiceModel.NetTcp.xml",
+        "fr/System.ServiceModel.NetTcp.xml",
+        "it/System.ServiceModel.NetTcp.xml",
+        "ja/System.ServiceModel.NetTcp.xml",
+        "ko/System.ServiceModel.NetTcp.xml",
+        "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.NetTcp.dll",
+        "lib/win8/_._",
+        "ref/dotnet/System.ServiceModel.NetTcp.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.ServiceModel.NetTcp.dll",
+        "ref/win8/_._",
+        "ru/System.ServiceModel.NetTcp.xml",
+        "zh-hans/System.ServiceModel.NetTcp.xml",
+        "zh-hant/System.ServiceModel.NetTcp.xml"
+      ]
+    },
+    "System.ServiceModel.Primitives/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "WN/PWwB26Nz73TIQWlYfxUMQC9fHG0QA4Gl/mSd5J1ETr7MtGTCfts+hLKhiwynY5I6HqcIqjedkgHxOhzCQxQ==",
+      "files": [
+        "System.ServiceModel.Primitives.4.0.1-beta-23311.nupkg",
+        "System.ServiceModel.Primitives.4.0.1-beta-23311.nupkg.sha512",
+        "System.ServiceModel.Primitives.nuspec",
+        "System.ServiceModel.Primitives.xml",
+        "de/System.ServiceModel.Primitives.xml",
+        "es/System.ServiceModel.Primitives.xml",
+        "fr/System.ServiceModel.Primitives.xml",
+        "it/System.ServiceModel.Primitives.xml",
+        "ja/System.ServiceModel.Primitives.xml",
+        "ko/System.ServiceModel.Primitives.xml",
+        "lib/DNXCore50/System.ServiceModel.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.Primitives.dll",
+        "lib/win8/_._",
+        "ref/dotnet/System.ServiceModel.Primitives.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.ServiceModel.Primitives.dll",
+        "ref/win8/_._",
+        "ru/System.ServiceModel.Primitives.xml",
+        "zh-hans/System.ServiceModel.Primitives.xml",
+        "zh-hant/System.ServiceModel.Primitives.xml"
+      ]
+    },
+    "System.ServiceModel.Security/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "BrYlXeAU3hcN42UWI2Q4X8dGFri2MWom3qb/3kncVe7vK5Vczz31LgoDJsXI55P8W/ALdzKyKzk7VbTxhtSz9w==",
+      "files": [
+        "System.ServiceModel.Security.4.0.1-beta-23311.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23311.nupkg.sha512",
+        "System.ServiceModel.Security.nuspec",
+        "System.ServiceModel.Security.xml",
+        "de/System.ServiceModel.Security.xml",
+        "es/System.ServiceModel.Security.xml",
+        "fr/System.ServiceModel.Security.xml",
+        "it/System.ServiceModel.Security.xml",
+        "ja/System.ServiceModel.Security.xml",
+        "ko/System.ServiceModel.Security.xml",
+        "lib/DNXCore50/System.ServiceModel.Security.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ServiceModel.Security.dll",
+        "lib/win8/_._",
+        "ref/dotnet/System.ServiceModel.Security.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.ServiceModel.Security.dll",
+        "ref/win8/_._",
+        "ru/System.ServiceModel.Security.xml",
+        "zh-hans/System.ServiceModel.Security.xml",
+        "zh-hant/System.ServiceModel.Security.xml"
+      ]
+    },
+    "System.Text.Encoding/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "aUEI/+T1kme5BQ8Oa0HO6tg34zBA4kxXvK0w4K8SOcvoGmpIXetl39myZ3tEdPd+gW+RL3J8XXhywjR+hlpphw==",
+      "files": [
+        "System.Text.Encoding.4.0.11-beta-23311.nupkg",
+        "System.Text.Encoding.4.0.11-beta-23311.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
+      ]
+    },
+    "System.Text.Encoding.CodePages/4.0.0": {
+      "serviceable": true,
+      "sha512": "ZHBTr1AXLjY9OuYR7pKx5xfN6QFye1kgd5QAbGrvfCOu7yxRnJs3VUaxERe1fOlnF0mi/xD/Dvb3T3x3HNuPWQ==",
+      "files": [
+        "System.Text.Encoding.CodePages.4.0.0.nupkg",
+        "System.Text.Encoding.CodePages.4.0.0.nupkg.sha512",
+        "System.Text.Encoding.CodePages.nuspec",
+        "lib/dotnet/System.Text.Encoding.CodePages.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.CodePages.dll",
+        "ref/dotnet/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/de/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/es/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/fr/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/it/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/ja/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/ko/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/ru/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.CodePages.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "ZGljnmeCx70Z8DVvdsCpT9FhvFVZlFs6BmVoV43aGpAKjHUSJBMhtvFgXJh9Z/sbYncGIZAljxIMtZX8Km345A==",
+      "files": [
+        "System.Text.Encoding.Extensions.4.0.11-beta-23311.nupkg",
+        "System.Text.Encoding.Extensions.4.0.11-beta-23311.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec",
+        "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
+      ]
+    },
+    "System.Text.RegularExpressions/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "yO9CqnajyJas2Q0GXL+Rcy/g3hsfjXTRPF2aVqrjzYWZqIkhpMyrfx+nJCvkUYKKXc3S7Fj+nULhc9Me79AZGA==",
+      "files": [
+        "System.Text.RegularExpressions.4.0.11-beta-23311.nupkg",
+        "System.Text.RegularExpressions.4.0.11-beta-23311.nupkg.sha512",
+        "System.Text.RegularExpressions.nuspec",
+        "System.Text.RegularExpressions.xml",
+        "de/System.Text.RegularExpressions.xml",
+        "es/System.Text.RegularExpressions.xml",
+        "fr/System.Text.RegularExpressions.xml",
+        "it/System.Text.RegularExpressions.xml",
+        "ja/System.Text.RegularExpressions.xml",
+        "ko/System.Text.RegularExpressions.xml",
+        "lib/dotnet/System.Text.RegularExpressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Text.RegularExpressions.xml",
+        "zh-hans/System.Text.RegularExpressions.xml",
+        "zh-hant/System.Text.RegularExpressions.xml"
+      ]
+    },
+    "System.Threading/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "cJUyevwthlAPMkTVIfWA96P1eSgWhPDnGJSQWHcA7J6fd8vlTi+j9L8YGTftfwULLhaRT+Zj4k94zbV5iRIzHg==",
+      "files": [
+        "System.Threading.4.0.11-beta-23311.nupkg",
+        "System.Threading.4.0.11-beta-23311.nupkg.sha512",
+        "System.Threading.nuspec",
+        "System.Threading.xml",
+        "de/System.Threading.xml",
+        "es/System.Threading.xml",
+        "fr/System.Threading.xml",
+        "it/System.Threading.xml",
+        "ja/System.Threading.xml",
+        "ko/System.Threading.xml",
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Threading.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "zh-hans/System.Threading.xml",
+        "zh-hant/System.Threading.xml"
+      ]
+    },
+    "System.Threading.Overlapped/4.0.0": {
+      "serviceable": true,
+      "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
+      "files": [
+        "System.Threading.Overlapped.4.0.0.nupkg",
+        "System.Threading.Overlapped.4.0.0.nupkg.sha512",
+        "System.Threading.Overlapped.nuspec",
+        "lib/DNXCore50/System.Threading.Overlapped.dll",
+        "lib/net46/System.Threading.Overlapped.dll",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
+        "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/dotnet/fr/System.Threading.Overlapped.xml",
+        "ref/dotnet/it/System.Threading.Overlapped.xml",
+        "ref/dotnet/ja/System.Threading.Overlapped.xml",
+        "ref/dotnet/ko/System.Threading.Overlapped.xml",
+        "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "ref/net46/System.Threading.Overlapped.dll"
+      ]
+    },
+    "System.Threading.Tasks/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "l3c4ZDB2UvqrMTKZJkEUcB1GE8dfI/7nPSry6rbCIv81c3tGmTYCDFiqciDrp+0rIuYPHsYD8dtUWCOsFoXt7Q==",
+      "files": [
+        "System.Threading.Tasks.4.0.11-beta-23311.nupkg",
+        "System.Threading.Tasks.4.0.11-beta-23311.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
+        "System.Threading.Tasks.xml",
+        "de/System.Threading.Tasks.xml",
+        "es/System.Threading.Tasks.xml",
+        "fr/System.Threading.Tasks.xml",
+        "it/System.Threading.Tasks.xml",
+        "ja/System.Threading.Tasks.xml",
+        "ko/System.Threading.Tasks.xml",
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Threading.Tasks.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "zh-hans/System.Threading.Tasks.xml",
+        "zh-hant/System.Threading.Tasks.xml"
+      ]
+    },
+    "System.Threading.Tasks.Dataflow/4.5.26-beta-23311": {
+      "serviceable": true,
+      "sha512": "lZYcestc5K3J0jl8HmxMlYXVVeopalRXOtKOc6tIzXtj3s6WJ+hD0ANhsv3gXl0lddTuJHcv9aut84Lpo0gOgA==",
+      "files": [
+        "System.Threading.Tasks.Dataflow.4.5.26-beta-23311.nupkg",
+        "System.Threading.Tasks.Dataflow.4.5.26-beta-23311.nupkg.sha512",
+        "System.Threading.Tasks.Dataflow.nuspec",
+        "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
+        "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML"
+      ]
+    },
+    "System.Threading.Tasks.Parallel/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "0ozx34/vL+Rl53U1MKqZqzO8bvvoU7B/y5t/Nq8+rvyURzoRp7IKxukrNE3cGSWsSmdbCN5w2d7Mnns+MDruxg==",
+      "files": [
+        "System.Threading.Tasks.Parallel.4.0.1-beta-23311.nupkg",
+        "System.Threading.Tasks.Parallel.4.0.1-beta-23311.nupkg.sha512",
+        "System.Threading.Tasks.Parallel.nuspec",
+        "System.Threading.Tasks.Parallel.xml",
+        "de/System.Threading.Tasks.Parallel.xml",
+        "es/System.Threading.Tasks.Parallel.xml",
+        "fr/System.Threading.Tasks.Parallel.xml",
+        "it/System.Threading.Tasks.Parallel.xml",
+        "ja/System.Threading.Tasks.Parallel.xml",
+        "ko/System.Threading.Tasks.Parallel.xml",
+        "lib/dotnet/System.Threading.Tasks.Parallel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Threading.Tasks.Parallel.dll",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ru/System.Threading.Tasks.Parallel.xml",
+        "zh-hans/System.Threading.Tasks.Parallel.xml",
+        "zh-hant/System.Threading.Tasks.Parallel.xml"
+      ]
+    },
+    "System.Threading.Thread/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "OgH6KflP3rlBmtrqE2xVcufOTIF3zQb/JN9aCl3rok0GZ8xnGS2xQy+F9hh6UHxQCkl0xWMhmvfdudvwvBkECw==",
+      "files": [
+        "System.Threading.Thread.4.0.0-beta-23311.nupkg",
+        "System.Threading.Thread.4.0.0-beta-23311.nupkg.sha512",
+        "System.Threading.Thread.nuspec",
+        "lib/DNXCore50/System.Threading.Thread.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Threading.ThreadPool/4.0.10-beta-23311": {
+      "serviceable": true,
+      "sha512": "KF1vm7tZIPslDE262oI6FXlKlXOoz5K4HMR1V6DlZIstkL6CyLISv8c6vhdj3R0k2vmmVKcp2GyF4sOWbD0Y2A==",
+      "files": [
+        "System.Threading.ThreadPool.4.0.10-beta-23311.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23311.nupkg.sha512",
+        "System.Threading.ThreadPool.nuspec",
+        "lib/DNXCore50/System.Threading.ThreadPool.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Threading.Timer/4.0.1-beta-23311": {
+      "serviceable": true,
+      "sha512": "UUoQSXLk6d8lndy+z/82N2N4C8UcMsIVF/V23Gs1eoMmGw/EUMwLy0NDDZwo9N0bwS284ZN/6VzDuKQxJGuVrw==",
+      "files": [
+        "System.Threading.Timer.4.0.1-beta-23311.nupkg",
+        "System.Threading.Timer.4.0.1-beta-23311.nupkg.sha512",
+        "System.Threading.Timer.nuspec",
+        "lib/DNXCore50/System.Threading.Timer.dll",
+        "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
+        "lib/win81/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/net451/_._",
+        "ref/netcore50/System.Threading.Timer.dll",
+        "ref/win81/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
+      ]
+    },
+    "System.Xml.ReaderWriter/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "8JCG+tzIOYIbKfCK9xAlzucdNU83/EfVc5eGl8bpL8N+NqcHh1I2dqUpX1yzoAE8gRtH37FiD2P9i7PzKc58KQ==",
+      "files": [
+        "System.Xml.ReaderWriter.4.0.11-beta-23311.nupkg",
+        "System.Xml.ReaderWriter.4.0.11-beta-23311.nupkg.sha512",
+        "System.Xml.ReaderWriter.nuspec",
+        "System.Xml.ReaderWriter.xml",
+        "de/System.Xml.ReaderWriter.xml",
+        "es/System.Xml.ReaderWriter.xml",
+        "fr/System.Xml.ReaderWriter.xml",
+        "it/System.Xml.ReaderWriter.xml",
+        "ja/System.Xml.ReaderWriter.xml",
+        "ko/System.Xml.ReaderWriter.xml",
+        "lib/dotnet/System.Xml.ReaderWriter.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Xml.ReaderWriter.xml",
+        "zh-hans/System.Xml.ReaderWriter.xml",
+        "zh-hant/System.Xml.ReaderWriter.xml"
+      ]
+    },
+    "System.Xml.XDocument/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "L/zxioIfAFz11mIEh8hhWnK8quBS3hi1ULvIPu7B7LdE1Rbht8aH+MfEOulZwCoU4E99bXtfpvUY0Hbi3hK6zg==",
+      "files": [
+        "System.Xml.XDocument.4.0.11-beta-23311.nupkg",
+        "System.Xml.XDocument.4.0.11-beta-23311.nupkg.sha512",
+        "System.Xml.XDocument.nuspec",
+        "System.Xml.XDocument.xml",
+        "de/System.Xml.XDocument.xml",
+        "es/System.Xml.XDocument.xml",
+        "fr/System.Xml.XDocument.xml",
+        "it/System.Xml.XDocument.xml",
+        "ja/System.Xml.XDocument.xml",
+        "ko/System.Xml.XDocument.xml",
+        "lib/dotnet/System.Xml.XDocument.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Xml.XDocument.xml",
+        "zh-hans/System.Xml.XDocument.xml",
+        "zh-hant/System.Xml.XDocument.xml"
+      ]
+    },
+    "System.Xml.XmlDocument/4.0.0": {
+      "serviceable": true,
+      "sha512": "H5qTx2+AXgaKE5wehU1ZYeYPFpp/rfFh69/937NvwCrDqbIkvJRmIFyKKpkoMI6gl9hGfuVizfIudVTMyowCXw==",
+      "files": [
+        "System.Xml.XmlDocument.4.0.0.nupkg",
+        "System.Xml.XmlDocument.4.0.0.nupkg.sha512",
+        "System.Xml.XmlDocument.nuspec",
+        "lib/dotnet/System.Xml.XmlDocument.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/dotnet/System.Xml.XmlDocument.xml",
+        "ref/dotnet/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet/es/System.Xml.XmlDocument.xml",
+        "ref/dotnet/fr/System.Xml.XmlDocument.xml",
+        "ref/dotnet/it/System.Xml.XmlDocument.xml",
+        "ref/dotnet/ja/System.Xml.XmlDocument.xml",
+        "ref/dotnet/ko/System.Xml.XmlDocument.xml",
+        "ref/dotnet/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet/zh-hans/System.Xml.XmlDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XmlDocument.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Xml.XmlSerializer/4.0.11-beta-23311": {
+      "serviceable": true,
+      "sha512": "K81LKzMEh1+GnHPcLVUoTH5ZXb6d+p/79r8tLJXCKppK0JT8uim459bksdPAK1Xuln+Zu74pps1F+4EpX7S4kQ==",
+      "files": [
+        "runtime.json",
+        "System.Xml.XmlSerializer.4.0.11-beta-23311.nupkg",
+        "System.Xml.XmlSerializer.4.0.11-beta-23311.nupkg.sha512",
+        "System.Xml.XmlSerializer.nuspec",
+        "System.Xml.XmlSerializer.xml",
+        "de/System.Xml.XmlSerializer.xml",
+        "es/System.Xml.XmlSerializer.xml",
+        "fr/System.Xml.XmlSerializer.xml",
+        "it/System.Xml.XmlSerializer.xml",
+        "ja/System.Xml.XmlSerializer.xml",
+        "ko/System.Xml.XmlSerializer.xml",
+        "lib/DNXCore50/System.Xml.XmlSerializer.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Xml.XmlSerializer.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlSerializer.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "ru/System.Xml.XmlSerializer.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
+        "zh-hans/System.Xml.XmlSerializer.xml",
+        "zh-hant/System.Xml.XmlSerializer.xml"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Microsoft.NETCore.Platforms >= 1.0.1-beta-*",
+      "Microsoft.NETCore.TestHost-x64 >= 1.0.0-beta-*",
+      "Microsoft.NETCore.Console >= 1.0.0-beta-*",
+      "Microsoft.Cci >= 4.0.0-beta-*",
+      "System.Diagnostics.TextWriterTraceListener >= 4.0.0-beta-*",
+      "System.Diagnostics.TraceSource >= 4.0.0-beta-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
+  <PropertyGroup>
+    <ToolRuntimeProjectJson Condition="'$(ToolRuntimeProjectJson)' == ''">$(MSBuildThisFileDirectory)tool-runtime\project.json</ToolRuntimeProjectJson>
+    <ToolRuntimeProjectLockJson Condition="'$(ToolRuntimeProjectLockJson)' == ''">$(MSBuildThisFileDirectory)tool-runtime\project.lock.json</ToolRuntimeProjectLockJson>
+    <!-- Invoke with the correct casing of corerun per-OS.  There are some process Tools
+         that check the invoked process name against known casing which fail under code coverage.
+         This is probably because the code coverage target invocation does not canonicalize the
+         process name. -->
+    <ToolHost Condition="'$(OS)' == 'Windows_NT'">CoreRun.exe</ToolHost>
+    <ToolHost Condition="'$(OS)' != 'Windows_NT'">corerun</ToolHost>
+
+    <ToolTargetFramework Condition="'$(ToolTargetFramework)' ==''">DNXCore,Version=v5.0</ToolTargetFramework>
+    <ToolArchitecture Condition="'$(ToolArchitecture)' == ''">x64</ToolArchitecture>
+    <ToolNugetRuntimeId Condition="'$(ToolNugetRuntimeId)' == ''">win7-$(ToolArchitecture)</ToolNugetRuntimeId>
+
+    <ToolRuntimePath Condition="'$(ToolRuntimePath)' == ''">$(BaseOutputPath)$(OSPlatformConfig)\ToolRuntime\</ToolRuntimePath>
+    <ToolRuntimeSempahore>$(ToolRuntimePath)\ToolRuntime.semaphore</ToolRuntimeSempahore>
+  </PropertyGroup>
+
+  <Target Name="EnsureBuildToolsRuntime"
+      Inputs="$(BuildToolsSemaphore)"
+      Outputs="$(ToolRuntimeSempahore)">
+
+    <!-- Restore tool runtime -->
+    <Exec Command="$(DnuRestoreCommand) &quot;$(ToolRuntimeProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
+
+    <!-- Resolve the tool runtime files -->
+    <PrereleaseResolveNuGetPackageAssets
+                               AllowFallbackOnTargetSelection="true"
+                               IncludeFrameworkReferences="false"
+                               NuGetPackagesDirectory="$(PackagesDir)"
+                               RuntimeIdentifier="$(ToolNugetRuntimeId)"
+                               ProjectLanguage="$(Language)"
+                               ProjectLockFile="$(ToolRuntimeProjectLockJson)"
+                               TargetMonikers="$(ToolTargetFramework)">
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="ToolCopyLocal" />
+    </PrereleaseResolveNuGetPackageAssets>
+
+    <!-- Ideally, we'd have UseHardLinksIfPossible on by default because we copy tons of files
+         but it doesn't currently work x-plat. So we only turn it on by default for Windows builds for now. -->
+    <PropertyGroup>
+      <CreateHardLinksForCopyTestToTestDirectoryIfPossible Condition="'$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)'=='' and '$(OS)' == 'Windows_NT'">true</CreateHardLinksForCopyTestToTestDirectoryIfPossible>
+      <CreateHardLinksForCopyTestToTestDirectoryIfPossible Condition="'$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)'==''">$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)</CreateHardLinksForCopyTestToTestDirectoryIfPossible>
+   </PropertyGroup>
+
+    <!-- Copy the runtime and libraries into the flat shared path $(ToolRuntimePath) -->
+    <Copy 
+      SourceFiles="@(ToolCopyLocal)" 
+      DestinationFolder="$(ToolRuntimePath)" 
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)" />
+
+    <Touch Files="$(ToolRuntimeSempahore)"
+       ContinueOnError="WarnAndContinue"
+       AlwaysCreate="true"
+       ForceTouch="true" />
+
+  </Target>
+
+</Project>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -30,6 +30,8 @@
     <file src="Microsoft.DotNet.Build.Tasks\coreAssembly.rsp" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\test-runtime\project.json" target="lib\test-runtime\project.json" />
     <file src="Microsoft.DotNet.Build.Tasks\test-runtime\project.lock.json" target="lib\test-runtime\project.lock.json" />
+    <file src="Microsoft.DotNet.Build.Tasks\tool-runtime\project.json" target="lib\tool-runtime\project.json" />
+    <file src="Microsoft.DotNet.Build.Tasks\tool-runtime\project.lock.json" target="lib\tool-runtime\project.lock.json" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\NuGet.*.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Newtonsoft.Json.dll" target="lib" />
@@ -41,6 +43,8 @@
     <file src="Microsoft.DotNet.Build.Tasks\NativeBinaries\amd64\git2-69db893.dll" target="lib\NativeBinaries\amd64" />
     <file src="Microsoft.DotNet.Build.Tasks\NativeBinaries\x86\git2-69db893.dll" target="lib\NativeBinaries\x86" />
     <file src="Microsoft.DotNet.Build.Tasks\AssemblyInfoPartial.*" target="lib" />
+    <file src="GenFacades\GenFacades.dll" target="lib" />
+    <file src="Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.dll" target="lib" />
   </files>
   
 </package>


### PR DESCRIPTION
Add support for running tools on top of .NET Core, things like GenFacades.

This change will restore a version of the Console .NET Core meta-package and any other dependencies into a shared directory, $(ToolRuntimePath), also including a host set via $(ToolHost).

Right now this only works on windows because we don't have all the necessary packages for x-plat yet. I'm actively working to get those enabled.