### PR TITLE
Show starting/finishing test progress in xunit console

### DIFF
--- a/src/xunit.console.netcore/CommandLine.cs
+++ b/src/xunit.console.netcore/CommandLine.cs
@@ -31,6 +31,8 @@ namespace Xunit.ConsoleClient
 
         public bool? ParallelizeTestCollections { get; set; }
 
+        public bool ShowProgress { get; protected set; }
+
         public bool TeamCity { get; protected set; }
 
         public bool Wait { get; protected set; }
@@ -161,6 +163,11 @@ namespace Xunit.ConsoleClient
                 {
                     GuardNoOptionValue(option);
                     AppVeyor = true;
+                }
+                else if (optionName == "-showprogress")
+                {
+                    GuardNoOptionValue(option);
+                    ShowProgress = true;
                 }
                 else if (optionName == "-noshadow")
                 {


### PR DESCRIPTION
When debugging problems in hanging tests, it's very useful to be able to know which tests have started but haven't finished.  This commit adds a "-showprogress" option to the xunit.console.netcore.exe command line which, when set, will result in xunit tracing out to the console the starting and finishing of each individual test, e.g.

```
   System.Threading.Tasks.Dataflow.Tests.ActionBlockTests.TestPost [STARTING]
   System.Threading.Tasks.Dataflow.Tests.ActionBlockTests.TestPost [FINISHED] Time: 0.0316922s
```

cc: @FiveTimesTheFun, @mellinoe, @weshaggard, @ellismg