### PR TITLE
Add AssemblyResolver to load conflicting assemblies without bindingRedirects

### DIFF
--- a/src/common/AssemblyResolver.cs
+++ b/src/common/AssemblyResolver.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Build.Common.Desktop
+{
+    /// <summary>
+    /// Used to enable app-local assembly unification.
+    /// </summary>
+    internal static class AssemblyResolver
+    {
+        static AssemblyResolver()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+        }
+
+        /// <summary>
+        /// Call to enable the assembly resolver for the current AppDomain.
+        /// </summary>
+        public static void Enable()
+        {
+            // intentionally empty.  This is just meant to ensure the static constructor
+            // has run.
+        }
+
+        private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            // apply any existing policy
+            AssemblyName referenceName = new AssemblyName(AppDomain.CurrentDomain.ApplyPolicy(args.Name));
+
+            string fileName = referenceName.Name + ".dll";
+            string assemblyPath = null;
+            string probingPath = null;
+            Assembly assm = null;
+
+            // look next to requesting assembly
+            assemblyPath = args.RequestingAssembly?.Location;
+            if (!String.IsNullOrEmpty(assemblyPath))
+            {
+                probingPath = Path.Combine(Path.GetDirectoryName(assemblyPath), fileName);
+                Debug.WriteLine($"Considering {probingPath} based on RequestingAssembly");
+                if (Probe(probingPath, referenceName.Version, out assm))
+                {
+                    return assm;
+                }
+            }
+
+            // look in AppDomain base directory
+            probingPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+            Debug.WriteLine($"Considering {probingPath} based on BaseDirectory");
+            if (Probe(probingPath, referenceName.Version, out assm))
+            {
+                return assm;
+            }
+
+            // look next to the executing assembly
+            assemblyPath = Assembly.GetExecutingAssembly().Location;
+            if (!String.IsNullOrEmpty(assemblyPath))
+            {
+                probingPath = Path.Combine(Path.GetDirectoryName(assemblyPath), fileName);
+
+                Debug.WriteLine($"Considering {probingPath} based on ExecutingAssembly");
+                if (Probe(probingPath, referenceName.Version, out assm))
+                {
+                    return assm;
+                }
+            }
+
+            // look in current directory
+            Debug.WriteLine($"Considering {fileName}");
+            if (Probe(fileName, referenceName.Version, out assm))
+            {
+                return assm;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Considers a path to load for satisfying an assembly ref and loads it
+        /// if the file exists and version is sufficient.
+        /// </summary>
+        /// <param name="filePath">Path to consider for load</param>
+        /// <param name="minimumVersion">Minimum version to consider</param>
+        /// <param name="assembly">loaded assembly</param>
+        /// <returns>true if assembly was loaded</returns>
+        private static bool Probe(string filePath, Version minimumVersion, out Assembly assembly)
+        {
+            if (File.Exists(filePath))
+            {
+                AssemblyName name = AssemblyName.GetAssemblyName(filePath);
+
+                if (name.Version >= minimumVersion)
+                {
+                    assm = Assembly.Load(name);
+                    return true;
+                }
+            }
+
+            assm = null;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
MSBuild does not provide a convention for task dll's to specify bindingRedirects.
Sometimes a task may need to use two different libraries that use use different versions
of a common library (EG: Newtonsoft.JSON).  NuGet ensures that the higher version, is
used by the task, but one dependency will still have static reference to the lower version.

Without binding redirects this will result in a failure to load the assembly with the
lower version.  Address this by hooking AssemblyResolve and probing for the
assembly by simple name and choosing the first assembly that satisfies the request,
permitting higher versions.