### PR TITLE
Changing ToolRuntimePath to be in the Intermediate folder instead of bin output

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/Targets/toolruntime.targets
@@ -17,7 +17,7 @@
     <ToolArchitecture Condition="'$(ToolArchitecture)' == ''">x64</ToolArchitecture>
     <ToolNugetRuntimeId Condition="'$(ToolNugetRuntimeId)' == ''">win7-$(ToolArchitecture)</ToolNugetRuntimeId>
 
-    <ToolRuntimePath Condition="'$(ToolRuntimePath)' == ''">$(BaseOutputPath)$(OSPlatformConfig)\ToolRuntime\</ToolRuntimePath>
+    <ToolRuntimePath Condition="'$(ToolRuntimePath)' == ''">$(IntermediateOutputRootPath)ToolRuntime\</ToolRuntimePath>
     <ToolRuntimeSempahore>$(ToolRuntimePath)\ToolRuntime.semaphore</ToolRuntimeSempahore>
     <ToolHostCmd>"$(ToolRuntimePath)$(ToolHost)"</ToolHostCmd>
     <!-- If COMPLUS_InstallRoot is set clear it before calling the ToolHost otherwise some root activations like PDB COM activation will fail -->


### PR DESCRIPTION
Changing ToolRuntimePath to be in the Intermediate folder instead of bin output