### PR TITLE
Fix coverage build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -32,6 +32,7 @@
          process name. -->
     <TestHost Condition="'$(OS)' == 'Windows_NT'">CoreRun.exe</TestHost>
     <TestHost Condition="'$(OS)' != 'Windows_NT'">corerun</TestHost>
+    <TestHost>$(TestPath)dnxcore50/$(TestHost)</TestHost>
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.netcore.exe</XunitExecutable>
     <DebugTestFrameworkFolder>dnxcore50</DebugTestFrameworkFolder>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
@@ -130,7 +131,7 @@
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
 
-    <Exec Command="$(TestPath)%(TestTargetFramework.Folder)/$(TestCommandLine)"
+    <Exec Command="$(TestCommandLine)"
           WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
           ContinueOnError="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />


### PR DESCRIPTION
Move the logic to produce a full path for corerun to when we define
$(TestHost) insteead of when we actually execute the tests. Doing so
fixes a break when we try to run coverage which overides $(TestHost)
with a full path to OpenCover (previously we would generate an invalid
path).