### PR TITLE
Updated perf testing targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -9,7 +9,7 @@
   <!-- Perf Runner NuGet package paths -->
   <PropertyGroup>
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageVersion>1.0.0-alpha-build0022</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageVersion>1.0.0-alpha-build0023</XunitPerfRunnerPackageVersion>
     <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
     <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/xunit.performance.run.exe</XunitPerfRunnerPath>
   </PropertyGroup>
@@ -17,9 +17,15 @@
   <!-- Perf Analysis NuGet package paths -->
   <PropertyGroup>
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
-    <XunitPerfAnalysisPackageVersion>1.0.0-alpha-build0022</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion>1.0.0-alpha-build0023</XunitPerfAnalysisPackageVersion>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
   </PropertyGroup>
+  
+  <!-- Perf testing assembly attribute -->
+  <ItemGroup Condition="'$(RunPerfTestsForProject)' == 'true' and '$(DisableTests)' != 'true'">
+    <AssemblyInfoUsings Include="using Microsoft.Xunit.Performance%3B" />
+    <AssemblyInfoLines Include="[assembly:OptimizeForBenchmarks]" />
+  </ItemGroup>
 
   <!-- Copy over the performance runners to the test directory-->
   <Target Name="CopyXunitExecutionDesktop" BeforeTargets="RunTestsForProject" Condition="'$(RunPerfTestsForProject)' == 'true'">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -8,8 +8,8 @@
       "OpenCover": "4.6.166",
       "ReportGenerator": "2.3.1",
 
-      "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0022",
-      "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0022",
+      "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0023",
+      "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0023",
 
       "xunit": "2.1.0",
       "xunit.console.netcore": "1.0.2-prerelease-00101",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.lock.json
@@ -33,10 +33,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0023": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0023": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -2021,10 +2021,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0023": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0023": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -4691,10 +4691,10 @@
           "lib/dotnet/Microsoft.CSharp.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0023": {
         "type": "package"
       },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0023": {
         "type": "package",
         "dependencies": {
           "xunit.runner.console": "2.1.0"
@@ -7398,13 +7398,13 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0022": {
+    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0023": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JwQJjSTP1HXDf9J2isVDlVauz/tcN9QJRuaABaAe9Y3qVlX56kcIr6mT22oEaWUOGo9kGIzt4iGHlZ/E655lhg==",
+      "sha512": "5HxKoXst0cF66OHUkvcHajilNjmeL1qMj5NQuam0CBWu2YLE9VB5Kt6xJ/AwCrWpvIc1IZBvB58sAy89R3pI6A==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0022.nupkg",
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0022.nupkg.sha512",
+        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0023.nupkg",
+        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0023.nupkg.sha512",
         "Microsoft.DotNet.xunit.performance.analysis.nuspec",
         "tools/MathNet.Numerics.dll",
         "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
@@ -7413,13 +7413,13 @@
         "tools/xunit.performance.analysis.pdb"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0022": {
+    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0023": {
       "type": "package",
       "serviceable": true,
-      "sha512": "YiCRPElKD5Rl1z8EVHYCeh9G74QSXe5EkSIFbSNbyGysEoS01i7apL6CzPUlJGyAigbLNUCsWmqtDsMhWTBvDA==",
+      "sha512": "Hwc3sfGZuX73x+RdoSMoIUL4uMJOblbNSIuqJhA3WXrzz39rxme+p9QVqPpnvADnj2DpcJxvdZH5h984lF9hAQ==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0022.nupkg",
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0022.nupkg.sha512",
+        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0023.nupkg",
+        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0023.nupkg.sha512",
         "Microsoft.DotNet.xunit.performance.runner.Windows.nuspec",
         "tools/amd64/KernelTraceControl.dll",
         "tools/amd64/msdia120.dll",
@@ -12125,8 +12125,8 @@
       "coveralls.io >= 1.4",
       "OpenCover >= 4.6.166",
       "ReportGenerator >= 2.3.1",
-      "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-alpha-build0022",
-      "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-alpha-build0022",
+      "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-alpha-build0023",
+      "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-alpha-build0023",
       "xunit >= 2.1.0",
       "xunit.console.netcore >= 1.0.2-prerelease-00101",
       "xunit.runner.utility >= 2.1.0"


### PR DESCRIPTION
Update to the latest xunit-performance package. Also added a target that will add the new OptimizeForBenchmarks assembly tag to any perf test build. This tag was added in https://github.com/Microsoft/xunit-performance/pull/94