### PR TITLE
disable perf as unit tests temporarily

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -63,6 +63,7 @@
     <XunitOptions Condition="'$(OSGroup)'=='Linux'">$(XunitOptions) -notrait category=nonlinuxtests</XunitOptions>
     <XunitOptions Condition="'$(OSGroup)'=='OSX'">$(XunitOptions) -notrait category=nonosxtests</XunitOptions>
     <XunitOptions Condition="'$(OSGroup)'=='FreeBSD'">$(XunitOptions) -notrait category=nonfreebsdtests</XunitOptions>
+    <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
     <XunitArguments>$(TargetFileName) $(XunitOptions)</XunitArguments>


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/4118 made it so that perf tests ran as unit tests by default. Although this is the desired behavior, the InnerIterations structure that they use is causing an unacceptable amount of slowdown to the other CoreFX unit tests.

I need to get a more permanent solution but in the meantime this commit is a quick and easy reversion that disables the perf tests by default. Running with Performance=true still works as expected.

@stephentoub @mellinoe 