### PR TITLE
Sync packaging infrastructure with TFS changes

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                 // Only add the lowest version for a particular inbox framework.  EG if both net45 and net46 are supported by this generation,
                 //        only add net45
-                inboxFrameworksList.RemoveWhere(fx => inboxFrameworksList.Any(otherFx => (otherFx.Framework == fx.Framework) && (otherFx.Version < fx.Version)));
+                inboxFrameworksList.RemoveWhere(fx => inboxFrameworksList.Any(otherFx => (otherFx.Framework.Equals(fx.Framework)) && (otherFx.Version < fx.Version)));
 
                 // Check for assets which have a ref, but not a lib asset. If we have any of these, then they are actually not supported frameworks 
                 // and we should not include them.                
@@ -123,6 +123,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                         if (string.IsNullOrEmpty(version))
                         {
                             version = dependency.GetMetadata("Version");
+
+                            int prereleaseIndex = version.IndexOf('-');
+                            if (prereleaseIndex != -1)
+                            {
+                                version = version.Substring(0, prereleaseIndex);
+                            }
                         }
                         if (!Frameworks.IsInbox(FrameworkListsPath, framework, dependency.ItemSpec, version))
                         {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Generations.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Generations.json
@@ -146,7 +146,7 @@
         "System.Runtime.Serialization.Primitives": "4.1.0.0",
         "System.Runtime.Serialization.Xml": "4.1.0.0",
         "System.ServiceModel.Primitives": "4.1.0.0",
-        "System.ServiceModel.Http": "4.0.10.0",
+        "System.ServiceModel.Http": "4.1.0.0",
         "System.Text.Encoding": "4.0.10.0",
         "System.Text.Encoding.Extensions": "4.0.10.0",
         "System.Text.RegularExpressions": "4.0.10.0",

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -7,12 +7,20 @@
   -->
   
   <PropertyGroup>
+    <Version Condition="'$(StableVersion)' != ''">$(StableVersion)</Version>
+    
     <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">rc2</PreReleaseLabel>
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
 
     <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">-$(PreReleaseLabel)</VersionSuffix>
     <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)</VersionSuffix>
-    
+
+    <!-- 
+      Empty out the project properties because we want configuration and platform to come from the individual
+      projects instead of being overridden by the value the packages have.
+    -->
+    <ProjectProperties></ProjectProperties>
+
     <PackageRevStableToPrerelease Condition="'$(PackageRevStableToPrerelease)' == ''">false</PackageRevStableToPrerelease>
     <DependencyRevStableToPrerelease Condition="'$(PackageRevStableToPrerelease)' == ''">false</DependencyRevStableToPrerelease>
   </PropertyGroup>
@@ -66,6 +74,13 @@
   </PropertyGroup>
 
   <Import Project="stable.packages.targets" />
+
+  <!-- If this package explicitly sets the StableVersion then add it to the stable list -->
+  <ItemGroup Condition="'$(StableVersion)' != ''">
+    <StablePackage Include="$(MSBuildProjectName)">
+      <Version>$(StableVersion)</Version>
+    </StablePackage>
+  </ItemGroup>
 
   <UsingTask TaskName="ApplyPreReleaseSuffix" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetAssemblyReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
@@ -387,7 +402,12 @@
       <!-- ensure that unconstrained dependencies are also expanded in constrained TFM groups -->
       <_PkgProjDependencyWithoutTFM Include="@(PkgProjDependency)" Condition="'%(PkgProjDependency.TargetFramework)' == '' AND '%(PkgProjDependency.DoNotExpand)' != 'true'" />
       <_AllPkgProjTFMs Include="%(PkgProjDependency.TargetFramework)" Condition="'%(PkgProjDependency.DependencyKind)' == 'Direct'" />
+      <!-- Include file TFMs -->
+      <_AllPkgProjTFMs Include="%(File.TargetFramework)" Condition="'%(File.TargetFramework)' != ''" />
 
+      <!-- Remove dependencies without a TFM so they can be replaced -->
+      <PkgProjDependency Remove="@(_PkgProjDependencyWithoutTFM)" />
+      <!-- operate on nuproj dependencies and file dependencies -->
       <PkgProjDependency Include="@(_PkgProjDependencyWithoutTFM)">
         <TargetFramework>%(_AllPkgProjTFMs.Identity)</TargetFramework>
       </PkgProjDependency>
@@ -534,6 +554,9 @@
     <!-- see if we have any runtime dependencies to write to runtime.json -->
     <ItemGroup>
       <RuntimeDependency Condition="'%(Dependency.TargetRuntime)' != ''" Include="@(Dependency)"/>
+      <RuntimeDependency>
+        <TargetPackage Condition="'%(RuntimeDependency.TargetPackage)' == ''">$(Id)</TargetPackage>
+      </RuntimeDependency>
       <!-- don't include runtime depdendencies in the dependency list, they'll be written to the runtime.json -->
       <Dependency Remove="@(RuntimeDependency)"/>
     </ItemGroup>
@@ -667,9 +690,12 @@
   <Target Name="GenerateRuntimeDependencies"
           DependsOnTargets="DetermineRuntimeDependencies"
           BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <LineupProjectReference Include="@(ProjectReference)" />
+    </ItemGroup>
 
     <!-- Lineups need to have all runtime dependencies to ensure that they are part of the compile graph -->
-    <MSBuild Projects="@(ProjectReference)" Targets="DetermineRuntimeDependencies" Condition="'$(IsLineupPackage)' == 'true'" Properties="$(ProjectProperties)">
+    <MSBuild Projects="@(LineupProjectReference)" Targets="DetermineRuntimeDependencies" Condition="'$(IsLineupPackage)' == 'true'" Properties="$(ProjectProperties)">
       <Output TaskParameter="TargetOutputs" ItemName="_indirectRuntimeDependencies" />
     </MSBuild>
 
@@ -697,21 +723,27 @@
 
   <Target Name="GetPackageDescription"
           BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <UseRuntimePackageDescription Condition="'$(UseRuntimePackageDescription)' == '' AND $(BaseId.StartsWith('runtime.native'))">true</UseRuntimePackageDescription>
+    </PropertyGroup>
+
     <GetPackageDescription DescriptionFile="$(PackageDescriptionFile)"
+                           Condition="'$(UseRuntimePackageDescription)' != 'true'"
                            PackageId="$(BaseId)">
       <Output TaskParameter="Description"
               PropertyName="Description" />
     </GetPackageDescription>
     
     <GetPackageDescription DescriptionFile="$(PackageDescriptionFile)"
-                           Condition="'$(PackageTargetRuntime)' != ''"
+                           Condition="'$(PackageTargetRuntime)' != '' OR '$(UseRuntimePackageDescription)' == 'true'"
                            PackageId="RuntimePackage">
       <Output TaskParameter="Description"
               PropertyName="RuntimeDisclaimer" />
     </GetPackageDescription>
     
     <PropertyGroup>
-      <Description Condition="'$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer) \r\n $(Description)</Description>
+      <Description Condition="'$(UseRuntimePackageDescription)' == 'true' AND '$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer)</Description>
+      <Description Condition="'$(UseRuntimePackageDescription)' != 'true' AND '$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer) \r\n $(Description)</Description>
       <Description Condition="'@(SyncInfoLines)' != ''">$(Description) \r\n %(SyncInfoLines.Identity)</Description>
     </PropertyGroup>
   </Target>
@@ -816,45 +848,25 @@
                      SuppressionFile="$(ValidationSuppressionFile)"
                      ContinueOnError="ErrorAndContinue"/>
   </Target>
-  
+
   <Target Name="ValidateMetaPackageFramework"
           Condition="'$(MetaPackageFramework)' != ''"
           BeforeTargets="GenerateNuspec">
-    
+
     <ItemGroup>
-      <_ExpectedMetaDependencies Include="@(ContractAssembly)" Condition="'%(ContractAssembly.Platform)' == '$(MetaPackageFramework)'">
-        <Version>$([System.Version]::Parse('%(Version)').ToString(3))</Version>
-      </_ExpectedMetaDependencies>
-      
+      <_ExpectedMetaDependencies Include="@(ContractAssembly)" Condition="'%(ContractAssembly.Platform)' == '$(MetaPackageFramework)'" />
+
       <_ExpectedMetaDependencies Remove="@(ExcludePackage);@(NoPackage)" />
 
       <_ActualMetaDependencies Include="@(Dependency);@(RuntimeDependency)"/>
-      <!-- also consider indirect dependencies that may come from the core package, 
-           TODO: right now this also picks up indirect dependencies other packages (eg: runtime pinning) -->
-      <_ActualMetaDependencies Include="@(PkgProjDependency)" Condition="'%(PkgProjDependency.DependencyKind)' == 'Indirect'" />
-      <_ActualMetaDependencies>
-        <Version>$([System.String]::new('%(Version)').Replace('$(VersionSuffix)', ''))</Version>
-      </_ActualMetaDependencies>
-      
-      <_MissingMetaDependencies Include="@(_ExpectedMetaDependencies)" Exclude="@(_ActualMetaDependencies)"/>
-      <_SatisfiedMetaDependencies Include="@(_ExpectedMetaDependencies)" Condition="'@(_ExpectedMetaDependencies)' == '@(_ActualMetaDependencies)' and '%(Identity)' != ''">
-        <!-- Use transform here because we don't want to effect the batching -->
-        <ActualVersion>@(_ActualMetaDependencies->'%(Version)')</ActualVersion>
-      </_SatisfiedMetaDependencies>
-      
-      <_SatisfiedMetaDependencies>
-        <!-- Compare and store the result in metadata -->
-        <!-- This cannot be done in a condition because MSBuild logical ops aren't short 
-             circuit and parse would throw on empty string as a result of empty _SatisfiedDependencies -->
-        <CompareResult>$([System.Version]::Parse('%(ActualVersion)').CompareTo( $([System.Version]::Parse('%(Version)')) ))</CompareResult>
-      </_SatisfiedMetaDependencies>
+      <!-- also consider indirect dependencies that may come from the core package -->
+      <_ActualMetaDependencies Include="@(NuProjDependency)" Condition="'%(NuProjDependency.DependencyKind)' == 'Indirect'" />
+
+      <_MissingMetaDependencies Include="@(_ExpectedMetaDependencies)" Exclude="@(_ActualMetaDependencies)" />
     </ItemGroup>
 
-    <Error Text="Packages @(_MissingMetaDependencies->'%(Identity)-%(Version)') should be included."
+    <Error Text="Packages @(_MissingMetaDependencies) should be included."
            Condition="'@(_MissingMetaDependencies)' != ''"
-           ContinueOnError="ErrorAndContinue" />
-    <Error Text="Package @(_SatisfiedMetaDependencies)-%(ActualVersion) is higher version than %(Version) expected." 
-           Condition="'@(_SatisfiedMetaDependencies)' != '' AND  %(CompareResult) &gt; 0"
            ContinueOnError="ErrorAndContinue" />
   </Target>
 


### PR DESCRIPTION
Generations.cs
Make dll probing in version calculation more flexible

We weren't finding a reference assembly for System.Threading.Tasks.Extensions
so were falling back to package store probing.  Package store brobing would
fail if no stable package existed (as is the case here).

To fix this I've made the probing much more flexible.  This is a temporary
fix, the code is dead in the Open-source port of the task which uses
the actual project references to do the generation calculation.

Generations.json
Move System.ServiceModel.Http 5.4 to 4.1.0.0.  API changes supported
by existing desktop framework 4.6.

Packaging.targets
@chcosta - Packaging for native shims.
@weshaggard - Support project-authored stable packages.
            - Project .builds work.

CreateTrimDependencies.cs
@chcosta - NuGetFramework == is not overloaded, use .Equals
         - handle pre-release dependencies w/o assemblyversion.