### PR TITLE
Adds ConditionalFact/Theory attributes and discoverers

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/ConditionalFactAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ConditionalFactAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    [XunitTestCaseDiscoverer("Xunit.NetCore.Extensions.ConditionalFactDiscoverer", "Xunit.NetCore.Extensions")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class ConditionalFactAttribute : FactAttribute
+    {
+        public string ConditionMemberName { get; private set; }
+
+        public ConditionalFactAttribute(string conditionMemberName)
+        {
+            ConditionMemberName = conditionMemberName;
+        }
+    }
+}

--- a/src/xunit.netcore.extensions/Attributes/ConditionalTheoryAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ConditionalTheoryAttribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    [XunitTestCaseDiscoverer("Xunit.NetCore.Extensions.ConditionalTheoryDiscoverer", "Xunit.NetCore.Extensions")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class ConditionalTheoryAttribute : TheoryAttribute
+    {
+        public string ConditionMemberName { get; private set; }
+
+        public ConditionalTheoryAttribute(string conditionMemberName)
+        {
+            ConditionMemberName = conditionMemberName;
+        }
+    }
+}

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalFactDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalFactDiscoverer.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.NetCore.Extensions
+{
+    public class ConditionalFactDiscoverer : FactDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public ConditionalFactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public override IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
+
+            string conditionMemberName = factAttribute.GetConstructorArguments().FirstOrDefault() as string;
+            MethodInfo conditionMethodInfo;
+            if (conditionMemberName == null ||
+                (conditionMethodInfo = LookupConditionalMethod(testMethodInfo.DeclaringType, conditionMemberName)) == null)
+            {
+                return new[] {
+                    new ExecutionErrorTestCase(
+                        _diagnosticMessageSink,
+                        discoveryOptions.MethodDisplayOrDefault(),
+                        testMethod,
+                        "An appropriate member \"" + conditionMemberName + "\" could not be found.")
+                };
+            }
+
+            object result = conditionMethodInfo.Invoke(null, null);
+            return (bool)result ?
+                base.Discover(discoveryOptions, testMethod, factAttribute) :
+                Array.Empty<IXunitTestCase>();
+        }
+
+        internal static MethodInfo LookupConditionalMethod(Type t, string name)
+        {
+            if (t == null || name == null)
+                return null;
+
+            TypeInfo ti = t.GetTypeInfo();
+
+            MethodInfo mi = ti.GetDeclaredMethod(name);
+            if (mi != null && mi.IsStatic && mi.GetParameters().Length == 0 && mi.ReturnType == typeof(bool))
+                return mi;
+
+            PropertyInfo pi = ti.GetDeclaredProperty(name);
+            if (pi != null && pi.PropertyType == typeof(bool) && pi.GetMethod != null && pi.GetMethod.IsStatic && pi.GetMethod.GetParameters().Length == 0)
+                return pi.GetMethod;
+
+            return LookupConditionalMethod(ti.BaseType, name);
+        }
+    }
+}

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.NetCore.Extensions
+{
+    public class ConditionalTheoryDiscoverer : TheoryDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public ConditionalTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        public override IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
+
+            string conditionMemberName = theoryAttribute.GetConstructorArguments().FirstOrDefault() as string;
+            MethodInfo conditionMethodInfo;
+            if (conditionMemberName == null ||
+                (conditionMethodInfo = ConditionalFactDiscoverer.LookupConditionalMethod(testMethodInfo.DeclaringType, conditionMemberName)) == null)
+            {
+                return new[] {
+                    new ExecutionErrorTestCase(
+                        _diagnosticMessageSink,
+                        discoveryOptions.MethodDisplayOrDefault(),
+                        testMethod,
+                        "An appropriate member \"" + conditionMemberName + "\" could not be found.")
+                };
+            }
+
+            object result = conditionMethodInfo.Invoke(null, null);
+            return (bool)result ?
+                base.Discover(discoveryOptions, testMethod, theoryAttribute) :
+                Array.Empty<IXunitTestCase>();
+        }
+    }
+}

--- a/src/xunit.netcore.extensions/SkippedTestCase.cs
+++ b/src/xunit.netcore.extensions/SkippedTestCase.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.NetCore.Extensions
+{
+    /// <summary>Wraps another test case that should be skipped.</summary>
+    internal sealed class SkippedTestCase : IXunitTestCase
+    {
+        private readonly IXunitTestCase _testCase;
+        private readonly string _skippedReason;
+
+        internal SkippedTestCase(IXunitTestCase testCase, string skippedReason)
+        {
+            _testCase = testCase;
+            _skippedReason = skippedReason;
+        }
+
+        public string DisplayName { get { return _testCase.DisplayName; } }
+
+        public IMethodInfo Method { get { return _testCase.Method; } }
+
+        public string SkipReason { get { return _skippedReason; } }
+
+        public ISourceInformation SourceInformation { get { return _testCase.SourceInformation; } set { _testCase.SourceInformation = value; } }
+
+        public ITestMethod TestMethod { get { return _testCase.TestMethod; } }
+
+        public object[] TestMethodArguments { get { return _testCase.TestMethodArguments; } }
+
+        public Dictionary<string, List<string>> Traits { get { return _testCase.Traits; } }
+
+        public string UniqueID { get { return _testCase.UniqueID; } }
+
+        public void Deserialize(IXunitSerializationInfo info) { _testCase.Deserialize(info); }
+
+        public Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments,
+            ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+        {
+            return new XunitTestCaseRunner(this, DisplayName, _skippedReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+        }
+
+        public void Serialize(IXunitSerializationInfo info) { _testCase.Serialize(info); }
+    }
+}

--- a/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
+++ b/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
@@ -25,6 +25,7 @@
     <Compile Include="Discoverers\OuterLoopTestsDiscoverer.cs" />
     <Compile Include="Discoverers\PlatformSpecificDiscoverer.cs" />
     <Compile Include="PlatformID.cs" />
+    <Compile Include="SkippedTestCase.cs" />
     <Compile Include="XunitConstants.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
+++ b/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
@@ -14,8 +14,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="Attributes\ConditionalFactAttribute.cs" />
+    <Compile Include="Attributes\ConditionalTheoryAttribute.cs" />
     <Compile Include="Attributes\ActiveIssueAttribute.cs" />
     <Compile Include="Attributes\PlatformSpecificAttribute.cs" />
+    <Compile Include="Discoverers\ConditionalFactDiscoverer.cs" />
+    <Compile Include="Discoverers\ConditionalTheoryDiscoverer.cs" />
     <Compile Include="Discoverers\ActiveIssueDiscoverer.cs" />
     <Compile Include="Attributes\OuterLoopAttribute.cs" />
     <Compile Include="Discoverers\OuterLoopTestsDiscoverer.cs" />


### PR DESCRIPTION
This lets us write tests like:
```C#
[ConditionalFact("RunningWithElevatedPrivileges")]
public void TestThatOnlyRunsAsAdmin() { ... }
...
private static bool RunningWithElevatedPrivileges() { ... }
```
and
```C#
[ConditionalTheory("WebSocketsAvailable")]
[InlineData("http://someUrl")]
[InlineData("https://someUrl")]
public void TestThatOnlyRunsWithWebSockets(string url) { ... }
...
private static bool WebSocketsAvailable { get { ... } }
```

cc: @davidsh, @weshaggard, @mellinoe, @Priya91, @Chrisboh 
Related to https://github.com/dotnet/corefx/issues/3349