### PR TITLE
Add a msbuild property to disable functional tests for cloud testing.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -83,7 +83,10 @@
   <Target Name="CreateTestListJson"
           DependsOnTargets="CreateFuncTestListJson;CreatePerfTestListJson" />
 
-  <Target Name="CreateFuncTestListJson" DependsOnTargets="CreateAzureStorage">
+  <!-- allow skipping this target if perf testing is enabled -->
+  <Target Name="CreateFuncTestListJson"
+          DependsOnTargets="CreateAzureStorage"
+          Condition="'$(Performance)' != 'true' or '$(FuncTestsDisabled)' != 'true'">
     <!-- create item group of functional tests -->
     <ItemGroup>
       <FunctionalTest Include="$(TestArchivesRoot)*.zip" />
@@ -156,7 +159,6 @@
     <ItemGroup>
       <ExcludeFromArchive Include="nupkg$" />
       <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
-      <ExcludeFromArchive Include="TestData" />
     </ItemGroup>
     <ZipFileCreateFromDirectory
         SourceDirectory="$(PackagesDir)"


### PR DESCRIPTION
There is currently no way to submit just the performance tests to the
cloud test infrastructure.  This new property, FuncTestsDisabled, will
disable the functional tests when perf tests are enabled.
Stop excluding test data from packages.zip as it causes test failures.