### PR TITLE
Add initial support for reporting build statistic.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -23,19 +23,27 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\common\AssemblyResolver.cs" />
     <Compile Include="CreateAzureContainer.cs" />
     <Compile Include="CreateAzureFileShare.cs" />
     <Compile Include="GetPerfTestAssemblies.cs" />
+    <Compile Include="SendJsonToDocumentDb.cs" />
     <Compile Include="SendToEventHub.cs" />
     <Compile Include="UploadToAzure.cs" />
+    <Compile Include="WriteBuildStatsJson.cs" />
     <Compile Include="WriteItemsToJson.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Azure.Documents.Client">
+      <HintPath>..\..\packages\Microsoft.Azure.DocumentDB.1.5.1\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Build.Tasks.v4.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="mscorlib" />
     <Reference Include="Microsoft.Build.Framework, Version=4.0.0.0" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Reflection.Metadata">
       <HintPath>..\..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -3,9 +3,11 @@
   <UsingTask TaskName="CreateAzureContainer" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="CreateAzureFileShare" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="GetPerfTestAssemblies" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="SendJsonToDocumentDb" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="SendToEventHub" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="UploadToAzure" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="WriteItemsToJson" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="WriteTestBuildStatsJson" AssemblyFile="$(ToolsDir)net45\Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
@@ -19,6 +21,7 @@
     <PackagesArchiveFile>$(ArchivesRoot)$(PackagesArchiveFilename)</PackagesArchiveFile>
     <FuncTestListFile>$(TestWorkingDir)$(OSPlatformConfig)\$(FuncTestListFilename)</FuncTestListFile>
     <PerfTestListFile>$(TestWorkingDir)$(OSPlatformConfig)\$(PerfTestListFilename)</PerfTestListFile>
+    <BuildStatsJsonFile>$(TestWorkingDir)$(OSPlatformConfig)\BuildStats.json</BuildStatsJsonFile>
   </PropertyGroup>
 
   <!-- main entrypoint -->
@@ -44,6 +47,8 @@
     <Error Condition="'$(FileShareAccessToken)' == ''" Text="Missing required property FileShareAccessToken." />
     <Error Condition="'$(BuildCompleteConnection)' == ''" Text="Missing required property BuildCompleteConnection." />
     <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(BuildIsOfficialConnection)' == ''" Text="Missing required property BuildIsOfficialConnection." />
+    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(DocumentDbKey)' == ''" Text="Missing required property DocumentDbKey." />
+    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(DocumentDbUri)' == ''" Text="Missing required property DocumentDbUri." />
     <!-- verify the test archives were created -->
     <Error Condition="'@(ForUpload->Count())' == '0'" Text="Didn't find any test archives in '$(ArchivesRoot)'." />
     <!-- add relative blob path metadata -->
@@ -94,7 +99,7 @@
     <ItemGroup>
       <FunctionalTest>
         <Command>%HELIX_PYTHONPATH% %HELIX_SCRIPT_ROOT%\xunitrunner.py --dll %(Filename).dll -- -notrait category=nonwindowstests</Command>
-        <CorrelationPayloadUris>[$(DropUri)$(Platform)$(ConfigurationGroup)/Packages.zip$(DropUriReadOnlyToken);;http://dotnetbuildscripts.blob.core.windows.net/scripts/xunit_210.zip;;http://dotnetbuildscripts.blob.core.windows.net/scripts/amd64ret/corerun.zip]</CorrelationPayloadUris>
+        <CorrelationPayloadUris>[$(DropUri)$(Platform)$(ConfigurationGroup)/Packages.zip$(DropUriReadOnlyToken)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>FunctionalTest.%(Filename)</WorkItemId>
       </FunctionalTest>
@@ -131,7 +136,7 @@
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest>
         <Command>%HELIX_PYTHONPATH% %HELIX_SCRIPT_ROOT%\xunitrunner.py --dll %(Filename).dll --perf-runner Microsoft.DotNet.xunit.performance.runner.Windows -- -notrait category=nonwindowstests</Command>
-        <CorrelationPayloadUris>[$(DropUri)$(Platform)$(ConfigurationGroup)/Packages.zip$(DropUriReadOnlyToken);;http://dotnetbuildscripts.blob.core.windows.net/scripts/xunit_210.zip;;http://dotnetbuildscripts.blob.core.windows.net/scripts/amd64ret/corerun.zip]</CorrelationPayloadUris>
+        <CorrelationPayloadUris>[$(DropUri)$(Platform)$(ConfigurationGroup)/Packages.zip$(DropUriReadOnlyToken)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>PerfTest.%(Filename)</WorkItemId>
         <TimeoutInSeconds>600</TimeoutInSeconds>
@@ -215,6 +220,17 @@
       </OfficialBuild>
     </ItemGroup>
     <WriteItemsToJson JsonFileName="%(TestListFile.OfficialBuildJson)" Items="@(OfficialBuild)" />
+    <!-- write out build statistics (only contains number of built projects at present) -->
+    <ItemGroup>
+      <BuiltSuccessfully Include="$(TestArchivesRoot)*.zip" />
+    </ItemGroup>
+    <WriteTestBuildStatsJson
+      CorrelationIds="@(TestListFile->'%(CorrelationId)')"
+      LogUri="none"
+      OutputFile="$(BuildStatsJsonFile)"
+      ProjectsBuiltCount="@(BuiltSuccessfully->Count())"
+      ProjectsFailed="@(FailedToBuild)"
+      TestCount="0" />
   </Target>
 
   <!-- send completion events -->
@@ -233,6 +249,14 @@
       EventHubPath="clrstats-events"
       EventData="%(TestListFile.OfficialBuildJson)"
       PartitionKey="%(TestListFile.CorrelationId)"/>
+    <SendJsonToDocumentDb
+      Condition="'$(BuildIsOfficial)' == 'true'"
+      AccountKey="$(DocumentDbKey)"
+      Collection="ExecutionSummary"
+      Database="HelixMonitoringService"
+      DocumentId="Build|%(TestListFile.CorrelationId)"
+      EndpointUri="$(DocumentDbUri)"
+      JsonFile="$(BuildStatsJsonFile)" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/SendJsonToDocumentDb.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/SendJsonToDocumentDb.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Common.Desktop;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    /// <summary>
+    /// Used to send JSON blobs to DocumentDb.
+    /// </summary>
+    public class SendJsonToDocumentDb : Task
+    {
+        /// <summary>
+        /// The account key used to connect to DocumentDB.
+        /// </summary>
+        [Required]
+        public string AccountKey { get; set; }
+
+        /// <summary>
+        /// The name of the document collection.
+        /// </summary>
+        [Required]
+        public string Collection { get; set; }
+
+        /// <summary>
+        /// The name of the document database.
+        /// </summary>
+        [Required]
+        public string Database { get; set; }
+
+        /// <summary>
+        /// The ID of the document to be created.
+        /// </summary>
+        [Required]
+        public string DocumentId { get; set; }
+
+        /// <summary>
+        /// The DocumentDB endpont URI.
+        /// </summary>
+        [Required]
+        public string EndpointUri { get; set; }
+
+        /// <summary>
+        /// The JSON file to be uploaded.
+        /// </summary>
+        [Required]
+        public string JsonFile { get; set; }
+
+        static SendJsonToDocumentDb()
+        {
+            AssemblyResolver.Enable();
+        }
+
+        public override bool Execute()
+        {
+            // load the JSON file
+            JObject json;
+
+            using (StreamReader streamReader = new StreamReader(JsonFile))
+            using (JsonTextReader jsonReader = new JsonTextReader(streamReader))
+            {
+                var jsonSerializer = new JsonSerializer();
+                json = (JObject)jsonSerializer.Deserialize(jsonReader);
+
+                // add the document ID to the JSON blob
+                json.Add("id", DocumentId);
+            }
+
+            using (var con = CreateDocumentDbConnection())
+            {
+                // for specified document ID check if there is a document for it, if there
+                // isn't then create a new one with the JSON blob that was loaded earlier.
+
+                var result = con.Client.CreateDocumentQuery(string.Format("dbs/{0}/colls/{1}", con.Database.Id, con.Collection.Id))
+                    .Where(doc => doc.Id == DocumentId)
+                    .AsEnumerable()
+                    .FirstOrDefault();
+
+                if (result == null)
+                {
+                    Log.LogMessage(MessageImportance.Normal, "Creating new document with ID '{0}'", DocumentId);
+                    con.Client.CreateDocumentAsync(con.Collection.SelfLink, json).Wait();
+                }
+                else
+                {
+                    Log.LogWarning("A document with ID '{0}' already exists, no content was uploaded.", DocumentId);
+                }
+            }
+
+            return true;
+        }
+
+        private class DocumentConnection : IDisposable
+        {
+            public DocumentConnection(Database db, DocumentClient client, DocumentCollection collection)
+            {
+                Database = db;
+                Client = client;
+                Collection = collection;
+            }
+
+            public Database Database { get; }
+
+            public DocumentClient Client { get; }
+
+            public DocumentCollection Collection { get; }
+
+            public void Dispose()
+            {
+                Client.Dispose();
+            }
+        }
+
+        private DocumentConnection CreateDocumentDbConnection()
+        {
+            var client = new DocumentClient(new Uri(EndpointUri), AccountKey);
+
+            // get the database and if it doesn't exist create it
+
+            Database database = client.CreateDatabaseQuery()
+                .Where(db => db.Id == Database)
+                .AsEnumerable()
+                .FirstOrDefault();
+
+            if (database == null)
+            {
+                Log.LogMessage(MessageImportance.Low, "The database {0} does not exist, will create it.", Database);
+                var task = client.CreateDatabaseAsync(new Database { Id = Database });
+                database = task.Result;
+            }
+
+            // get the document collection and if it doesn't exist create it
+
+            DocumentCollection collection = client.CreateDocumentCollectionQuery(database.SelfLink)
+                .Where(c => c.Id == Collection)
+                .AsEnumerable()
+                .FirstOrDefault();
+
+            if (collection == null)
+            {
+                Log.LogMessage(MessageImportance.Low, "The collection {0} does not exist, will create it.", Collection);
+                var task = client.CreateDocumentCollectionAsync(database.SelfLink, new DocumentCollection { Id = Collection });
+                collection = task.Result;
+            }
+
+            Log.LogMessage(MessageImportance.Normal, "Connected to DocumentDB database {0}, collection {1}.", Database, Collection);
+            return new DocumentConnection(database, client, collection);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/WriteBuildStatsJson.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/WriteBuildStatsJson.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    /// <summary>
+    /// Used to write build stats to a JSON file.
+    /// </summary>
+    public class WriteTestBuildStatsJson : Task
+    {
+        /// <summary>
+        /// Helper class to be serialized to JSON.
+        /// </summary>
+        class TestBuildStatsJson
+        {
+            internal class FailedProject
+            {
+                public FailedProject(string name)
+                {
+                    ProjectName = name;
+                }
+
+                public string ProjectName { get; }
+            }
+
+            public TestBuildStatsJson(ITaskItem[] correlationIDs, string logUri, int builtCount, ITaskItem[] buildFailures, int testCount)
+            {
+                Aggregates = new List<string>();
+                ProjectsFailed = new List<FailedProject>();
+
+                foreach (var correlationId in correlationIDs)
+                    Aggregates.Add(correlationId.ItemSpec);
+
+                foreach (var buildFailure in buildFailures)
+                    ProjectsFailed.Add(new FailedProject(buildFailure.ItemSpec));
+
+                LogUri = logUri;
+                ProjectsBuiltCount = builtCount;
+                TestCount = testCount;
+            }
+
+            public List<string> Aggregates { get; }
+
+            public string LogUri { get; }
+
+            public int ProjectsBuiltCount { get; }
+
+            public List<FailedProject> ProjectsFailed { get; }
+
+            public string Stage { get { return "Build"; } }
+
+            public int TestCount { get; }
+        }
+
+        /// <summary>
+        /// The collection of correlation IDs to which these build stats apply.
+        /// </summary>
+        [Required]
+        public ITaskItem[] CorrelationIds { get; set; }
+
+        /// <summary>
+        /// The URI of the build log.
+        /// </summary>
+        [Required]
+        public string LogUri { get; set; }
+
+        /// <summary>
+        /// The name of the build stats JSON file to create.
+        /// </summary>
+        [Required]
+        public string OutputFile { get; set; }
+
+        /// <summary>
+        /// The number of projects successfully built.
+        /// </summary>
+        [Required]
+        public int ProjectsBuiltCount { get; set; }
+
+        /// <summary>
+        /// The collection of project names that failed to build.
+        /// </summary>
+        [Required]
+        public ITaskItem[] ProjectsFailed { get; set; }
+
+        /// <summary>
+        /// The total number of tests across all test binaries.
+        /// </summary>
+        [Required]
+        public int TestCount { get; set; }
+
+        public override bool Execute()
+        {
+            using (StreamWriter streamWriter = new StreamWriter(OutputFile))
+            using (JsonTextWriter jsonWriter = new JsonTextWriter(streamWriter))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+
+                var buildStats = new TestBuildStatsJson(CorrelationIds, LogUri, ProjectsBuiltCount, ProjectsFailed, TestCount);
+
+                var serializer = new JsonSerializer();
+                serializer.Serialize(jsonWriter, buildStats);
+            }
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/packages.config
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/packages.config
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Azure.DocumentDB" version="1.5.1" targetFramework="net45" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.7.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
   <package id="WindowsAzure.ServiceBus" version="3.0.4" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="5.0.2" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.lock.json
@@ -426,7 +426,7 @@
     },
     "NuGet.Versioning/3.3.0": {
       "type": "package",
-      "sha512": "f87vlVEFb4TyAqE7cpv4uX2cZkg70NeyzSTJ0D1w9kaGiYNv4l9/niKpuF8ek3PUAYCau+3YnxEp1wswVvWgAQ==",
+      "sha512": "90wrt/mbOApvWYz/skYYS9w2Y1YdGrHp7irAflAWEW4C1NKzFX80XB3h8BaGKJPcZ6gWNZhh+zZ21MdZ8rJETg==",
       "files": [
         "lib/dnxcore50/NuGet.Versioning.dll",
         "lib/dnxcore50/NuGet.Versioning.xml",

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -20,6 +20,7 @@
   </metadata>
   <files>
     <file src="Microsoft.DotNet.Build.Tasks.net45\*.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.Azure.Documents.Client.dll" target="lib\net45" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.DotNet.Build.CloudTestTasks.dll" target="lib\net45" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.Azure.KeyVault.Core.dll" target="lib\net45" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\Microsoft.Data.Edm.dll" target="lib\net45" />


### PR DESCRIPTION
These changes are currently scoped to the cloud-based test infrastructure.

Generate a JSON file containing test build statistics and upload it to
DocumentDB for later processing.  At present, the only statistic captured
is the number of successfully built tests.

Stop adding xunit and corerun zip packages to the list of downloads as
they are no longer required (they are pulled from packages.zip).