### PR TITLE
Only write project.json when changes are required

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 bool changedAnyPackage = FindAllDependencyProperties(projectRoot)
                     .Select(package => VisitPackage(package, projectJsonPath))
                     .ToArray()
-                    .Any();
+                    .Any(shouldWrite => shouldWrite);
 
                 if (changedAnyPackage)
                 {


### PR DESCRIPTION
Previously this was re-writing any project.json that
had dependencies.  It should have been checking
the flag returned by VisitPackage to ensure that a
write was required.

/cc @dagood @weshaggard