### PR TITLE
Enable testing when running cross plat

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -124,6 +124,10 @@
     </ItemGroup>
 
     <Copy Condition="'$(BUILDTOOLS_OVERRIDE_RUNTIME)' != ''" SourceFiles="@(TestRuntimeSource)" DestinationFolder="$(TestPath)%(TestTargetFramework.Folder)" />
+
+    <Exec Condition="'$(OS)'=='Unix'"
+          Command="chmod a+x &quot;$(TestPath)%(TestTargetFramework.Folder)/corerun&quot;" />
+
   </Target>
 
   <Target Name="CreateAssemblyListTxt" DependsOnTargets="CopyTestToTestDirectory">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -58,7 +58,11 @@
   <PropertyGroup>
     <XunitResultsFileName>testResults.xml</XunitResultsFileName>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
-    <XunitOptions Condition="'$(OS)'=='Windows_NT'">$(XunitOptions) -notrait category=nonwindowstests</XunitOptions>
+    <XunitOptions Condition="'$(OSGroup)'=='Windows_NT'">$(XunitOptions) -notrait category=nonwindowstests</XunitOptions>
+    <XunitOptions Condition="'$(OSGroup)'=='Linux'">$(XunitOptions) -notrait category=nonlinuxtests</XunitOptions>
+    <XunitOptions Condition="'$(OSGroup)'=='OSX'">$(XunitOptions) -notrait category=nonosxtests</XunitOptions>
+    <XunitOptions Condition="'$(OSGroup)'=='FreeBSD'">$(XunitOptions) -notrait category=nonfreebsdtests</XunitOptions>
+
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
     <XunitArguments>$(TargetFileName) $(XunitOptions)</XunitArguments>
 
@@ -126,7 +130,7 @@
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
 
-    <Exec Command="$(TestCommandLine)"
+    <Exec Command="$(TestPath)%(TestTargetFramework.Folder)/$(TestCommandLine)"
           WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
           ContinueOnError="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />


### PR DESCRIPTION
Some minor changes needed to the build tools to enable the testing
targets to work cross platform.

 - We need to ensure corerun is executable before we run it.
 - corerun is not on the path and neither with the CWD, so we pass a
   full path to corerun when invoking it.
 - Use OSGroup to compute the platform specific attribute to pass to
   xunit to disable tests that are not valid for the OS in question.