### PR TITLE
Bringing back Full Framework version of the task library to be able to build in razzle and linux

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -6,7 +6,7 @@
   <UsingTask TaskName="SendToEventHub" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="UploadToAzure" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="WriteItemsToJson" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
-  <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ContainerName>$(TestProduct)-$(Branch)-$(BuildMoniker)</ContainerName>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.DotNet.Build.Tasks</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.Build.Tasks</AssemblyName>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <SkipSigning>true</SkipSigning>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\Delegates.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ExecWithMutex.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\GenerateResourcesCode.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\GenerateEncodingTable.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\GetPackageVersion.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\GetPackageDependencies.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\GetNextRevisionNumber.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\NormalizePaths.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\GetDoItemsIntersect.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\OpenSourceSign.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ParseTestCoverageInfo.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\RemoveDuplicatesWithLastOneWinsPolicy.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\PrereleaseResolveNuGetPackageAssets.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileCreateFromDirectory.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\Strings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\Microsoft.DotNet.Build.Tasks\Strings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="mscorlib" />
+    <Reference Include="LibGit2Sharp">
+      <HintPath>..\..\packages\LibGit2Sharp\0.19.0\lib\net40\LibGit2Sharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build.Framework, Version=4.0.0.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.NuManifest.DotNet\1.0.1-alpha\lib\net45\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json\6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NuGet.Core, Version=2.8.50926.602, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.NuManifest.DotNet\1.0.1-alpha\lib\net45\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.NuManifest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fde1dfc9ddcb8e3e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.NuManifest\1.0.1-alpha\lib\net45\NuGet.NuManifest.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.NuManifest.DotNet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fde1dfc9ddcb8e3e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.NuManifest.DotNet\1.0.1-alpha\lib\net45\NuGet.NuManifest.DotNet.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\packages\System.Collections.Immutable\1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\..\packages\System.Reflection.Metadata\1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Target Name="AfterBuild">
+    <PropertyGroup>
+      <!-- This version should be kept up to date with project.json -->
+      <NuProjVersion>0.10.4-beta-gf7fc34e7d8</NuProjVersion>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageFiles Include="$(MSBuildThisProjectDirectory)PackageFiles\**\*.*" />
+      <NativeBinariesx86 Include="$(PackagesDir)LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\x86\*.*" />
+      <NativeBinariesamd64 Include="$(PackagesDir)LibGit2Sharp.0.19.0.0\lib\net40\NativeBinaries\amd64\*.*" />
+      <NuProjFiles Include="$(PackagesDir)NuProj\$(NuProjVersion)\tools\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(OutputPath)\PackageFiles\%(RecursiveDir)" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(NativeBinariesx86)" DestinationFolder="$(OutputPath)NativeBinaries\x86" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(NativeBinariesamd64)" DestinationFolder="$(OutputPath)NativeBinaries\amd64" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(NuProjFiles)" DestinationFolder="$(OutputPath)\NuProj\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": {
+    "LibGit2Sharp": "0.19.0.0",
+	"Microsoft.Web.Xdt": "2.1.1",
+	"Newtonsoft.Json": "6.0.8",
+	"NuGet.Core": "2.8.3",
+	"NuGet.NuManifest": "1.0.1-alpha",
+	"NuGet.NuManifest.DotNet": "1.0.1-alpha",
+	"System.Collections.Immutable": "1.1.32-beta",
+	"System.Reflection.Metadata": "1.0.17-beta",
+	"xunit.runners": "2.0.0-beta5-build2785"
+  },
+  "frameworks": {
+    "net45": { }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.lock.json
@@ -1,0 +1,441 @@
+{
+  "locked": false,
+  "version": 2,
+  "targets": {
+    ".NETFramework,Version=v4.5": {
+      "LibGit2Sharp/0.19.0": {
+        "type": "package",
+        "compile": {
+          "lib/net40/LibGit2Sharp.dll": {}
+        },
+        "runtime": {
+          "lib/net40/LibGit2Sharp.dll": {}
+        }
+      },
+      "Microsoft.Web.Xdt/2.1.1": {
+        "type": "package",
+        "compile": {
+          "lib/net40/Microsoft.Web.XmlTransform.dll": {}
+        },
+        "runtime": {
+          "lib/net40/Microsoft.Web.XmlTransform.dll": {}
+        }
+      },
+      "Newtonsoft.Json/6.0.8": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      },
+      "NuGet.Core/2.8.3": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.0"
+        },
+        "compile": {
+          "lib/net40-Client/NuGet.Core.dll": {}
+        },
+        "runtime": {
+          "lib/net40-Client/NuGet.Core.dll": {}
+        }
+      },
+      "NuGet.NuManifest/1.0.1-alpha": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.1",
+          "NuGet.Core": "2.8.3",
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/net45/NuGet.NuManifest.dll": {}
+        },
+        "runtime": {
+          "lib/net45/NuGet.NuManifest.dll": {}
+        }
+      },
+      "NuGet.NuManifest.DotNet/1.0.1-alpha": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/net45/Microsoft.Web.XmlTransform.dll": {},
+          "lib/net45/NuGet.Core.dll": {},
+          "lib/net45/NuGet.NuManifest.DotNet.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.Web.XmlTransform.dll": {},
+          "lib/net45/NuGet.Core.dll": {},
+          "lib/net45/NuGet.NuManifest.DotNet.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.32-beta": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.0.17-beta": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "xunit.runners/2.0.0-beta5-build2785": {
+        "type": "package"
+      }
+    },
+    ".NETFramework,Version=v4.5/win7-x86": {
+      "LibGit2Sharp/0.19.0": {
+        "type": "package",
+        "compile": {
+          "lib/net40/LibGit2Sharp.dll": {}
+        },
+        "runtime": {
+          "lib/net40/LibGit2Sharp.dll": {}
+        }
+      },
+      "Microsoft.Web.Xdt/2.1.1": {
+        "type": "package",
+        "compile": {
+          "lib/net40/Microsoft.Web.XmlTransform.dll": {}
+        },
+        "runtime": {
+          "lib/net40/Microsoft.Web.XmlTransform.dll": {}
+        }
+      },
+      "Newtonsoft.Json/6.0.8": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      },
+      "NuGet.Core/2.8.3": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.0"
+        },
+        "compile": {
+          "lib/net40-Client/NuGet.Core.dll": {}
+        },
+        "runtime": {
+          "lib/net40-Client/NuGet.Core.dll": {}
+        }
+      },
+      "NuGet.NuManifest/1.0.1-alpha": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.1",
+          "NuGet.Core": "2.8.3",
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/net45/NuGet.NuManifest.dll": {}
+        },
+        "runtime": {
+          "lib/net45/NuGet.NuManifest.dll": {}
+        }
+      },
+      "NuGet.NuManifest.DotNet/1.0.1-alpha": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/net45/Microsoft.Web.XmlTransform.dll": {},
+          "lib/net45/NuGet.Core.dll": {},
+          "lib/net45/NuGet.NuManifest.DotNet.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.Web.XmlTransform.dll": {},
+          "lib/net45/NuGet.Core.dll": {},
+          "lib/net45/NuGet.NuManifest.DotNet.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.32-beta": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.0.17-beta": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "xunit.runners/2.0.0-beta5-build2785": {
+        "type": "package"
+      }
+    },
+    ".NETFramework,Version=v4.5/win7-x64": {
+      "LibGit2Sharp/0.19.0": {
+        "type": "package",
+        "compile": {
+          "lib/net40/LibGit2Sharp.dll": {}
+        },
+        "runtime": {
+          "lib/net40/LibGit2Sharp.dll": {}
+        }
+      },
+      "Microsoft.Web.Xdt/2.1.1": {
+        "type": "package",
+        "compile": {
+          "lib/net40/Microsoft.Web.XmlTransform.dll": {}
+        },
+        "runtime": {
+          "lib/net40/Microsoft.Web.XmlTransform.dll": {}
+        }
+      },
+      "Newtonsoft.Json/6.0.8": {
+        "type": "package",
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      },
+      "NuGet.Core/2.8.3": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.0"
+        },
+        "compile": {
+          "lib/net40-Client/NuGet.Core.dll": {}
+        },
+        "runtime": {
+          "lib/net40-Client/NuGet.Core.dll": {}
+        }
+      },
+      "NuGet.NuManifest/1.0.1-alpha": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Web.Xdt": "2.1.1",
+          "NuGet.Core": "2.8.3",
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/net45/NuGet.NuManifest.dll": {}
+        },
+        "runtime": {
+          "lib/net45/NuGet.NuManifest.dll": {}
+        }
+      },
+      "NuGet.NuManifest.DotNet/1.0.1-alpha": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/net45/Microsoft.Web.XmlTransform.dll": {},
+          "lib/net45/NuGet.Core.dll": {},
+          "lib/net45/NuGet.NuManifest.DotNet.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.Web.XmlTransform.dll": {},
+          "lib/net45/NuGet.Core.dll": {},
+          "lib/net45/NuGet.NuManifest.DotNet.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.32-beta": {
+        "type": "package",
+        "compile": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.0.17-beta": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.Immutable": "1.1.32-beta"
+        },
+        "compile": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win8/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "xunit.runners/2.0.0-beta5-build2785": {
+        "type": "package"
+      }
+    }
+  },
+  "libraries": {
+    "LibGit2Sharp/0.19.0": {
+      "type": "package",
+      "sha512": "kJQoiQJ0DzGXIPqfkl92o9XzugB2SpFd7cixsy3f3ME8vQ8Mux6ThDD1vL98W0ydkslTTiq8TDynq1IjdskT5Q==",
+      "files": [
+        "App_Readme/libgit2.license.txt",
+        "App_Readme/LibGit2Sharp.CHANGES.md",
+        "App_Readme/LibGit2Sharp.LICENSE.md",
+        "App_Readme/LibGit2Sharp.README.md",
+        "lib/net40/LibGit2Sharp.dll",
+        "lib/net40/LibGit2Sharp.xml",
+        "lib/net40/NativeBinaries/amd64/git2-69db893.dll",
+        "lib/net40/NativeBinaries/amd64/git2-69db893.pdb",
+        "lib/net40/NativeBinaries/x86/git2-69db893.dll",
+        "lib/net40/NativeBinaries/x86/git2-69db893.pdb",
+        "LibGit2Sharp.0.19.0.nupkg",
+        "LibGit2Sharp.0.19.0.nupkg.sha512",
+        "LibGit2Sharp.nuspec",
+        "Tools/GetLibGit2SharpPostBuildCmd.ps1",
+        "Tools/install.ps1",
+        "Tools/uninstall.ps1"
+      ]
+    },
+    "Microsoft.Web.Xdt/2.1.1": {
+      "type": "package",
+      "sha512": "PHoqib4d+f2lmnluVwMFM8M4AF8Z7y2g18hUTi5UCKkjNQIzkNnB1uyqnS5od2sMsRcI/9mexQjDO6e5dL/MeA==",
+      "files": [
+        "lib/net40/Microsoft.Web.XmlTransform.dll",
+        "Microsoft.Web.Xdt.2.1.1.nupkg",
+        "Microsoft.Web.Xdt.2.1.1.nupkg.sha512",
+        "Microsoft.Web.Xdt.nuspec"
+      ]
+    },
+    "Newtonsoft.Json/6.0.8": {
+      "type": "package",
+      "sha512": "7ut47NDedTW19EbL0JpFDYUP62fcuz27hJrehCDNajdCS5NtqL+E39+7Um3OkNc2wl2ym7K8Ln5eNuLus6mVGQ==",
+      "files": [
+        "lib/net20/Newtonsoft.Json.dll",
+        "lib/net20/Newtonsoft.Json.xml",
+        "lib/net35/Newtonsoft.Json.dll",
+        "lib/net35/Newtonsoft.Json.xml",
+        "lib/net40/Newtonsoft.Json.dll",
+        "lib/net40/Newtonsoft.Json.xml",
+        "lib/net45/Newtonsoft.Json.dll",
+        "lib/net45/Newtonsoft.Json.xml",
+        "lib/netcore45/Newtonsoft.Json.dll",
+        "lib/netcore45/Newtonsoft.Json.xml",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.dll",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.xml",
+        "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.dll",
+        "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.xml",
+        "Newtonsoft.Json.6.0.8.nupkg",
+        "Newtonsoft.Json.6.0.8.nupkg.sha512",
+        "Newtonsoft.Json.nuspec",
+        "tools/install.ps1"
+      ]
+    },
+    "NuGet.Core/2.8.3": {
+      "type": "package",
+      "sha512": "2Z+8+UzWeKPl0D2uFGZGZxXM61cRcjLi6UjUqxt0PBMpMREt+G/7E12o/l/YrpBQXiNpGAd2i0s2X4j/GKfNdg==",
+      "files": [
+        "lib/net40-Client/NuGet.Core.dll",
+        "NuGet.Core.2.8.3.nupkg",
+        "NuGet.Core.2.8.3.nupkg.sha512",
+        "NuGet.Core.nuspec"
+      ]
+    },
+    "NuGet.NuManifest/1.0.1-alpha": {
+      "type": "package",
+      "sha512": "yztahLM8iUQG8H4VNyxngKR5uqANmG7onpCvLTbDVrVvDqH2bO2fs3IMNv4mNZTNgRyNrK/JqBHIS1WpBXKfLQ==",
+      "files": [
+        "lib/net45/NuGet.NuManifest.dll",
+        "lib/net45/NuGet.NuManifest.pdb",
+        "NuGet.NuManifest.1.0.1-alpha.nupkg",
+        "NuGet.NuManifest.1.0.1-alpha.nupkg.sha512",
+        "NuGet.NuManifest.nuspec"
+      ]
+    },
+    "NuGet.NuManifest.DotNet/1.0.1-alpha": {
+      "type": "package",
+      "sha512": "6d42FiYZNtzJRGbC32+UcFC5uKhY6Y/gNUhcUFciyeAzkDliWhCtbffswSo9eo/Z0Q+6Kx1hy9Rw9XMaGa7oZw==",
+      "files": [
+        "lib/net45/Microsoft.Web.XmlTransform.dll",
+        "lib/net45/NuGet.Core.dll",
+        "lib/net45/NuGet.NuManifest.DotNet.dll",
+        "lib/net45/NuGet.NuManifest.DotNet.pdb",
+        "NuGet.NuManifest.DotNet.1.0.1-alpha.nupkg",
+        "NuGet.NuManifest.DotNet.1.0.1-alpha.nupkg.sha512",
+        "NuGet.NuManifest.DotNet.nuspec"
+      ]
+    },
+    "System.Collections.Immutable/1.1.32-beta": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ckfFUM6keywtdZ+DT7/KWSmQ0YRLHu4OCnKKWbumvO8uDcKtCoxjLKcaWNzguGCSTy2r2Ap9gojazgCwMYw0bQ==",
+      "files": [
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
+        "License-Stable.rtf",
+        "System.Collections.Immutable.1.1.32-beta.nupkg",
+        "System.Collections.Immutable.1.1.32-beta.nupkg.sha512",
+        "System.Collections.Immutable.nuspec"
+      ]
+    },
+    "System.Reflection.Metadata/1.0.17-beta": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "PyXG0gfs9gDDj4Km2PKadmPOMsH7IL+S4zckKMESdgv34f0I063VKi+RgmZ8f4wtgBVQTw8UrYE911lpePFAgA==",
+      "files": [
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml",
+        "License-Stable.rtf",
+        "System.Reflection.Metadata.1.0.17-beta.nupkg",
+        "System.Reflection.Metadata.1.0.17-beta.nupkg.sha512",
+        "System.Reflection.Metadata.nuspec"
+      ]
+    },
+    "xunit.runners/2.0.0-beta5-build2785": {
+      "type": "package",
+      "sha512": "5LO4Hlgpqqcwai8Owe2qJ9P7t53zXHex48zUvGIC0AfzxAEbQ9dd8vGhmklsgw/xLnJQwTYrcmWx/SGP+vSqxg==",
+      "files": [
+        "tools/HTML.xslt",
+        "tools/xunit.abstractions.dll",
+        "tools/xunit.console.exe",
+        "tools/xunit.console.exe.config",
+        "tools/xunit.console.x86.exe",
+        "tools/xunit.console.x86.exe.config",
+        "tools/xunit.runner.msbuild.dll",
+        "tools/xunit.runner.utility.dll",
+        "tools/xUnit1.xslt",
+        "xunit.runners.2.0.0-beta5-build2785.nupkg",
+        "xunit.runners.2.0.0-beta5-build2785.nupkg.sha512",
+        "xunit.runners.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "LibGit2Sharp >= 0.19.0",
+      "Microsoft.Web.Xdt >= 2.1.1",
+      "Newtonsoft.Json >= 6.0.8",
+      "NuGet.Core >= 2.8.3",
+      "NuGet.NuManifest >= 1.0.1-alpha",
+      "NuGet.NuManifest.DotNet >= 1.0.1-alpha",
+      "System.Collections.Immutable >= 1.1.32-beta",
+      "System.Reflection.Metadata >= 1.0.17-beta",
+      "xunit.runners >= 2.0.0-beta5-build2785"
+    ],
+    ".NETFramework,Version=v4.5": []
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -2,6 +2,8 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"  InitialTargets="CheckDesignTime">
 
   <PropertyGroup>
+    <BuildToolsTaskDir Condition="'$(BuildToolsTaskDir)' == ''">$(ToolsDir)</BuildToolsTaskDir>
+  
     <!-- A number of the imports below depend on these default properties -->
     <IsTestProject Condition="'$(IsTestProject)'=='' And $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -91,7 +91,7 @@
 
   </Target>
 
-  <UsingTask TaskName="ParseTestCoverageInfo" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ParseTestCoverageInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <!-- Generates VisitedMethodsReport.xml -->
   <Target Name="GenerateVisitedReport"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/UpdateBuildValues.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/UpdateBuildValues.targets
@@ -1,5 +1,5 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="GetNextRevisionNumber" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GetNextRevisionNumber" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <GitWorkingBranch Condition="'$(GitWorkingBranch)' == ''">master</GitWorkingBranch>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/encoding.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/encoding.targets
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="GenerateEncodingTable" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GenerateEncodingTable" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <!-- Include the following in the .csproj of a project which needs to generate an encoding data-table, uncomment as appropriate:
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/gitpush.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/gitpush.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="GitPush" />
+  <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="GitPush" />
   
   <Target Name="GitPush">
     <GitPush

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="GetPackageVersion" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GetPackageVersion" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <ItemGroup>
     <PackagesNuSpecFiles Include="$(SourceDir)nuget\*.nuspec" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <!-- Hook both partial-facade-related targets into TargetsTriggeredByCompilation. This will cause them
           to only be invoked upon a successful compilation; they can conceptualized as an extension

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="RemoveDuplicatesWithLastOneWinsPolicy" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ZipFileCreateFromDirectory" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="RemoveDuplicatesWithLastOneWinsPolicy" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ZipFileCreateFromDirectory" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
-  <UsingTask TaskName="GenerateAssemblyList" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="GenerateAssemblyList" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
   <PropertyGroup>
     <SerializeProjects Condition="'$(TestWithLocalLibraries)'=='true'">true</SerializeProjects>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="GenerateResourcesCode" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GenerateResourcesCode" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <ResourcesSourceOutputDirectory Condition="'$(ResourcesSourceOutputDirectory)' == ''">$(MSBuildProjectDirectory)/Resources/</ResourcesSourceOutputDirectory>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -9,7 +9,7 @@
     </FilesToSign>
   </ItemGroup>
 
-  <UsingTask AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="OpenSourceSign" />
+  <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="OpenSourceSign" />
   
   <PropertyGroup Condition="'$(SkipSigning)'!='true'">
     <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/toolruntime.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/toolruntime.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ToolRuntimeProjectJson Condition="'$(ToolRuntimeProjectJson)' == ''">$(MSBuildThisFileDirectory)tool-runtime\project.json</ToolRuntimeProjectJson>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -19,7 +19,16 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.DotNet.Build.CloudTestTasks\*.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.Tasks.net45\*.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.DotNet.Build.CloudTestTasks.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.Azure.KeyVault.Core.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.Data.Edm.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.Data.OData.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.Data.Services.Client.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.ServiceBus.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.WindowsAzure.Configuration.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.WindowsAzure.Storage.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\System.Spatial.dll" target="lib\net45" />
     <file src="Microsoft.Dotnet.Build.CloudTestTasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\*.dll" target="lib" />


### PR DESCRIPTION
Bringing back Full Framework version of the task library to be able to build in razzle and linux.

When we moved this Task library to .Net Core we verified that it would be able to be loaded also when using full framework. What we didn't validate, is that it requires full framework 4.6 which means that it won't work in linux(mono msbuild doesn't support 4.6) nor Razzle builds(razzle runs with full framework 4.5). Because of this, after upgrading the buildtools version broke corefx repo in both environments. This change will add back the 4.5 version of the task library and store it under the 'net45' folder inside the package, so that razzle and linux builds can load that instead of the .Net Core version.