### PR TITLE
Add a hook for dropping marker files

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/depProj.targets
@@ -70,6 +70,12 @@ Licensed under the MIT license. See LICENSE file in the project root for full li
 
     <Error Condition="'@(NuGetDeploy)' == ''" Text="Error no assets were resolved from NuGet packages." />
     <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'%(FileName)%(Extension)')" />
+    
+    <!-- Include marker files if an extension has been provided -->
+    <!-- internal builds use this to distinguish files which have already been signed -->
+    <Touch Condition="'$(DeployMarkerExtension)' != ''" Files="@(NuGetDeploy->'$(TargetDir)%(FileName)$(DeployMarkerExtension)')" AlwaysCreate="true">
+      <Output TaskParameter="TouchedFiles" ItemName="FileWrites"/>
+    </Touch>
   </Target>
   
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />


### PR DESCRIPTION
Our internal build needs to distinguish newly built files from
redistributed binaries.  Provide a hook in depProj.targets to
do this for assets that are copied from nuget packages.

/cc @weshaggard 