### PR TITLE
Update SendToEventHub with PartitionKey property any use it.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CloudTest.targets
@@ -229,7 +229,8 @@
       Condition="'$(BuildIsOfficial)' == 'true'"
       ConnectionString="$(BuildIsOfficialConnection)"
       EventHubPath="clrstats-events"
-      EventData="%(TestListFile.OfficialBuildJson)" />
+      EventData="%(TestListFile.OfficialBuildJson)"
+      PartitionKey="%(TestListFile.CorrelationId)"/>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/SendToEventHub.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/SendToEventHub.cs
@@ -30,12 +30,20 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string EventData { get; set; }
 
+        /// <summary>
+        /// The partition key for the event.
+        /// </summary>
+        public string PartitionKey { get; set; }
+
         public override bool Execute()
         {
             using (var streamReader = new StreamReader(EventData))
             {
                 EventHubClient client = EventHubClient.CreateFromConnectionString(ConnectionString, EventHubPath);
-                client.Send(new EventData(Encoding.UTF8.GetBytes(streamReader.ReadToEnd())));
+                client.Send(new EventData(Encoding.UTF8.GetBytes(streamReader.ReadToEnd()))
+                {
+                    PartitionKey = PartitionKey
+                });
                 Log.LogMessage(MessageImportance.Normal, "Successfully sent notification to event hub path {0}.", EventHubPath);
             }
             return true;


### PR DESCRIPTION
This change adds an optional PartitionKey property to the SendToEventHub build task and then consumes it to send the official build event to the appropriate partition.

This fixes a caching issue where test runs could be duplicated.