### PR TITLE
Fix running test projects in VS

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -86,7 +86,7 @@
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">
     <StartWorkingDirectory Condition="'$(StartWorkingDirectory)'==''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
     <StartAction Condition="'$(StartAction)'==''">Program</StartAction>
-    <StartProgram Condition="'$(StartProgram)'==''">$(StartWorkingDirectory)\$(TestProgram)</StartProgram>
+    <StartProgram Condition="'$(StartProgram)'==''">$(TestProgram)</StartProgram>
     <StartArguments Condition="'$(StartArguments)'==''">$(TestArguments) -wait</StartArguments>
   </PropertyGroup>
 


### PR DESCRIPTION
$(TestProgram) is now a full path, so we don't need to prepend it with
the working directory.