### PR TITLE
Updated perf testing targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/PerfTesting.targets
@@ -2,12 +2,12 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <RunPerfTestsForProject Condition="'$(Performance)' == 'true' and '$(RunPerfTestsForProject)' != 'false' and '$(OS)' == 'Windows_NT'">true</RunPerfTestsForProject>
+    <RunPerfTestsForProject Condition="'$(Performance)' == 'true' and '$(RunPerfTestsForProject)' != 'false' and '$(OS)' == 'Windows_NT' and Exists('$(MSBuildProgramFiles32)\MSBuild\Microsoft\Portable\v5.0\Microsoft.Portable.CSharp.targets')" >true</RunPerfTestsForProject>
     <AnalyzePerfResults Condition="'$(RunPerfTestsForProject)' == 'true' And '$(AnalyzePerfResults)' != 'false'">true</AnalyzePerfResults>
     <PerfRunId Condition="'$(PerfRunId)' == ''">latest-perf-build</PerfRunId>
     <AnalysisReportFileName>$(PerfRunId)-analysis.html</AnalysisReportFileName>
   </PropertyGroup>
-  
+
   <!-- Perf Runner NuGet package paths -->
   <PropertyGroup>
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
@@ -52,6 +52,12 @@
   <PropertyGroup Condition="'$(RunPerfTestsForProject)' == 'true'">
     <TestCommandLine>$(PerfTestCommandLine)</TestCommandLine>
   </PropertyGroup>
+  
+  <!-- Perf tests require TargetFrameworkVersion=v5.0. If it isn't installed, throw a helpful warning and run unit tests instead -->
+  <Target Name="ValidateFrameworkVersion" BeforeTargets="RestorePackages">
+    <Error Text="To run performance tests, .NET Portable v5.0 must be installed with VS 2015. Installation instructions available at: https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/performance-tests.md"
+      Condition="'$(Performance)' == 'true' and '$(RunPerfTestsForProject)' != 'true'" />
+  </Target>
 
   <Target Name="AnalyzePerfResults"
           AfterTargets="RunTestsForProject"


### PR DESCRIPTION
Updated perf testing targets to throw an error if an attempt is made to run performance tests without the required v5.0 .NET libraries.

Goes along with PR: https://github.com/dotnet/corefx/pull/3304