### PR TITLE
Added modifications for AssemblyList generated during Cloud Tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class GenerateAssemblyList : Task
+    {
+        [Required]
+        public string InputListLocation { get; set; }
+
+        [Required]
+        public string OutputListLocation { get; set; }
+
+        public override bool Execute()
+        {
+            HashSet<string> processedFileNames = new HashSet<string>();
+            AssemblyList corerun = new AssemblyList("Microsoft.NETCore.Runtime", "Microsoft.NETCore.TestHost", "Microsoft.NETCore.Windows.ApiSets");
+            AssemblyList xunit = new AssemblyList("xunit");
+            List<string> unmatched = new List<string>();
+            bool foundDuplicates = false;
+            Stream inputListLocationStream = File.OpenRead(InputListLocation);
+            Stream outputListLocationStream = File.OpenWrite(OutputListLocation);
+
+            using (StreamReader listReader = new StreamReader(inputListLocationStream))
+            {
+                string line;
+                while ((line = listReader.ReadLine()) != null)
+                {
+                    var fileName = Path.GetFileName(line);
+                    if (!processedFileNames.Add(fileName))
+                    {
+                        Log.LogError("Duplicate assembly found: {0}", fileName);
+                        foundDuplicates = true;
+                        continue;
+                    }
+
+                    if (corerun.TryAdd(line))
+                    {
+                        continue;
+                    }
+
+                    if (xunit.TryAdd(line))
+                    {
+                        continue;
+                    }
+
+                    unmatched.Add(line);
+                }
+            }
+
+            if (foundDuplicates)
+            {
+                return false;
+            }
+
+            Dictionary<string, List<string>> headers = new Dictionary<string, List<string>>
+            {
+                {"corerun", corerun.Dependencies},
+                {"xunit", xunit.Dependencies},
+                {"testdependency", unmatched},
+            };
+
+            using (StreamWriter listRewriter = new StreamWriter(outputListLocationStream))
+            using (JsonWriter jsonWriter = new JsonTextWriter(listRewriter))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Serialize(jsonWriter, headers);
+            }
+
+            return true;
+        }
+
+        private class AssemblyList
+        {
+            public List<string> Dependencies { get; private set; }
+            private readonly List<string> _patternToContain;
+
+            public AssemblyList(params string[] patterns)
+            {
+                _patternToContain = new List<string>(patterns);
+                Dependencies = new List<string>();
+            }
+
+            public bool TryAdd(string packageId)
+            {
+                if (_patternToContain.Any(packageId.Contains))
+                {
+                    Dependencies.Add(packageId);
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9AB674A0-AEF7-4539-8049-0406D2C7BB32}</ProjectGuid>
+    <ProjectGuid>{17C66BCE-EB35-44CA-893C-8AAFB67708E9}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.DotNet.Build.Tasks</RootNamespace>
     <AssemblyName>Microsoft.DotNet.Build.Tasks</AssemblyName>
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="Delegates.cs" />
     <Compile Include="ExecWithMutex.cs" />
+    <Compile Include="GenerateAssemblyList.cs" />
     <Compile Include="GenerateResourcesCode.cs" />
     <Compile Include="GenerateEncodingTable.cs" />
     <Compile Include="GetPackageVersion.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -5,6 +5,8 @@
   <UsingTask TaskName="RemoveDuplicatesWithLastOneWinsPolicy" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileCreateFromDirectory" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
+  <UsingTask TaskName="GenerateAssemblyList" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  
   <PropertyGroup>
     <SerializeProjects Condition="'$(TestWithLocalLibraries)'=='true'">true</SerializeProjects>
   </PropertyGroup>
@@ -134,10 +136,14 @@
       <AssemblyPaths Include="$([MSBuild]::MakeRelative($(PackagesDir), %(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)))" Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.NugetPackageId)' != ''" />
     </ItemGroup>
     <WriteLinesToFile
-      File="$(OutDir)AssemblyList.txt"
+      File="$(OutDir)AssemblyList.flat.txt"
       Lines="@(AssemblyPaths)"
       Overwrite="true"
       Encoding="Ascii" />
+    <GenerateAssemblyList
+      InputListLocation="$(OutDir)AssemblyList.flat.txt"
+      OutputListLocation="$(OutDir)AssemblyList.txt"
+     />
   </Target>
 
   <!-- archive the test binaries along with some supporting files -->


### PR DESCRIPTION
Added modifications for AssemblyList generated during Cloud Tests to add pattern support. This is to help differentiate Runtime dependencies and xunit dependencies during test execution.