### PR TITLE
Throw exception if ProjectLanguage is null

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
@@ -401,6 +401,12 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private bool IsFileValid(string file, string expectedLanguage, string unExpectedLanguage)
         {
+
+            if(ProjectLanguage == null)
+            {
+                throw new ExceptionFromResource("NoProgrammingLanguageSpecified");
+            }
+
             var expectedProjectLanguage = expectedLanguage;
             expectedLanguage = expectedLanguage == "C#" ? "cs" : expectedLanguage;
             unExpectedLanguage = unExpectedLanguage == "C#" ? "cs" : unExpectedLanguage;

--- a/src/Microsoft.DotNet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Strings.Designer.cs
@@ -11,7 +11,7 @@
 namespace Microsoft.DotNet.Build.Tasks {
     using System;
     using System.Reflection;
-
+    
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Build.Tasks {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.Build.Tasks {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Strings() {
         }
         
@@ -83,6 +85,15 @@ namespace Microsoft.DotNet.Build.Tasks {
         internal static string MissingEntryInLockFile {
             get {
                 return ResourceManager.GetString("MissingEntryInLockFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;The ProjectLanguage task parameter cannot be null.&quot;.
+        /// </summary>
+        internal static string NoProgrammingLanguageSpecified {
+            get {
+                return ResourceManager.GetString("NoProgrammingLanguageSpecified", resourceCulture);
             }
         }
         

--- a/src/Microsoft.DotNet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.DotNet.Build.Tasks/Strings.resx
@@ -138,4 +138,7 @@
   <data name="ResolvedReferencesFromPackage" xml:space="preserve">
     <value>Resolved references from {0}:</value>
   </data>
+  <data name="NoProgrammingLanguageSpecified" xml:space="preserve">
+    <value>"The ProjectLanguage task parameter cannot be null."</value>
+  </data>
 </root>


### PR DESCRIPTION
After I bumped the build tools version up I started getting NPEs from the resolve assets tasks. Apparently the ProjectLanguage task parameter is now mandatory.

In order to save investigation time I added a null check and an error message.

An alternative implementation would be to mark the task parameter as required.