### PR TITLE
Disable RAR warning about mismatched portable references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/FrameworkTargeting.targets
@@ -36,6 +36,8 @@
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <TargetFrameworkMonikerDisplayName>.NET Portable Subset</TargetFrameworkMonikerDisplayName>
     <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
+    <!-- Disable RAR complaining about us referencing higher .NET Portable libraries as we aren't a traditional portable library -->
+    <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
   </PropertyGroup>
 
   <!-- Need to add references to the mscorlib design-time facade for some old-style portable dependencies like xunit -->


### PR DESCRIPTION
While we label ourselves as .NETPortable v4.5 we aren't a traditional
portable project and we can correctly reference a .NETPortable v5.0 project.
So this disabled the RAR warning for projects that target the default.

We will eventually switch our defaults to .NETPortable v5.0 as that is
closer to what we truely are be we aren't ready to force everyone to use
VS 2015 yet and require the new portable targeting pack when we don't even
really use it.

cc @ericstj @nguerrera 