### PR TITLE
UndefineProperties OSGroup and TargetGroup for contract project references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
@@ -35,11 +35,13 @@
       <ProjectReference Include="$(_versionReferenceAssemblyProject)" Condition="Exists('$(_versionReferenceAssemblyProject)')">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <OutputItemType>ResolvedMatchingContract</OutputItemType>
+        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
       </ProjectReference>
       <!-- fall back to 'current' version -->
       <ProjectReference Include="$(_referenceAssemblyProject)" Condition="!Exists('$(_versionReferenceAssemblyProject)') AND Exists('$(_referenceAssemblyProject)')">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <OutputItemType>ResolvedMatchingContract</OutputItemType>
+        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
       </ProjectReference>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Now with the builds files we get race conditions for projects like
System.Collections that build multple partial facades in parallel and so
the building of the ref with different OSGroup or TargetGroup combinations
causes this to build multiple times which conflict given that the output
directores aren't parameterized on those properties. This change simply
undefines these global properties so the project references get folded into one
and there is no longer a race.

cc @ericstj @mellinoe 