### PR TITLE
IL.Targets: Support Multiple Compile Items and Additional Arguments

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/IL.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/IL.targets
@@ -17,7 +17,7 @@
       <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">/KEY=$(KeyOriginatorFile)</_KeyFileArgument>
     </PropertyGroup>
 
-    <Exec Command="ilasm /QUIET $(_OutputTypeArgument) /OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile)">
+    <Exec Command="ilasm /QUIET $(_OutputTypeArgument) $(IlasmFlags) /OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile, ' ')">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
     <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />


### PR DESCRIPTION
Add property $(IlasmFlags) to the exec command to support additional arguments if necessary.

Change the separator between compile items to a space, so it doesn't break.

Fixes #262