### PR TITLE
Deploy xunit.console.netcore.exe via NuGet

### DIFF
--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -33,11 +33,16 @@
       <dependency id="System.Threading" version="4.0.10" />
       <dependency id="System.Threading.Tasks" version="4.0.10" />
       <dependency id="System.Xml.XDocument" version="4.0.10" />
+      <dependency id="xunit.runner.utility" version="2.1.0-rc1-build3168" />
     </dependencies>
   </metadata>
   <files>
     <!-- xunit runner for .NET Core -->
     <file src="xunit.console.netcore\xunit.console.netcore.exe" target="lib\aspnetcore50" />
+    <file src="xunit.console.netcore\_._" target="lib\dnxcore50" />
+    <file src="xunit.console.netcore\_._" target="lib\dotnet" />
+  
+    <file src="xunit.console.netcore\xunit.console.netcore.exe" target="runtimes\any\native" />
   </files>
   
 </package>

--- a/src/xunit.console.netcore/project.json
+++ b/src/xunit.console.netcore/project.json
@@ -13,7 +13,7 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Xml.XDocument": "4.0.10",
     "xunit": "2.1.0-rc1-*",
-    "xunit.runner.utility": "2.1.0-rc1-*"
+    "xunit.runner.utility": "2.1.0-rc1-build3168"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/xunit.console.netcore/project.lock.json
+++ b/src/xunit.console.netcore/project.lock.json
@@ -35,7 +35,7 @@
           "lib/dotnet/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23316": {
+      "System.Console/4.0.0-beta-23318": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -618,10 +618,10 @@
         "System.Collections.Concurrent.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23316": {
+    "System.Console/4.0.0-beta-23318": {
       "type": "package",
       "serviceable": true,
-      "sha512": "pYDflUHKD2oIllR+HsbgfkbwNsjivEgYsFjM3eZWS6KVqa5vYVMl93OvC+WfB0Va3Q9gAZYzxXQJUv6gWoJGLw==",
+      "sha512": "7O8pbiNDUzI4arqyeMUFOFBiUAY1eHh0z4HclT8iPi+P+i5TZcBP65JoqdS784HQGdkdKUAidJlpCIi7knHvzA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -635,8 +635,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-beta-23316.nupkg",
-        "System.Console.4.0.0-beta-23316.nupkg.sha512",
+        "System.Console.4.0.0-beta-23318.nupkg",
+        "System.Console.4.0.0-beta-23318.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
@@ -1731,7 +1731,7 @@
       "System.Runtime.Extensions >= 4.0.10",
       "System.Xml.XDocument >= 4.0.10",
       "xunit >= 2.1.0-rc1-*",
-      "xunit.runner.utility >= 2.1.0-rc1-*"
+      "xunit.runner.utility >= 2.1.0-rc1-build3168"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -62,6 +62,9 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="project.json" />
+    <None Include="_._">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This will allow the test runner to be deployed by NuGet when xunit.console.netcore package is referenced from project.json in test projects.  For example, see [here](https://github.com/dsplaisted/msbuild/blob/00d48e80ff5c46c86e08c3bf0f1ede98863ba7bc/src/Framework/UnitTests/project.json#L26)