### PR TITLE
Add support for filtering resolved packages from targeting packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -96,4 +96,22 @@
     <Message Text="Excluding @(_ReferenceFileNamesToRemove);@(_ReferenceCopyLocalPathsFileNamesToRemove) from package references since the same file is provided by a project refrence."
              Condition="'@(_ReferenceFileNamesToRemove)' != '' or '@(_ReferenceCopyLocalPathsFileNamesToRemove)' != ''"/>
   </Target>
+
+  <Target Name="FilterTargetingPackResolvedNugetPackages" AfterTargets="ResolveNuGetPackages"
+   	       Condition="'$(TargetingPackNugetPackageId)' != ''">
+
+    <ItemGroup>
+      <ResolvedTargetingPackReference Include="@(Reference)" Condition="'%(Reference.NuGetPackageId)' == '$(TargetingPackNugetPackageId)'"  />
+      <ResolvedTargetingPackReferenceFilename Include="@(ResolvedTargetingPackReference -> '%(Filename)')">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </ResolvedTargetingPackReferenceFilename>
+      <ResolvedTargetingPackReferenceFilename Remove="@(TargetingPackReference)"  /> 
+
+      <PackageReferencesToRemove Include="@(ResolvedTargetingPackReferenceFilename -> '%(OriginalIdentity)')" />
+      <Reference Remove="@(PackageReferencesToRemove)" />
+    </ItemGroup>
+
+    <Message Importance="Low" 
+        Text="Removed all ResolvedTagetingPackReferences that were not specified explicitly as a TargetingPackReference=[@(TargetingPackReference)]. PackageReferencesToRemove=[@(PackageReferencesToRemove)]." />
+  </Target>
 </Project>


### PR DESCRIPTION
This add support for filtering out resolved assets from the
targeting pack packages. It does this based on the following property
TargetingPackNugetPackageId which is set to the id of the package
to filter. It will remove any packages references from that package
except for the ones explicitly listed in the TargetingPackageReference
item group.

cc @mellinoe @ericstj 