### PR TITLE
Add Pack to packaging targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/Microsoft.DotNet.Build.Tasks.Packaging.Desktop.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/Microsoft.DotNet.Build.Tasks.Packaging.Desktop.csproj
@@ -27,5 +27,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Metadata.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PackageDirectory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NuGetPack.cs" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/NuGetPack.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/NuGetPack.cs
@@ -1,0 +1,148 @@
+﻿using Microsoft.Build.Framework;
+using NuGet;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class NuGetPack : PackagingTask
+    {
+
+        [Required]
+        public ITaskItem[] Nuspecs
+        {
+            get;
+            set;
+        }
+
+        [Required]
+        public string OutputDirectory
+        {
+            get;
+            set;
+        }
+
+        public string[] Properties
+        {
+            get;
+            set;
+        }
+
+        public bool ExcludeEmptyDirectories
+        {
+            get;
+            set;
+        }
+
+        public override bool Execute()
+        {
+            if (Nuspecs == null || Nuspecs.Length == 0)
+            {
+                _log.LogError("Nuspecs argument must be specified");
+                return false;
+            }
+
+            if (String.IsNullOrEmpty(OutputDirectory))
+            {
+                _log.LogError("OuputDirectory argument must be specified");
+                return false;
+            }
+
+            if (!Directory.Exists(OutputDirectory))
+            {
+                Directory.CreateDirectory(OutputDirectory);
+            }
+
+            IPropertyProvider properties = null;
+
+            if (Properties != null && Properties.Length > 0)
+            {
+                Dictionary<string, string> propertyDictionary = new Dictionary<string, string>();
+                foreach (string property in Properties)
+                {
+                    var propertyPair = property.Split(new[] { '=' }, 2);
+
+                    if (propertyPair.Length < 2)
+                    {
+                        _log.LogError($"Invalid property pair {property}.  Properties should be of the form name=value.");
+                        continue;
+                    }
+
+                    propertyDictionary[propertyPair[0]] = propertyPair[1];
+                }
+
+                properties = new DictionaryPropertyProvider(propertyDictionary);
+            }
+
+
+            foreach (var nuspec in Nuspecs)
+            {
+                string nuspecPath = nuspec.GetMetadata("FullPath");
+
+                if (!File.Exists(nuspecPath))
+                {
+                    _log.LogError($"Nuspec {nuspecPath} does not exist");
+                    continue;
+                }
+
+                try
+                {
+                    PackageBuilder builder = new PackageBuilder(nuspecPath, properties, !ExcludeEmptyDirectories);
+
+                    string id = builder.Id, version = builder.Version.ToString();
+
+                    if (String.IsNullOrEmpty(id))
+                    {
+                        _log.LogError($"Nuspec {nuspecPath} does not contain a valid Id");
+                        continue;
+                    }
+
+                    if (String.IsNullOrEmpty(version))
+                    {
+                        _log.LogError($"Nuspec {nuspecPath} does not contain a valid version");
+                        continue;
+                    }
+
+                    string nupkgPath = Path.Combine(OutputDirectory, $"{id}.{version}.nupkg");
+
+                    using (var fileStream = File.Create(nupkgPath))
+                    {
+                        builder.Save(fileStream);
+                    }
+
+                    _log.LogMessage($"Created '{nupkgPath}'");
+                }
+                catch (Exception e)
+                {
+                    _log.LogError($"Error when creating nuget package from {nuspecPath}. {e}");
+                }
+            }
+
+            return !_log.HasLoggedErrors;
+        }
+
+        private class DictionaryPropertyProvider : IPropertyProvider
+        {
+            private readonly IDictionary<string, string> _properties;
+
+            public DictionaryPropertyProvider(IDictionary<string, string> properties)
+            {
+                _properties = properties;
+            }
+
+            public dynamic GetPropertyValue(string propertyName)
+            {
+                string value;
+                if (_properties.TryGetValue(propertyName, out value))
+                {
+                    return value;
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -53,8 +53,9 @@
   <PropertyGroup>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg\</PackageOutputPath>
     <OutputPath>$(PackageOutputPath)</OutputPath>
-    <NuSpecPath>$(OutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
-    <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(OutputPath)$(Id)$(NuspecSuffix)\runtime.json</RuntimeFilePath>
+    <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs\</NuSpecOutputPath>
+    <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
+    <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)\runtime.json</RuntimeFilePath>
     <PlaceholderFile>$(MSBuildThisFileDirectory)_._</PlaceholderFile>
     <PackageDescriptionFile Condition="'$(PackageDescriptionFile)' == ''">path to descriptions.json must be specified</PackageDescriptionFile>
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
@@ -76,6 +77,7 @@
   <UsingTask TaskName="ValidatePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="CreateTrimDependencyGroups" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GenerateNuSpec" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms 
@@ -92,7 +94,10 @@
     <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND $(PackageTargetRuntime.Contains('-$(PackagePlatform)'))">true</ShouldGenerateNuSpec>
     <!-- build if PackagePlatforms is not specified and arch is x86 or AnyCPU -->
     <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND ('$(PackagePlatform)' == 'x86' OR '$(PackagePlatform)' == 'AnyCPU')">true</ShouldGenerateNuSpec>
+    <!-- if we built a nuspec, also pack unless explicitly set -->
+    <ShouldCreatePackage Condition="'$(ShouldCreatePackage)' == ''">$(ShouldGenerateNuSpec)</ShouldCreatePackage>
     <BuildDependsOn Condition="'$(ShouldGenerateNuSpec)' == 'true'">GenerateNuSpec</BuildDependsOn>
+    <BuildDependsOn Condition="'$(ShouldCreatePackage)' == 'true'">$(BuildDependsOn);CreatePackage</BuildDependsOn>
   </PropertyGroup>
 
   <!-- Redefine build to just create the NuSpec only, we'll create the package during ArcProjects phase -->
@@ -109,8 +114,15 @@
   </Target>
 
   <Target Name="Clean">
+    <!-- package version is calculated so read the last version from the marker file. -->
+    <ReadLinesFromFile File="$(NuSpecPath).pkgpath"
+                       Condition="Exists('$(NuSpecPath).pkgpath')">
+      <Output TaskParameter="Lines" ItemName="_ToBeDeleted"/>
+    </ReadLinesFromFile>
+                       
     <ItemGroup>
       <_ToBeDeleted Include="$(NuSpecPath)" />
+      <_ToBeDeleted Include="$(NuSpecPath).pkgpath" />
       <_ToBeDeleted Include="$(RuntimeFilePath)" />
     </ItemGroup>
     <Delete Files="@(_ToBeDeleted)" />
@@ -844,5 +856,18 @@
     <Error Text="Package @(_SatisfiedMetaDependencies)-%(ActualVersion) is higher version than %(Version) expected." 
            Condition="'@(_SatisfiedMetaDependencies)' != '' AND  %(CompareResult) &gt; 0"
            ContinueOnError="ErrorAndContinue" />
+  </Target>
+
+  <Target Name="CreatePackage"
+          Inputs="$(NuSpecPath)"
+          Outputs="$(PackageOutputPath)$(Id).$(Version).nupkg">
+    <NugetPack Nuspecs="$(NuSpecPath)"
+               OutputDirectory="$(PackageOutputPath)"
+               Properties="$(PackageProperties)"
+               ExcludeEmptyDirectories="true" />
+    <!-- Create a marker that records the path to the generated package -->
+    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(Version).nupkg"
+                      File="$(NuSpecPath).pkgpath"
+                      Overwrite="true"/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
@@ -36,7 +36,7 @@
       Condition="'@(PackagesNuSpecFiles)'!=''"
       IgnoreStandardErrorWarningFormat="true"
       StandardOutputImportance="Low"
-      Command="$(NuGetExe) pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath $(NuGetBasePath) -OutputDirectory $(NuGetOutputDirectory) %(PackagesNuSpecFiles.PackageVersion) -NoPackageAnalysis -NoDefaultExcludes" />
+      Command="$(NuGetExe) pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath $(NuGetBasePath) -OutputDirectory $(NuGetOutputDirectory) %(PackagesNuSpecFiles.PackageVersion) -NoPackageAnalysis -NoDefaultExcludes -ExcludeEmptyDirectories" />
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"


### PR DESCRIPTION
.pkgprojs will now produce a nupkg.
This ports some code that was using NuGet.Core
to do the packing and thus it is only in the desktop
build of the tasks.  We'll eventually need a core-CLR
friendly implementation of this.  Once we have that
library from NuGet we can move this to the shared
source.