### PR TITLE
Support a project type to deploy assets from nuget packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/FrameworkTargeting.targets
@@ -55,6 +55,9 @@
     </ItemGroup>
   </Target>
 
+  <Import Project="depProj.targets"
+          Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
+
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" 
           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/ReferenceAssemblies.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/ReferenceAssemblies.targets
@@ -20,6 +20,9 @@
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)ref\$(AssemblyName)\$(AssemblyVersion)</IntermediateOutputPath>
 
     <OmitTransitiveCompileReferences>true</OmitTransitiveCompileReferences>
+    <!-- if this is a reference assembly deployment project use compile assets 
+         instead of runtime -->
+    <NuGetDeploySourceItem>Reference</NuGetDeploySourceItem>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsReferenceAssembly)'=='true'">

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
@@ -53,8 +53,11 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
       <!-- Don't set IntermediateAssembly since this is not produced -->
       <IntermediateAssembly Remove="@(IntermediateAssembly)" />
       
-      <!-- filter to items that came from packages -->
-      <NuGetDeploy Include="@($(NuGetDeploySourceItem))" Condition="'%($(NuGetDeploySourceItem).NuGetPackageId)' != ''" />
+      <NuGetDeploy Include="@($(NuGetDeploySourceItem))" />
+      <!-- filter to only items that came from packages -->
+      <!-- the following condition must be applied after the include because msbuild doesn't seem
+           to support property-defined-item-names in a metadata statement -->
+      <NuGetDeploy Remove="@(NuGetDeploy)" Condition="'%(NugetDeploy.NuGetPackageId)' == ''" />
       
       <!-- remove all existing items from NuGet packages we'll be defining these in our own item -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''"/>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+***********************************************************************************************
+depProj.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+This file defines the steps in the standard build process specific for NuGet deployment
+projects. The remainder of the build process is defined in Microsoft.Common.targets, 
+which is imported by this file.
+
+Copyright (c) Microsoft. All rights reserved.
+Licensed under the MIT license. See LICENSE file in the project root for full license information.
+***********************************************************************************************
+-->
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Deployment project
+       Restores NuGet dependencies and copies them to the output directory.
+       
+       NuGetTargetMoniker - determined by the TargetFramework* and TargetPlatform* 
+                            properties of the project, can be overidden.
+       NuGetRuntimeIdentifier - defaults to win-$(PlatformTarget), can be overidden
+       NuGetDeploySourceItem - defaults to ReferenceCopyLocalPaths, can be overidden to
+                               specify Reference (for compile assets) or Analyzer(for
+                               analyzer assets)
+                         
+       For the appropriate behavior of P2P references the project should set the 
+       TargetName and TargetExt to match one of the files that will be copied
+       from the packages.
+  -->
+  
+  <PropertyGroup>
+    <NuGetDeploySourceItem Condition="'$(NuGetDeploySourceItem)' == ''">ReferenceCopyLocalPaths</NuGetDeploySourceItem>
+
+    <!-- suppress the attempt to copy build output. -->
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+  </PropertyGroup>
+  
+  <Target Name="CoreCompile">
+
+    <Error Condition="'$(NuGetDeploySourceItem)' != 'ReferenceCopyLocalPaths' AND
+                      '$(NuGetDeploySourceItem)' != 'Reference' AND
+                      '$(NuGetDeploySourceItem)' != 'Analyzer'"
+           Text="Unexpected value for NuGetDeploySourceItem:'$(NuGetDeploySourceItem)'.  Expected ReferenceCopyLocalPaths, Reference, or Analyzer." />
+
+    <ItemGroup>
+      <!-- Don't set IntermediateAssembly since this is not produced -->
+      <IntermediateAssembly Remove="@(IntermediateAssembly)" />
+      
+      <!-- filter to items that came from packages -->
+      <NuGetDeploy Include="@($(NuGetDeploySourceItem))" Condition="'%($(NuGetDeploySourceItem).NuGetPackageId)' != ''" />
+      
+      <!-- remove all existing items from NuGet packages we'll be defining these in our own item -->
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''"/>
+      <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' != ''"/>
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' != ''"/>
+
+      <!-- add items defined by NuGetDeployItem property to ReferenceCopyLocalPaths -->
+      <ReferenceCopyLocalPaths Include="@(NuGetDeploy)" />
+    </ItemGroup>
+
+    <Error Condition="'@(NuGetDeploy)' == ''" Text="Error no assets were resolved from NuGet packages." />
+    <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'%(FileName)%(Extension)')" />
+  </Target>
+  
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+
+  <!-- Required by Common.Targets but not used for depproj -->
+  <Target Name="CreateManifestResourceNames" />
+  
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
@@ -37,6 +37,9 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <!-- suppress the attempt to copy build output. -->
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+
+    <!-- make sure we tell nuget targets to copy, even if output type would not by default -->
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
   </PropertyGroup>
   
   <Target Name="CoreCompile">

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -44,13 +44,27 @@
       $(ResolveAssemblyReferencesDependsOn);
       ResolveNuGetPackages;
     </ResolveAssemblyReferencesDependsOn>
+    
+    <!-- temporarily accept the old name NuGetTargetFrameworkMoniker until all projects are moved forward -->
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">(NuGetTargetFrameworkMoniker)</NuGetTargetMoniker>
     <!-- We use dotnet as the framework for our reference assemblies, in the future we'll move to 
          targets that are closer to what shipped in Dev14 and we won't need to special case this.-->
-    <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == '' and '$(IsReferenceAssembly)' == 'true'">.NETPlatform,Version=v5.0</NugetTargetFrameworkMoniker>    
-    <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == ''">$(TargetFrameworkMoniker)</NugetTargetFrameworkMoniker>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' and '$(IsReferenceAssembly)' == 'true'">.NETPlatform,Version=v5.0</NuGetTargetMoniker>
+    <UseTargetPlatformAsNuGetTargetMoniker Condition="'$(UseTargetPlatformAsNuGetTargetMoniker)' == '' AND '$(TargetFrameworkMoniker)' == '.NETCore,Version=v5.0'">true</UseTargetPlatformAsNuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' == 'true'">$(TargetPlatformIdentifier),Version=v$([System.Version]::Parse('$(TargetPlatformMinVersion)').ToString(3))</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '' AND '$(UseTargetPlatformAsNuGetTargetMoniker)' != 'true'">$(TargetFrameworkMoniker)</NuGetTargetMoniker>
 
+
+    <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == '' and '$(TargetPlatformIdentifier)' == 'UAP'">win10</BaseNuGetRuntimeIdentifier>
     <BaseNuGetRuntimeIdentifier Condition="'$(BaseNuGetRuntimeIdentifier)' == ''">win</BaseNuGetRuntimeIdentifier>
-    <NuGetRuntimeIdentifier Condition="'$(NuGetRuntimeIdentifier)' == ''">$(BaseNuGetRuntimeIdentifier)-$(PlatformTarget.ToLower())</NuGetRuntimeIdentifier>
+    <CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == '' and '$(OutputType)' != 'library' and ('$(OutputType)' != 'winmdobj' or '$(AppxPackage)' == 'true')">true</CopyNuGetImplementations>
+  </PropertyGroup>
+
+  <!-- If a RuntimeIndentifier wasn't already specified, let's go generate it -->
+  <PropertyGroup Condition="'$(NuGetRuntimeIdentifier)' == '' and '$(CopyNuGetImplementations)' == 'true'">
+    <_NuGetRuntimeIdentifierWithoutAot>$(BaseNuGetRuntimeIdentifier)-$(PlatformTarget.ToLower())</_NuGetRuntimeIdentifierWithoutAot>
+    <NuGetRuntimeIdentifier>$(_NuGetRuntimeIdentifierWithoutAot)</NuGetRuntimeIdentifier>
+    <NuGetRuntimeIdentifier Condition="'$(UseDotNetNativeToolchain)' == 'true'">$(_NuGetRuntimeIdentifierWithoutAot)-aot</NuGetRuntimeIdentifier>
   </PropertyGroup>
 
   <Target Name="ResolveNuGetPackages"
@@ -63,7 +77,7 @@
                           Platform="$(PlatformTarget)"
                           Configuration="$(Configuration)"
                           Language="$(Language)"
-                          TargetFramework="$(NugetTargetFrameworkMoniker)"
+                          TargetFramework="$(NuGetTargetMoniker)"
                           TargetPlatformMoniker="$(TargetPlatformMoniker)">
 
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
@@ -73,7 +87,7 @@
 
     <PropertyGroup>
       <!-- Temporary workaround -->
-      <NugetTargetFrameworkMoniker Condition="'$(NugetTargetFrameworkMoniker)' == '.NETPortable,Version=v4.5,Profile=Profile7'">DNXCore,Version=v5.0</NugetTargetFrameworkMoniker>
+      <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '.NETPortable,Version=v4.5,Profile=Profile7'">DNXCore,Version=v5.0</NuGetTargetMoniker>
     </PropertyGroup>
 
     <PrereleaseResolveNuGetPackageAssets Condition="Exists('$(ProjectLockJson)')"
@@ -83,7 +97,7 @@
                                RuntimeIdentifier="$(NuGetRuntimeIdentifier)"
                                ProjectLanguage="$(Language)"
                                ProjectLockFile="$(ProjectLockJson)"
-                               TargetMonikers="$(NugetTargetFrameworkMoniker)"
+                               TargetMonikers="$(NuGetTargetMoniker)"
                                OmitTransitiveCompileReferences="$(OmitTransitiveCompileReferences)">
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/packageresolve.targets
@@ -68,7 +68,7 @@
 
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
-      <Output TaskParameter="ResolvedCopyLocal" ItemName="None" />
+      <Output TaskParameter="ResolvedCopyLocal" ItemName="ReferenceCopyLocalPaths" />
     </ResolveNuGetPackages>
 
     <PropertyGroup>
@@ -87,20 +87,20 @@
                                OmitTransitiveCompileReferences="$(OmitTransitiveCompileReferences)">
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
-      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="None" />
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="ReferenceCopyLocalPaths" />
     </PrereleaseResolveNuGetPackageAssets>
 
     <!-- We may have an indirect package reference that we want to replace with a project reference -->
     <ItemGroup>
       <!-- Intersect project-refs with package-refs -->
       <_ReferenceFileNamesToRemove Include="@(Reference)" Condition="'@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
-      <_NoneFileNamesToRemove Include="@(None)" Condition="'@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
+      <_ReferenceCopyLocalPathsFileNamesToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
 
       <Reference Remove="@(_ReferenceFileNamesToRemove)" />
-      <None Remove="@(_NoneFileNamesToRemove)"/>
+      <ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsFileNamesToRemove)"/>
     </ItemGroup>
 
-    <Message Text="Excluding @(_ReferenceFileNamesToRemove);@(_NoneFileNamesToRemove) from package references since the same file is provided by a project refrence."
-             Condition="'@(_ReferenceFileNamesToRemove)' != '' or '@(_NoneFileNamesToRemove)' != ''"/>
+    <Message Text="Excluding @(_ReferenceFileNamesToRemove);@(_ReferenceCopyLocalPathsFileNamesToRemove) from package references since the same file is provided by a project refrence."
+             Condition="'@(_ReferenceFileNamesToRemove)' != '' or '@(_ReferenceCopyLocalPathsFileNamesToRemove)' != ''"/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/partialfacades.targets
@@ -98,7 +98,7 @@
 
     <MakeDir Directories="$(CustomPartialFacadeDirectory)" />
     <WriteLinesToFile File="$(CustomPartialFacadeJsonFile)" Overwrite="true"
-                      Lines="{&quot;dependencies&quot;:{&quot;$(AssemblyName)&quot;: &quot;$(AssemblyVersionString)-*&quot;},&quot;frameworks&quot;:{&quot;$(NugetTargetFrameworkMoniker)&quot;: { }}}"
+                      Lines="{&quot;dependencies&quot;:{&quot;$(AssemblyName)&quot;: &quot;$(AssemblyVersionString)-*&quot;},&quot;frameworks&quot;:{&quot;$(NuGetTargetMoniker)&quot;: { }}}"
     />
 
     <!-- Restore the special partial facade json file, which must contain the contract package to use in GenFacades -->
@@ -112,7 +112,7 @@
                                RuntimeIdentifier=""
                                ProjectLanguage="$(Language)"
                                ProjectLockFile="$(CustomPartialFacadeLockJsonFile)"
-                               TargetMonikers="$(NugetTargetFrameworkMoniker)">
+                               TargetMonikers="$(NuGetTargetMoniker)">
       <Output TaskParameter="ResolvedReferences" ItemName="PossibleContractRefs" />
     </PrereleaseResolveNuGetPackageAssets>
 


### PR DESCRIPTION
This adds depProj.targets which minimally extend Microsoft.Common.Targets
to merely copy assets out of packages referenced by project.json.  The targets
can be configured to copy a specific asset type: (default) ReferenceCopyLocalPaths
for runtime assets, Reference for compile assets, or Analyzer for analyzers.

They do very little to change the nuget resolution process so that remains
driven as it is today by the normal project properties like TargetFramework,
TargetPlatform, and PlatformTarget.

I also made a change to plug these in to build tools for .depproj extension,
and a change to our reference assembly targets to set the property to indicate
that compile time assets should be used.

I plan to follow this up with changes in corefx that use .depproj's to deploy
older versions of our previously shipped reference assemblies.  These will
be consumed by future packages using dotnet "generations" to have
packages include their entire history of surface area and thus support
older platforms rather than drop them.

/cc @weshaggard @chcosta @FiveTimesTheFun 