### PR TITLE
Add netci.groovy for automatic job generation

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1,0 +1,34 @@
+// Import the utility functionality.
+
+import jobs.generation.Utilities;
+
+def project = 'dotnet/buildtools'
+// Define build string
+def buildString = '''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd /p:SkipTests=true'''
+
+// Generate the builds for debug and release
+
+def commitJob = job(Utilities.getFullJobName(project, '', false)) {
+  label('windows')
+  steps {
+    batchFile(buildString)
+  }
+}
+             
+def PRJob = job(Utilities.getFullJobName(project, '', true)) {
+  label('windows')
+  steps {
+    batchFile(buildString)
+  }
+}
+
+Utilities.addScm(commitJob, project)
+Utilities.addStandardOptions(commitJob)
+Utilities.addStandardNonPRParameters(commitJob)
+Utilities.addGithubPushTrigger(commitJob)
+             
+
+Utilities.addPRTestSCM(PRJob, project)
+Utilities.addStandardOptions(PRJob)
+Utilities.addStandardPRParameters(PRJob, project)
+Utilities.addGithubPRTrigger(PRJob, 'Windows Debug')


### PR DESCRIPTION
This adds a file that defines the CI information for the buildtools repo.  This is a transition from the manually configured jobs.