### PR TITLE
Fix remaining nuproj references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -407,7 +407,7 @@
 
       <!-- Remove dependencies without a TFM so they can be replaced -->
       <PkgProjDependency Remove="@(_PkgProjDependencyWithoutTFM)" />
-      <!-- operate on nuproj dependencies and file dependencies -->
+      <!-- operate on pkgproj dependencies and file dependencies -->
       <PkgProjDependency Include="@(_PkgProjDependencyWithoutTFM)">
         <TargetFramework>%(_AllPkgProjTFMs.Identity)</TargetFramework>
       </PkgProjDependency>
@@ -860,7 +860,7 @@
 
       <_ActualMetaDependencies Include="@(Dependency);@(RuntimeDependency)"/>
       <!-- also consider indirect dependencies that may come from the core package -->
-      <_ActualMetaDependencies Include="@(NuProjDependency)" Condition="'%(NuProjDependency.DependencyKind)' == 'Indirect'" />
+      <_ActualMetaDependencies Include="@(PkgProjDependency)" Condition="'%(PkgProjDependency.DependencyKind)' == 'Indirect'" />
 
       <_MissingMetaDependencies Include="@(_ExpectedMetaDependencies)" Exclude="@(_ActualMetaDependencies)" />
     </ItemGroup>


### PR DESCRIPTION
I had a typo where I was still using "nuproj" in
an item name.  This was causing a problem when
trying to consume buildtools in our internal build
where we build and validate meta-packages.