### PR TITLE
[WIP] Task that examines lockfiles to validate packages restored as requested

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/FixNonExistentProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/FixNonExistentProjectDependencies.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.Build.Framework;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class FixNonExistentProjectDependencies : ValidateRestoredProjectDependencies
+    {
+        [Required]
+        public string NuGetToolPath { get; set; }
+
+        [Required]
+        public ITaskItem[] NuGetSources { get; set; }
+
+        protected override void HandleNonExistentDependency(
+            string name,
+            string version,
+            IEnumerable<string> libraryVersionsRestored,
+            string lockFilePath)
+        {
+            // If possible, choose a stable version.
+            var requestedVersion = NuGetVersion.Parse(version);
+            var restoredVersions = libraryVersionsRestored.Select(v => NuGetVersion.Parse(v));
+
+            if (!requestedVersion.IsPrerelease)
+            {
+                Console.WriteLine(
+                    "Can't find upgrade path for nonexistent stable dependency '{0}' '{1}'",
+                    name,
+                    version);
+                return;
+            }
+
+            var matchingStableVersion = restoredVersions.FirstOrDefault(v =>
+                !v.IsPrerelease &&
+                v.Major == requestedVersion.Major &&
+                v.Minor == requestedVersion.Minor &&
+                v.Patch == requestedVersion.Patch);
+
+            if (matchingStableVersion != null)
+            {
+                Log.LogWarning(
+                    "For {0}, changing nonexistent version '{1}' to stable '{2}'",
+                    name,
+                    version,
+                    matchingStableVersion.ToNormalizedString());
+            }
+            else
+            {
+                // Find a version of the same package on any source that matches the prerelease version.
+                string sourceArgString = string.Join(" ", NuGetSources.Select(item => "-Source " + item.ItemSpec));
+
+                NuGetVersion matchedVersion = null;
+
+                using (var nugetList = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = NuGetToolPath,
+                        Arguments = "list " + name + " -Prerelease -AllVersions -NonInteractive " + sourceArgString,
+                        RedirectStandardOutput = true,
+                        UseShellExecute = false,
+                    }
+                })
+                {
+                    Log.LogMessage("Running NuGet list for package " + name);
+
+                    nugetList.OutputDataReceived += (sender, e) =>
+                    {
+                        if (e.Data == null)
+                        {
+                            return;
+                        }
+
+                        string[] parts = e.Data.Split(' ');
+
+                        if (parts[0] == name)
+                        {
+                            var foundVersion = NuGetVersion.Parse(parts[1]);
+                            if (foundVersion.Release == requestedVersion.Release)
+                            {
+                                matchedVersion = foundVersion;
+                                // Quit NuGet list early if possible.
+                                nugetList.Kill();
+                            }
+                        }
+                    };
+
+                    if (nugetList.Start())
+                    {
+                        nugetList.BeginOutputReadLine();
+                        nugetList.WaitForExit();
+
+                        if (matchedVersion == null)
+                        {
+                            Log.LogError("No package found with id {0} and prerelease '{1}'", name, version);
+                        }
+                        else
+                        {
+                            Log.LogWarning(
+                                "For {0}, changing nonexistent version '{1}' to discovered prerelease '{2}'",
+                                name,
+                                version,
+                                matchedVersion.ToNormalizedString());
+                        }
+                    }
+                    else
+                    {
+                        Log.LogError("Could not start NuGet process to retrieve package versions.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -33,6 +33,7 @@
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
     <Compile Include="UpdatePackageDependencyVersion.cs" />
+    <Compile Include="ValidateRestoredProjectDependencies.cs" />
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="ZipFileCreateFromDirectory.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <Compile Include="Delegates.cs" />
     <Compile Include="ExecWithMutex.cs" />
+    <Compile Include="FixNonExistentProjectDependencies.cs" />
     <Compile Include="GenerateAssemblyList.cs" />
     <Compile Include="GenerateResourcesCode.cs" />
     <Compile Include="GenerateEncodingTable.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateRestoredProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateRestoredProjectDependencies.cs
@@ -44,14 +44,23 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 if (!versionsRestored.Contains(requestedVersion))
                 {
-                    Log.LogError(
-                        "Desired version {0} '{1}' not restored, found '{2}' in {3}",
-                        requestedId,
-                        requestedVersion,
-                        string.Join(", ", versionsRestored),
-                        lockFilePath);
+                    HandleNonExistentDependency(requestedId, requestedVersion, versionsRestored, lockFilePath);
                 }
             }
+        }
+
+        protected virtual void HandleNonExistentDependency(
+            string name,
+            string version,
+            IEnumerable<string> libraryVersionsRestored,
+            string lockFilePath)
+        {
+            Log.LogError(
+                "Desired version {0} {1} not restored, found '{2}' for {3}",
+                name,
+                version,
+                string.Join(", ", libraryVersionsRestored),
+                lockFilePath);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateRestoredProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateRestoredProjectDependencies.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class ValidateRestoredProjectDependencies : Task
+    {
+        [Required]
+        public ITaskItem[] ProjectLockJsons { get; set; }
+
+        public override bool Execute()
+        {
+            foreach (var projectLockItem in ProjectLockJsons)
+            {
+                var lockfile = VisitProjectDependencies.ReadJsonFile(projectLockItem.ItemSpec);
+                ValidateLockFile(lockfile, projectLockItem.ItemSpec);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ValidateLockFile(JObject lockfile, string lockFilePath)
+        {
+            var lockedDependencyVersions = lockfile["libraries"]
+                .Children<JProperty>()
+                .Select(p => p.Name.Split('/'))
+                .ToLookup(libParts => libParts[0], libParts => libParts[1]);
+
+            var requestedDependencies = lockfile["projectFileDependencyGroups"]
+                .Children<JProperty>()
+                .Where(group => group.Name == "")
+                .SelectMany(group => group.Value.Value<JArray>().Values<string>());
+
+            foreach (string dependency in requestedDependencies)
+            {
+                string[] dependencyParts = dependency.Split(' ');
+                string requestedId = dependencyParts[0];
+                string requestedVersion = dependencyParts[2];
+
+                IEnumerable<string> versionsRestored = lockedDependencyVersions[requestedId];
+
+                if (!versionsRestored.Contains(requestedVersion))
+                {
+                    Log.LogError(
+                        "Desired version {0} '{1}' not restored, found '{2}' in {3}",
+                        requestedId,
+                        requestedVersion,
+                        string.Join(", ", versionsRestored),
+                        lockFilePath);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
@@ -14,9 +14,9 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public ITaskItem[] ProjectJsons { get; set; }
 
-        private static JObject ReadProject(string projectJsonPath)
+        public static JObject ReadJsonFile(string jsonPath)
         {
-            using (TextReader projectFileReader = File.OpenText(projectJsonPath))
+            using (TextReader projectFileReader = File.OpenText(jsonPath))
             {
                 var projectJsonReader = new JsonTextReader(projectFileReader);
 
@@ -25,11 +25,11 @@ namespace Microsoft.DotNet.Build.Tasks
             }
         }
 
-        private static void WriteProject(JObject projectRoot, string projectJsonPath)
+        public static void WriteJsonFile(JObject projectRoot, string jsonPath)
         {
             string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
 
-            File.WriteAllText(projectJsonPath, projectJson + Environment.NewLine);
+            File.WriteAllText(jsonPath, projectJson + Environment.NewLine);
         }
 
         private static IEnumerable<JProperty> FindAllDependencyProperties(JObject projectJsonRoot)
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             foreach (var projectJsonPath in ProjectJsons.Select(item => item.ItemSpec))
             {
-                JObject projectRoot = ReadProject(projectJsonPath);
+                JObject projectRoot = ReadJsonFile(projectJsonPath);
 
                 bool changedAnyPackage = FindAllDependencyProperties(projectRoot)
                     .Select(package => VisitPackage(package, projectJsonPath))
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 if (changedAnyPackage)
                 {
                     Log.LogMessage("Writing changes to {0}", projectJsonPath);
-                    WriteProject(projectRoot, projectJsonPath);
+                    WriteJsonFile(projectRoot, projectJsonPath);
                 }
             }
 


### PR DESCRIPTION
Right now automatic package upgrade can set up dependencies on packages that don't exist. (I describe this in the [project.json doc page](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/project-nuget-dependencies.md#recovering-from-a-non-existent-prerelease-dependency).)

Currently I don't know of a way to check for these invalid dependencies other than reacting to build breaks they cause--but they don't always cause build breaks. This task looks at lockfiles to see if the requested package version was the one installed. It's designed to be used as a validation step after package restore.

A few concerns with actually using this:

* `project.lock.json` schema is still in flux, and is different between DNU restore and nuget.exe restore.
* It might be ok for the locked library to be different than the actual dependency in some cases.
* Currently this only checks untargeted (?) dependencies.

These are the dependencies on nonexistent packages that the task currently finds in corefx:

    System.Linq.Expressions '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Composition.Convention\tests\project.lock.json
    System.Runtime '4.0.20-rc2-23604' not restored, found '4.0.20' in E:\git\corefx\src\System.Composition.Convention\tests\project.lock.json
    System.Diagnostics.Process '4.0.0-rc2-23604' not restored, found '4.1.0-beta-23302' in E:\git\corefx\src\System.Console\tests\project.lock.json
    System.Diagnostics.Process '4.0.0-rc2-23604' not restored, found '4.1.0-beta-23302' in E:\git\corefx\src\System.Diagnostics.TraceSource\tests\project.lock.json
    System.Collections '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Diagnostics.Contracts '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Diagnostics.Tracing '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Runtime '4.0.20-rc2-23604' not restored, found '4.0.20' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Runtime.Extensions '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Resources.ResourceManager '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Threading '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Threading.Tasks '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Runtime.InteropServices '4.0.20-rc2-23604' not restored, found '4.0.20' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Runtime.Handles '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Globalization '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Diagnostics.Debug '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.NameResolution\src\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.NetworkInformation\tests\FunctionalTests\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.NetworkInformation\tests\UnitTests\project.lock.json
    System.Diagnostics.Contracts '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.Security\src\unix\project.lock.json
    System.Threading '4.0.0-rc2-23604' not restored, found '4.0.0' in E:\git\corefx\src\System.Net.Security\src\unix\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.Security\src\unix\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.Security\tests\FunctionalTests\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.Security\tests\UnitTests\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.Utilities\src\project.lock.json
    System.Net.Primitives '4.0.10-rc2-23604' not restored, found '4.0.10' in E:\git\corefx\src\System.Net.Utilities\tests\FunctionalTests\project.lock.json
    System.Diagnostics.Process '4.0.0-rc2-23604' not restored, found '4.1.0-beta-23302' in E:\git\corefx\src\System.ServiceProcess.ServiceController\tests\System.ServiceProcess.ServiceController.Tests\project.lock.json

Is this worth bringing into corefx as a post-restore validation step?

/cc @ericstj @weshaggard