### PR TITLE
Add tool-runtime and test-runtime project.json validation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -99,9 +99,9 @@
              Condition="'@(_ReferenceFileNamesToRemove)' != '' or '@(_ReferenceCopyLocalPathsFileNamesToRemove)' != ''"/>
   </Target>
 
-  <Target Name="ValidatePackageVersions">
-    <ValidateProjectDependencyVersions Condition="Exists('$(ProjectJson)')"
-                                       ProjectJsons="$(ProjectJson)"
+  <Target Name="ValidatePackageVersions"
+          Condition="'$(RestorePackages)'=='true' and '$(ValidatePackageVersions)'=='true' and Exists('$(ProjectJson)')">
+    <ValidateProjectDependencyVersions ProjectJsons="$(ProjectJson)"
                                        ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
                                        ValidationPatterns="@(ValidationPattern)" />
   </Target>


### PR DESCRIPTION
Add two new targets that run automatically during the build to validate `tool-runtime/project.json` and `test-runtime/project.json` automatically.

These new validation steps (and the earlier project.json validation) are individually optional. This should be useful because it makes sense to keep the `test-runtime/project.json` override in the corefx repo in step, but with `tool-runtime/project.json` in the buildtools package it doesn't seem worth it to keep that in step.

/cc @ericstj @weshaggard