### PR TITLE
Workaround nullref in Mono's MSBuild

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/NuGetPack.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/NuGetPack.cs
@@ -42,13 +42,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (Nuspecs == null || Nuspecs.Length == 0)
             {
-                _log.LogError("Nuspecs argument must be specified");
+                Log.LogError("Nuspecs argument must be specified");
                 return false;
             }
 
             if (String.IsNullOrEmpty(OutputDirectory))
             {
-                _log.LogError("OuputDirectory argument must be specified");
+                Log.LogError("OuputDirectory argument must be specified");
                 return false;
             }
 
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                     if (propertyPair.Length < 2)
                     {
-                        _log.LogError($"Invalid property pair {property}.  Properties should be of the form name=value.");
+                        Log.LogError($"Invalid property pair {property}.  Properties should be of the form name=value.");
                         continue;
                     }
 
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                 if (!File.Exists(nuspecPath))
                 {
-                    _log.LogError($"Nuspec {nuspecPath} does not exist");
+                    Log.LogError($"Nuspec {nuspecPath} does not exist");
                     continue;
                 }
 
@@ -97,13 +97,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                     if (String.IsNullOrEmpty(id))
                     {
-                        _log.LogError($"Nuspec {nuspecPath} does not contain a valid Id");
+                        Log.LogError($"Nuspec {nuspecPath} does not contain a valid Id");
                         continue;
                     }
 
                     if (String.IsNullOrEmpty(version))
                     {
-                        _log.LogError($"Nuspec {nuspecPath} does not contain a valid version");
+                        Log.LogError($"Nuspec {nuspecPath} does not contain a valid version");
                         continue;
                     }
 
@@ -114,15 +114,15 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                         builder.Save(fileStream);
                     }
 
-                    _log.LogMessage($"Created '{nupkgPath}'");
+                    Log.LogMessage($"Created '{nupkgPath}'");
                 }
                 catch (Exception e)
                 {
-                    _log.LogError($"Error when creating nuget package from {nuspecPath}. {e}");
+                    Log.LogError($"Error when creating nuget package from {nuspecPath}. {e}");
                 }
             }
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
         private class DictionaryPropertyProvider : IPropertyProvider

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
@@ -56,13 +56,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (null == OriginalPackages || OriginalPackages.Length == 0)
             {
-                _log.LogError("OriginalPackages argument must be specified");
+                Log.LogError("OriginalPackages argument must be specified");
                 return false;
             }
 
             if (String.IsNullOrEmpty(PreReleaseSuffix))
             {
-                _log.LogError("PreReleaseSuffix argument must be specified");
+                Log.LogError("PreReleaseSuffix argument must be specified");
                 return false;
             }
 
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             UpdatedPackages = updatedPackages.ToArray();
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
         private static Version ParseAs3PartVersion(string versionString)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
@@ -53,12 +53,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (null == Dependencies)
             {
-                _log.LogError("Dependencies argument must be specified");
+                Log.LogError("Dependencies argument must be specified");
                 return false;
             }
             if (null == FrameworkListsPath)
             {
-                _log.LogError("FrameworkListsPath argument must be specified");
+                Log.LogError("FrameworkListsPath argument must be specified");
                 return false;
             }
 
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
             TrimmedDependencies = collapsedDependencies.ToArray();
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
         private bool IsSupported(NuGetFramework inboxFx, NuGetAssetResolver resolver)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/EnsureOOBFramework.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/EnsureOOBFramework.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (!String.IsNullOrEmpty(RuntimeJson) && !File.Exists(RuntimeJson))
             {
-                _log.LogError("Could not load runtime file: {0}", RuntimeJson);
+                Log.LogError("Could not load runtime file: {0}", RuntimeJson);
                 RuntimeJson = null;
             }
 
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             AdditionalFiles = newItems.ToArray();
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
         private IEnumerable<string> GetObscuredAssetFolders(ContentItemGroup assets, ContentItemGroup obscuredAssets, NuGetFramework targetFramework, string targetFrameworkName, string expectedAssetFolder, string ignoredAssetFolder = null)
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             var resolvedFramework = assets.Properties["tfm"] as NuGetFramework;
             if (targetFramework.Equals(resolvedFramework))
             {
-                _log.LogMessage(LogImportance.Low, $"Not overriding explicit placeholder for {targetFrameworkName}");
+                Log.LogMessage(LogImportance.Low, $"Not overriding explicit placeholder for {targetFrameworkName}");
                 return Enumerable.Empty<string>();
             }
 
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 var unexpectedAssetPaths = obscuredAssetPaths.Where(ri => !ri.StartsWith(expectedAssetFolder, StringComparison.OrdinalIgnoreCase));
                 foreach (var unexpectedAssetPath in unexpectedAssetPaths)
                 {
-                    _log.LogWarning($"Unexpected targetPath {unexpectedAssetPath}.  Expected only {expectedAssetFolder}.");
+                    Log.LogWarning($"Unexpected targetPath {unexpectedAssetPath}.  Expected only {expectedAssetFolder}.");
                 }
 
                 // filter after we've warned
@@ -139,7 +139,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             {
                 // it's acceptable to have no override, this is the case for packages which 
                 // carry implementation in a runtime-specific package
-                _log.LogMessage(LogImportance.Low, $"No {expectedAssetFolder} assets could be found to override inbox placeholder for {targetFrameworkName}.");
+                Log.LogMessage(LogImportance.Low, $"No {expectedAssetFolder} assets could be found to override inbox placeholder for {targetFrameworkName}.");
             }
 
             return obscuredAssetPaths;
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     if (packageItem.TargetPath.StartsWith(keyAsset))
                     {
                         string subPath = packageItem.TargetPath.Substring(keyAsset.Length);
-                        _log.LogMessage(LogImportance.Low, $"Copying {packageItem.TargetPath} to {targetAssetFolder}/{targetFrameworkName}{subPath}.");
+                        Log.LogMessage(LogImportance.Low, $"Copying {packageItem.TargetPath} to {targetAssetFolder}/{targetFrameworkName}{subPath}.");
                         yield return GetOOBItem(packageItem, $"{targetAssetFolder}/{targetFrameworkName}{subPath}", targetFrameworkName);
                     }
                 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateRuntimeDependencies.cs
@@ -54,19 +54,19 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (Dependencies == null || Dependencies.Length == 0)
             {
-                _log.LogError("Dependencies argument must be specified");
+                Log.LogError("Dependencies argument must be specified");
                 return false;
             }
 
             if (String.IsNullOrEmpty(PackageId))
             {
-                _log.LogError("PackageID argument must be specified");
+                Log.LogError("PackageID argument must be specified");
                 return false;
             }
 
             if (RuntimeJson == null)
             {
-                _log.LogError("RuntimeJson argument must be specified");
+                Log.LogError("RuntimeJson argument must be specified");
                 return false;
             }
 
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     continue;
                 }
 
-                _log.LogMessage(LogImportance.Low, "Aliasing {0} -> {1}", alias, dependency.ItemSpec);
+                Log.LogMessage(LogImportance.Low, "Aliasing {0} -> {1}", alias, dependency.ItemSpec);
                 packageAliases[alias] = dependency.ItemSpec;
             }
 
@@ -114,17 +114,17 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                 if (String.IsNullOrEmpty(targetRuntimeId))
                 {
-                    _log.LogMessage(LogImportance.Low, "Skipping dependency {0} since it doesn't have a TargetRuntime.", dependency.ItemSpec);
+                    Log.LogMessage(LogImportance.Low, "Skipping dependency {0} since it doesn't have a TargetRuntime.", dependency.ItemSpec);
                     continue;
                 }
 
                 if (!String.IsNullOrEmpty(targetPackageAlias) && !packageAliases.TryGetValue(targetPackageAlias, out targetPackageId))
                 {
-                    _log.LogWarning("Dependency {0} specified TargetPackageAlias {1} but no package was found defining this alias.", dependency.ItemSpec, targetPackageAlias);
+                    Log.LogWarning("Dependency {0} specified TargetPackageAlias {1} but no package was found defining this alias.", dependency.ItemSpec, targetPackageAlias);
                 }
                 else
                 {
-                    _log.LogMessage(LogImportance.Low, "Using {0} for TargetPackageAlias {1}", targetPackageId, targetPackageAlias);
+                    Log.LogMessage(LogImportance.Low, "Using {0} for TargetPackageAlias {1}", targetPackageId, targetPackageAlias);
                 }
 
                 RuntimeSpec targetRuntime = null;
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                 if (String.IsNullOrEmpty(targetPackageId))
                 {
-                    _log.LogMessage(LogImportance.Low, "Dependency {0} has no parent so will assume {1}.", dependency.ItemSpec, PackageId);
+                    Log.LogMessage(LogImportance.Low, "Dependency {0} has no parent so will assume {1}.", dependency.ItemSpec, PackageId);
                     targetPackageId = PackageId;
                 }
 
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 {
                     if (String.IsNullOrEmpty(dependencyVersion))
                     {
-                        _log.LogWarning("Dependency {0} has no version", dependency.ItemSpec);
+                        Log.LogWarning("Dependency {0} has no version", dependency.ItemSpec);
                     }
 
                     ImplementationSpec existing;
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     if (targetPackage.Implementations.TryGetValue(dependencyId, out existing))
                     {
                         string newVersion = CompareSemanticVersion(dependencyVersion, existing.Version) > 0 ? dependencyVersion : existing.Version;
-                        _log.LogMessage(LogImportance.Low, "Dependency {0} has been added more than once, {1}, {2}, using {3}", dependencyId, existing.Version, dependencyVersion, newVersion);
+                        Log.LogMessage(LogImportance.Low, "Dependency {0} has been added more than once, {1}, {2}, using {3}", dependencyId, existing.Version, dependencyVersion, newVersion);
                         dependencyVersion = newVersion;
                     }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetAssemblyReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetAssemblyReferences.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 {
                     if (!File.Exists(assemblyItem.ItemSpec))
                     {
-                        _log.LogError($"File {assemblyItem.ItemSpec} does not exist, ensure you have built libraries before building the package.");
+                        Log.LogError($"File {assemblyItem.ItemSpec} does not exist, ensure you have built libraries before building the package.");
                         continue;
                     }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetInboxFrameworks.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetInboxFrameworks.cs
@@ -41,28 +41,28 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (null == FrameworkListsPath)
             {
-                _log.LogError("FrameworkListsPath argument must be specified");
+                Log.LogError("FrameworkListsPath argument must be specified");
                 return false;
             }
 
             if (String.IsNullOrEmpty(AssemblyName))
             {
-                _log.LogError("AssemblyName argument must be specified");
+                Log.LogError("AssemblyName argument must be specified");
                 return false;
             }
 
             if (!Directory.Exists(FrameworkListsPath))
             {
-                _log.LogError("FrameworkListsPath '{0}' does not exist", FrameworkListsPath);
+                Log.LogError("FrameworkListsPath '{0}' does not exist", FrameworkListsPath);
                 return false;
             }
 
-            _log.LogMessage(LogImportance.Low, "Determining inbox frameworks for {0}, {1}", AssemblyName, AssemblyVersion);
+            Log.LogMessage(LogImportance.Low, "Determining inbox frameworks for {0}, {1}", AssemblyName, AssemblyVersion);
 
 
-            InboxFrameworks = Frameworks.GetInboxFrameworksList(FrameworkListsPath, AssemblyName, AssemblyVersion, _log);
+            InboxFrameworks = Frameworks.GetInboxFrameworksList(FrameworkListsPath, AssemblyName, AssemblyVersion, Log);
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDescription.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageDescription.cs
@@ -40,13 +40,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (null == DescriptionFile)
             {
-                _log.LogError("DescriptionFile argument must be specified");
+                Log.LogError("DescriptionFile argument must be specified");
                 return false;
             }
 
             if (String.IsNullOrEmpty(PackageId))
             {
-                _log.LogError("PackageId argument must be specified");
+                Log.LogError("PackageId argument must be specified");
                 return false;
             }
 
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (!File.Exists(descriptionPath))
             {
-                _log.LogError("DescriptionFile '{0}' does not exist", descriptionPath);
+                Log.LogError("DescriptionFile '{0}' does not exist", descriptionPath);
                 return false;
             }
 
@@ -77,12 +77,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (String.IsNullOrEmpty(description))
             {
-                _log.LogError("Unable to find description for package {0}", PackageId);
+                Log.LogError("Unable to find description for package {0}", PackageId);
             }
 
             Description = description;
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
         private Dictionary<string, string> LoadDescriptions(string descriptionPath)
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             {
                 if (excep is IOException || excep is UnauthorizedAccessException)
                 {
-                    _log.LogError("Error loading {0}, {1}", descriptionPath, excep);
+                    Log.LogError("Error loading {0}, {1}", descriptionPath, excep);
                     return null;
                 }
                 else
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (String.IsNullOrEmpty(metadata.Description))
             {
-                _log.LogError("Package {0} has no Description, please add it to {1}", metadata.Name, descriptionPath);
+                Log.LogError("Package {0} has no Description, please add it to {1}", metadata.Name, descriptionPath);
             }
 
             StringBuilder description = new StringBuilder(metadata.Description);

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageVersion.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (Files == null || Files.Length == 0)
             {
-                _log.LogError("Files argument must be specified");
+                Log.LogError("Files argument must be specified");
                 return false;
             }
 
@@ -72,11 +72,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             {
                 if (!permittedVersions.Contains(file.Version))
                 {
-                    _log.LogError("File {0} has version {1} which is inconsistent with other libs and doesn't match any reference assembly", file.File, file.Version);
+                    Log.LogError("File {0} has version {1} which is inconsistent with other libs and doesn't match any reference assembly", file.File, file.Version);
                 }
             }
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackagingTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackagingTask.cs
@@ -8,11 +8,15 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
     public abstract partial class PackagingTask : ITask
     {
-        internal Log _log;
+        private Log _log = null;
+
+        internal Log Log
+        {
+            get { return _log ?? (_log = new Log(new TaskLoggingHelper(this))); }
+        }
 
         public PackagingTask()
         {
-            _log = new Log(new TaskLoggingHelper(this));
         }
 
         public IBuildEngine BuildEngine

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
         private void ValidateGenerations()
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             {
                 if (validateFile.TargetFramework.Version < minSupportedGeneration)
                 {
-                    _log.LogError($"Invalid generation {validateFile.TargetFramework.Version} for {validateFile.SourcePath}, must be at least {minSupportedGeneration} based on the implementations in the package.  If you meant to target the lower generation you may be missing an implementation for a framework on that lower generation.  If not you should raise the generation of the reference assembly to match that of the lowest supported generation of all implementations/placeholders.");
+                    Log.LogError($"Invalid generation {validateFile.TargetFramework.Version} for {validateFile.SourcePath}, must be at least {minSupportedGeneration} based on the implementations in the package.  If you meant to target the lower generation you may be missing an implementation for a framework on that lower generation.  If not you should raise the generation of the reference assembly to match that of the lowest supported generation of all implementations/placeholders.");
                 }
             }
         }
@@ -195,16 +195,16 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                         if (hasCompileAsset && (hasRuntimeAsset & !permitImplementation))
                         {
-                            _log.LogError($"{ContractName} should not be supported on {target} but has both compile and runtime assets.");
+                            Log.LogError($"{ContractName} should not be supported on {target} but has both compile and runtime assets.");
                         }
                         else if (hasRuntimeAsset & !permitImplementation)
                         {
-                            _log.LogError($"{ContractName} should not be supported on {target} but has runtime assets.");
+                            Log.LogError($"{ContractName} should not be supported on {target} but has runtime assets.");
                         }
 
                         if (hasRuntimePlaceHolder && hasCompilePlaceHolder)
                         {
-                            _log.LogError($"{ContractName} should not be supported on {target} but has placeholders for both compile and runtime which will permit the package to install.");
+                            Log.LogError($"{ContractName} should not be supported on {target} but has placeholders for both compile and runtime which will permit the package to install.");
                         }
                     }
                     else
@@ -213,20 +213,20 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                         {
                             if (!hasCompileAsset && !hasCompilePlaceHolder)
                             {
-                                _log.LogError($"Framework {fx} should support {ContractName} inbox but was missing a placeholder for compile-time.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
+                                Log.LogError($"Framework {fx} should support {ContractName} inbox but was missing a placeholder for compile-time.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
                             }
                             else if (hasCompileAsset)
                             {
-                                _log.LogError($"Framework {fx} should support {ContractName} inbox but contained a reference assemblies: {String.Join(", ", compileAssetPaths)}.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
+                                Log.LogError($"Framework {fx} should support {ContractName} inbox but contained a reference assemblies: {String.Join(", ", compileAssetPaths)}.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
                             }
 
                             if (!hasRuntimeAsset && !hasRuntimePlaceHolder)
                             {
-                                _log.LogError($"Framework {fx} should support {ContractName} inbox but was missing a placeholder for run-time.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
+                                Log.LogError($"Framework {fx} should support {ContractName} inbox but was missing a placeholder for run-time.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
                             }
                             else if (hasRuntimeAsset)
                             {
-                                _log.LogError($"Framework {fx} should support {ContractName} inbox but contained a implementation assemblies: {String.Join(", ", runtimeAssetPaths)}.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
+                                Log.LogError($"Framework {fx} should support {ContractName} inbox but contained a implementation assemblies: {String.Join(", ", runtimeAssetPaths)}.  You may need to add <InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> to your project.");
                             }
                         }
                         else
@@ -234,7 +234,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                             Version referenceAssemblyVersion = null;
                             if (!hasCompileAsset)
                             {
-                                _log.LogError($"{ContractName} should be supported on {target} but has no compile assets.");
+                                Log.LogError($"{ContractName} should be supported on {target} but has no compile assets.");
                             }
                             else
                             {
@@ -242,7 +242,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                                 if (referenceAssemblies.Count() > 1)
                                 {
-                                    _log.LogError($"{ContractName} should only contain a single compile asset for {target}.");
+                                    Log.LogError($"{ContractName} should only contain a single compile asset for {target}.");
                                 }
 
                                 foreach (var referenceAssembly in referenceAssemblies)
@@ -251,14 +251,14 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                                     if (!VersionUtility.IsCompatibleApiVersion(supportedVersion, referenceAssemblyVersion))
                                     {
-                                        _log.LogError($"{ContractName} should support API version {supportedVersion} on {target} but {referenceAssembly} was found to support {referenceAssemblyVersion?.ToString() ?? "<unknown version>"}.");
+                                        Log.LogError($"{ContractName} should support API version {supportedVersion} on {target} but {referenceAssembly} was found to support {referenceAssemblyVersion?.ToString() ?? "<unknown version>"}.");
                                     }
                                 }
                             }
 
                             if (!hasRuntimeAsset && !IsGeneration(validateFramework.Framework))
                             {
-                                _log.LogError($"{ContractName} should be supported on {target} but has no runtime assets.");
+                                Log.LogError($"{ContractName} should be supported on {target} but has no runtime assets.");
                             }
                             else
                             {
@@ -271,19 +271,19 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                                     if (!VersionUtility.IsCompatibleApiVersion(supportedVersion, implementationVersion))
                                     {
-                                        _log.LogError($"{ContractName} should support API version {supportedVersion} on {target} but {implementationAssembly} was found to support {implementationVersion?.ToString() ?? "<unknown version>"}.");
+                                        Log.LogError($"{ContractName} should support API version {supportedVersion} on {target} but {implementationAssembly} was found to support {implementationVersion?.ToString() ?? "<unknown version>"}.");
                                     }
 
                                     if (referenceAssemblyVersion != null && implementationVersion != referenceAssemblyVersion)
                                     {
-                                        _log.LogError($"{ContractName} has mismatched compile ({referenceAssemblyVersion}) and runtime ({implementationVersion}) versions on {target}.");
+                                        Log.LogError($"{ContractName} has mismatched compile ({referenceAssemblyVersion}) and runtime ({implementationVersion}) versions on {target}.");
                                     }
 
                                     string fileName = Path.GetFileName(implementationAssembly);
 
                                     if (implementationFiles.ContainsKey(fileName))
                                     {
-                                        _log.LogError($"{ContractName} includes both {implementationAssembly} and {implementationFiles[fileName]} an on {target} which have the same name and will clash when both packages are used.");
+                                        Log.LogError($"{ContractName} includes both {implementationAssembly} and {implementationFiles[fileName]} an on {target} which have the same name and will clash when both packages are used.");
                                     }
                                     else
                                     {
@@ -359,7 +359,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 assetLog.AppendLine();
                 assetLog.Append("  <none>");
             }
-            _log.LogMessage(LogImportance.Low, assetLog.ToString());
+            Log.LogMessage(LogImportance.Low, assetLog.ToString());
         }
 
         private void LoadSuppressions()
@@ -396,7 +396,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     }
                     else
                     {
-                        _log.LogError($"{SuppressionFile} contained unkown suppression {keyString}");
+                        Log.LogError($"{SuppressionFile} contained unkown suppression {keyString}");
                     }
                 }
             }
@@ -413,18 +413,18 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                     if (String.IsNullOrWhiteSpace(validateFile.TargetPath))
                     {
-                        _log.LogError($"{validateFile.TargetPath} is missing TargetPath metadata");
+                        Log.LogError($"{validateFile.TargetPath} is missing TargetPath metadata");
                     }
 
                     if (IsDll(validateFile.SourcePath))
                     {
                         if (validateFile.TargetFramework == null)
                         {
-                            _log.LogError($"{validateFile.SourcePath} is missing TargetFramework metadata");
+                            Log.LogError($"{validateFile.SourcePath} is missing TargetFramework metadata");
                         }
                         else if (validateFile.TargetPath.IndexOf(validateFile.TargetFramework.GetShortFolderName(), StringComparison.OrdinalIgnoreCase) == -1)
                         {
-                            _log.LogError($"{validateFile.SourcePath} specifies TargetFramework {validateFile.TargetFramework} but TargetPath {validateFile.TargetPath} is missing the {validateFile.TargetFramework.GetShortFolderName()} qualifier");
+                            Log.LogError($"{validateFile.SourcePath} specifies TargetFramework {validateFile.TargetFramework} but TargetPath {validateFile.TargetPath} is missing the {validateFile.TargetFramework.GetShortFolderName()} qualifier");
                         }
                     }
 
@@ -436,7 +436,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 }
                 catch (Exception ex)
                 {
-                    _log.LogError($"Could not parse File {file.ItemSpec}. {ex}");
+                    Log.LogError($"Could not parse File {file.ItemSpec}. {ex}");
                     // skip it.
                 }
             }
@@ -452,7 +452,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                     if (_targetPathToPackageItem.ContainsKey(packageSpecificTargetPath))
                     {
-                        _log.LogError($"Files {_targetPathToPackageItem[packageSpecificTargetPath].SourcePath} and {validateFile.SourcePath} have the same TargetPath {packageSpecificTargetPath}.");
+                        Log.LogError($"Files {_targetPathToPackageItem[packageSpecificTargetPath].SourcePath} and {validateFile.SourcePath} have the same TargetPath {packageSpecificTargetPath}.");
                     }
                     _targetPathToPackageItem[packageSpecificTargetPath] = validateFile;
                 }
@@ -469,10 +469,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             foreach (var packageId in _validateFiles.Keys)
             {
-                _log.LogMessage(LogImportance.Low, $"Package {packageId}");
+                Log.LogMessage(LogImportance.Low, $"Package {packageId}");
                 foreach (var targetPath in _validateFiles[packageId].Select(pi => pi.TargetPath))
                 {
-                    _log.LogMessage(LogImportance.Low, $"  {targetPath}");
+                    Log.LogMessage(LogImportance.Low, $"  {targetPath}");
                 }
             }
         }
@@ -491,13 +491,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 }
                 catch (Exception ex)
                 {
-                    _log.LogError($"Could not parse Framework {framework.ItemSpec}. {ex}");
+                    Log.LogError($"Could not parse Framework {framework.ItemSpec}. {ex}");
                     continue;
                 }
 
                 if (fx.Equals(NuGetFramework.UnsupportedFramework))
                 {
-                    _log.LogError($"Did not recognize {framework.ItemSpec} as valid Framework.");
+                    Log.LogError($"Did not recognize {framework.ItemSpec} as valid Framework.");
                     continue;
                 }
 
@@ -505,7 +505,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 
                 if (_frameworks.ContainsKey(fx))
                 {
-                    _log.LogError($"Framework {fx} has been listed in Frameworks more than once.");
+                    Log.LogError($"Framework {fx} has been listed in Frameworks more than once.");
                     continue;
                 }
 
@@ -537,13 +537,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 }
                 catch (Exception ex)
                 {
-                    _log.LogError($"Could not parse TargetFramework {fxString} as a SupportedFramework. {ex}");
+                    Log.LogError($"Could not parse TargetFramework {fxString} as a SupportedFramework. {ex}");
                     continue;
                 }
 
                 if (fx.Equals(NuGetFramework.UnsupportedFramework))
                 {
-                    _log.LogError($"Did not recognize TargetFramework {fxString} as a SupportedFramework.");
+                    Log.LogError($"Did not recognize TargetFramework {fxString} as a SupportedFramework.");
                     continue;
                 }
 
@@ -555,14 +555,14 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 }
                 catch (Exception ex)
                 {
-                    _log.LogError($"Could not parse Version {version} on SupportedFramework item {supportedFramework.ItemSpec}. {ex}");
+                    Log.LogError($"Could not parse Version {version} on SupportedFramework item {supportedFramework.ItemSpec}. {ex}");
                     continue;
                 }
 
                 ValidationFramework validationFramework = null;
                 if (!_frameworks.TryGetValue(fx, out validationFramework))
                 {
-                    _log.LogError($"SupportedFramework {fx} was specified but is not part of the Framework list to use for validation.");
+                    Log.LogError($"SupportedFramework {fx} was specified but is not part of the Framework list to use for validation.");
                     continue;
                 }
 
@@ -571,7 +571,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 {
                     if (validationFramework.SupportedVersion != supportedVersion)
                     {
-                        _log.LogError($"Framework {fx} has been listed in SupportedFrameworks more than once with different versions {validationFramework.SupportedVersion} and {supportedVersion}.  Framework should only be listed once with the expected API version for that platform.");
+                        Log.LogError($"Framework {fx} has been listed in SupportedFrameworks more than once with different versions {validationFramework.SupportedVersion} and {supportedVersion}.  Framework should only be listed once with the expected API version for that platform.");
                     }
                     continue;
                 }
@@ -621,13 +621,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                                 (supportedVersion.Major == inboxVersion.Major && supportedVersion.Minor > inboxVersion.Minor)))
                             {
                                 // Higher major.minor
-                                _log.LogMessage(LogImportance.Low, $"Framework {fx} supported {ContractName} as inbox but the current supported version {supportedVersion} is higher in major.minor than inbox version {inboxVersion}.  Assuming out of box.");
+                                Log.LogMessage(LogImportance.Low, $"Framework {fx} supported {ContractName} as inbox but the current supported version {supportedVersion} is higher in major.minor than inbox version {inboxVersion}.  Assuming out of box.");
                                 continue;
                             }
                             else if (supportedVersion != null && supportedVersion < inboxVersion)
                             {
                                 // Lower version
-                                _log.LogError($"Framework {fx} supports {ContractName} as inbox but the current supported version {supportedVersion} is lower than the inbox version {inboxVersion}");
+                                Log.LogError($"Framework {fx} supports {ContractName} as inbox but the current supported version {supportedVersion} is lower than the inbox version {inboxVersion}");
                             }
 
                             // equal major.minor, build.revision difference is permitted, prefer the version listed by ContractSupport item
@@ -661,14 +661,14 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             foreach (var framework in portableFrameworks)
             {
                 NuGetFramework generation = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetPlatform, Generations.DetermineGenerationForFramework(framework.Framework));
-                _log.LogMessage(LogImportance.Low, $"Validating {generation} for {ContractName}, {framework.SupportedVersion} since it is supported by {framework.Framework}");
+                Log.LogMessage(LogImportance.Low, $"Validating {generation} for {ContractName}, {framework.SupportedVersion} since it is supported by {framework.Framework}");
 
                 ValidationFramework existingGeneration = null;
                 if (generationsToValidate.TryGetValue(generation, out existingGeneration))
                 {
                     if (!VersionUtility.IsCompatibleApiVersion(framework.SupportedVersion, existingGeneration.SupportedVersion) && !genVersionSuppression.Contains(framework.Framework.ToString()))
                     {
-                        _log.LogError($"Framework {framework.Framework} supports {ContractName} at {framework.SupportedVersion} which is lower than {existingGeneration.SupportedVersion} supported by generation {generation.GetShortFolderName()}");
+                        Log.LogError($"Framework {framework.Framework} supports {ContractName} at {framework.SupportedVersion} which is lower than {existingGeneration.SupportedVersion} supported by generation {generation.GetShortFolderName()}");
                     }
                 }
                 else
@@ -700,7 +700,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                     Version supportedVersion = generationalImplementation.Version;
 
-                    _log.LogMessage(LogImportance.Low, $"Validating {generation} for {ContractName}, {supportedVersion} since it is supported by {generationalImplementation.TargetPath}");
+                    Log.LogMessage(LogImportance.Low, $"Validating {generation} for {ContractName}, {supportedVersion} since it is supported by {generationalImplementation.TargetPath}");
 
                     _frameworks.Add(generation, new ValidationFramework(generation) { SupportedVersion = supportedVersion });
                 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackageTargetFramework.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackageTargetFramework.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             if (String.IsNullOrEmpty(PackageTargetFramework))
             {
-                _log.LogMessage(LogImportance.Low, $"Skipping validation since PackageTargetFramework is not defined");
+                Log.LogMessage(LogImportance.Low, $"Skipping validation since PackageTargetFramework is not defined");
                 return true;
             }
 
@@ -64,20 +64,20 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
             catch(Exception ex)
             {
-                _log.LogError($"Could not parse PackageTargetFramework {PackageTargetFramework}. {ex}");
+                Log.LogError($"Could not parse PackageTargetFramework {PackageTargetFramework}. {ex}");
                 return false;
             }
 
             Version assemblyVersion = null;
             if (!Version.TryParse(AssemblyVersion, out assemblyVersion))
             {
-                _log.LogError($"Could not parse AssemblyVersion {AssemblyVersion}.");
+                Log.LogError($"Could not parse AssemblyVersion {AssemblyVersion}.");
                 return false;
             }
 
             if (fx.Framework != FrameworkConstants.FrameworkIdentifiers.NetPlatform)
             {
-                _log.LogMessage(LogImportance.Low, $"Skipping validation since PackageTargetFramework {fx} is not {FrameworkConstants.FrameworkIdentifiers.NetPlatform}");
+                Log.LogMessage(LogImportance.Low, $"Skipping validation since PackageTargetFramework {fx} is not {FrameworkConstants.FrameworkIdentifiers.NetPlatform}");
                 return true;
             }
 
@@ -85,10 +85,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             Dictionary<string, string> candidateRefs = CandidateReferences.ToDictionary(r => r.GetMetadata("FileName"), r => r.GetMetadata("FullPath"));
 
-            Version idealGeneration = _generations.DetermineGenerationFromSeeds(AssemblyName, assemblyVersion, _log) ?? new Version(0, 0, 0, 0);
+            Version idealGeneration = _generations.DetermineGenerationFromSeeds(AssemblyName, assemblyVersion, Log) ?? new Version(0, 0, 0, 0);
             if (idealGeneration > fx.Version)
             {
-                _log.LogError($"Assembly {AssemblyName}, Version={assemblyVersion} is generation {idealGeneration} based on the seed data in {GenerationDefinitionsFile} which is greater than project generation {fx.Version}.");
+                Log.LogError($"Assembly {AssemblyName}, Version={assemblyVersion} is generation {idealGeneration} based on the seed data in {GenerationDefinitionsFile} which is greater than project generation {fx.Version}.");
             }
 
             HashSet<string> ignoredRefs = null;
@@ -118,15 +118,15 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 
                 if (!File.Exists(path))
                 {
-                    _log.LogError($"Reference {path} does not exist.");
+                    Log.LogError($"Reference {path} does not exist.");
                     continue;
                 }
 
-                var dependencyGeneration = _generations.DetermineGenerationFromFile(path, _log, candidateRefs: candidateRefs, ignoredRefs: ignoredRefs) ?? FrameworkConstants.CommonFrameworks.DotNet.Version;
+                var dependencyGeneration = _generations.DetermineGenerationFromFile(path, Log, candidateRefs: candidateRefs, ignoredRefs: ignoredRefs) ?? FrameworkConstants.CommonFrameworks.DotNet.Version;
 
                 if (dependencyGeneration > fx.Version)
                 {
-                    _log.LogError($"Dependency {path} is generation {dependencyGeneration} which is greater than project generation {fx.Version}.");
+                    Log.LogError($"Dependency {path} is generation {dependencyGeneration} which is greater than project generation {fx.Version}.");
                 }
                 
                 if (dependencyGeneration > idealGeneration)
@@ -137,11 +137,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (fx.Version > idealGeneration)
             {
-                _log.LogMessage(LogImportance.Low, $"Generation {fx.Version} is higher than the ideal miniumum {idealGeneration}.");
+                Log.LogMessage(LogImportance.Low, $"Generation {fx.Version} is higher than the ideal miniumum {idealGeneration}.");
             }
 
 
-            return !_log.HasLoggedErrors;
+            return !Log.HasLoggedErrors;
         }
 
     }


### PR DESCRIPTION
Mono's implementation of TaskLoggingHelper seems
to capture the BuildEngine property of the task during
construction of the TaskLoggingHelper.  This breaks
when someone constructs a TasksLoggingHelper in
the constuctor of their task, since none of the fields
are initialized.

Work around this by making our TaskLoggingHelper
lazily initialized.