### PR TITLE
Honor UsePackageTargetRuntimeDefaults

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PackageLibs.targets
@@ -60,6 +60,12 @@
     <Error Condition="'$(IsReferenceAssembly)' == 'true' AND '$(PackageTargetRuntime)' != ''"
            Text="Reference assemblies should not specify the PackageTargetRuntime property since runtimes cannot effect compile time assets."/>
 
+    <!-- PackageTargetRuntime Defaults -->
+    <PropertyGroup Condition="'$(UsePackageTargetRuntimeDefaults)' == 'true' AND '$(PackageTargetRuntime)' == ''">
+      <PackageTargetRuntime Condition=" '$(TargetsWindows)' == 'true'">win7</PackageTargetRuntime>
+      <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
+    </PropertyGroup>
+    
     <!-- *** determine destination path for assets *** -->
     <PropertyGroup>
       <_packageTargetRefLib>lib</_packageTargetRefLib>


### PR DESCRIPTION
Looks like all our open projects were setting this property but it wasn't having an effect.  I caught this with a new validation task I am working on.
/cc @weshaggard @chcosta 