### PR TITLE
Assign package refs to OOB tfm as well

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -394,9 +394,8 @@
 
   </Target>
 
-  <!-- Don't infer TFM from files.  Instead allow explicit definition of TFM by projects/references.-->
   <Target Name="AssignPkgProjPackageDependenciesTargetFramework"
-          DependsOnTargets="GetPkgProjPackageDependencies;GetFiles">
+          DependsOnTargets="GetPkgProjPackageDependencies;GetFiles;EnsureOOBFramework">
 
     <ItemGroup>
       <!-- ensure that unconstrained dependencies are also expanded in constrained TFM groups -->


### PR DESCRIPTION
We were collecting the list of TFMs to project
naked project references to before adding the
OOB framework assets.  As a result we were
not projecting to netcore50.