### PR TITLE
Fix build breaks on Linux with 00097

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
@@ -53,7 +53,7 @@
       RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)" />
 
     <Exec
-      Condition="'$(OS)' != 'Windows_NT'"
+      Condition="'$(OS)' != 'Windows_NT' and Exists('$(ToolRuntimePath)/corerun')"
       Command="chmod a+x &quot;$(ToolRuntimePath)/corerun&quot;" />
 
     <Touch Files="$(ToolRuntimeSempahore)"


### PR DESCRIPTION
By default, build tools would restore the windows version of the runtime
packages (even when '$(OS)' was not 'Windows_NT'). While a project
consuming the build tools could override this, it meant if they did not
the chmod would fail because it couldn't find corerun (since we instead
restored CoreRun.exe).

Guard the chmod with a test to ensure corerun actually exists.

Fixes #292