### PR TITLE
Allow multiple dependency updates to one project.json

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
@@ -57,7 +57,9 @@ namespace Microsoft.DotNet.Build.Tasks
                 JObject projectRoot = ReadProject(projectJsonPath);
 
                 bool changedAnyPackage = FindAllDependencyProperties(projectRoot)
-                    .Any(package => VisitPackage(package, projectJsonPath));
+                    .Select(package => VisitPackage(package, projectJsonPath))
+                    .ToArray()
+                    .Any();
 
                 if (changedAnyPackage)
                 {


### PR DESCRIPTION
When I used `.Any(...)` to check if dependencies needed to change after being visited, only the first change happens because `.Any` short-circuits. Changed to `.Select(...).ToArray().Any()` so that all visits are always evaluated.

/cc @ericstj @weshaggard