### PR TITLE
Packaging fixes for TFS build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Generations.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Generations.json
@@ -5,7 +5,7 @@
     "Contracts may be moved down in generations as a compatible change if every framework assigned",
     "to that generation either supports the contract at that API version or doesn't support the",
     "contract at all.  Support may mean an out of band implementation is provided in the package.",
-    
+
     "Contracts may be added to a generation as a compatible change, but higher versions of that contract",
     "need to be supported by all frameworks assigned to that generation or the higher version needs to be",
     "assigned to a new generation.",
@@ -103,7 +103,7 @@
         "System.Diagnostics.Tracing": "4.0.10.0",
         "System.Runtime": "4.0.10.0",
         "System.Runtime.InteropServices": "4.0.10.0",
-        "System.Runtime.WindowsRuntime":  "4.0.10.0",
+        "System.Runtime.WindowsRuntime": "4.0.10.0",
         "System.Threading.Timer": "4.0.0.0"
       }
     },
@@ -113,7 +113,7 @@
 
         "S.IO.Compression, S.R.Serialization.Primitives, S.R.Serialization.Xml, and S.ServiceModel.Primitives can",
         "only be OOB'ed in 5.4 since Windows Store and Windows Phone do not permit OOBing",
- 
+
         "System.ComponentModel.Annotations 4.1 needs to be in 5.5 but we cannot move it until NuGet/DNX are updated",
         "to make UAP support 5.5"
       ],
@@ -124,7 +124,7 @@
         "System.ComponentModel.Annotations": "4.1.0.0",
         "System.ComponentModel.EventBasedAsync": "4.0.10.0",
         "System.Diagnostics.Debug": "4.0.10.0",
-        "System.Diagnostics.Process":  "4.0.0.0",
+        "System.Diagnostics.Process": "4.0.0.0",
         "System.Diagnostics.Tracing": "4.0.20.0",
         "System.Dynamic.Runtime": "4.0.10.0",
         "System.Globalization": "4.0.10.0",
@@ -164,7 +164,7 @@
         "System.Diagnostics.Process is added here because it required changes to desktop in 4.6.1 that could not be OOBed"
       ],
       "assemblies": {
-        "System.Diagnostics.Process":  "4.1.0.0"
+        "System.Diagnostics.Process": "4.1.0.0"
       }
     }
   }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -4,9 +4,9 @@
     <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
     <GenerationDefinitionFile Condition="'$(GenerationDefinitionFile)' == ''">$(MSBuildThisFileDirectory)Generations.json</GenerationDefinitionFile>
   </PropertyGroup>
-  
+
   <UsingTask TaskName="ValidatePackageTargetFramework" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  
+
   <!-- Returns the set of files to be included in the nuget package
        with appropriate metadata.-->
   <Target Name="GetFilesToPackage"
@@ -84,24 +84,24 @@
       <PackageTargetRuntime Condition=" '$(TargetsWindows)' == 'true'">win7</PackageTargetRuntime>
       <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
     </PropertyGroup>
-    
+
     <!-- *** determine destination path for assets *** -->
     <PropertyGroup>
       <_packageTargetRefLib>lib</_packageTargetRefLib>
       <_packageTargetRefLib Condition="'$(IsReferenceAssembly)' == 'true'">ref</_packageTargetRefLib>
-      
+
       <!-- no path or runtime, but framework: lib/{txm}-->
       <PackageTargetPath Condition="'$(PackageTargetPath)' == '' AND '$(PackageTargetRuntime)' == '' AND '$(PackageTargetFramework)' != ''">$(_packageTargetRefLib)/$(PackageTargetFramework)</PackageTargetPath>
 
       <!-- no path but runtime and framework: runtimes/{rid}/lib/{txm}-->
       <PackageTargetPath Condition="'$(PackageTargetPath)' == '' AND '$(PackageTargetFramework)' != '' AND '$(PackageTargetRuntime)' != ''">runtimes/$(PackageTargetRuntime)/lib/$(PackageTargetFramework)</PackageTargetPath>
     </PropertyGroup>
-    
+
     <!-- specifying $(PackageTargetPath) overrides defaults and project specific items -->
     <ItemGroup Condition="'$(PackageTargetPath)' != ''">
       <!-- remove anything specified by the project-->
       <PackageDestination Remove="@(PackageDestination)" />
-      
+
       <!-- only use $(PackageTargetPath) -->
       <PackageDestination Include="$(PackageTargetPath)">
         <TargetFramework Condition="'$(PackageTargetFramework)' != ''">$(PackageTargetFramework)</TargetFramework>
@@ -120,8 +120,8 @@
         <TargetFramework>dotnet</TargetFramework>
       </PackageDestination>
     </ItemGroup>
-    
-    
+
+
     <!-- *** include assets *** -->
     <ItemGroup>
       <!-- Include primary output -->
@@ -159,14 +159,14 @@
     <ItemGroup Condition="'@(ValidateIgnoreReference)' == ''">
       <ValidateIgnoreReference Include="mscorlib;System.Private.Uri;Windows" />
     </ItemGroup>
-    
+
     <ValidatePackageTargetFramework AssemblyName="$(AssemblyName)"
                                     AssemblyVersion="$(AssemblyVersion)"
                                     GenerationDefinitionsFile="$(GenerationDefinitionFile)"
                                     PackageTargetFramework="$(PackageTargetFramework)"
                                     DirectReferences="@(ReferencePath)"
-                                    CandidateReferences="@(ReferencePath);@(IndirectReference)" 
+                                    CandidateReferences="@(ReferencePath);@(IndirectReference)"
                                     IgnoredReferences="@(ValidateIgnoreReference)"/>
   </Target>
-  
+
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -23,6 +23,9 @@
 
     <PackageRevStableToPrerelease Condition="'$(PackageRevStableToPrerelease)' == ''">false</PackageRevStableToPrerelease>
     <DependencyRevStableToPrerelease Condition="'$(PackageRevStableToPrerelease)' == ''">false</DependencyRevStableToPrerelease>
+
+    <!-- By default we'll build libraries referenced by packages -->
+    <BuildPackageLibraryReferences Condition="'$(BuildPackageLibraryReferences)' == ''">true</BuildPackageLibraryReferences>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(IsRuntimePackage)' == 'true' or '$(PackageTargetRuntime)' != ''">
@@ -314,6 +317,13 @@
        to determine the contents of the package-->
   <Target Name="ExpandProjectReferences"
           DependsOnTargets="SplitProjectReferences">
+
+    <!-- Only rebuild project references when specified -->
+    <MSBuild Targets="Build"
+             Condition="'$(BuildPackageLibraryReferences)' == 'true'"
+             Projects="@(_NonPkgProjProjectReference)"
+             Properties="$(ProjectProperties)"
+             ContinueOnError="WarnAndContinue"/>
 
     <MSBuild Targets="GetFilesToPackage"
              BuildInParallel="$(BuildInParallel)"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -5,10 +5,10 @@
        Beta -> RC - RTM. We should set $(IncludeBuildNumberInPackageVersion)
        to false for the Beta/RC builds that get uploaded to NuGet.
   -->
-  
+
   <PropertyGroup>
     <Version Condition="'$(StableVersion)' != ''">$(StableVersion)</Version>
-    
+
     <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">rc2</PreReleaseLabel>
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
 
@@ -27,7 +27,7 @@
     <!-- By default we'll build libraries referenced by packages -->
     <BuildPackageLibraryReferences Condition="'$(BuildPackageLibraryReferences)' == ''">true</BuildPackageLibraryReferences>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(IsRuntimePackage)' == 'true' or '$(PackageTargetRuntime)' != ''">
     <IdPrefix>runtime.</IdPrefix>
     <IdPrefix Condition="'$(PackageTargetRuntime)' != ''">$(IdPrefix)$(PackageTargetRuntime).</IdPrefix>
@@ -119,13 +119,13 @@
   </PropertyGroup>
 
   <!-- Redefine build to just create the NuSpec only, we'll create the package during ArcProjects phase -->
-  <Target Name="Build" 
+  <Target Name="Build"
           DependsOnTargets="$(BuildDependsOn)">
-    
+
     <Message Condition="'$(ShouldGenerateNuSpec)' == 'true'"
              Text="$(MSBuildProjectName) -> $(NuSpecPath)"
              Importance="high" />
-    
+
     <Message Condition="'$(ShouldGenerateNuSpec)' != 'true'"
              Text="Skipping nuspec generation for this platform."
              Importance="high" />
@@ -137,7 +137,7 @@
                        Condition="Exists('$(NuSpecPath).pkgpath')">
       <Output TaskParameter="Lines" ItemName="_ToBeDeleted"/>
     </ReadLinesFromFile>
-                       
+
     <ItemGroup>
       <_ToBeDeleted Include="$(NuSpecPath)" />
       <_ToBeDeleted Include="$(NuSpecPath).pkgpath" />
@@ -148,7 +148,7 @@
 
   <Target Name="Rebuild"
           DependsOnTargets="Clean;Build" />
-  
+
   <Target Name="SplitProjectReferences"
           DependsOnTargets="_GetProjectClosure">
     <ItemGroup>
@@ -302,7 +302,7 @@
       </ProjectReference>
     </ItemGroup>
   </Target>
-  
+
   <PropertyGroup>
     <!-- exclude reference assets for runtime packages 
          these assets are only packaged in the reference packages.  Even
@@ -310,7 +310,7 @@
          for better compression.  -->
     <ExcludeReferenceAssets Condition="'$(ExcludeReferenceAssets)' == '' AND '$(PackageTargetRuntime)' != ''">true</ExcludeReferenceAssets>
   </PropertyGroup>
-  
+
   <!-- We define a custom target: GetFilesToPackage which does a minimal build of the project
        and passes all information in a single item group.
        This helps minimize the number of project evaluations and targets that build in order
@@ -351,7 +351,7 @@
            Text="Package $(ID) contains file with name %(File.FileName).  If this is expected you can disable this filename checking for this item or package by setting SkipPackageFileCheck = true"
            ContinueOnError="ErrorAndContinue" />
   </Target>
-  
+
   <!-- Permit setting TargetFramework and add our own metadata (TargetRuntime) -->
   <Target Name="GetPackageIdentity"
           Returns="@(_PackageIdentity)"
@@ -370,7 +370,7 @@
        strict about assets that are included in the package.  -->
   <Target Name="_GetProjectClosure"
           Returns="@(_ProjectReferenceClosure)">
-          
+
     <!-- Get closure of indirect references if they opt-in -->
     <MSBuild Projects="@(ProjectReference)"
              Targets="_GetProjectClosure"
@@ -422,7 +422,7 @@
       </PkgProjDependency>
     </ItemGroup>
   </Target>
-  
+
   <!-- Don't do any filtering of files. 
        We explicitly determine package content so we do not need to
        filter out files that come from dependent packages. -->
@@ -461,20 +461,20 @@
       <Output TaskParameter="ReferencedAssemblies"
               ItemName="_FileReferencedAssemblies"/>
     </GetAssemblyReferences>
-    
+
     <PropertyGroup>
       <_IsClassicAssembly>false</_IsClassicAssembly>
       <_IsClassicAssembly Condition="'%(_FileReferencedAssemblies.FileName)' == 'mscorlib'">true</_IsClassicAssembly>
       <_IsClassicAssembly Condition="'%(_FileReferencedAssemblies.FileName)' == 'System.Private.Corelib'">true</_IsClassicAssembly>
       <_TargetFramework>%(File.TargetFramework)</_TargetFramework>
     </PropertyGroup>
-    
+
     <ItemGroup Condition="'@(_FileReferencedAssemblies)' != ''">
-      <_FilePackageReference Include="@(_FileReferencedAssemblies)" 
+      <_FilePackageReference Include="@(_FileReferencedAssemblies)"
                              Exclude="corefx;mscorlib;System;System.Core;System.Xml;Windows">
         <AssemblyVersion>%(Version)</AssemblyVersion>
       </_FilePackageReference>
-      
+
       <_FilePackageReference Remove="@(_FilePackageReference)"
                              Condition="$([System.String]::new('%(Identity)').StartsWith('Internal.'))"/>
       <_FilePackageReference Remove="@(_FilePackageReference)"
@@ -527,7 +527,7 @@
     <Error Text="No version could be detected.  Either specify the Version property or provide at least one managed assembly."
            Condition="'$(Version)' == '' AND '$(_AssemblyVersion)' == ''"
            ContinueOnError="ErrorAndContinue" />
-    
+
     <ItemGroup>
       <_thisPackage Include="$(Id)">
         <Version Condition="'$(Version)' != ''">$(Version)</Version>
@@ -539,7 +539,7 @@
     <ApplyPreReleaseSuffix StablePackages="@(StablePackage)" OriginalPackages="@(_thisPackage)" PreReleaseSuffix="$(VersionSuffix)" RevStableToPrerelease="$(PackageRevStableToPrerelease)">
       <Output TaskParameter="UpdatedPackages" ItemName="_thisPackageFinal"/>
     </ApplyPreReleaseSuffix>
-    
+
     <PropertyGroup>
       <Version>%(_thisPackageFinal.Version)</Version>
     </PropertyGroup>
@@ -571,7 +571,7 @@
     </ItemGroup>
 
     <Error Text="Packages that are constrained by runtime should not have runtime dependencies.  They will be ignored by nuget"
-           Condition="'$(PackageTargetRuntime)' != '' AND '@(RuntimeDependency)' != ''" 
+           Condition="'$(PackageTargetRuntime)' != '' AND '@(RuntimeDependency)' != ''"
            ContinueOnError="ErrorAndContinue" />
 
     <!-- determine if there is a file to be updated, and setup the output file -->
@@ -589,7 +589,7 @@
       </PackageFile>
     </ItemGroup>
   </Target>
-  
+
   <Target Name="EnsureEmptyPackage"
           DependsOnTargets="DetermineRuntimeDependencies"
           BeforeTargets="GenerateNuSpec">
@@ -676,7 +676,7 @@
       <Output TaskParameter="AdditionalFiles" ItemName="File" />
     </EnsureOOBFramework>
   </Target>
-  
+
   <!-- We can reduce the number of dependencies listed for any framework that has
        inbox implementations since that framework doesn't need the packages for
        compile/runtime.  This reduces the noise when consuming our packages in 
@@ -690,12 +690,12 @@
                       Files="@(File)"
                       Condition="'@(Dependency)' != ''">
       <Output TaskParameter="TrimmedDependencies" ItemName="TrimmedDependency" />
-    </CreateTrimDependencyGroups>                    
+    </CreateTrimDependencyGroups>
     <ItemGroup>
-       <Dependency Include="@(TrimmedDependency)" />
-   </ItemGroup>                      
+      <Dependency Include="@(TrimmedDependency)" />
+    </ItemGroup>
   </Target>
-  
+
   <!-- Generates a runtime.json file containing all dependencies with TargetRuntime -->
   <Target Name="GenerateRuntimeDependencies"
           DependsOnTargets="DetermineRuntimeDependencies"
@@ -743,21 +743,21 @@
       <Output TaskParameter="Description"
               PropertyName="Description" />
     </GetPackageDescription>
-    
+
     <GetPackageDescription DescriptionFile="$(PackageDescriptionFile)"
                            Condition="'$(PackageTargetRuntime)' != '' OR '$(UseRuntimePackageDescription)' == 'true'"
                            PackageId="RuntimePackage">
       <Output TaskParameter="Description"
               PropertyName="RuntimeDisclaimer" />
     </GetPackageDescription>
-    
+
     <PropertyGroup>
       <Description Condition="'$(UseRuntimePackageDescription)' == 'true' AND '$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer)</Description>
       <Description Condition="'$(UseRuntimePackageDescription)' != 'true' AND '$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer) \r\n $(Description)</Description>
       <Description Condition="'@(SyncInfoLines)' != ''">$(Description) \r\n %(SyncInfoLines.Identity)</Description>
     </PropertyGroup>
   </Target>
-  
+
   <ItemGroup>
     <!-- Default validation frameworks : every framework that supports contracts -->
     <DefaultValidateFramework Include="dnxcore50">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -100,9 +100,9 @@
        If this is not done then the package will build if the target runtime contains the current
        architecture or if we're building for x86. -->
   <PropertyGroup>
-    <PackagePlatform>$(Platform)</PackagePlatform>
-    <PackagePlatform Condition="'$(Platform)' == 'amd64'">x64</PackagePlatform>
-    
+    <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
+    <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
+
     <!-- build if the package specifically requests current architecture via PackagePlatforms -->
     <ShouldGenerateNuSpec Condition="$(PackagePlatforms.Contains('$(PackagePlatform);'))">true</ShouldGenerateNuSpec>
     <!-- build if PackagePlatforms is not specified and the PackageTargetRuntime contains the current architecture -->

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/stable.packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/stable.packages.targets
@@ -347,7 +347,7 @@
     <StablePackage Include="System.Numerics.Vectors.WindowsRuntime">
       <Version>4.0.0</Version>
     </StablePackage>
-    
+
     <!-- Dowlevel packages that shipped in a previous release -->
     <StablePackage Include="System.Collections.Concurrent">
       <Version>4.0.0</Version>


### PR DESCRIPTION
Make packages build library references by default.
Allow TFS to set PackagePlatform.
Fix up formatting.

/cc @weshaggard 