### PR TITLE
Updated build tools to use xunit-rc1

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/test-runtime/project.json
@@ -37,9 +37,9 @@
        "System.Threading.Thread": "4.0.0-beta-*",
        "System.Xml.ReaderWriter": "4.0.10",
        "System.Xml.XDocument": "4.0.10",
-       "xunit": "2.1.0-beta3-*",
+       "xunit": "2.1.0-rc1-*",
        "xunit.console.netcore": "1.0.2-prerelease-*",
-       "xunit.runner.utility": "2.1.0-beta3-*"
+       "xunit.runner.utility": "2.1.0-rc1-*"
     },
     "frameworks": {
        "dnxcore50": { }

--- a/src/xunit.console.netcore/CommandLine.cs
+++ b/src/xunit.console.netcore/CommandLine.cs
@@ -44,7 +44,6 @@ namespace Xunit.ConsoleClient
                 {
                     AssemblyFilename = Path.GetFullPath(assembly.Item1),
                     ConfigFilename = assembly.Item2 != null ? Path.GetFullPath(assembly.Item2) : null,
-                    ShadowCopy = true
                 });
 
             return result;
@@ -167,7 +166,7 @@ namespace Xunit.ConsoleClient
                 {
                     GuardNoOptionValue(option);
                     foreach (var assembly in project.Assemblies)
-                        assembly.ShadowCopy = false;
+                        assembly.Configuration.ShadowCopy = false;
                 }
                 else if (optionName == "-trait")
                 {

--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -284,7 +284,7 @@ namespace Xunit.ConsoleClient
                         Console.WriteLine("Discovering: {0}", Path.GetFileNameWithoutExtension(assembly.AssemblyFilename));
                 }
 
-                using (var controller = new XunitFrontController(assembly.AssemblyFilename, assembly.ConfigFilename, assembly.ShadowCopy))
+                using (var controller = new XunitFrontController(AppDomainSupport.Denied, assembly.AssemblyFilename, assembly.ConfigFilename, assembly.Configuration.ShadowCopyOrDefault))
                 using (var discoveryVisitor = new TestDiscoveryVisitor())
                 {
                     controller.Find(includeSourceInformation: false, messageSink: discoveryVisitor, discoveryOptions: discoveryOptions);

--- a/src/xunit.console.netcore/project.json
+++ b/src/xunit.console.netcore/project.json
@@ -12,8 +12,8 @@
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime.Extensions": "4.0.10",
     "System.Xml.XDocument": "4.0.10",
-    "xunit": "2.1.0-beta3-*",
-    "xunit.runner.utility": "2.1.0-beta3-*"
+    "xunit": "2.1.0-rc1-*",
+    "xunit.runner.utility": "2.1.0-rc1-*"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/xunit.netcore.extensions/project.json
+++ b/src/xunit.netcore.extensions/project.json
@@ -10,7 +10,7 @@
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime.Extensions": "4.0.10",
     "System.Runtime.InteropServices.RuntimeInformation":"4.0.0-beta-*",
-    "xunit": "2.1.0-beta3-*"
+    "xunit": "2.1.0-rc1-*"
     },
   "frameworks": {
     "dnxcore50": {}


### PR DESCRIPTION
For performance tests to function correctly with corefx, we need to upgrade from xunit-beta3. Since xunit-rc1 is already out, I skipped beta4 and updated buildtools straight to rc1 instead.

I've excluded the project.lock.jsons with the intention of uploading them when they have an updated buildtools nuget package to reference.

I tested this with CoreFX and unit tests passed with the exception of a System.Console import error that is known and is being fixed by @weshaggard. With that said, I would greatly appreciate another tester :)

cc: @mellinoe 