### PR TITLE
Consolidate copying of supplemental test data.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -164,6 +164,7 @@
     <ItemGroup>
       <ExcludeFromArchive Include="nupkg$" />
       <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
+      <ExcludeFromArchive Include="TestData" />
     </ItemGroup>
     <ZipFileCreateFromDirectory
         SourceDirectory="$(PackagesDir)"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -130,6 +130,45 @@
 
   </Target>
 
+  <!--
+    Temporary until we have proper nuget support to deploy content files.
+    Copies supplemental test data to the build output and test directories.
+  -->
+  <Target Name="CopySupplementalTestData"
+          AfterTargets="CopyTestToTestDirectory"
+          Inputs="@(SupplementalTestData)"
+          Outputs="%(TestTargetFramework.Folder)">
+    <PropertyGroup>
+      <TestTargetFrameworkFolder>%(TestTargetFramework.Folder)</TestTargetFrameworkFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <SupplementalTestDataTestDir Include="@(SupplementalTestData->'$(TestPath)$(TestTargetFrameworkFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+      <SupplementalTestDataOutDir Include="@(SupplementalTestData->'$(OutDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(SupplementalTestData)"
+      DestinationFiles="@(SupplementalTestDataTestDir)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+    <Copy
+      SourceFiles="@(SupplementalTestData)"
+      DestinationFiles="@(SupplementalTestDataOutDir)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+  </Target>
+
   <Target Name="CreateAssemblyListTxt" DependsOnTargets="CopyTestToTestDirectory">
     <Message Text="Generating $(OutDir)AssemblyList.txt" />
     <ItemGroup>


### PR DESCRIPTION
Add a new target, CopySupplementalTestData, that projects can use to copy
test data to the test directory.  In addition, the task will also copy the
assets to the output directory so it can be picked up by the cloud test
infrastructure (it will be included in the test archive).
Exclude the test data from packages.zip as it's now being distributed with
the test binary.