### PR TITLE
Fix build races with BUILDTOOLS_OVERRIDE_RUNTIME

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -87,6 +87,10 @@
       <TestCopyLocal Include="@(_ExistingReplacementCandidate)" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(BUILDTOOLS_OVERRIDE_RUNTIME)' != ''">
+      <TestCopyLocal Include="$(BUILDTOOLS_OVERRIDE_RUNTIME)\*.*" />
+    </ItemGroup>
+
     <!-- Remove duplicates. Note that we musn't just copy in sequence and let 
          the last one win that way because it will cause copies to occur on 
          every incremental build. -->
@@ -118,12 +122,6 @@
       
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
-
-    <ItemGroup Condition="'$(BUILDTOOLS_OVERRIDE_RUNTIME)' != ''">
-      <TestRuntimeSource Include="$(BUILDTOOLS_OVERRIDE_RUNTIME)\*.*" />
-    </ItemGroup>
-
-    <Copy Condition="'$(BUILDTOOLS_OVERRIDE_RUNTIME)' != ''" SourceFiles="@(TestRuntimeSource)" DestinationFolder="$(TestPath)%(TestTargetFramework.Folder)" />
 
     <Exec Condition="'$(OS)'=='Unix'"
           Command="chmod a+x &quot;$(TestPath)%(TestTargetFramework.Folder)/corerun&quot;" />


### PR DESCRIPTION
When BUILDTOOLS_OVERRIDE_RUNTIME is set, if we are hard linking the shared
runtime in the test folder, then trying to copy an updated coreclr (or
other files used by the runtime) will cause races due to a file being in
use.

Update the logic to fold the over-ridden files into the general ItemGroup
we filter and then copy as needed.