### PR TITLE
Revert "Clean-up GenFacade individual packages"

### DIFF
--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{8B5A7D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{097CEB51-8AD7-454B-A027-475C58C16A1A}"
 	ProjectSection(SolutionItems) = preProject
+		nuget\GenFacades-Win7-x64.nuspec = nuget\GenFacades-Win7-x64.nuspec
+		nuget\GenFacades.Desktop.nuspec = nuget\GenFacades.Desktop.nuspec
 		nuget\Microsoft.DotNet.BuildTools.GenAPI.nuspec = nuget\Microsoft.DotNet.BuildTools.GenAPI.nuspec
 		nuget\Microsoft.DotNet.BuildTools.nuspec = nuget\Microsoft.DotNet.BuildTools.nuspec
 		nuget\Microsoft.DotNet.PerfTools.nuspec = nuget\Microsoft.DotNet.PerfTools.nuspec

--- a/src/GenFacades/GenFacades.csproj
+++ b/src/GenFacades/GenFacades.csproj
@@ -1,25 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
-    <OutputType>Library</OutputType>
+    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>GenFacades</RootNamespace>
     <AssemblyName>GenFacades</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
-    <ProjectGuid>{BD307691-0A85-4CA2-A7ED-6747EECDCEC2}</ProjectGuid>
   </PropertyGroup>
-  <!-- Default configurations to help VS understand the configurations -->
+
+    <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' " />
+
   <ItemGroup>
     <Compile Include="FacadeGenerationException.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="VersionResourceSerializer.cs" />
   </ItemGroup>
+
   <!-- Common command-line helper sources -->
   <ItemGroup>
     <Compile Include="$(CommonPath)\CommandLine.cs">
@@ -32,11 +35,15 @@
       <Link>Common\ConsoleTraceListener.cs</Link>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.CCI.Extensions\Microsoft.CCI.Extensions.csproj" />
   </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), publishexe.targets))\publishexe.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/nuget/GenFacades-Win7-x64.nuspec
+++ b/src/nuget/GenFacades-Win7-x64.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
+  <metadata minClientVersion="2.8.1">
+    <id>GenFacades-Win7-x64</id>
+    <version>1.0.0-experimental</version> 
+    <title>GenFacades</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>This package provides the GenFacades tool, used for creating full and partial facades as part of the dotnet/corefx repository's build process.</description>
+    <summary>Provides the GenFacades build tool</summary>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>BCL GenFacades buildtools</tags>
+  </metadata>
+  <files>
+    <file src="GenFacades\*.dll" target="tools" />
+    <file src="GenFacades\*.exe" target="tools" />
+  </files>
+</package>

--- a/src/nuget/GenFacades.Desktop.nuspec
+++ b/src/nuget/GenFacades.Desktop.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
+  <metadata minClientVersion="2.8.1">
+    <id>GenFacades.Desktop</id>
+    <version>1.0.0-experimental</version> 
+    <title>GenFacades.Desktop</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>This package provides the desktop version of the GenFacades tool, used for creating full and partial facades as part of the dotnet/corefx repository's build process. Supports generating PDB files, but only on Windows.</description>
+    <summary>Provides the GenFacades build tool</summary>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags>BCL GenFacades buildtools</tags>
+  </metadata>
+  <files>
+    <file src="GenFacades.Desktop\*.dll" target="tools" />
+    <file src="GenFacades.Desktop\*.exe" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
Reverts dotnet/buildtools#263

This actually break running GenFacades on .NETCore because it no longer has an entry point. I will revisit this after I push an updated buildtools to unblock other issues.