### PR TITLE
Skip ignored references during Generation validation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Generations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Generations.cs
@@ -21,13 +21,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// </summary>
         private static Dictionary<string, Generations> s_generationsCache = new Dictionary<string, Generations>(StringComparer.OrdinalIgnoreCase); // file paths are case insensitive
 
-        private static HashSet<string> s_ignoredReferences = new HashSet<string>()
-        {
-            "mscorlib",
-            "System.Private.Uri",
-            "Windows"
-        };
-
         private readonly List<Generation> _generations = new List<Generation>();
 
         private Generations()
@@ -78,7 +71,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             string assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
-            if (s_ignoredReferences.Contains(assemblyName) || (ignoredRefs != null && ignoredRefs.Contains(assemblyName)))
+            if (ignoredRefs != null && ignoredRefs.Contains(assemblyName))
             {
                 return null;
             }
@@ -89,7 +82,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 AssemblyDefinition assemblyDef = reader.GetAssemblyDefinition();
 
                 assemblyName = reader.GetString(assemblyDef.Name);
-                if (s_ignoredReferences.Contains(assemblyName) || (ignoredRefs != null && ignoredRefs.Contains(assemblyName)))
+                if (ignoredRefs != null && ignoredRefs.Contains(assemblyName))
                 {
                     return null;
                 }
@@ -117,7 +110,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     AssemblyReference reference = reader.GetAssemblyReference(handle);
                     string referenceName = reader.GetString(reference.Name);
 
-                    if (s_ignoredReferences.Contains(referenceName) || (ignoredRefs != null && ignoredRefs.Contains(referenceName)))
+                    if (ignoredRefs != null && ignoredRefs.Contains(referenceName))
                     {
                         continue;
                     }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -153,7 +153,7 @@
   <Target Name="ValidatePackageTargetFramework"
           Inputs="$(MSBuildAllProjects);@(CustomAdditionalCompileInputs);@(ReferencePath)"
           Outputs="@(IntermediateAssembly)"
-          Condition="'$(PackageTargetFramework)' != ''"
+          Condition="'$(PackageTargetFramework)' != '' AND '$(SkipValidatePackageTargetFramework)' != 'true'"
           AfterTargets="ResolveReferences">
     <ValidatePackageTargetFramework AssemblyName="$(AssemblyName)"
                                     AssemblyVersion="$(AssemblyVersion)"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -160,7 +160,8 @@
                                     GenerationDefinitionsFile="$(GenerationDefinitionFile)"
                                     PackageTargetFramework="$(PackageTargetFramework)"
                                     DirectReferences="@(ReferencePath)"
-                                    CandidateReferences="@(ReferencePath);@(IndirectReference)" />
+                                    CandidateReferences="@(ReferencePath);@(IndirectReference)" 
+                                    IgnoredReferences="@(ValidateIgnoreReference)"/>
   </Target>
   
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -155,6 +155,10 @@
           Outputs="@(IntermediateAssembly)"
           Condition="'$(PackageTargetFramework)' != '' AND '$(SkipValidatePackageTargetFramework)' != 'true'"
           AfterTargets="ResolveReferences">
+    <ItemGroup Condition="'@(ValidateIgnoreReference)' == ''">
+      <ValidateIgnoreReference Include="mscorlib;System.Private.Uri;Windows" />
+    </ItemGroup>
+    
     <ValidatePackageTargetFramework AssemblyName="$(AssemblyName)"
                                     AssemblyVersion="$(AssemblyVersion)"
                                     GenerationDefinitionsFile="$(GenerationDefinitionFile)"


### PR DESCRIPTION
Previously we weren't skipping ignored references if they
were direct (only indirect).  This fixes that.

I've also added an override in case we hit something similar
again.

Previously I made this fix for some NETNative assemblies
that were claiming to be generational.  We'll need that 
in the future if we make NETNative more generic than
just netcore50.