### PR TITLE
Remove tool runtime hardlinks and add extensibility for cmd

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
@@ -174,7 +174,7 @@
     />
 
     <PropertyGroup>
-      <GenFacadesCmd>"$(ToolRuntimePath)$(ToolHost)" "$(ToolsDir)GenFacades.dll"</GenFacadesCmd>
+      <GenFacadesCmd>$(ToolHostCmd) "$(ToolsDir)GenFacades.dll"</GenFacadesCmd>
     </PropertyGroup>
 
     <Exec Command="$(GenFacadesCmd) $(GenFacadesArgs)" WorkingDirectory="$(ToolRuntimePath)" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
@@ -19,6 +19,9 @@
 
     <ToolRuntimePath Condition="'$(ToolRuntimePath)' == ''">$(BaseOutputPath)$(OSPlatformConfig)\ToolRuntime\</ToolRuntimePath>
     <ToolRuntimeSempahore>$(ToolRuntimePath)\ToolRuntime.semaphore</ToolRuntimeSempahore>
+    <ToolHostCmd>"$(ToolRuntimePath)$(ToolHost)"</ToolHostCmd>
+    <!-- If COMPLUS_InstallRoot is set clear it before calling the ToolHost otherwise some root activations like PDB COM activation will fail -->
+    <ToolHostCmd Condition="'$(COMPLUS_InstallRoot)' != ''">(set COMPLUS_InstallRoot=) &amp; $(ToolHostCmd)</ToolHostCmd>
   </PropertyGroup>
 
   <Target Name="EnsureBuildToolsRuntime"
@@ -40,13 +43,6 @@
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="ToolCopyLocal" />
     </PrereleaseResolveNuGetPackageAssets>
 
-    <!-- Ideally, we'd have UseHardLinksIfPossible on by default because we copy tons of files
-         but it doesn't currently work x-plat. So we only turn it on by default for Windows builds for now. -->
-    <PropertyGroup>
-      <CreateHardLinksForCopyTestToTestDirectoryIfPossible Condition="'$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)'=='' and '$(OS)' == 'Windows_NT'">true</CreateHardLinksForCopyTestToTestDirectoryIfPossible>
-      <CreateHardLinksForCopyTestToTestDirectoryIfPossible Condition="'$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)'==''">$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)</CreateHardLinksForCopyTestToTestDirectoryIfPossible>
-   </PropertyGroup>
-
     <!-- Copy the runtime and libraries into the flat shared path $(ToolRuntimePath) -->
     <Copy 
       SourceFiles="@(ToolCopyLocal)" 
@@ -54,8 +50,7 @@
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"
-      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-      UseHardlinksIfPossible="$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)" />
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)" />
 
     <Touch Files="$(ToolRuntimeSempahore)"
        ContinueOnError="WarnAndContinue"


### PR DESCRIPTION
We believe hardlinks make for an interesting race condition in some cases
while writing to the same location. Given that this is only copied to
the one location we will disable the hardlinks to see if it helps with
reliability.

While running CoreRun in a build enviroment that as COMPLUS_InstallRoot
set the COM activation for things like the PDB APIs fail to activate
because the runtimes don't match. To help eliminate this problem
we clear the COMPLUS_InstallRoot before calling CoreRun. This new
ToolHostCmd also allows folks to also add other such env variable tweaks
as part of the command if necessary.