### PR TITLE
Add platform support to test-runtime\project.json

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
        "coveralls.io": "1.4",
+       "Microsoft.NETCore.Platforms":  "1.0.1-beta-*",
        "Microsoft.NETCore.TestHost-x64": "1.0.0-beta-*",
        "Microsoft.NETCore.TestHost-x86": "1.0.0-beta-*",
        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.lock.json
@@ -4,80 +4,81 @@
   "targets": {
     "DNXCore,Version=v5.0": {
       "coveralls.io/1.4": {},
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0012": {},
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0012": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0013": {},
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0013": {
         "dependencies": {
           "xunit.runner.console": "2.1.0-beta4-build3109"
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23311": {},
+      "Microsoft.NETCore.Runtime/1.0.1-beta-23311": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23302",
-          "Microsoft.NETCore.Runtime.Native": "1.0.1-beta-23302"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23311",
+          "Microsoft.NETCore.Runtime.Native": "1.0.1-beta-23311"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23302",
-          "System.Collections": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23302]",
-          "System.Globalization": "[4.0.11-beta-23302]",
-          "System.IO": "[4.0.11-beta-23302]",
-          "System.ObjectModel": "[4.0.11-beta-23302]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23302]",
-          "System.Text.Encoding": "[4.0.11-beta-23302]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23302]",
-          "System.Threading": "[4.0.11-beta-23302]",
-          "System.Threading.Tasks": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23302]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23302]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23302]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23302]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23302]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23302]",
-          "System.Runtime.Handles": "[4.0.1-beta-23302]",
-          "System.Threading.Timer": "[4.0.1-beta-23302]",
-          "System.Private.Uri": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23302]",
-          "System.Runtime": "[4.0.21-beta-23302]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23302]",
-          "System.Reflection": "[4.1.0-beta-23302]"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23311",
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23311": {
         "dependencies": {
-          "System.Collections": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23302]",
-          "System.Globalization": "[4.0.11-beta-23302]",
-          "System.IO": "[4.0.11-beta-23302]",
-          "System.ObjectModel": "[4.0.11-beta-23302]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23302]",
-          "System.Text.Encoding": "[4.0.11-beta-23302]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23302]",
-          "System.Threading": "[4.0.11-beta-23302]",
-          "System.Threading.Tasks": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23302]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23302]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23302]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23302]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23302]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23302]",
-          "System.Runtime.Handles": "[4.0.1-beta-23302]",
-          "System.Threading.Timer": "[4.0.1-beta-23302]",
-          "System.Private.Uri": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23302]",
-          "System.Runtime": "[4.0.21-beta-23302]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23302]",
-          "System.Reflection": "[4.1.0-beta-23302]"
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
         }
       },
       "Microsoft.NETCore.TestHost-x64/1.0.0-beta-23225": {},
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23225": {},
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {},
       "OpenCover/4.6.166": {},
-      "ReportGenerator/2.1.6.0": {},
+      "ReportGenerator/2.3.0.0": {},
       "System.Collections/4.0.10": {
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -108,23 +109,13 @@
           "lib/dotnet/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23302": {
+      "System.Console/4.0.0-beta-23311": {
         "dependencies": {
-          "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Contracts/4.0.0": {
@@ -149,7 +140,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23302": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Reflection": "4.0.0"
@@ -194,7 +185,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23302": {
+      "System.Globalization.Calendars/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Globalization": "4.0.0"
@@ -268,7 +259,7 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23302": {
+      "System.ObjectModel/4.0.11-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.20",
           "System.Resources.ResourceManager": "4.0.0",
@@ -283,7 +274,7 @@
           "lib/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23302": {
+      "System.Private.Uri/4.0.1-beta-23311": {
         "runtime": {
           "lib/DNXCore50/System.Private.Uri.dll": {}
         }
@@ -313,7 +304,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23302": {
+      "System.Reflection.Primitives/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -458,7 +449,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23302": {
+      "System.Threading.Thread/4.0.0-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -469,7 +460,7 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+      "System.Threading.ThreadPool/4.0.10-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
@@ -481,7 +472,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23302": {
+      "System.Threading.Timer/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -559,7 +550,7 @@
           "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
         }
       },
-      "xunit.console.netcore/1.0.2-prerelease-00081": {
+      "xunit.console.netcore/1.0.2-prerelease-00085": {
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Collections.Concurrent": "4.0.10",
@@ -627,73 +618,74 @@
     },
     "DNXCore,Version=v5.0/win7-x64": {
       "coveralls.io/1.4": {},
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0012": {},
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0012": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0013": {},
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0013": {
         "dependencies": {
           "xunit.runner.console": "2.1.0-beta4-build3109"
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23311": {},
+      "Microsoft.NETCore.Runtime/1.0.1-beta-23311": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23302",
-          "Microsoft.NETCore.Runtime.Native": "1.0.1-beta-23302"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23311",
+          "Microsoft.NETCore.Runtime.Native": "1.0.1-beta-23311"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23302",
-          "System.Collections": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23302]",
-          "System.Globalization": "[4.0.11-beta-23302]",
-          "System.IO": "[4.0.11-beta-23302]",
-          "System.ObjectModel": "[4.0.11-beta-23302]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23302]",
-          "System.Text.Encoding": "[4.0.11-beta-23302]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23302]",
-          "System.Threading": "[4.0.11-beta-23302]",
-          "System.Threading.Tasks": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23302]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23302]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23302]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23302]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23302]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23302]",
-          "System.Runtime.Handles": "[4.0.1-beta-23302]",
-          "System.Threading.Timer": "[4.0.1-beta-23302]",
-          "System.Private.Uri": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23302]",
-          "System.Runtime": "[4.0.21-beta-23302]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23302]",
-          "System.Reflection": "[4.1.0-beta-23302]"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23311",
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23311": {
         "dependencies": {
-          "System.Collections": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23302]",
-          "System.Globalization": "[4.0.11-beta-23302]",
-          "System.IO": "[4.0.11-beta-23302]",
-          "System.ObjectModel": "[4.0.11-beta-23302]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23302]",
-          "System.Text.Encoding": "[4.0.11-beta-23302]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23302]",
-          "System.Threading": "[4.0.11-beta-23302]",
-          "System.Threading.Tasks": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23302]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23302]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23302]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23302]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23302]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23302]",
-          "System.Runtime.Handles": "[4.0.1-beta-23302]",
-          "System.Threading.Timer": "[4.0.1-beta-23302]",
-          "System.Private.Uri": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23302]",
-          "System.Runtime": "[4.0.21-beta-23302]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23302]",
-          "System.Reflection": "[4.1.0-beta-23302]"
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
         }
       },
       "Microsoft.NETCore.TestHost-x64/1.0.0-beta-23225": {
@@ -702,10 +694,26 @@
         }
       },
       "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23225": {},
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {},
       "OpenCover/4.6.166": {},
-      "ReportGenerator/2.1.6.0": {},
-      "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
+      "ReportGenerator/2.3.0.0": {},
+      "runtime.win7.System.Console/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10"
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Console.dll": {}
+        }
+      },
+      "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
         "runtime": {
           "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll": {}
         },
@@ -719,12 +727,12 @@
           "runtimes/win7-x64/native/mscorrc.dll": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {
+      "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
         "native": {
           "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -787,13 +795,13 @@
           "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -875,23 +883,13 @@
           "lib/dotnet/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23302": {
+      "System.Console/4.0.0-beta-23311": {
         "dependencies": {
-          "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Contracts/4.0.0": {
@@ -916,7 +914,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23302": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Reflection": "4.0.0"
@@ -961,7 +959,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23302": {
+      "System.Globalization.Calendars/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Globalization": "4.0.0"
@@ -1035,7 +1033,7 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23302": {
+      "System.ObjectModel/4.0.11-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.20",
           "System.Resources.ResourceManager": "4.0.0",
@@ -1050,7 +1048,7 @@
           "lib/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23302": {
+      "System.Private.Uri/4.0.1-beta-23311": {
         "runtime": {
           "lib/DNXCore50/System.Private.Uri.dll": {}
         }
@@ -1080,7 +1078,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23302": {
+      "System.Reflection.Primitives/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -1225,7 +1223,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23302": {
+      "System.Threading.Thread/4.0.0-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -1236,7 +1234,7 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+      "System.Threading.ThreadPool/4.0.10-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
@@ -1248,7 +1246,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23302": {
+      "System.Threading.Timer/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -1326,7 +1324,7 @@
           "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
         }
       },
-      "xunit.console.netcore/1.0.2-prerelease-00081": {
+      "xunit.console.netcore/1.0.2-prerelease-00085": {
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Collections.Concurrent": "4.0.10",
@@ -1394,73 +1392,74 @@
     },
     "DNXCore,Version=v5.0/win7-x86": {
       "coveralls.io/1.4": {},
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0012": {},
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0012": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0013": {},
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0013": {
         "dependencies": {
           "xunit.runner.console": "2.1.0-beta4-build3109"
         }
       },
-      "Microsoft.NETCore.Runtime/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23311": {},
+      "Microsoft.NETCore.Runtime/1.0.1-beta-23311": {
         "dependencies": {
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23302",
-          "Microsoft.NETCore.Runtime.Native": "1.0.1-beta-23302"
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23311",
+          "Microsoft.NETCore.Runtime.Native": "1.0.1-beta-23311"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23302",
-          "System.Collections": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23302]",
-          "System.Globalization": "[4.0.11-beta-23302]",
-          "System.IO": "[4.0.11-beta-23302]",
-          "System.ObjectModel": "[4.0.11-beta-23302]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23302]",
-          "System.Text.Encoding": "[4.0.11-beta-23302]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23302]",
-          "System.Threading": "[4.0.11-beta-23302]",
-          "System.Threading.Tasks": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23302]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23302]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23302]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23302]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23302]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23302]",
-          "System.Runtime.Handles": "[4.0.1-beta-23302]",
-          "System.Threading.Timer": "[4.0.1-beta-23302]",
-          "System.Private.Uri": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23302]",
-          "System.Runtime": "[4.0.21-beta-23302]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23302]",
-          "System.Reflection": "[4.1.0-beta-23302]"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23311",
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
         }
       },
-      "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23302": {
+      "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23311": {
         "dependencies": {
-          "System.Collections": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23302]",
-          "System.Globalization": "[4.0.11-beta-23302]",
-          "System.IO": "[4.0.11-beta-23302]",
-          "System.ObjectModel": "[4.0.11-beta-23302]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23302]",
-          "System.Text.Encoding": "[4.0.11-beta-23302]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23302]",
-          "System.Threading": "[4.0.11-beta-23302]",
-          "System.Threading.Tasks": "[4.0.11-beta-23302]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23302]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23302]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23302]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23302]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23302]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23302]",
-          "System.Runtime.Handles": "[4.0.1-beta-23302]",
-          "System.Threading.Timer": "[4.0.1-beta-23302]",
-          "System.Private.Uri": "[4.0.1-beta-23302]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23302]",
-          "System.Runtime": "[4.0.21-beta-23302]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23302]",
-          "System.Reflection": "[4.1.0-beta-23302]"
+          "System.Collections": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Debug": "[4.0.11-beta-23311]",
+          "System.Globalization": "[4.0.11-beta-23311]",
+          "System.IO": "[4.0.11-beta-23311]",
+          "System.ObjectModel": "[4.0.11-beta-23311]",
+          "System.Runtime.Extensions": "[4.0.11-beta-23311]",
+          "System.Text.Encoding": "[4.0.11-beta-23311]",
+          "System.Text.Encoding.Extensions": "[4.0.11-beta-23311]",
+          "System.Threading": "[4.0.11-beta-23311]",
+          "System.Threading.Tasks": "[4.0.11-beta-23311]",
+          "System.Diagnostics.Contracts": "[4.0.1-beta-23311]",
+          "System.Diagnostics.StackTrace": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tools": "[4.0.1-beta-23311]",
+          "System.Globalization.Calendars": "[4.0.1-beta-23311]",
+          "System.Reflection.Extensions": "[4.0.1-beta-23311]",
+          "System.Reflection.Primitives": "[4.0.1-beta-23311]",
+          "System.Resources.ResourceManager": "[4.0.1-beta-23311]",
+          "System.Runtime.Handles": "[4.0.1-beta-23311]",
+          "System.Threading.Timer": "[4.0.1-beta-23311]",
+          "System.Private.Uri": "[4.0.1-beta-23311]",
+          "System.Diagnostics.Tracing": "[4.0.21-beta-23311]",
+          "System.Runtime": "[4.0.21-beta-23311]",
+          "System.Runtime.InteropServices": "[4.0.21-beta-23311]",
+          "System.Reflection": "[4.1.0-beta-23311]"
         }
       },
       "Microsoft.NETCore.TestHost-x64/1.0.0-beta-23225": {},
@@ -1469,10 +1468,26 @@
           "runtimes/win7-x86/native/CoreRun.exe": {}
         }
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {},
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {},
       "OpenCover/4.6.166": {},
-      "ReportGenerator/2.1.6.0": {},
-      "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
+      "ReportGenerator/2.3.0.0": {},
+      "runtime.win7.System.Console/4.0.0-beta-23311": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10"
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet/System.Console.dll": {}
+        }
+      },
+      "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
         "runtime": {
           "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll": {}
         },
@@ -1486,12 +1501,12 @@
           "runtimes/win7-x86/native/mscorrc.dll": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {
+      "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -1554,13 +1569,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -1642,23 +1657,13 @@
           "lib/dotnet/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23302": {
+      "System.Console/4.0.0-beta-23311": {
         "dependencies": {
-          "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.IO": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Console.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Contracts/4.0.0": {
@@ -1683,7 +1688,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23302": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Reflection": "4.0.0"
@@ -1728,7 +1733,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23302": {
+      "System.Globalization.Calendars/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Globalization": "4.0.0"
@@ -1802,7 +1807,7 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23302": {
+      "System.ObjectModel/4.0.11-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.20",
           "System.Resources.ResourceManager": "4.0.0",
@@ -1817,7 +1822,7 @@
           "lib/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23302": {
+      "System.Private.Uri/4.0.1-beta-23311": {
         "runtime": {
           "lib/DNXCore50/System.Private.Uri.dll": {}
         }
@@ -1847,7 +1852,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23302": {
+      "System.Reflection.Primitives/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -1992,7 +1997,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23302": {
+      "System.Threading.Thread/4.0.0-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -2003,7 +2008,7 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+      "System.Threading.ThreadPool/4.0.10-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
@@ -2015,7 +2020,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23302": {
+      "System.Threading.Timer/4.0.1-beta-23311": {
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
@@ -2093,7 +2098,7 @@
           "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll": {}
         }
       },
-      "xunit.console.netcore/1.0.2-prerelease-00081": {
+      "xunit.console.netcore/1.0.2-prerelease-00085": {
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Collections.Concurrent": "4.0.10",
@@ -2164,9 +2169,10 @@
     "coveralls.io/1.4": {
       "sha512": "QJLuUzAD50drCp5P+PiWHh/TKcNBbsgnnZiN600YtRPx5DP4aY4MpVeY1oYs8eOnuhCZW+5TqcpUct3oHJigIQ==",
       "files": [
-        "coveralls.io.1.4.0.nupkg",
-        "coveralls.io.1.4.0.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "coveralls.io.nuspec",
+        "package/services/metadata/core-properties/746ff290a4d24d1aa0f9843c51cd2208.psmdcp",
         "tools/CommandLine.dll",
         "tools/CommandLine.xml",
         "tools/Coveralls.dll",
@@ -2184,13 +2190,13 @@
         "tools/Newtonsoft.Json.xml"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0012": {
-      "serviceable": true,
-      "sha512": "UyJsPalrRDqgwY2xUJBVCBUAz3xcMyNCO7vEKuQlVAyayj/57rR0GR8Xz0HyqdmC3BDrreoWc3pYf/b2vOLoSA==",
+    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0013": {
+      "sha512": "64CjnG4XGwQyptRZiv2prAr/OHg/yY1/RccXasII3tEuC8ZtKIofAD3ocHLLszXKOctl5ObtYLd29yMDKNJv3g==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0012.nupkg",
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0012.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "Microsoft.DotNet.xunit.performance.analysis.nuspec",
+        "package/services/metadata/core-properties/67a9e09b59a74d2788a984e19be06852.psmdcp",
         "tools/MathNet.Numerics.dll",
         "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
         "tools/xunit.performance.analysis.exe",
@@ -2198,16 +2204,20 @@
         "tools/xunit.performance.analysis.pdb"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0012": {
-      "serviceable": true,
-      "sha512": "bsM2z4/g1Da7WjZRMPbTHfKB+52vOo8WEOj+SC86QUSOZZweClzNuNnuNSwHw98WaHeC+Ns6n1icpSNVLdoinA==",
+    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0013": {
+      "sha512": "CRCx/9vsiCff638U3Kgmp/uWSrF5Y5c3L/bxKRMFTBSeGnSYs/P0rtehyb2nrT4venNXj92yEE6mtHCSHYfoAg==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0012.nupkg",
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0012.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "Microsoft.DotNet.xunit.performance.runner.Windows.nuspec",
+        "package/services/metadata/core-properties/79ed7e8387814017adbde831707a71bb.psmdcp",
+        "tools/amd64/KernelTraceControl.dll",
+        "tools/amd64/msdia120.dll",
         "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
         "tools/ProcDomain.dll",
         "tools/ProcDomain.pdb",
+        "tools/x86/KernelTraceControl.dll",
+        "tools/x86/msdia120.dll",
         "tools/xunit.abstractions.dll",
         "tools/xunit.core.dll",
         "tools/xunit.core.pdb",
@@ -2224,78 +2234,90 @@
         "tools/xunit.performance.run.exe.config",
         "tools/xunit.performance.run.pdb",
         "tools/xunit.runner.utility.desktop.dll",
-        "tools/xunit.runner.utility.desktop.pdb",
-        "tools/amd64/KernelTraceControl.dll",
-        "tools/amd64/msdia120.dll",
-        "tools/x86/KernelTraceControl.dll",
-        "tools/x86/msdia120.dll"
+        "tools/xunit.runner.utility.desktop.pdb"
       ]
     },
-    "Microsoft.NETCore.Runtime/1.0.1-beta-23302": {
-      "sha512": "veqhTWhZHLZb1+Sr2yYCn36NArQuWUtM2bnrM918uRlsDNxifxFfx7i+2WbOf0y/xQZLqI9VoM42UhRvmgV9+A==",
+    "Microsoft.NETCore.Platforms/1.0.1-beta-23311": {
+      "sha512": "dHNQXYEiFTPiUQoMI0bOnRKLN/NI5yQwqZ/Ncn5EomAPYFbtxBTQwDtipbWM1hcfnFhLwgf/q8BzS9fqJfxeTA==",
       "files": [
-        "Microsoft.NETCore.Runtime.1.0.1-beta-23302.nupkg",
-        "Microsoft.NETCore.Runtime.1.0.1-beta-23302.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.nuspec",
-        "_._"
-      ]
-    },
-    "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
-      "sha512": "I0p55d2fDuLUsEsbL+zmDy90saozpuO9JSz75OsEoT4n7e46KubEqsgLldl1inndQP+bcrsmWxQFdtCyChOLyA==",
-      "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23302.nupkg",
-        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23302.nupkg.sha512",
-        "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23311.nupkg",
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23311.nupkg.sha512",
+        "Microsoft.NETCore.Platforms.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23302": {
-      "sha512": "iuyhowd7kWdVMjTh//HoFE3/nxnweKwMnlSixlNzfSBBRGtxlZnfhI2bQwOSw5ONZHKIm3JUfFREy133FWdJPA==",
+    "Microsoft.NETCore.Runtime/1.0.1-beta-23311": {
+      "sha512": "rWTG8QAV0nScqJ4n7tdTEKSyiqdQb07ywQW3dsStd329Tw/yNKOdRF1pEkGYY3Q7B/jhnu1JEmOo1LHTb1X9mw==",
       "files": [
-        "Microsoft.NETCore.Runtime.Native.1.0.1-beta-23302.nupkg",
-        "Microsoft.NETCore.Runtime.Native.1.0.1-beta-23302.nupkg.sha512",
+        "[Content_Types].xml",
+        "_._",
+        "_rels/.rels",
+        "Microsoft.NETCore.Runtime.nuspec",
+        "package/services/metadata/core-properties/ee4d50b1500c44cabc245af03fefdc3e.psmdcp"
+      ]
+    },
+    "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+      "sha512": "/VCAiycb0NrigRzRTJE+E0nlS23Jt9CWAsvWU+jDHYRbnp3N7wy3WE+lliWsroLDg+/84b7na9vjGr02UO3oFg==",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "package/services/metadata/core-properties/dc33e2fdbf0d489ab8bcb63866878734.psmdcp",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Runtime.Native/1.0.1-beta-23311": {
+      "sha512": "ZPKIdlU+FFRFum8Mbgmo2VV580YeTwfSRYZ4wwPYH3eXLIA/ZJO4jdwanjLq/3o5XHEefMB4J64QXWfNmlWQWA==",
+      "files": [
+        "[Content_Types].xml",
+        "_._",
+        "_rels/.rels",
         "Microsoft.NETCore.Runtime.Native.nuspec",
-        "_._"
+        "package/services/metadata/core-properties/c8a37d81be5b4537a84544a764c09b78.psmdcp"
       ]
     },
     "Microsoft.NETCore.TestHost-x64/1.0.0-beta-23225": {
       "sha512": "D+OrRHthQ/ViCNveXP8ClxEVKJdDTFwp4s9ubLhagMPTWsJKh3NWmUw35sGEXzZcRNAKAEDjaH8iybD7T285QQ==",
       "files": [
-        "Microsoft.NETCore.TestHost-x64.1.0.0-beta-23225.nupkg",
-        "Microsoft.NETCore.TestHost-x64.1.0.0-beta-23225.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "Microsoft.NETCore.TestHost-x64.nuspec",
+        "package/services/metadata/core-properties/f72cd73704b8482e88186e3d16f77b5a.psmdcp",
         "runtimes/win7-x64/native/CoreRun.exe"
       ]
     },
     "Microsoft.NETCore.TestHost-x86/1.0.0-beta-23225": {
       "sha512": "MBJ6VGE6mkmWs8fnIQucHrLzNM4VOemMzFtyPSR1AceVn35BFpiACvvKZKkcJ47il+m9MqnfcKMGJVDNm+IdLA==",
       "files": [
-        "Microsoft.NETCore.TestHost-x86.1.0.0-beta-23225.nupkg",
-        "Microsoft.NETCore.TestHost-x86.1.0.0-beta-23225.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "Microsoft.NETCore.TestHost-x86.nuspec",
+        "package/services/metadata/core-properties/12518f97a3414352b8f842f7d0e54f4f.psmdcp",
         "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
-    "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {
-      "sha512": "s0J24bb/gYT+He2ldLwzCgRnH/lNc1YyNaQGZQEM/B3M/eX+OlZufngvrtWiEpBHs4/WBhooGBYZpv+ehKRRgQ==",
+    "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
+      "sha512": "SV5WFOHAXEJABi9OaikQWLHpuDHriGxTNvt6QIvVmDw25vEWlIwhu1LIA2+jrlpTZZTiJLBrZzydvkHVGGpncg==",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23302.nupkg",
-        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23302.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "Microsoft.NETCore.Windows.ApiSets.nuspec",
+        "package/services/metadata/core-properties/1dac4b52885643d09201eec78d2a7eb6.psmdcp",
         "runtime.json"
       ]
     },
     "OpenCover/4.6.166": {
       "sha512": "bor8lEgWH0upmsYg4/aj0CMOsczSwwGy6tBZRC26T1pBs1D2IkVQ/EHU/Shn5SjQ8M04cp8N4xiLFMzF8GzT6g==",
       "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
         "docs/ReleaseNotes.txt",
         "docs/Usage.rtf",
         "License.rtf",
         "MSBuild/OpenCover.MSBuild.dll",
         "MSBuild/OpenCover.targets",
-        "OpenCover.4.6.166.nupkg",
-        "OpenCover.4.6.166.nupkg.sha512",
         "OpenCover.nuspec",
+        "package/services/metadata/core-properties/4fe83ffa9479499aaa3f61a5f28de643.psmdcp",
         "readme.txt",
         "Samples/x64/OpenCover.Simple.Target.exe",
         "Samples/x64/OpenCover.Simple.Target.pdb",
@@ -2334,30 +2356,56 @@
         "transform/transform.ps1"
       ]
     },
-    "ReportGenerator/2.1.6.0": {
-      "sha512": "8cr+MlgMULmllLE/EKCfVfdbx12bdDEuQVUi7tG60OtZ0Uh7VHHUsHr2A6P7oZReR0Rwwr2GoOgIfZJa15lcQw==",
+    "ReportGenerator/2.3.0.0": {
+      "sha512": "xa4La+rR2d0dbAN2ZABa2+mY/zjcbPRM5TwEMT4qZrTjLSQFbslnywcfeiZiAtZvBF3c0kOD4opk8sXkvAzBbg==",
       "files": [
-        "ICSharpCode.NRefactory.CSharp.dll",
-        "ICSharpCode.NRefactory.dll",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "LICENSE.txt",
-        "log4net.dll",
+        "package/services/metadata/core-properties/855ca210c2b845718b9f871b418b5f02.psmdcp",
         "Readme.txt",
-        "ReportGenerator.2.1.6.nupkg",
-        "ReportGenerator.2.1.6.nupkg.sha512",
-        "ReportGenerator.exe",
         "ReportGenerator.nuspec",
-        "ReportGenerator.Reporting.dll",
-        "ReportGenerator.Reporting.XML",
-        "ReportGenerator.XML"
+        "tools/ICSharpCode.NRefactory.CSharp.dll",
+        "tools/ICSharpCode.NRefactory.dll",
+        "tools/log4net.dll",
+        "tools/ReportGenerator.exe",
+        "tools/ReportGenerator.Reporting.dll",
+        "tools/ReportGenerator.Reporting.XML",
+        "tools/ReportGenerator.XML"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
-      "sha512": "0feZ89tTNUycxsJosWls7IjuJNSPwZcLW16stWtU23wfJ+zQXC3jVqcSRcFH38gbayLIrOTViHIBgdEiquJ3Bw==",
+    "runtime.win7.System.Console/4.0.0-beta-23311": {
+      "serviceable": true,
+      "sha512": "z3nkl8x0HvPR4VP0dOZk7sm+wDHGP1gAk/18mQ/05MbJHuHl1InE6hfDYQ0XI2vQlg9atU4knUaHTAymW9iOSA==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23302.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23302.nupkg.sha512",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "runtime.win7.System.Console.4.0.0-beta-23311.nupkg",
+        "runtime.win7.System.Console.4.0.0-beta-23311.nupkg.sha512",
+        "runtime.win7.System.Console.nuspec",
+        "System.Console.xml",
+        "de/System.Console.xml",
+        "es/System.Console.xml",
+        "fr/System.Console.xml",
+        "it/System.Console.xml",
+        "ja/System.Console.xml",
+        "ko/System.Console.xml",
+        "lib/win8/_._",
+        "lib/wp8/_._",
+        "lib/wpa81/_._",
         "ref/dotnet/_._",
+        "ru/System.Console.xml",
+        "runtimes/win7/lib/dotnet/System.Console.dll",
+        "zh-hans/System.Console.xml",
+        "zh-hant/System.Console.xml"
+      ]
+    },
+    "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+      "sha512": "nMRY83TeOv6w4w4lmEn1/RL44os+5s8ciyUyYeS2r9fTP680SBfMFWmMvn7v2fU9YW6UNQj/oZaF2I5BBK37PQ==",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/fa5535535d8f48f4847d040885d1e8ba.psmdcp",
+        "ref/dotnet/_._",
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x64/native/clretwrc.dll",
         "runtimes/win7-x64/native/coreclr.dll",
@@ -2368,17 +2416,18 @@
         "runtimes/win7-x64/native/mscorrc.dll"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {
-      "sha512": "WU2ICCbnhjzHFRR0wSCl8kuzCVNS09QuLTK+t1+q4cZqtqoh4OH8CfDtsMwqAwI3Fzrovc0mjNojW4dD/HHKiw==",
+    "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
+      "sha512": "EUGN4DCOJZGlyzC+r7rU9GiblXMSwVL0anF3b2k4HvUWHG05Nntkw36qRbY+sLDpP3pgO+c1UNbdA4zOXbq+sg==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23302.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23302.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/8f59269f257740ab896d2f43ac330333.psmdcp",
         "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win10-x64/native/_._",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -2441,13 +2490,13 @@
         "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -2497,6 +2546,14 @@
         "runtimes/win7-x64/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x64/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x64/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -2511,8 +2568,8 @@
         "runtimes/win8-x64/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -2522,24 +2579,17 @@
         "runtimes/win8-x64/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x64/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x64/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x64/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x64/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x64/native/api-ms-win-security-cpwl-l1-1-0.dll"
+        "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23302": {
-      "sha512": "hh6ymSHKa4/ewGUEc9OaWUnKbq0xpMhKhCUIgBkvoQJ58F/D5CbxnbZEZ2zYHn7wuRQza1tPIyjlLFm5dpO1NQ==",
+    "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23311": {
+      "sha512": "1VznSbjFeB6JTtJ1oDE+QbUvCuOkzQy1LoesIOx328268437+fEOacFToKCyxJ62VDzUpFDz7QYYu1AMgVNllQ==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23302.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23302.nupkg.sha512",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/e64ab3a3e9e64ba5af553ad0ef6bf215.psmdcp",
         "ref/dotnet/_._",
+        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
         "runtimes/win7-x86/native/coreclr.dll",
@@ -2550,17 +2600,18 @@
         "runtimes/win7-x86/native/mscorrc.dll"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23302": {
-      "sha512": "fqAkU5sxaMUZtV5TJDG3C870rcHSos8Cz5rcAj22ZMUalUpCrKKkS6meZPP/loMvCZXIL1/HwCU6pZQcBF3bLA==",
+    "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23311": {
+      "sha512": "r49cjQeVLgdrt7Twhuun/QCwAzhWj45PX7O6A2HJSsVF6zNmTE693Z2k+NnASsfvwW2PKaYZe6ewjWwoKwX/PQ==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23302.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23302.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/c424bbc522d44fd2992a49587f7bea85.psmdcp",
         "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll",
@@ -2623,13 +2674,13 @@
         "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
+        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll",
         "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
-        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll",
+        "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll",
         "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll",
@@ -2679,6 +2730,14 @@
         "runtimes/win7-x86/native/api-ms-win-service-private-l1-1-1.dll",
         "runtimes/win7-x86/native/api-ms-win-service-winsvc-l1-1-0.dll",
         "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
+        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
+        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
+        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-file-l2-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-kernel32-legacy-l1-1-1.dll",
@@ -2693,8 +2752,8 @@
         "runtimes/win8-x86/native/api-ms-win-core-privateprofile-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-processthreads-l1-1-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-shutdown-l1-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-stringloader-l1-1-1.dll",
+        "runtimes/win8-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-1.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
         "runtimes/win8-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
@@ -2704,24 +2763,14 @@
         "runtimes/win8-x86/native/api-ms-win-security-cpwl-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-cryptoapi-l1-1-0.dll",
         "runtimes/win8-x86/native/api-ms-win-security-lsalookup-l2-1-1.dll",
-        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-kernel32-legacy-l1-1-2.dll",
-        "runtimes/win81-x86/native/API-MS-Win-Core-Kernel32-Private-L1-1-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-memory-l1-1-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-namedpipe-l1-2-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-2.dll",
-        "runtimes/win81-x86/native/api-ms-win-core-sysinfo-l1-2-3.dll",
-        "runtimes/win81-x86/native/api-ms-win-security-cpwl-l1-1-0.dll"
+        "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
     "System.Collections/4.0.10": {
-      "serviceable": true,
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "files": [
-        "System.Collections.4.0.10.nupkg",
-        "System.Collections.4.0.10.nupkg.sha512",
-        "System.Collections.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2729,8 +2778,7 @@
         "lib/netcore50/System.Collections.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.dll",
-        "ref/dotnet/System.Collections.xml",
+        "package/services/metadata/core-properties/b4f8061406e54dbda8f11b23186be11a.psmdcp",
         "ref/dotnet/de/System.Collections.xml",
         "ref/dotnet/es/System.Collections.xml",
         "ref/dotnet/fr/System.Collections.xml",
@@ -2738,6 +2786,8 @@
         "ref/dotnet/ja/System.Collections.xml",
         "ref/dotnet/ko/System.Collections.xml",
         "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
         "ref/dotnet/zh-hans/System.Collections.xml",
         "ref/dotnet/zh-hant/System.Collections.xml",
         "ref/MonoAndroid10/_._",
@@ -2745,24 +2795,22 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.nuspec"
       ]
     },
     "System.Collections.Concurrent/4.0.10": {
-      "serviceable": true,
       "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
       "files": [
-        "System.Collections.Concurrent.4.0.10.nupkg",
-        "System.Collections.Concurrent.4.0.10.nupkg.sha512",
-        "System.Collections.Concurrent.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dotnet/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
+        "package/services/metadata/core-properties/c982a1e1e1644b62952fc4d4dcbe0d42.psmdcp",
         "ref/dotnet/de/System.Collections.Concurrent.xml",
         "ref/dotnet/es/System.Collections.Concurrent.xml",
         "ref/dotnet/fr/System.Collections.Concurrent.xml",
@@ -2770,50 +2818,51 @@
         "ref/dotnet/ja/System.Collections.Concurrent.xml",
         "ref/dotnet/ko/System.Collections.Concurrent.xml",
         "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
         "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.Collections.Concurrent.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23302": {
-      "serviceable": true,
-      "sha512": "rpWEkJWW29TjVZdDz5zr8VnBv4IN9BQHmP4Ky9tEbvkdhkJRb0ZO59acXMpVD1tSM2VhGlLnq0kpdjOLNmejNA==",
+    "System.Console/4.0.0-beta-23311": {
+      "sha512": "aCYId/+628/CuOEBKx7sGxQ9fpqvLDqkOMuc0rqWRUCAIgNLtLd5htaQo58aXjzrP8D4/X35xVC+PQoHHis4Mg==",
       "files": [
-        "System.Console.4.0.0-beta-23302.nupkg",
-        "System.Console.4.0.0-beta-23302.nupkg.sha512",
-        "System.Console.nuspec",
-        "lib/DNXCore50/System.Console.dll",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/91b26dd39a0e48e6af2a474b606e3257.psmdcp",
         "ref/dotnet/System.Console.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Contracts/4.0.0": {
       "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
       "files": [
-        "System.Diagnostics.Contracts.4.0.0.nupkg",
-        "System.Diagnostics.Contracts.4.0.0.nupkg.sha512",
-        "System.Diagnostics.Contracts.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Contracts.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Contracts.dll",
-        "ref/dotnet/System.Diagnostics.Contracts.xml",
+        "package/services/metadata/core-properties/c6cd3d0bbc304cbca14dc3d6bff6579c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Contracts.xml",
         "ref/dotnet/es/System.Diagnostics.Contracts.xml",
         "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
@@ -2821,6 +2870,8 @@
         "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
         "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
         "ref/net45/_._",
@@ -2829,16 +2880,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
-      "serviceable": true,
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "files": [
-        "System.Diagnostics.Debug.4.0.10.nupkg",
-        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
-        "System.Diagnostics.Debug.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2846,8 +2896,7 @@
         "lib/netcore50/System.Diagnostics.Debug.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Debug.dll",
-        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Debug.xml",
         "ref/dotnet/es/System.Diagnostics.Debug.xml",
         "ref/dotnet/fr/System.Diagnostics.Debug.xml",
@@ -2855,6 +2904,8 @@
         "ref/dotnet/ja/System.Diagnostics.Debug.xml",
         "ref/dotnet/ko/System.Diagnostics.Debug.xml",
         "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
         "ref/MonoAndroid10/_._",
@@ -2862,16 +2913,21 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.StackTrace/4.0.1-beta-23302": {
-      "serviceable": true,
-      "sha512": "rPTlsqpHPqAmiVmYn6exfek3sgSh6D2brTE4sodMfDxz0Tqn/pARGqV9tZj9hj6WE6S7AoJqd0DvPYL6ViKMEA==",
+    "System.Diagnostics.StackTrace/4.0.1-beta-23311": {
+      "sha512": "jZ3+0apsOdgdtB1RjnVq2AgCRgt2abCVUYHrZKENw52K7nZbE74SpxfbUb2bHLs/2rqS/Hxtsn66Ltjl6AJvmw==",
       "files": [
-        "System.Diagnostics.StackTrace.4.0.1-beta-23302.nupkg",
-        "System.Diagnostics.StackTrace.4.0.1-beta-23302.nupkg.sha512",
-        "System.Diagnostics.StackTrace.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "de/System.Diagnostics.StackTrace.xml",
+        "es/System.Diagnostics.StackTrace.xml",
+        "fr/System.Diagnostics.StackTrace.xml",
+        "it/System.Diagnostics.StackTrace.xml",
+        "ja/System.Diagnostics.StackTrace.xml",
+        "ko/System.Diagnostics.StackTrace.xml",
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2879,30 +2935,33 @@
         "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/bcd207330ac44655839cced19923a05d.psmdcp",
         "ref/dotnet/System.Diagnostics.StackTrace.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll"
+        "ru/System.Diagnostics.StackTrace.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
+        "System.Diagnostics.StackTrace.nuspec",
+        "System.Diagnostics.StackTrace.xml",
+        "zh-hans/System.Diagnostics.StackTrace.xml",
+        "zh-hant/System.Diagnostics.StackTrace.xml"
       ]
     },
     "System.Diagnostics.Tools/4.0.0": {
-      "serviceable": true,
       "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
       "files": [
-        "System.Diagnostics.Tools.4.0.0.nupkg",
-        "System.Diagnostics.Tools.4.0.0.nupkg.sha512",
-        "System.Diagnostics.Tools.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Diagnostics.Tools.dll",
-        "ref/dotnet/System.Diagnostics.Tools.xml",
+        "package/services/metadata/core-properties/20f622a1ae5b4e3992fc226d88d36d59.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tools.xml",
         "ref/dotnet/es/System.Diagnostics.Tools.xml",
         "ref/dotnet/fr/System.Diagnostics.Tools.xml",
@@ -2910,6 +2969,8 @@
         "ref/dotnet/ja/System.Diagnostics.Tools.xml",
         "ref/dotnet/ko/System.Diagnostics.Tools.xml",
         "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
         "ref/net45/_._",
@@ -2918,16 +2979,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
-      "serviceable": true,
       "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
       "files": [
-        "System.Diagnostics.Tracing.4.0.20.nupkg",
-        "System.Diagnostics.Tracing.4.0.20.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2935,8 +2995,7 @@
         "lib/netcore50/System.Diagnostics.Tracing.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
         "ref/dotnet/de/System.Diagnostics.Tracing.xml",
         "ref/dotnet/es/System.Diagnostics.Tracing.xml",
         "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
@@ -2944,6 +3003,8 @@
         "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
         "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
         "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
         "ref/MonoAndroid10/_._",
@@ -2951,15 +3012,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "System.Diagnostics.Tracing.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
       "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
       "files": [
-        "System.Globalization.4.0.10.nupkg",
-        "System.Globalization.4.0.10.nupkg.sha512",
-        "System.Globalization.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2967,8 +3028,7 @@
         "lib/netcore50/System.Globalization.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Globalization.dll",
-        "ref/dotnet/System.Globalization.xml",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
         "ref/dotnet/de/System.Globalization.xml",
         "ref/dotnet/es/System.Globalization.xml",
         "ref/dotnet/fr/System.Globalization.xml",
@@ -2976,6 +3036,8 @@
         "ref/dotnet/ja/System.Globalization.xml",
         "ref/dotnet/ko/System.Globalization.xml",
         "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
         "ref/dotnet/zh-hans/System.Globalization.xml",
         "ref/dotnet/zh-hant/System.Globalization.xml",
         "ref/MonoAndroid10/_._",
@@ -2983,16 +3045,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.nuspec"
       ]
     },
-    "System.Globalization.Calendars/4.0.1-beta-23302": {
-      "serviceable": true,
-      "sha512": "ncuSvS8GVEnDp9blpHMIJl/gPqR5HtoIFxAtSrgKSTyvfNfpE4d8hBcCe4WB8xPgixLb11YbpDXMTqJSgEhoiw==",
+    "System.Globalization.Calendars/4.0.1-beta-23311": {
+      "sha512": "kiFDf9I66eYQCJDV/W9H7uWevx6BHvgNJDsZmiEycEeuABj4+J7mLaI3EZ/goGzNGt+TFkmm2U26IvFyv1CTwQ==",
       "files": [
-        "System.Globalization.Calendars.4.0.1-beta-23302.nupkg",
-        "System.Globalization.Calendars.4.0.1-beta-23302.nupkg.sha512",
-        "System.Globalization.Calendars.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3000,22 +3061,22 @@
         "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/d54ee646f5c64d50a89711ca354e32b5.psmdcp",
         "ref/dotnet/System.Globalization.Calendars.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.nuspec"
       ]
     },
     "System.IO/4.0.10": {
-      "serviceable": true,
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "files": [
-        "System.IO.4.0.10.nupkg",
-        "System.IO.4.0.10.nupkg.sha512",
-        "System.IO.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3023,8 +3084,7 @@
         "lib/netcore50/System.IO.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.dll",
-        "ref/dotnet/System.IO.xml",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
         "ref/dotnet/de/System.IO.xml",
         "ref/dotnet/es/System.IO.xml",
         "ref/dotnet/fr/System.IO.xml",
@@ -3032,6 +3092,8 @@
         "ref/dotnet/ja/System.IO.xml",
         "ref/dotnet/ko/System.IO.xml",
         "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
         "ref/dotnet/zh-hans/System.IO.xml",
         "ref/dotnet/zh-hant/System.IO.xml",
         "ref/MonoAndroid10/_._",
@@ -3039,16 +3101,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.IO.dll"
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.nuspec"
       ]
     },
     "System.IO.FileSystem/4.0.0": {
-      "serviceable": true,
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "files": [
-        "System.IO.FileSystem.4.0.0.nupkg",
-        "System.IO.FileSystem.4.0.0.nupkg.sha512",
-        "System.IO.FileSystem.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.IO.FileSystem.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3056,8 +3117,7 @@
         "lib/netcore50/System.IO.FileSystem.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.dll",
-        "ref/dotnet/System.IO.FileSystem.xml",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.xml",
         "ref/dotnet/es/System.IO.FileSystem.xml",
         "ref/dotnet/fr/System.IO.FileSystem.xml",
@@ -3065,30 +3125,30 @@
         "ref/dotnet/ja/System.IO.FileSystem.xml",
         "ref/dotnet/ko/System.IO.FileSystem.xml",
         "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.IO.FileSystem.nuspec"
       ]
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
-      "serviceable": true,
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "files": [
-        "System.IO.FileSystem.Primitives.4.0.0.nupkg",
-        "System.IO.FileSystem.Primitives.4.0.0.nupkg.sha512",
-        "System.IO.FileSystem.Primitives.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
         "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
@@ -3096,30 +3156,30 @@
         "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
         "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
-      "serviceable": true,
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "files": [
-        "System.Linq.4.0.0.nupkg",
-        "System.Linq.4.0.0.nupkg.sha512",
-        "System.Linq.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Linq.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
         "ref/dotnet/de/System.Linq.xml",
         "ref/dotnet/es/System.Linq.xml",
         "ref/dotnet/fr/System.Linq.xml",
@@ -3127,6 +3187,8 @@
         "ref/dotnet/ja/System.Linq.xml",
         "ref/dotnet/ko/System.Linq.xml",
         "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
         "ref/dotnet/zh-hans/System.Linq.xml",
         "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
@@ -3134,50 +3196,60 @@
         "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "ref/wpa81/_._"
+        "ref/wpa81/_._",
+        "System.Linq.nuspec"
       ]
     },
-    "System.ObjectModel/4.0.11-beta-23302": {
-      "serviceable": true,
-      "sha512": "eOk43taKiAccmNYDcW5+EDNlU7r8KQNNu3EYCPHG5b4ijOXlyQjONU6bPwkIFmzn5z3kOwxuaLbLxI607UgsZw==",
+    "System.ObjectModel/4.0.11-beta-23311": {
+      "sha512": "w3KLOdj/MCNB3k53bhm5KW2UzOgTFZ71s/M5xzIQBUZEo0dM2/T3iWf6KnKy/mRz5YstFxZioyllc5VUDQZYPg==",
       "files": [
-        "System.ObjectModel.4.0.11-beta-23302.nupkg",
-        "System.ObjectModel.4.0.11-beta-23302.nupkg.sha512",
-        "System.ObjectModel.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "de/System.ObjectModel.xml",
+        "es/System.ObjectModel.xml",
+        "fr/System.ObjectModel.xml",
+        "it/System.ObjectModel.xml",
+        "ja/System.ObjectModel.xml",
+        "ko/System.ObjectModel.xml",
         "lib/dotnet/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/c2871c9291b943868c621d9d138d4645.psmdcp",
         "ref/dotnet/System.ObjectModel.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "ru/System.ObjectModel.xml",
+        "System.ObjectModel.nuspec",
+        "System.ObjectModel.xml",
+        "zh-hans/System.ObjectModel.xml",
+        "zh-hant/System.ObjectModel.xml"
       ]
     },
-    "System.Private.Uri/4.0.1-beta-23302": {
-      "serviceable": true,
-      "sha512": "HQKaa/NoZF1FYSIKCM7ZXHntaadwUoWb+EeXdIiutQXAPGmUOLszeJrn7voBzYDjWy/Wh6zdvTIkKmF4dgxC1w==",
+    "System.Private.Uri/4.0.1-beta-23311": {
+      "sha512": "LeCKGhHcwNQ/YHtIolX2pBVaRgWmrMpvX2bhuIz5HOmoFBYAhAsTgcAH/psj+xGFbBoBLzLGv+reuLo4R81ySg==",
       "files": [
-        "System.Private.Uri.4.0.1-beta-23302.nupkg",
-        "System.Private.Uri.4.0.1-beta-23302.nupkg.sha512",
-        "System.Private.Uri.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Private.Uri.dll",
         "lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/56c25158d7ff4fa19cb2fa9dda97d594.psmdcp",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.nuspec"
       ]
     },
     "System.Reflection/4.0.10": {
       "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
       "files": [
-        "System.Reflection.4.0.10.nupkg",
-        "System.Reflection.4.0.10.nupkg.sha512",
-        "System.Reflection.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3185,8 +3257,7 @@
         "lib/netcore50/System.Reflection.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Reflection.dll",
-        "ref/dotnet/System.Reflection.xml",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
         "ref/dotnet/de/System.Reflection.xml",
         "ref/dotnet/es/System.Reflection.xml",
         "ref/dotnet/fr/System.Reflection.xml",
@@ -3194,6 +3265,8 @@
         "ref/dotnet/ja/System.Reflection.xml",
         "ref/dotnet/ko/System.Reflection.xml",
         "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
         "ref/dotnet/zh-hans/System.Reflection.xml",
         "ref/dotnet/zh-hant/System.Reflection.xml",
         "ref/MonoAndroid10/_._",
@@ -3201,24 +3274,22 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
-      "serviceable": true,
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "files": [
-        "System.Reflection.Extensions.4.0.0.nupkg",
-        "System.Reflection.Extensions.4.0.0.nupkg.sha512",
-        "System.Reflection.Extensions.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Extensions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Reflection.Extensions.dll",
-        "ref/dotnet/System.Reflection.Extensions.xml",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
         "ref/dotnet/de/System.Reflection.Extensions.xml",
         "ref/dotnet/es/System.Reflection.Extensions.xml",
         "ref/dotnet/fr/System.Reflection.Extensions.xml",
@@ -3226,6 +3297,8 @@
         "ref/dotnet/ja/System.Reflection.Extensions.xml",
         "ref/dotnet/ko/System.Reflection.Extensions.xml",
         "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
         "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
         "ref/net45/_._",
@@ -3234,46 +3307,54 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Primitives/4.0.1-beta-23302": {
-      "serviceable": true,
-      "sha512": "G9GVzXbwAAFPhRh2BCs/Hz5Fe936s9wXwDyDfud1zSXb1Fufncg1hSs8VMby9C/mGsCYfg3alXQ4NkwDXfbnYg==",
+    "System.Reflection.Primitives/4.0.1-beta-23311": {
+      "sha512": "NtBa8OyGPH5WISeOmbl4fHn5t4TmxmfERvmjRSnEharhSpXZjgYBPW5hPx0wdc+Cd6qCG4XYxlu3kXMScJEkcQ==",
       "files": [
-        "System.Reflection.Primitives.4.0.1-beta-23302.nupkg",
-        "System.Reflection.Primitives.4.0.1-beta-23302.nupkg.sha512",
-        "System.Reflection.Primitives.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "de/System.Reflection.Primitives.xml",
+        "es/System.Reflection.Primitives.xml",
+        "fr/System.Reflection.Primitives.xml",
+        "it/System.Reflection.Primitives.xml",
+        "ja/System.Reflection.Primitives.xml",
+        "ko/System.Reflection.Primitives.xml",
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Reflection.Primitives.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "package/services/metadata/core-properties/08a4f0cea1634bb3af0632fb290dfa8d.psmdcp",
         "ref/dotnet/System.Reflection.Primitives.dll",
         "ref/net45/_._",
         "ref/netcore50/System.Reflection.Primitives.dll",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll"
+        "ru/System.Reflection.Primitives.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.nuspec",
+        "System.Reflection.Primitives.xml",
+        "zh-hans/System.Reflection.Primitives.xml",
+        "zh-hant/System.Reflection.Primitives.xml"
       ]
     },
     "System.Resources.ResourceManager/4.0.0": {
-      "serviceable": true,
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "files": [
-        "System.Resources.ResourceManager.4.0.0.nupkg",
-        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
-        "System.Resources.ResourceManager.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
         "lib/netcore50/System.Resources.ResourceManager.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/System.Resources.ResourceManager.dll",
-        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
         "ref/dotnet/de/System.Resources.ResourceManager.xml",
         "ref/dotnet/es/System.Resources.ResourceManager.xml",
         "ref/dotnet/fr/System.Resources.ResourceManager.xml",
@@ -3281,6 +3362,8 @@
         "ref/dotnet/ja/System.Resources.ResourceManager.xml",
         "ref/dotnet/ko/System.Resources.ResourceManager.xml",
         "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
         "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
         "ref/net45/_._",
@@ -3289,16 +3372,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.nuspec"
       ]
     },
     "System.Runtime/4.0.20": {
-      "serviceable": true,
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "files": [
-        "System.Runtime.4.0.20.nupkg",
-        "System.Runtime.4.0.20.nupkg.sha512",
-        "System.Runtime.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3306,8 +3388,7 @@
         "lib/netcore50/System.Runtime.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.dll",
-        "ref/dotnet/System.Runtime.xml",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
         "ref/dotnet/de/System.Runtime.xml",
         "ref/dotnet/es/System.Runtime.xml",
         "ref/dotnet/fr/System.Runtime.xml",
@@ -3315,6 +3396,8 @@
         "ref/dotnet/ja/System.Runtime.xml",
         "ref/dotnet/ko/System.Runtime.xml",
         "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
         "ref/dotnet/zh-hans/System.Runtime.xml",
         "ref/dotnet/zh-hant/System.Runtime.xml",
         "ref/MonoAndroid10/_._",
@@ -3322,16 +3405,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.nuspec"
       ]
     },
     "System.Runtime.Extensions/4.0.10": {
-      "serviceable": true,
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "files": [
-        "System.Runtime.Extensions.4.0.10.nupkg",
-        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
-        "System.Runtime.Extensions.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3339,8 +3421,7 @@
         "lib/netcore50/System.Runtime.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Extensions.dll",
-        "ref/dotnet/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
         "ref/dotnet/de/System.Runtime.Extensions.xml",
         "ref/dotnet/es/System.Runtime.Extensions.xml",
         "ref/dotnet/fr/System.Runtime.Extensions.xml",
@@ -3348,6 +3429,8 @@
         "ref/dotnet/ja/System.Runtime.Extensions.xml",
         "ref/dotnet/ko/System.Runtime.Extensions.xml",
         "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
         "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
         "ref/MonoAndroid10/_._",
@@ -3355,16 +3438,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.nuspec"
       ]
     },
     "System.Runtime.Handles/4.0.0": {
-      "serviceable": true,
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "files": [
-        "System.Runtime.Handles.4.0.0.nupkg",
-        "System.Runtime.Handles.4.0.0.nupkg.sha512",
-        "System.Runtime.Handles.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3372,8 +3454,7 @@
         "lib/netcore50/System.Runtime.Handles.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.Handles.dll",
-        "ref/dotnet/System.Runtime.Handles.xml",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
         "ref/dotnet/de/System.Runtime.Handles.xml",
         "ref/dotnet/es/System.Runtime.Handles.xml",
         "ref/dotnet/fr/System.Runtime.Handles.xml",
@@ -3381,6 +3462,8 @@
         "ref/dotnet/ja/System.Runtime.Handles.xml",
         "ref/dotnet/ko/System.Runtime.Handles.xml",
         "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
         "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
         "ref/MonoAndroid10/_._",
@@ -3388,16 +3471,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.nuspec"
       ]
     },
     "System.Runtime.InteropServices/4.0.20": {
-      "serviceable": true,
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "files": [
-        "System.Runtime.InteropServices.4.0.20.nupkg",
-        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
-        "System.Runtime.InteropServices.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3405,8 +3487,7 @@
         "lib/netcore50/System.Runtime.InteropServices.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Runtime.InteropServices.dll",
-        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
         "ref/dotnet/de/System.Runtime.InteropServices.xml",
         "ref/dotnet/es/System.Runtime.InteropServices.xml",
         "ref/dotnet/fr/System.Runtime.InteropServices.xml",
@@ -3414,6 +3495,8 @@
         "ref/dotnet/ja/System.Runtime.InteropServices.xml",
         "ref/dotnet/ko/System.Runtime.InteropServices.xml",
         "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
         "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
         "ref/MonoAndroid10/_._",
@@ -3421,15 +3504,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
       "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
       "files": [
-        "System.Text.Encoding.4.0.10.nupkg",
-        "System.Text.Encoding.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3437,8 +3520,7 @@
         "lib/netcore50/System.Text.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.dll",
-        "ref/dotnet/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.xml",
         "ref/dotnet/es/System.Text.Encoding.xml",
         "ref/dotnet/fr/System.Text.Encoding.xml",
@@ -3446,6 +3528,8 @@
         "ref/dotnet/ja/System.Text.Encoding.xml",
         "ref/dotnet/ko/System.Text.Encoding.xml",
         "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.xml",
         "ref/MonoAndroid10/_._",
@@ -3453,15 +3537,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.nuspec"
       ]
     },
     "System.Text.Encoding.Extensions/4.0.10": {
       "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
       "files": [
-        "System.Text.Encoding.Extensions.4.0.10.nupkg",
-        "System.Text.Encoding.Extensions.4.0.10.nupkg.sha512",
-        "System.Text.Encoding.Extensions.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3469,8 +3553,7 @@
         "lib/netcore50/System.Text.Encoding.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.Encoding.Extensions.dll",
-        "ref/dotnet/System.Text.Encoding.Extensions.xml",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
         "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
@@ -3478,6 +3561,8 @@
         "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
         "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
         "ref/MonoAndroid10/_._",
@@ -3485,24 +3570,22 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.nuspec"
       ]
     },
     "System.Text.RegularExpressions/4.0.10": {
-      "serviceable": true,
       "sha512": "0vDuHXJePpfMCecWBNOabOKCvzfTbFMNcGgklt3l5+RqHV5SzmF7RUVpuet8V0rJX30ROlL66xdehw2Rdsn2DA==",
       "files": [
-        "System.Text.RegularExpressions.4.0.10.nupkg",
-        "System.Text.RegularExpressions.4.0.10.nupkg.sha512",
-        "System.Text.RegularExpressions.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dotnet/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Text.RegularExpressions.dll",
-        "ref/dotnet/System.Text.RegularExpressions.xml",
+        "package/services/metadata/core-properties/548eb1bd139e4c8cbc55e9f7f4f404dd.psmdcp",
         "ref/dotnet/de/System.Text.RegularExpressions.xml",
         "ref/dotnet/es/System.Text.RegularExpressions.xml",
         "ref/dotnet/fr/System.Text.RegularExpressions.xml",
@@ -3510,22 +3593,23 @@
         "ref/dotnet/ja/System.Text.RegularExpressions.xml",
         "ref/dotnet/ko/System.Text.RegularExpressions.xml",
         "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
         "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.Text.RegularExpressions.nuspec"
       ]
     },
     "System.Threading/4.0.10": {
-      "serviceable": true,
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "files": [
-        "System.Threading.4.0.10.nupkg",
-        "System.Threading.4.0.10.nupkg.sha512",
-        "System.Threading.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Threading.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3533,8 +3617,7 @@
         "lib/netcore50/System.Threading.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.dll",
-        "ref/dotnet/System.Threading.xml",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
         "ref/dotnet/de/System.Threading.xml",
         "ref/dotnet/es/System.Threading.xml",
         "ref/dotnet/fr/System.Threading.xml",
@@ -3542,6 +3625,8 @@
         "ref/dotnet/ja/System.Threading.xml",
         "ref/dotnet/ko/System.Threading.xml",
         "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
         "ref/dotnet/zh-hans/System.Threading.xml",
         "ref/dotnet/zh-hant/System.Threading.xml",
         "ref/MonoAndroid10/_._",
@@ -3549,21 +3634,19 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.nuspec"
       ]
     },
     "System.Threading.Overlapped/4.0.0": {
-      "serviceable": true,
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "files": [
-        "System.Threading.Overlapped.4.0.0.nupkg",
-        "System.Threading.Overlapped.4.0.0.nupkg.sha512",
-        "System.Threading.Overlapped.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
         "lib/netcore50/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.dll",
-        "ref/dotnet/System.Threading.Overlapped.xml",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
         "ref/dotnet/de/System.Threading.Overlapped.xml",
         "ref/dotnet/es/System.Threading.Overlapped.xml",
         "ref/dotnet/fr/System.Threading.Overlapped.xml",
@@ -3571,18 +3654,19 @@
         "ref/dotnet/ja/System.Threading.Overlapped.xml",
         "ref/dotnet/ko/System.Threading.Overlapped.xml",
         "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
-        "ref/net46/System.Threading.Overlapped.dll"
+        "ref/net46/System.Threading.Overlapped.dll",
+        "System.Threading.Overlapped.nuspec"
       ]
     },
     "System.Threading.Tasks/4.0.10": {
-      "serviceable": true,
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "files": [
-        "System.Threading.Tasks.4.0.10.nupkg",
-        "System.Threading.Tasks.4.0.10.nupkg.sha512",
-        "System.Threading.Tasks.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3590,8 +3674,7 @@
         "lib/netcore50/System.Threading.Tasks.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Threading.Tasks.dll",
-        "ref/dotnet/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
         "ref/dotnet/de/System.Threading.Tasks.xml",
         "ref/dotnet/es/System.Threading.Tasks.xml",
         "ref/dotnet/fr/System.Threading.Tasks.xml",
@@ -3599,6 +3682,8 @@
         "ref/dotnet/ja/System.Threading.Tasks.xml",
         "ref/dotnet/ko/System.Threading.Tasks.xml",
         "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
         "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
         "ref/MonoAndroid10/_._",
@@ -3606,86 +3691,84 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.Thread/4.0.0-beta-23302": {
-      "serviceable": true,
-      "sha512": "0tn5ET6NNDVjJdpacPXM9lwa3tZeKiIYZHOZPtsbORXop84IN93KenlcqEdPizxPsnOAgauVIgeKftnvwcvlsQ==",
+    "System.Threading.Thread/4.0.0-beta-23311": {
+      "sha512": "OgH6KflP3rlBmtrqE2xVcufOTIF3zQb/JN9aCl3rok0GZ8xnGS2xQy+F9hh6UHxQCkl0xWMhmvfdudvwvBkECw==",
       "files": [
-        "System.Threading.Thread.4.0.0-beta-23302.nupkg",
-        "System.Threading.Thread.4.0.0-beta-23302.nupkg.sha512",
-        "System.Threading.Thread.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Threading.Thread.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/7dde605c80294d2aa0249e59eb875007.psmdcp",
         "ref/dotnet/System.Threading.Thread.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.Threading.Thread.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23302": {
-      "serviceable": true,
-      "sha512": "dwwA7ce4yVXenjpJU20JyNn3zrXsWWkbw9UMNK49C09D7tmrYLSxzWSzY7/4034okFcOjQmtP5g36ZRZANZL9A==",
+    "System.Threading.ThreadPool/4.0.10-beta-23311": {
+      "sha512": "KF1vm7tZIPslDE262oI6FXlKlXOoz5K4HMR1V6DlZIstkL6CyLISv8c6vhdj3R0k2vmmVKcp2GyF4sOWbD0Y2A==",
       "files": [
-        "System.Threading.ThreadPool.4.0.10-beta-23302.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23302.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
+        "package/services/metadata/core-properties/5d2f768c22a244ff9369a4a3fef2be06.psmdcp",
         "ref/dotnet/System.Threading.ThreadPool.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.Threading.ThreadPool.nuspec"
       ]
     },
-    "System.Threading.Timer/4.0.1-beta-23302": {
-      "serviceable": true,
-      "sha512": "b5I5ZrJ/A0NoxLI+yYYWjE3cYCiBQJ6lqXWGBX1SL0OLEcYHbIgsWuFI4tflwqqlgQSkO4o9ya10mYytjjhgtg==",
+    "System.Threading.Timer/4.0.1-beta-23311": {
+      "sha512": "UUoQSXLk6d8lndy+z/82N2N4C8UcMsIVF/V23Gs1eoMmGw/EUMwLy0NDDZwo9N0bwS284ZN/6VzDuKQxJGuVrw==",
       "files": [
-        "System.Threading.Timer.4.0.1-beta-23302.nupkg",
-        "System.Threading.Timer.4.0.1-beta-23302.nupkg.sha512",
-        "System.Threading.Timer.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
         "lib/netcore50/System.Threading.Timer.dll",
         "lib/win81/_._",
         "lib/wpa81/_._",
+        "package/services/metadata/core-properties/935f56c0830b43768fb57980c49d4c6f.psmdcp",
         "ref/dotnet/System.Threading.Timer.dll",
         "ref/net451/_._",
         "ref/netcore50/System.Threading.Timer.dll",
         "ref/win81/_._",
         "ref/wpa81/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.nuspec"
       ]
     },
     "System.Xml.ReaderWriter/4.0.10": {
-      "serviceable": true,
       "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
       "files": [
-        "System.Xml.ReaderWriter.4.0.10.nupkg",
-        "System.Xml.ReaderWriter.4.0.10.nupkg.sha512",
-        "System.Xml.ReaderWriter.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
+        "package/services/metadata/core-properties/ef76b636720e4f2d8cfd570899d52df8.psmdcp",
         "ref/dotnet/de/System.Xml.ReaderWriter.xml",
         "ref/dotnet/es/System.Xml.ReaderWriter.xml",
         "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
@@ -3693,30 +3776,30 @@
         "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
         "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
         "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.Xml.ReaderWriter.nuspec"
       ]
     },
     "System.Xml.XDocument/4.0.10": {
-      "serviceable": true,
       "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
       "files": [
-        "System.Xml.XDocument.4.0.10.nupkg",
-        "System.Xml.XDocument.4.0.10.nupkg.sha512",
-        "System.Xml.XDocument.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
+        "package/services/metadata/core-properties/f5c45d6b065347dfaa1d90d06221623d.psmdcp",
         "ref/dotnet/de/System.Xml.XDocument.xml",
         "ref/dotnet/es/System.Xml.XDocument.xml",
         "ref/dotnet/fr/System.Xml.XDocument.xml",
@@ -3724,61 +3807,68 @@
         "ref/dotnet/ja/System.Xml.XDocument.xml",
         "ref/dotnet/ko/System.Xml.XDocument.xml",
         "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
         "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._"
+        "ref/xamarinmac20/_._",
+        "System.Xml.XDocument.nuspec"
       ]
     },
     "xunit/2.1.0-beta3-build3029": {
       "sha512": "NMFXV0ePe/GrfhMSPGAlWmiUZCzjaatpdAGcavf2B6vYTRyMTpyJT01LI6jemMV/VSDXLrtHp0Ov9xZyR1cLLg==",
       "files": [
-        "xunit.2.1.0-beta3-build3029.nupkg",
-        "xunit.2.1.0-beta3-build3029.nupkg.sha512",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/d8f65b6e50974443be49b52c7aaafb11.psmdcp",
         "xunit.nuspec"
       ]
     },
     "xunit.abstractions/2.0.0": {
       "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
       "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/net35/xunit.abstractions.dll",
         "lib/net35/xunit.abstractions.xml",
         "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
         "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml",
-        "xunit.abstractions.2.0.0.nupkg",
-        "xunit.abstractions.2.0.0.nupkg.sha512",
+        "package/services/metadata/core-properties/24083640fee244bf9de77f4c35d40a72.psmdcp",
         "xunit.abstractions.nuspec"
       ]
     },
     "xunit.assert/2.1.0-beta3-build3029": {
       "sha512": "AMS7Fv77DayXVRCBMmVEDwOXPcbxk8dCBA/iACsve+6+UQqopMtNyAynyIcXPFRK/peeitUKID4ChOXWisJmUw==",
       "files": [
-        "xunit.assert.2.1.0-beta3-build3029.nupkg",
-        "xunit.assert.2.1.0-beta3-build3029.nupkg.sha512",
-        "xunit.assert.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.dll",
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.pdb",
-        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.xml"
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.assert.xml",
+        "package/services/metadata/core-properties/38c52763215f45f28d084a9c1b6e4fa2.psmdcp",
+        "xunit.assert.nuspec"
       ]
     },
-    "xunit.console.netcore/1.0.2-prerelease-00081": {
-      "sha512": "SAiD0CNmlGGsAFHIbrOcgdMZ2w5tYxgJegbHSW0Wuibuyufo1HMOS0nL0kyQNeaJ36J1qml6s6NJI3K3LLPlvw==",
+    "xunit.console.netcore/1.0.2-prerelease-00085": {
+      "sha512": "BXI7VLUrk/sNU0Ewjax/Yl3ZN6RGizAMF/sEwtKbVpWHlPTQ+gr/hcJGWsEHTL8tKhFsSFpmICiaoFTX5h+i5A==",
       "files": [
-        "xunit.console.netcore.1.0.2-prerelease-00081.nupkg",
-        "xunit.console.netcore.1.0.2-prerelease-00081.nupkg.sha512",
-        "xunit.console.netcore.nuspec",
-        "lib/aspnetcore50/xunit.console.netcore.exe"
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/aspnetcore50/xunit.console.netcore.exe",
+        "package/services/metadata/core-properties/6275b27c6b3b484ca69ec908c96b60f1.psmdcp",
+        "xunit.console.netcore.nuspec"
       ]
     },
     "xunit.core/2.1.0-beta3-build3029": {
       "sha512": "uDUBbwZSRx226BMwj6VylzXQPVpEIelNIulT+LxbSEH52y2a4btR9d5ptQmkSVjmJXP5/hGCc4cu1DSCu0pgUA==",
       "files": [
-        "xunit.core.2.1.0-beta3-build3029.nupkg",
-        "xunit.core.2.1.0-beta3-build3029.nupkg.sha512",
-        "xunit.core.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "build/_Desktop/xunit.execution.desktop.dll",
         "build/monoandroid/xunit.core.props",
         "build/monoandroid/xunit.execution.MonoAndroid.dll",
         "build/monotouch/xunit.core.props",
@@ -3793,29 +3883,30 @@
         "build/wp8/xunit.execution.wp8.dll",
         "build/Xamarin.iOS/xunit.core.props",
         "build/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
-        "build/_Desktop/xunit.execution.desktop.dll"
+        "package/services/metadata/core-properties/7cc532c455474d1dac8f8b0cfe0b3522.psmdcp",
+        "xunit.core.nuspec"
       ]
     },
     "xunit.extensibility.core/2.1.0-beta3-build3029": {
       "sha512": "lsPro5U3NLasHI/RwqjKzXiRlh9N0IOlR3cluwXYVtihXbGtySeSnU/Fh5MTcWYxh+MVpoNop5zDD0/A2nrHsA==",
       "files": [
-        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg",
-        "xunit.extensibility.core.2.1.0-beta3-build3029.nupkg.sha512",
-        "xunit.extensibility.core.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll",
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.dll.tdnet",
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.pdb",
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.core.xml",
         "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.tdnet.dll",
-        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.utility.desktop.dll"
+        "lib/portable-net45+dnxcore50+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.runner.utility.desktop.dll",
+        "package/services/metadata/core-properties/40eb326fb1ea4e05a77fef0e7c6571cc.psmdcp",
+        "xunit.extensibility.core.nuspec"
       ]
     },
     "xunit.extensibility.execution/2.1.0-beta3-build3029": {
       "sha512": "WuUYamK4RHrHxihvNuX7NkryMhQrpH1+ziJ/mPIQbm18zevSgre8BwUuVZvmLZa8uVob3xS4dvAah2+HCgLiXg==",
       "files": [
-        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg",
-        "xunit.extensibility.execution.2.1.0-beta3-build3029.nupkg.sha512",
-        "xunit.extensibility.execution.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dnx451/xunit.execution.dnx.dll",
         "lib/dnx451/xunit.execution.dnx.pdb",
         "lib/dnx451/xunit.execution.dnx.xml",
@@ -3840,15 +3931,17 @@
         "lib/wp8/xunit.execution.wp8.xml",
         "lib/Xamarin.iOS/xunit.execution.iOS-Universal.dll",
         "lib/Xamarin.iOS/xunit.execution.iOS-Universal.pdb",
-        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.xml"
+        "lib/Xamarin.iOS/xunit.execution.iOS-Universal.xml",
+        "package/services/metadata/core-properties/632d17654a7d4ee58b8c7032b6bae6bf.psmdcp",
+        "xunit.extensibility.execution.nuspec"
       ]
     },
     "xunit.runner.console/2.1.0-beta4-build3109": {
       "sha512": "lz+sZtqfQhD6CA+u1KhahQD8ijyL64HNqiiPK4eplvM9r5f6C2OP9EiWS6nVT3rZlPCUXmGzf5kCCWh45kFf6w==",
       "files": [
-        "xunit.runner.console.2.1.0-beta4-build3109.nupkg",
-        "xunit.runner.console.2.1.0-beta4-build3109.nupkg.sha512",
-        "xunit.runner.console.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "package/services/metadata/core-properties/23dac145d7e04a5fac9971b73d372c76.psmdcp",
         "tools/HTML.xslt",
         "tools/NUnitXml.xslt",
         "tools/xunit.abstractions.dll",
@@ -3858,15 +3951,15 @@
         "tools/xunit.console.x86.exe.config",
         "tools/xunit.runner.reporters.desktop.dll",
         "tools/xunit.runner.utility.desktop.dll",
-        "tools/xUnit1.xslt"
+        "tools/xUnit1.xslt",
+        "xunit.runner.console.nuspec"
       ]
     },
     "xunit.runner.utility/2.1.0-beta3-build3029": {
       "sha512": "cm5lVNYtypOLgu6Vnd30UWPVNrcILzWmSul7tFrW/xT+ZjPYSES7kvYc80rKAUWXQl/awglhc5IMtAbHJi4abg==",
       "files": [
-        "xunit.runner.utility.2.1.0-beta3-build3029.nupkg",
-        "xunit.runner.utility.2.1.0-beta3-build3029.nupkg.sha512",
-        "xunit.runner.utility.nuspec",
+        "[Content_Types].xml",
+        "_rels/.rels",
         "lib/dnx451/xunit.runner.utility.dnx.dll",
         "lib/dnx451/xunit.runner.utility.dnx.pdb",
         "lib/dnx451/xunit.runner.utility.dnx.xml",
@@ -3891,20 +3984,23 @@
         "lib/wp8/xunit.runner.utility.wp8.xml",
         "lib/Xamarin.iOS/xunit.runner.utility.iOS-Universal.dll",
         "lib/Xamarin.iOS/xunit.runner.utility.iOS-Universal.pdb",
-        "lib/Xamarin.iOS/xunit.runner.utility.iOS-Universal.xml"
+        "lib/Xamarin.iOS/xunit.runner.utility.iOS-Universal.xml",
+        "package/services/metadata/core-properties/d5bfe374756f4c0382773bf877f506f8.psmdcp",
+        "xunit.runner.utility.nuspec"
       ]
     }
   },
   "projectFileDependencyGroups": {
     "": [
       "coveralls.io >= 1.4",
+      "Microsoft.NETCore.Platforms >= 1.0.1-beta-*",
       "Microsoft.NETCore.TestHost-x64 >= 1.0.0-beta-*",
       "Microsoft.NETCore.TestHost-x86 >= 1.0.0-beta-*",
       "Microsoft.NETCore.Runtime >= 1.0.1-beta-*",
       "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-*",
       "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-*",
       "OpenCover >= 4.6.166",
-      "ReportGenerator >= 2.1.6.0",
+      "ReportGenerator >= 2.3.0.0",
       "System.Collections >= 4.0.10",
       "System.Collections.Concurrent >= 4.0.10",
       "System.Console >= 4.0.0-beta-*",


### PR DESCRIPTION
With this change we are now importing Microsoft.NETCore.Platforms
which gives us the runtime mappings for windows and unix. For
example win7-x86 falls back to win7 and win-x86 and win etc.

This also refreshes the project.lock.json file as it was not updated after the last merge.