### PR TITLE
Add PerfTesting.targets back

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <RunPerfTestsForProject Condition="'$(Performance)' == 'true' and '$(RunPerfTestsForProject)' != 'false' and '$(OS)' == 'Windows_NT'">true</RunPerfTestsForProject>
+    <AnalyzePerfResults Condition="'$(RunPerfTestsForProject)' == 'true' And '$(AnalyzePerfResults)' != 'false'">true</AnalyzePerfResults>
+    <PerfRunId Condition="'$(PerfRunId)' == ''">latest-perf-build</PerfRunId>
+    <AnalysisReportFileName>$(PerfRunId)-analysis.html</AnalysisReportFileName>
+  </PropertyGroup>
+  
+  <!-- Perf Runner NuGet package paths -->
+  <PropertyGroup>
+    <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
+    <XunitPerfRunnerPackageVersion>1.0.0-alpha-build0014</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
+    <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/tools/xunit.performance.run.exe</XunitPerfRunnerPath>
+  </PropertyGroup>
+
+  <!-- Perf Analysis NuGet package paths -->
+  <PropertyGroup>
+    <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
+    <XunitPerfAnalysisPackageVersion>1.0.0-alpha-build0014</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
+  </PropertyGroup>
+
+  <!-- Copy over the performance runners to the test directory-->
+  <Target Name="CopyXunitExecutionDesktop" BeforeTargets="RunTestsForProject" Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <ItemGroup>
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.run.exe" />
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.metrics.dll" />
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.logger.exe" />
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/ProcDomain.dll" />
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll" />
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/*/*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PerfRunners)"
+          DestinationFiles="@(PerfRunners->'$(TestPath)$(DebugTestFrameworkFolder)\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- Executable properties -->
+  <PropertyGroup>
+    <XunitRunnerArgs>$(TargetFileName) -runnerhost $(TestHost) -runner $(XunitExecutable) -runid $(PerfRunId) -verbose</XunitRunnerArgs>
+    <PerfTestCommandLine>$(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
+
+    <PerfRunOutputFile>$(TestPath)$(DebugTestFrameworkFolder)/$(PerfRunId).xml</PerfRunOutputFile>
+    <XunitAnalysisArgs>$(PerfRunOutputFile) -html $(AnalysisReportFileName) $(AdditionalXunitAnalysisArgs)</XunitAnalysisArgs>
+    <PerfAnalysisCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisArgs)</PerfAnalysisCommandLine>
+  </PropertyGroup>
+
+  <!-- Override test settings if RunPerfTestsForProject == true -->
+  <PropertyGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
+    <TestCommandLine>$(PerfTestCommandLine)</TestCommandLine>
+  </PropertyGroup>
+
+  <Target Name="AnalyzePerfResults"
+          AfterTargets="RunTestsForProject"
+          Condition="'$(AnalyzePerfResults)' == 'true' and Exists('$(PerfRunOutputFile)')">
+    <Exec Command="$(PerfAnalysisCommandLine)"
+          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          ContinueOnError="false">
+      <Output PropertyName="PerfTestRunExitCode" TaskParameter="ExitCode" />
+    </Exec>
+    <Message Text="Performance test analysis report is available at $(TestPath)$(DebugTestFrameworkFolder)/$(AnalysisReportFileName)" />
+  </Target>
+
+  <Target Name="WarnForDebugPerfConfiguration"
+          BeforeTargets="RunTestsForProject"
+          Condition="'$(RunPerfTestsForProject)' == 'true' and !$(Configuration.ToLower().Contains('release'))">
+    <Warning Text="You are running performance tests in a configuration other than Release. Your results may be unreliable." />
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/tests.targets
@@ -74,6 +74,9 @@
   <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
   <Import Project="$(MSBuildThisFileDirectory)CodeCoverage.targets" />
 
+  <!-- import settings for perf testing -->
+  <Import Project="$(MSBuildThisFileDirectory)PerfTesting.targets" />
+
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">
     <StartWorkingDirectory Condition="'$(StartWorkingDirectory)'==''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>


### PR DESCRIPTION
PerfTesting.targets was inadvertently deleted in commit ca22795; this
change adds it back along with some fixes provided by ianhays.