### PR TITLE
Add project.json tooling for an alternative to checking in lockfiles

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -72,6 +72,7 @@
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefx/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxtestdata/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/nugetbuild/" />
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -35,6 +35,8 @@
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ParseTestCoverageInfo.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\PrereleaseResolveNuGetPackageAssets.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\UpdateProjectDependencies.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ValidateProjectDependencyVersions.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileCreateFromDirectory.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\Strings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -35,6 +35,8 @@
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ParseTestCoverageInfo.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\PrereleaseResolveNuGetPackageAssets.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\UpdatePackageDependencyVersion.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\UpdatePrereleaseDependencies.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\UpdateProjectDependencies.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ValidateProjectDependencyVersions.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileCreateFromDirectory.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -37,7 +37,7 @@
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\PrereleaseResolveNuGetPackageAssets.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\UpdatePackageDependencyVersion.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\UpdatePrereleaseDependencies.cs" />
-    <Compile Include="..\Microsoft.DotNet.Build.Tasks\UpdateProjectDependencies.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VisitProjectDependencies.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ValidateProjectDependencyVersions.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileCreateFromDirectory.cs" />
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\Strings.Designer.cs">

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -6,6 +6,7 @@
 	"NuGet.Core": "2.8.3",
 	"NuGet.NuManifest": "1.0.1-alpha",
 	"NuGet.NuManifest.DotNet": "1.0.1-alpha",
+    "NuGet.Versioning": "3.3.0",
 	"System.Collections.Immutable": "1.1.32-beta",
 	"System.Reflection.Metadata": "1.0.17-beta",
 	"xunit.runners": "2.0.0-beta5-build2785"

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,15 +1,15 @@
 {
   "dependencies": {
     "LibGit2Sharp": "0.19.0.0",
-	"Microsoft.Web.Xdt": "2.1.1",
-	"Newtonsoft.Json": "6.0.8",
-	"NuGet.Core": "2.8.3",
-	"NuGet.NuManifest": "1.0.1-alpha",
-	"NuGet.NuManifest.DotNet": "1.0.1-alpha",
+    "Microsoft.Web.Xdt": "2.1.1",
+    "Newtonsoft.Json": "6.0.8",
+    "NuGet.Core": "2.8.3",
+    "NuGet.NuManifest": "1.0.1-alpha",
+    "NuGet.NuManifest.DotNet": "1.0.1-alpha",
     "NuGet.Versioning": "3.3.0",
-	"System.Collections.Immutable": "1.1.32-beta",
-	"System.Reflection.Metadata": "1.0.17-beta",
-	"xunit.runners": "2.0.0-beta5-build2785"
+    "System.Collections.Immutable": "1.1.32-beta",
+    "System.Reflection.Metadata": "1.0.17-beta",
+    "xunit.runners": "2.0.0-beta5-build2785"
   },
   "frameworks": {
     "net45": { }

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.lock.json
@@ -72,6 +72,21 @@
           "lib/net45/NuGet.NuManifest.DotNet.dll": {}
         }
       },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "frameworkAssemblies": [
+          "Microsoft.CSharp",
+          "mscorlib",
+          "System",
+          "System.Core"
+        ],
+        "compile": {
+          "lib/net45/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/net45/NuGet.Versioning.dll": {}
+        }
+      },
       "System.Collections.Immutable/1.1.32-beta": {
         "type": "package",
         "compile": {
@@ -167,6 +182,21 @@
           "lib/net45/NuGet.NuManifest.DotNet.dll": {}
         }
       },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "frameworkAssemblies": [
+          "Microsoft.CSharp",
+          "mscorlib",
+          "System",
+          "System.Core"
+        ],
+        "compile": {
+          "lib/net45/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/net45/NuGet.Versioning.dll": {}
+        }
+      },
       "System.Collections.Immutable/1.1.32-beta": {
         "type": "package",
         "compile": {
@@ -260,6 +290,21 @@
           "lib/net45/Microsoft.Web.XmlTransform.dll": {},
           "lib/net45/NuGet.Core.dll": {},
           "lib/net45/NuGet.NuManifest.DotNet.dll": {}
+        }
+      },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "frameworkAssemblies": [
+          "Microsoft.CSharp",
+          "mscorlib",
+          "System",
+          "System.Core"
+        ],
+        "compile": {
+          "lib/net45/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/net45/NuGet.Versioning.dll": {}
         }
       },
       "System.Collections.Immutable/1.1.32-beta": {
@@ -379,6 +424,19 @@
         "NuGet.NuManifest.DotNet.nuspec"
       ]
     },
+    "NuGet.Versioning/3.3.0": {
+      "type": "package",
+      "sha512": "f87vlVEFb4TyAqE7cpv4uX2cZkg70NeyzSTJ0D1w9kaGiYNv4l9/niKpuF8ek3PUAYCau+3YnxEp1wswVvWgAQ==",
+      "files": [
+        "lib/dnxcore50/NuGet.Versioning.dll",
+        "lib/dnxcore50/NuGet.Versioning.xml",
+        "lib/net45/NuGet.Versioning.dll",
+        "lib/net45/NuGet.Versioning.xml",
+        "NuGet.Versioning.3.3.0.nupkg",
+        "NuGet.Versioning.3.3.0.nupkg.sha512",
+        "NuGet.Versioning.nuspec"
+      ]
+    },
     "System.Collections.Immutable/1.1.32-beta": {
       "type": "package",
       "serviceable": true,
@@ -432,6 +490,7 @@
       "NuGet.Core >= 2.8.3",
       "NuGet.NuManifest >= 1.0.1-alpha",
       "NuGet.NuManifest.DotNet >= 1.0.1-alpha",
+      "NuGet.Versioning >= 3.3.0",
       "System.Collections.Immutable >= 1.1.32-beta",
       "System.Reflection.Metadata >= 1.0.17-beta",
       "xunit.runners >= 2.0.0-beta5-build2785"

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -32,6 +32,8 @@
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
+    <Compile Include="UpdateProjectDependencies.cs" />
+    <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="ZipFileCreateFromDirectory.cs" />
     <Compile Include="Strings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -32,6 +32,8 @@
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
+    <Compile Include="UpdatePackageDependencyVersion.cs" />
+    <Compile Include="UpdatePrereleaseDependencies.cs" />
     <Compile Include="UpdateProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="ZipFileCreateFromDirectory.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -34,7 +34,7 @@
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
     <Compile Include="UpdatePackageDependencyVersion.cs" />
     <Compile Include="UpdatePrereleaseDependencies.cs" />
-    <Compile Include="UpdateProjectDependencies.cs" />
+    <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="ZipFileCreateFromDirectory.cs" />
     <Compile Include="Strings.Designer.cs">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -101,7 +101,7 @@
 
   <Target Name="ValidatePackageVersions">
     <ValidateProjectDependencyVersions Condition="Exists('$(ProjectJson)')"
-                                       ProjectJson="$(ProjectJson)"
+                                       ProjectJsons="$(ProjectJson)"
                                        ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
                                        ValidationPatterns="@(ValidationPattern)" />
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -103,9 +103,8 @@
   <Target Name="ValidatePackageVersions">
     <ValidateProjectDependencyVersions Condition="Exists('$(ProjectJson)')"
                                        ProjectJson="$(ProjectJson)"
-                                       ValidPrereleaseVersion="$(CoreFXDependencyPrereleaseVersion)"
-                                       FloatingDependenciesInvalid="$(FloatingDependenciesInvalid)"
-                                       OurPackageIdentities="$(OurPackageIdentityRegex)" />
+                                       ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
+                                       ValidationPatterns="@(ValidationPattern)" />
   </Target>
 
   <Target Name="UpdateDependencies">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -3,7 +3,6 @@
 
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ValidateProjectDependencyVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="UpdateProjectDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>
@@ -105,16 +104,6 @@
                                        ProjectJson="$(ProjectJson)"
                                        ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
                                        ValidationPatterns="@(ValidationPattern)" />
-  </Target>
-
-  <Target Name="UpdateDependencies">
-    <UpdateProjectDependencies Condition="Exists('$(ProjectJson)')"
-                               ProjectJson="$(ProjectJson)"
-                               OldPrerelease="$(OldPrerelease)"
-                               NewPrerelease="$(NewPrerelease)"
-                               PackageId="$(PackageId)"
-                               OldVersion="$(OldVersion)"
-                               NewVersion="$(NewVersion)" />
   </Target>
 
   <Target Name="FilterTargetingPackResolvedNugetPackages" AfterTargets="ResolveNuGetPackages"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -2,8 +2,8 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ValidateProjectDependencyVersions" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="UpdateProjectDependencies" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ValidateProjectDependencyVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="UpdateProjectDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>
@@ -118,7 +118,7 @@
   </Target>
 
   <Target Name="FilterTargetingPackResolvedNugetPackages" AfterTargets="ResolveNuGetPackages"
-           Condition="'$(TargetingPackNugetPackageId)' != ''">
+          Condition="'$(TargetingPackNugetPackageId)' != ''">
 
     <ItemGroup>
       <ResolvedTargetingPackReference Include="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == '$(TargetingPackNugetPackageId)'"  />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -2,6 +2,8 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ValidateProjectDependencyVersions" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="UpdateProjectDependencies" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <ProjectJson Condition="'$(ProjectJson)'=='' and Exists('$(MSBuildProjectDirectory)/project.json')">$(MSBuildProjectDirectory)/project.json</ProjectJson>
@@ -21,7 +23,7 @@
 
   <!-- Restoring packages during a background (designtime) build will cause VS 2015 (v14) to get into an endless loop of resolving references. -->
   <Target Name="RestorePackages"
-          BeforeTargets="ResolveNuGetPackages"
+          BeforeTargets="ResolveNuGetPackages;ValidatePackageVersions"
           Condition="'$(RestorePackages)'=='true' and !('$(VSDesignTimeBuild)'=='true' and '$(VisualStudioVersion)' >= '14.0')">
 
     <Error Condition="'$(DnuRestoreCommand)'=='' and Exists('$(ProjectJson)')" Text="RestorePackages target needs a predefined DnuRestoreCommand property set in order to restore $(ProjectJson)" /> 
@@ -37,6 +39,7 @@
     <ResolveAssemblyReferencesDependsOn>
       $(ResolveAssemblyReferencesDependsOn);
       ResolveNuGetPackages;
+      ValidatePackageVersions;
     </ResolveAssemblyReferencesDependsOn>
     
     <!-- temporarily accept the old name NuGetTargetFrameworkMoniker until all projects are moved forward -->
@@ -97,8 +100,26 @@
              Condition="'@(_ReferenceFileNamesToRemove)' != '' or '@(_ReferenceCopyLocalPathsFileNamesToRemove)' != ''"/>
   </Target>
 
+  <Target Name="ValidatePackageVersions">
+    <ValidateProjectDependencyVersions Condition="Exists('$(ProjectJson)')"
+                                       ProjectJson="$(ProjectJson)"
+                                       ValidPrereleaseVersion="$(CoreFXDependencyPrereleaseVersion)"
+                                       FloatingDependenciesInvalid="$(FloatingDependenciesInvalid)"
+                                       OurPackageIdentities="$(OurPackageIdentityRegex)" />
+  </Target>
+
+  <Target Name="UpdateDependencies">
+    <UpdateProjectDependencies Condition="Exists('$(ProjectJson)')"
+                               ProjectJson="$(ProjectJson)"
+                               OldPrerelease="$(OldPrerelease)"
+                               NewPrerelease="$(NewPrerelease)"
+                               PackageId="$(PackageId)"
+                               OldVersion="$(OldVersion)"
+                               NewVersion="$(NewVersion)" />
+  </Target>
+
   <Target Name="FilterTargetingPackResolvedNugetPackages" AfterTargets="ResolveNuGetPackages"
-   	       Condition="'$(TargetingPackNugetPackageId)' != ''">
+           Condition="'$(TargetingPackNugetPackageId)' != ''">
 
     <ItemGroup>
       <ResolvedTargetingPackReference Include="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == '$(TargetingPackNugetPackageId)'"  />
@@ -112,6 +133,6 @@
     </ItemGroup>
 
     <Message Importance="Low" 
-        Text="Removed all ResolvedTagetingPackReferences that were not specified explicitly as a TargetingPackReference=[@(TargetingPackReference)]. PackageReferencesToRemove=[@(PackageReferencesToRemove)]." />
+             Text="Removed all ResolvedTagetingPackReferences that were not specified explicitly as a TargetingPackReference=[@(TargetingPackReference)]. PackageReferencesToRemove=[@(PackageReferencesToRemove)]." />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/UpdatePackageDependencyVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdatePackageDependencyVersion.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class UpdatePackageDependencyVersion : UpdateProjectDependencies
+    {
+        [Required]
+        public string PackageId { get; set; }
+
+        [Required]
+        public string OldVersion { get; set; }
+
+        [Required]
+        public string NewVersion { get; set; }
+
+        public override bool UpdatePackage(JProperty package, string projectJsonPath)
+        {
+            var dependencyIdentifier = package.Name;
+            var dependencyVersion = package.Value.ToObject<string>();
+
+            if (dependencyIdentifier == PackageId && dependencyVersion == OldVersion)
+            {
+                Log.LogMessage(
+                    "Changing {0} {1} to {2} in {3}",
+                    dependencyIdentifier,
+                    dependencyVersion,
+                    NewVersion,
+                    projectJsonPath);
+
+                package.Value = NewVersion;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/UpdatePackageDependencyVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdatePackageDependencyVersion.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class UpdatePackageDependencyVersion : UpdateProjectDependencies
+    public class UpdatePackageDependencyVersion : VisitProjectDependencies
     {
         [Required]
         public string PackageId { get; set; }
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string NewVersion { get; set; }
 
-        public override bool UpdatePackage(JProperty package, string projectJsonPath)
+        public override bool VisitPackage(JProperty package, string projectJsonPath)
         {
             var dependencyIdentifier = package.Name;
             var dependencyVersion = package.Value.ToObject<string>();

--- a/src/Microsoft.DotNet.Build.Tasks/UpdatePrereleaseDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdatePrereleaseDependencies.cs
@@ -5,7 +5,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class UpdatePrereleaseDependencies : UpdateProjectDependencies
+    public class UpdatePrereleaseDependencies : VisitProjectDependencies
     {
         [Required]
         public string OldPrerelease { get; set; }
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string NewPrerelease { get; set; }
 
-        public override bool UpdatePackage(JProperty package, string projectJsonPath)
+        public override bool VisitPackage(JProperty package, string projectJsonPath)
         {
             var dependencyIdentifier = package.Name;
             var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());

--- a/src/Microsoft.DotNet.Build.Tasks/UpdatePrereleaseDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdatePrereleaseDependencies.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class UpdatePrereleaseDependencies : UpdateProjectDependencies
+    {
+        [Required]
+        public string OldPrerelease { get; set; }
+
+        [Required]
+        public string NewPrerelease { get; set; }
+
+        public override bool UpdatePackage(JProperty package, string projectJsonPath)
+        {
+            var dependencyIdentifier = package.Name;
+            var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());
+            var dependencyVersion = dependencyVersionRange.MinVersion;
+
+            if (dependencyVersion.Release == OldPrerelease)
+            {
+                Log.LogMessage(
+                    "Changing {0} {1} to {2} in {3}",
+                    dependencyIdentifier,
+                    dependencyVersion,
+                    NewPrerelease,
+                    projectJsonPath);
+
+                package.Value = dependencyVersionRange.OriginalString.Replace(OldPrerelease, NewPrerelease);
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
@@ -2,7 +2,6 @@
 using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using NuGet.Versioning;
 using System;
 using System.IO;
 using System.Linq;
@@ -51,68 +50,6 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             return !Log.HasLoggedErrors;
-        }
-    }
-
-    public class UpdatePrereleaseDependencies : UpdateProjectDependencies
-    {
-        [Required]
-        public string OldPrerelease { get; set; }
-
-        [Required]
-        public string NewPrerelease { get; set; }
-
-        public override bool UpdatePackage(JProperty package, string projectJsonPath)
-        {
-            var dependencyIdentifier = package.Name;
-            var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());
-            var dependencyVersion = dependencyVersionRange.MinVersion;
-
-            if (dependencyVersion.Release == OldPrerelease)
-            {
-                Log.LogMessage(
-                    "Changing {0} {1} to {2} in {3}",
-                    dependencyIdentifier,
-                    dependencyVersion,
-                    NewPrerelease,
-                    projectJsonPath);
-
-                package.Value = dependencyVersionRange.OriginalString.Replace(OldPrerelease, NewPrerelease);
-                return true;
-            }
-            return false;
-        }
-    }
-
-    public class UpdatePackageDependencyVersion : UpdateProjectDependencies
-    {
-        [Required]
-        public string PackageId { get; set; }
-
-        [Required]
-        public string OldVersion { get; set; }
-
-        [Required]
-        public string NewVersion { get; set; }
-
-        public override bool UpdatePackage(JProperty package, string projectJsonPath)
-        {
-            var dependencyIdentifier = package.Name;
-            var dependencyVersion = package.Value.ToObject<string>();
-
-            if (dependencyIdentifier == PackageId && dependencyVersion == OldVersion)
-            {
-                Log.LogMessage(
-                    "Changing {0} {1} to {2} in {3}",
-                    dependencyIdentifier,
-                    dependencyVersion,
-                    NewVersion,
-                    projectJsonPath);
-
-                package.Value = NewVersion;
-                return true;
-            }
-            return false;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
@@ -26,16 +26,22 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-            bool anyPrereleaseUpdateParams = new[] { OldPrerelease, NewPrerelease }.Any(s => !string.IsNullOrEmpty(s));
-            bool anyVersionUpdateParams = new[] { PackageId, OldVersion, NewVersion }.Any(s => !string.IsNullOrEmpty(s));
+            var prereleaseUpdateParams = new[] { OldPrerelease, NewPrerelease }
+                .Select(param => !string.IsNullOrEmpty(param));
+
+            var versionUpdateParams = new[] { PackageId, OldVersion, NewVersion }
+                .Select(param => !string.IsNullOrEmpty(param));
+
+            bool anyPrereleaseUpdateParams = prereleaseUpdateParams.Any(p => p);
+            bool anyVersionUpdateParams = versionUpdateParams.Any(p => p);
 
             if (anyPrereleaseUpdateParams ^ anyVersionUpdateParams)
             {
-                if (new[] { OldPrerelease, NewPrerelease }.All(s => !string.IsNullOrEmpty(s)))
+                if (prereleaseUpdateParams.All(p => p))
                 {
                     ReplacePrerelease();
                 }
-                else if (new[] { PackageId, OldVersion, NewVersion }.All(s => !string.IsNullOrEmpty(s)))
+                else if (versionUpdateParams.All(p => p))
                 {
                     ReplacePackageVersion();
                 }

--- a/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
@@ -9,125 +9,14 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class UpdateProjectDependencies : Task
+    public abstract class UpdateProjectDependencies : Task
     {
         [Required]
-        public ITaskItem ProjectJson { get; set; }
+        public ITaskItem[] ProjectJsons { get; set; }
 
-        public string OldPrerelease { get; set; }
-
-        public string NewPrerelease { get; set; }
-
-        public string PackageId { get; set; }
-
-        public string OldVersion { get; set; }
-
-        public string NewVersion { get; set; }
-
-        public override bool Execute()
+        private static JObject ReadProject(string projectJsonPath)
         {
-            var prereleaseUpdateParams = new[] { OldPrerelease, NewPrerelease }
-                .Select(param => !string.IsNullOrEmpty(param));
-
-            var versionUpdateParams = new[] { PackageId, OldVersion, NewVersion }
-                .Select(param => !string.IsNullOrEmpty(param));
-
-            bool anyPrereleaseUpdateParams = prereleaseUpdateParams.Any(p => p);
-            bool anyVersionUpdateParams = versionUpdateParams.Any(p => p);
-
-            if (anyPrereleaseUpdateParams ^ anyVersionUpdateParams)
-            {
-                if (prereleaseUpdateParams.All(p => p))
-                {
-                    ReplacePrerelease();
-                }
-                else if (versionUpdateParams.All(p => p))
-                {
-                    ReplacePackageVersion();
-                }
-                else
-                {
-                    if (anyPrereleaseUpdateParams)
-                    {
-                        Log.LogError("Not all properties found: expected (OldPrerelease, NewPrerelease)");
-                    }
-                    else
-                    {
-                        Log.LogError("Not all properties found: expected (PackageId, OldVersion, NewVersion)");
-                    }
-                }
-            }
-            else
-            {
-                Log.LogError(
-                    "Expected properties from one of (OldPrerelease, NewPrerelease) or (PackageId, OldVersion, NewVersion) but found {0}.",
-                    (anyPrereleaseUpdateParams && anyVersionUpdateParams) ? "properties from both" : "none");
-            }
-            return !Log.HasLoggedErrors;
-        }
-
-        public void ReplacePrerelease()
-        {
-            JObject projectRoot = ReadProject();
-            bool changed = false;
-
-            foreach (var package in projectRoot["dependencies"].OfType<JProperty>())
-            {
-                var dependencyIdentifier = package.Name;
-                var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());
-                var dependencyVersion = dependencyVersionRange.MinVersion;
-
-                if (dependencyVersion.Release == OldPrerelease)
-                {
-                    Log.LogMessage(
-                        "Changing {0} {1} to {2} in {3}",
-                        dependencyIdentifier,
-                        dependencyVersion,
-                        NewPrerelease,
-                        ProjectJson);
-
-                    package.Value = dependencyVersionRange.OriginalString.Replace(OldPrerelease, NewPrerelease);
-                    changed = true;
-                }
-            }
-            if (changed)
-            {
-                WriteProject(projectRoot);
-            }
-        }
-
-        public void ReplacePackageVersion()
-        {
-            JObject projectRoot = ReadProject();
-            bool changed = false;
-
-            foreach (var package in projectRoot["dependencies"].OfType<JProperty>())
-            {
-                var dependencyIdentifier = package.Name;
-                var dependencyVersion = package.Value.ToObject<string>();
-
-                if (dependencyIdentifier == PackageId && dependencyVersion == OldVersion)
-                {
-                    Log.LogMessage(
-                        "Changing {0} {1} to {2} in {3}",
-                        dependencyIdentifier,
-                        dependencyVersion,
-                        NewVersion,
-                        ProjectJson);
-
-                    package.Value = NewVersion;
-                    changed = true;
-                }
-            }
-            if (changed)
-            {
-                WriteProject(projectRoot);
-            }
-        }
-
-        public JObject ReadProject()
-        {
-            using (TextReader projectFileReader = File.OpenText(ProjectJson.ItemSpec))
+            using (TextReader projectFileReader = File.OpenText(projectJsonPath))
             {
                 var projectJsonReader = new JsonTextReader(projectFileReader);
 
@@ -136,11 +25,94 @@ namespace Microsoft.DotNet.Build.Tasks
             }
         }
 
-        public void WriteProject(JObject projectRoot)
+        private static void WriteProject(JObject projectRoot, string projectJsonPath)
         {
             string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
 
-            File.WriteAllText(ProjectJson.ItemSpec, projectJson + Environment.NewLine);
+            File.WriteAllText(projectJsonPath, projectJson + Environment.NewLine);
+        }
+
+        public abstract bool UpdatePackage(JProperty package, string projectJsonPath);
+
+        public override bool Execute()
+        {
+            foreach (var projectJsonPath in ProjectJsons.Select(item => item.ItemSpec))
+            {
+                JObject projectRoot = ReadProject(projectJsonPath);
+
+                bool changedAnyPackage = projectRoot["dependencies"]
+                    .OfType<JProperty>()
+                    .Any(package => UpdatePackage(package, projectJsonPath));
+
+                if (changedAnyPackage)
+                {
+                    WriteProject(projectRoot, projectJsonPath);
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+
+    public class UpdatePrereleaseDependencies : UpdateProjectDependencies
+    {
+        [Required]
+        public string OldPrerelease { get; set; }
+
+        [Required]
+        public string NewPrerelease { get; set; }
+
+        public override bool UpdatePackage(JProperty package, string projectJsonPath)
+        {
+            var dependencyIdentifier = package.Name;
+            var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());
+            var dependencyVersion = dependencyVersionRange.MinVersion;
+
+            if (dependencyVersion.Release == OldPrerelease)
+            {
+                Log.LogMessage(
+                    "Changing {0} {1} to {2} in {3}",
+                    dependencyIdentifier,
+                    dependencyVersion,
+                    NewPrerelease,
+                    projectJsonPath);
+
+                package.Value = dependencyVersionRange.OriginalString.Replace(OldPrerelease, NewPrerelease);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public class UpdatePackageDependencyVersion : UpdateProjectDependencies
+    {
+        [Required]
+        public string PackageId { get; set; }
+
+        [Required]
+        public string OldVersion { get; set; }
+
+        [Required]
+        public string NewVersion { get; set; }
+
+        public override bool UpdatePackage(JProperty package, string projectJsonPath)
+        {
+            var dependencyIdentifier = package.Name;
+            var dependencyVersion = package.Value.ToObject<string>();
+
+            if (dependencyIdentifier == PackageId && dependencyVersion == OldVersion)
+            {
+                Log.LogMessage(
+                    "Changing {0} {1} to {2} in {3}",
+                    dependencyIdentifier,
+                    dependencyVersion,
+                    NewVersion,
+                    projectJsonPath);
+
+                package.Value = NewVersion;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdateProjectDependencies.cs
@@ -1,0 +1,126 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class UpdateProjectDependencies : Task
+    {
+        [Required]
+        public ITaskItem ProjectJson { get; set; }
+
+        public string OldPrerelease { get; set; }
+
+        public string NewPrerelease { get; set; }
+
+        public string PackageId { get; set; }
+
+        public string OldVersion { get; set; }
+
+        public string NewVersion { get; set; }
+
+        public override bool Execute()
+        {
+            if (new[] { OldPrerelease, NewPrerelease }.All(s => !string.IsNullOrEmpty(s)))
+            {
+                ReplacePrerelease();
+            }
+            if (new[] { PackageId, OldVersion, NewVersion }.All(s => !string.IsNullOrEmpty(s)))
+            {
+                ReplacePackageVersion();
+            }
+            return !Log.HasLoggedErrors;
+        }
+
+        public void ReplacePrerelease()
+        {
+            Log.LogMessage(
+                "Changing all packages with prerelease {0} to prerelease {1} in {2}",
+                OldPrerelease,
+                NewPrerelease,
+                ProjectJson.ItemSpec);
+
+            JObject projectRoot = ReadProject();
+            bool changed = false;
+
+            foreach (var package in projectRoot["dependencies"].OfType<JProperty>())
+            {
+                var dependencyIdentifier = package.Name;
+                var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());
+                var dependencyVersion = dependencyVersionRange.MinVersion;
+
+                if (dependencyVersion.Release == OldPrerelease)
+                {
+                    Log.LogMessage(
+                        "Changing {0} {1}",
+                        dependencyIdentifier,
+                        dependencyVersion);
+
+                    package.Value = dependencyVersionRange.OriginalString.Replace(OldPrerelease, NewPrerelease);
+                    changed = true;
+                }
+            }
+            if (changed)
+            {
+                WriteProject(projectRoot);
+            }
+        }
+
+        public void ReplacePackageVersion()
+        {
+            Log.LogMessage(
+                "Changing {0} version {1} to version {2} in {3}",
+                PackageId,
+                OldVersion,
+                NewVersion,
+                ProjectJson.ItemSpec);
+
+            JObject projectRoot = ReadProject();
+            bool changed = false;
+
+            foreach (var package in projectRoot["dependencies"].OfType<JProperty>())
+            {
+                var dependencyIdentifier = package.Name;
+                var dependencyVersion = package.Value.ToObject<string>();
+
+                if (dependencyIdentifier == PackageId && dependencyVersion == OldVersion)
+                {
+                    Log.LogMessage(
+                        "Changing {0} {1}",
+                        dependencyIdentifier,
+                        dependencyVersion);
+
+                    package.Value = NewVersion;
+                    changed = true;
+                }
+            }
+            if (changed)
+            {
+                WriteProject(projectRoot);
+            }
+        }
+
+        public JObject ReadProject()
+        {
+            using (TextReader projectFileReader = File.OpenText(ProjectJson.ItemSpec))
+            {
+                var projectJsonReader = new JsonTextReader(projectFileReader);
+
+                var serializer = new JsonSerializer();
+                return serializer.Deserialize<JObject>(projectJsonReader);
+            }
+        }
+
+        public void WriteProject(JObject projectRoot)
+        {
+            string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
+
+            File.WriteAllText(ProjectJson.ItemSpec, projectJson + Environment.NewLine);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
@@ -3,6 +3,7 @@ using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Versioning;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -11,28 +12,75 @@ namespace Microsoft.DotNet.Build.Tasks
 {
     public class ValidateProjectDependencyVersions : Task
     {
+        private class ValidationPattern
+        {
+            private Regex _idPattern;
+            private string _expectedVersion;
+            private string _expectedPrerelease;
+
+            public ValidationPattern(ITaskItem item)
+            {
+                _idPattern = new Regex(item.ItemSpec);
+                _expectedVersion = item.GetMetadata("ExpectedVersion");
+                _expectedPrerelease = item.GetMetadata("ExpectedPrerelease");
+
+                if (string.IsNullOrWhiteSpace(_expectedVersion))
+                {
+                    if (string.IsNullOrWhiteSpace(_expectedPrerelease))
+                    {
+                        throw new ArgumentException(string.Format(
+                            "Can't find ExpectedVersion or ExpectedPrerelease metadata on item {0}",
+                            item.ItemSpec));
+                    }
+                }
+                else if (!string.IsNullOrWhiteSpace(_expectedPrerelease))
+                {
+                    throw new ArgumentException(string.Format(
+                        "Both ExpectedVersion and ExpectedPrerelease metadata found on item {0}, but only one permitted",
+                        item.ItemSpec));
+                }
+            }
+
+            public string FindValidationError(string packageId, string version)
+            {
+                var dependencyVersionRange = VersionRange.Parse(version);
+                NuGetVersion dependencyVersion = dependencyVersionRange.MinVersion;
+
+                if (_idPattern.IsMatch(packageId))
+                {
+                    if (!string.IsNullOrWhiteSpace(_expectedVersion) && _expectedVersion != version)
+                    {
+                        return string.Format(
+                            "package version '{0}', but expected '{1}' for packages matching '{2}'",
+                            version,
+                            _expectedVersion,
+                            _idPattern);
+                    }
+                    if (!string.IsNullOrWhiteSpace(_expectedPrerelease) &&
+                        dependencyVersion.IsPrerelease &&
+                        _expectedPrerelease != dependencyVersion.Release)
+                    {
+                        return string.Format(
+                            "package prerelease '{0}', but expected '{1}' for packages matching '{2}'",
+                            dependencyVersion.Release,
+                            _expectedPrerelease,
+                            _idPattern);
+                    }
+                }
+                return null;
+            }
+        }
+
         [Required]
         public ITaskItem ProjectJson { get; set; }
 
-        public string ValidPrereleaseVersion { get; set; }
+        public bool ProhibitFloatingDependencies { get; set; }
 
-        public bool FloatingDependenciesInvalid { get; set; }
-
-        public string OurPackageIdentities { get; set; }
+        public ITaskItem[] ValidationPatterns { get; set; }
 
         public override bool Execute()
         {
-            Regex ourPackageRegex = null;
-            if (!string.IsNullOrEmpty(OurPackageIdentities))
-            {
-                ourPackageRegex = new Regex(OurPackageIdentities);
-            }
-
-            Log.LogMessage(
-                "Checking {0}, valid prerelease {1} matching our packages with {2}",
-                ProjectJson.ItemSpec,
-                ValidPrereleaseVersion,
-                OurPackageIdentities);
+            var patterns = ValidationPatterns.Select(item => new ValidationPattern(item));
 
             using (TextReader projectFileReader = File.OpenText(ProjectJson.ItemSpec))
             {
@@ -43,31 +91,32 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 foreach (var package in projectRoot["dependencies"].OfType<JProperty>())
                 {
-                    var dependencyIdentifier = package.Name;
-                    var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());
-                    var dependencyVersion = dependencyVersionRange.MinVersion;
+                    string id = package.Name;
+                    string version = package.Value.ToObject<string>();
 
                     string versionMessage = string.Format(
                         "{0} {1} in {2}",
-                        dependencyIdentifier,
-                        dependencyVersionRange.OriginalString,
+                        id,
+                        version,
                         ProjectJson);
 
-                    if (FloatingDependenciesInvalid && dependencyVersionRange.OriginalString.Contains('*'))
+                    if (ProhibitFloatingDependencies && version.Contains('*'))
                     {
                         Log.LogError("Floating dependency detected: {0}", versionMessage);
                     }
-                    else if (dependencyVersion.IsPrerelease &&
-                        ourPackageRegex != null &&
-                        ourPackageRegex.IsMatch(dependencyIdentifier) &&
-                        !string.IsNullOrEmpty(ValidPrereleaseVersion) &&
-                        ValidPrereleaseVersion != dependencyVersion.Release)
+                    else
                     {
-                        Log.LogError(
-                            "Expected '{0}' for owned prerelease dependencies, but found '{1}' for {2}",
-                            ValidPrereleaseVersion,
-                            dependencyVersion.Release,
-                            versionMessage);
+                        string validationError = patterns
+                            .Select(pattern => pattern.FindValidationError(id, version))
+                            .FirstOrDefault(error => error != null);
+
+                        if (validationError != null)
+                        {
+                            Log.LogError(
+                                "Dependency validation error: {0} for {1}",
+                                validationError,
+                                versionMessage);
+                        }
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class ValidateProjectDependencyVersions : Task
+    {
+        [Required]
+        public ITaskItem ProjectJson { get; set; }
+
+        public string ValidPrereleaseVersion { get; set; }
+
+        public bool FloatingDependenciesInvalid { get; set; }
+
+        public string OurPackageIdentities { get; set; }
+
+        public override bool Execute()
+        {
+            Regex ourPackageRegex = null;
+            if (!string.IsNullOrEmpty(OurPackageIdentities))
+            {
+                ourPackageRegex = new Regex(OurPackageIdentities);
+            }
+
+            Log.LogMessage(
+                "Checking {0}, valid prerelease {1} matching our packages with {2}",
+                ProjectJson.ItemSpec,
+                ValidPrereleaseVersion,
+                OurPackageIdentities);
+
+            using (TextReader projectFileReader = File.OpenText(ProjectJson.ItemSpec))
+            {
+                var projectJsonReader = new JsonTextReader(projectFileReader);
+
+                var serializer = new JsonSerializer();
+                JObject projectRoot = serializer.Deserialize<JObject>(projectJsonReader);
+
+                foreach (var package in projectRoot["dependencies"].OfType<JProperty>())
+                {
+                    var dependencyIdentifier = package.Name;
+                    var dependencyVersionRange = VersionRange.Parse(package.Value.ToObject<string>());
+                    var dependencyVersion = dependencyVersionRange.MinVersion;
+
+                    string versionMessage = string.Format(
+                        "{0} {1} in {2}",
+                        dependencyIdentifier,
+                        dependencyVersionRange.OriginalString,
+                        ProjectJson);
+
+                    if (FloatingDependenciesInvalid && dependencyVersionRange.OriginalString.Contains('*'))
+                    {
+                        Log.LogError("Floating dependency detected: {0}", versionMessage);
+                    }
+                    else if (dependencyVersion.IsPrerelease &&
+                        ourPackageRegex != null &&
+                        ourPackageRegex.IsMatch(dependencyIdentifier) &&
+                        !string.IsNullOrEmpty(ValidPrereleaseVersion) &&
+                        ValidPrereleaseVersion != dependencyVersion.Release)
+                    {
+                        Log.LogError(
+                            "Expected '{0}' for owned prerelease dependencies, but found '{1}' for {2}",
+                            ValidPrereleaseVersion,
+                            dependencyVersion.Release,
+                            versionMessage);
+                    }
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
@@ -96,7 +96,13 @@ namespace Microsoft.DotNet.Build.Tasks
                 var serializer = new JsonSerializer();
                 JObject projectRoot = serializer.Deserialize<JObject>(projectJsonReader);
 
-                foreach (var package in projectRoot["dependencies"].OfType<JProperty>())
+                var dependencyObjects = projectRoot
+                    .Descendants()
+                    .OfType<JProperty>()
+                    .Where(property => property.Name == "dependencies")
+                    .Select(property => property.Value);
+
+                foreach (var package in dependencyObjects.SelectMany(o => o.Children<JProperty>()))
                 {
                     string id = package.Name;
                     string version = package.Value.ToObject<string>();

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -13,7 +13,8 @@
     "System.Xml.XPath.XmlDocument": "4.0.0",
     "System.Reflection": "4.0.10",
     "System.Reflection.Metadata": "1.1.0-alpha-*",
-    "Newtonsoft.Json": "7.0.1"
+    "Newtonsoft.Json": "7.0.1",
+    "NuGet.Versioning": "3.3.0"
   },
   "frameworks": {
     "dnxcore50": { }

--- a/src/Microsoft.DotNet.Build.Tasks/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.lock.json
@@ -176,6 +176,23 @@
           "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll": {}
         }
       },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-23109",
+          "System.Diagnostics.Tools": "4.0.0-beta-23109",
+          "System.Linq": "4.0.0-beta-23109",
+          "System.Reflection": "4.0.10-beta-23109",
+          "System.Resources.ResourceManager": "4.0.0-beta-23109",
+          "System.Runtime.Extensions": "4.0.10-beta-23109"
+        },
+        "compile": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        }
+      },
       "NuProj/0.10.4-beta-gf7fc34e7d8": {
         "type": "package"
       },
@@ -307,6 +324,18 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-23109": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23109"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
@@ -1151,6 +1180,23 @@
           "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll": {}
         }
       },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-23109",
+          "System.Diagnostics.Tools": "4.0.0-beta-23109",
+          "System.Linq": "4.0.0-beta-23109",
+          "System.Reflection": "4.0.10-beta-23109",
+          "System.Resources.ResourceManager": "4.0.0-beta-23109",
+          "System.Runtime.Extensions": "4.0.10-beta-23109"
+        },
+        "compile": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        }
+      },
       "NuProj/0.10.4-beta-gf7fc34e7d8": {
         "type": "package"
       },
@@ -1347,6 +1393,18 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-23109": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23109"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
@@ -2267,6 +2325,23 @@
           "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll": {}
         }
       },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-23109",
+          "System.Diagnostics.Tools": "4.0.0-beta-23109",
+          "System.Linq": "4.0.0-beta-23109",
+          "System.Reflection": "4.0.10-beta-23109",
+          "System.Resources.ResourceManager": "4.0.0-beta-23109",
+          "System.Runtime.Extensions": "4.0.10-beta-23109"
+        },
+        "compile": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        }
+      },
       "NuProj/0.10.4-beta-gf7fc34e7d8": {
         "type": "package"
       },
@@ -2463,6 +2538,18 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-23109": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23109"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
@@ -3383,6 +3470,23 @@
           "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll": {}
         }
       },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-23109",
+          "System.Diagnostics.Tools": "4.0.0-beta-23109",
+          "System.Linq": "4.0.0-beta-23109",
+          "System.Reflection": "4.0.10-beta-23109",
+          "System.Resources.ResourceManager": "4.0.0-beta-23109",
+          "System.Runtime.Extensions": "4.0.10-beta-23109"
+        },
+        "compile": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        }
+      },
       "NuProj/0.10.4-beta-gf7fc34e7d8": {
         "type": "package"
       },
@@ -3579,6 +3683,18 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-23109": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23109"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
@@ -4477,6 +4593,23 @@
           "lib/portable-net45+wp80+win8+wpa81+dnxcore50/Newtonsoft.Json.dll": {}
         }
       },
+      "NuGet.Versioning/3.3.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10-beta-23109",
+          "System.Diagnostics.Tools": "4.0.0-beta-23109",
+          "System.Linq": "4.0.0-beta-23109",
+          "System.Reflection": "4.0.10-beta-23109",
+          "System.Resources.ResourceManager": "4.0.0-beta-23109",
+          "System.Runtime.Extensions": "4.0.10-beta-23109"
+        },
+        "compile": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        },
+        "runtime": {
+          "lib/dnxcore50/NuGet.Versioning.dll": {}
+        }
+      },
       "NuProj/0.10.4-beta-gf7fc34e7d8": {
         "type": "package"
       },
@@ -4673,6 +4806,18 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-23109": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23109"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
@@ -5551,6 +5696,19 @@
         "tools/install.ps1"
       ]
     },
+    "NuGet.Versioning/3.3.0": {
+      "type": "package",
+      "sha512": "f87vlVEFb4TyAqE7cpv4uX2cZkg70NeyzSTJ0D1w9kaGiYNv4l9/niKpuF8ek3PUAYCau+3YnxEp1wswVvWgAQ==",
+      "files": [
+        "lib/dnxcore50/NuGet.Versioning.dll",
+        "lib/dnxcore50/NuGet.Versioning.xml",
+        "lib/net45/NuGet.Versioning.dll",
+        "lib/net45/NuGet.Versioning.xml",
+        "NuGet.Versioning.3.3.0.nupkg",
+        "NuGet.Versioning.3.3.0.nupkg.sha512",
+        "NuGet.Versioning.nuspec"
+      ]
+    },
     "NuProj/0.10.4-beta-gf7fc34e7d8": {
       "type": "package",
       "sha512": "E/xNhHQo+9XbojAxgMUlo0d0tLS8kIeXKCiNnuWIZjNdygX2e0AszBkhqmHeCnOvHeJl0d+vUUidx55bspHwaw==",
@@ -5900,6 +6058,40 @@
         "System.Diagnostics.Process.4.0.0-beta-23123.nupkg",
         "System.Diagnostics.Process.4.0.0-beta-23123.nupkg.sha512",
         "System.Diagnostics.Process.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tools/4.0.0-beta-23109": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "6tFdP3p3SV6DZOagwW5ThfUF+zp5pUIyW4CY2K4B2RxV6HGVyY/8J2EuZGrcEP3wdO5fXnb9MmdOZa5Tn01Hmg==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tools.xml",
+        "ref/dotnet/it/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.4.0.0-beta-23109.nupkg",
+        "System.Diagnostics.Tools.4.0.0-beta-23109.nupkg.sha512",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.TraceSource/4.0.0-beta-23019": {
@@ -7470,7 +7662,8 @@
       "System.Xml.XPath.XmlDocument >= 4.0.0",
       "System.Reflection >= 4.0.10",
       "System.Reflection.Metadata >= 1.1.0-alpha-*",
-      "Newtonsoft.Json >= 7.0.1"
+      "Newtonsoft.Json >= 7.0.1",
+      "NuGet.Versioning >= 3.3.0"
     ],
     "DNXCore,Version=v5.0": []
   }


### PR DESCRIPTION
This adds a new target `ValidatePackageVersions` and two tasks `UpdatePrereleaseDependencies` and `UpdatePackageDependencyVersion`. This diff shows what I needed to do to use them in corefx: https://github.com/dotnet/corefx/compare/master...dagood:dagood/no-lockfile-tooling

(Note: this adds a NuGet source of the nugetbuild MyGet repository to `dir.props` for `NuGet.Versioning`, but it was already in `src/NuGet.config` anyway.)

---

`ValidatePackageVersions` runs after `ResolveNuGetPackages` and can check all project.json files for `*` (floating) dependencies and/or can make sure all packages match a given prerelease version. What it does depends on the properties/item collections when the target is run. By default, the task runs but no validation happens when no properties are passed.

This is what I added to corefx to configure validation: https://github.com/dotnet/corefx/compare/master...dagood:dagood/no-lockfile-tooling#diff-0b192804a6349e8c26d2b027afbd89a2R60

This adds some confidence that `project.json` dependencies don't get out of sync and enforces the new update workflow.

---

`UpdatePrereleaseDependencies` is a task that rewrites given project.json files with specified changes. After adding a task to `build.proj` in corefx, example usage:

    msbuild /t:UpdatePrereleaseDependencies /p:OldPrerelease=beta-45678;NewPrerelease=beta-45679

Updates *all packages* of version `*-beta-45678` to `*-beta-45679`.

---

`UpdatePackageDependencyVersion` rewrites given project.json files to replace exact matches of PackageId of OldVersion to NewVersion. Using a task added to `build.proj` in corefx:

    msbuild /t:UpdatePackageDependencyVersion /p:PackageId=xunit;OldVersion=2.0.0;NewVersion=2.1.0

Updates all dependencies on `xunit 2.0.0` to `xunit 2.1.0` in all project.json files.

---

The purpose of the update tasks is to have a way to update all package versions across the repository that's an easy alternative to `*` dependencies, even when upgrades need to happen often. (Where previously we would use `*` dependencies and relock.) Without `*` dependencies we no longer need the lockfile in source control to have a repeatable build.

/cc @weshaggard @ericstj 