### PR TITLE
Update OpenCover and ReportGenerator versions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.lock.json
@@ -921,7 +921,7 @@
     },
     "NuGet.Packaging.Core/3.3.0": {
       "type": "package",
-      "sha512": "6gfzKM6uk/e44iuLS2KglZPs3JiZmLL9lCTBUhDtet8gjmKrHa5RbNctaKNotpQl3NbihSo3F+iDM/SnRO7E/Q==",
+      "sha512": "Ix5M5F7eYIduNIFWQeYgzSo0HKs4Y4ZrLi7TjZC/tMSL5ioiuIF56r2AwLPy98g6J2HWP6j/M6bjkO1vRgIZxA==",
       "files": [
         "lib/dnxcore50/NuGet.Packaging.Core.dll",
         "lib/dnxcore50/NuGet.Packaging.Core.xml",
@@ -934,7 +934,7 @@
     },
     "NuGet.Packaging.Core.Types/3.3.0": {
       "type": "package",
-      "sha512": "J23niUhKIG/J8yDakRwc9UieQvcgTaknYeUsOCxaDb4DrXVDnZ+5GNQMsEyQohNr+4I0b4lEQJvpjoPaxR3+cw==",
+      "sha512": "HjmbxDHozO9DMczF8Iyw2WPpbXHebfxFN18WBPpEabLEK9gNEAqyHS02wd5I8VS2VMBOzRljo24UIVb9yJEimA==",
       "files": [
         "lib/dnxcore50/NuGet.Packaging.Core.Types.dll",
         "lib/dnxcore50/NuGet.Packaging.Core.Types.xml",
@@ -947,7 +947,7 @@
     },
     "NuGet.Repositories/3.3.0": {
       "type": "package",
-      "sha512": "p8OG6CkIVr1wu27J11bVympOhiS5CLL4yhdrq8EkH4NhC7cNCYx9wcsbWMcVIM5JsLIMPkDf53fHVSr1dmF8YQ==",
+      "sha512": "mX7wcpFKH9/Awu+pTJTV5MtSNk2OSQeEg/gwZ6y5dmfL9lmOIpWXSHZJnIzcgFfoHBXiduuaeoCstayUobud8Q==",
       "files": [
         "lib/dnxcore50/NuGet.Repositories.dll",
         "lib/dnxcore50/NuGet.Repositories.xml",
@@ -960,7 +960,7 @@
     },
     "NuGet.RuntimeModel/3.3.0": {
       "type": "package",
-      "sha512": "5TxZt0NJEA1kOA/rXyo8b26BgktJO64yaDAPiyuBBvMuGTpqbq2uDVYE/dKL/D/yCOawPEIawY955Rn+V7JyRA==",
+      "sha512": "+sQzErPT7g7lU8jiKpjZ8JBEhFu9ohxfLZZOiB+E9gjR9rcur+MmtKAyX5Dm1OI90qsHSCSShdB5Xyt5rNFz1A==",
       "files": [
         "lib/dnxcore50/NuGet.RuntimeModel.dll",
         "lib/dnxcore50/NuGet.RuntimeModel.xml",
@@ -973,7 +973,7 @@
     },
     "NuGet.Versioning/3.3.0": {
       "type": "package",
-      "sha512": "/dR3pxThkahpSuYvWUiq0KdBetg8F64WulokAPI7+3z+SsmPh57IXUbhkFdRxxRf9P3fdWkkcDabTwq5YoGr5A==",
+      "sha512": "90wrt/mbOApvWYz/skYYS9w2Y1YdGrHp7irAflAWEW4C1NKzFX80XB3h8BaGKJPcZ6gWNZhh+zZ21MdZ8rJETg==",
       "files": [
         "lib/dnxcore50/NuGet.Versioning.dll",
         "lib/dnxcore50/NuGet.Versioning.xml",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -5,8 +5,8 @@
     Code coverage package versions go here and in the test-runtime-packages.config
   -->
   <PropertyGroup>
-    <OpenCoverVersion>4.6.166</OpenCoverVersion>
-    <ReportGeneratorVersion>2.3.4</ReportGeneratorVersion>
+    <OpenCoverVersion>4.6.261-rc</OpenCoverVersion>
+    <ReportGeneratorVersion>2.4.0-beta1</ReportGeneratorVersion>
     <CoverallsUploaderVersion>1.4</CoverallsUploaderVersion>
   </PropertyGroup>
   

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -5,8 +5,8 @@
       "Microsoft.NETCore.Console": "1.0.0-rc2-23530",
 
       "coveralls.io": "1.4",
-      "OpenCover": "4.6.166",
-      "ReportGenerator": "2.3.4",
+      "OpenCover": "4.6.261-rc",
+      "ReportGenerator": "2.4.0-beta1",
 
       "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0025",
       "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0025",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.lock.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.lock.json
@@ -218,10 +218,10 @@
           "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "OpenCover/4.6.166": {
+      "OpenCover/4.6.261-rc": {
         "type": "package"
       },
-      "ReportGenerator/2.3.4": {
+      "ReportGenerator/2.4.0-beta1": {
         "type": "package"
       },
       "System.AppContext/4.0.1-rc2-23530": {
@@ -2134,10 +2134,10 @@
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
-      "OpenCover/4.6.166": {
+      "OpenCover/4.6.261-rc": {
         "type": "package"
       },
-      "ReportGenerator/2.3.4": {
+      "ReportGenerator/2.4.0-beta1": {
         "type": "package"
       },
       "runtime.any.System.Linq.Expressions/4.0.11-rc2-23530": {
@@ -2829,8 +2829,8 @@
         "native": {
           "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -2893,13 +2893,13 @@
           "runtimes/win7-x64/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x64/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x64/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x64/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x64/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -4941,10 +4941,10 @@
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
-      "OpenCover/4.6.166": {
+      "OpenCover/4.6.261-rc": {
         "type": "package"
       },
-      "ReportGenerator/2.3.4": {
+      "ReportGenerator/2.4.0-beta1": {
         "type": "package"
       },
       "runtime.any.System.Linq.Expressions/4.0.11-rc2-23530": {
@@ -5636,8 +5636,8 @@
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-com-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-comm-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-com-private-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-console-l2-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-datetime-l1-1-0.dll": {},
@@ -5700,13 +5700,13 @@
           "runtimes/win7-x86/native/api-ms-win-core-shlwapi-obsolete-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-shutdown-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-string-l1-1-0.dll": {},
           "runtimes/win7-x86/native/API-MS-Win-Core-String-L2-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
-          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
-          "runtimes/win7-x86/native/API-MS-Win-Core-StringAnsi-L1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-stringloader-l1-1-1.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-0.dll": {},
+          "runtimes/win7-x86/native/api-ms-win-core-string-obsolete-l1-1-1.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-1-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-synch-l1-2-0.dll": {},
           "runtimes/win7-x86/native/api-ms-win-core-sysinfo-l1-1-0.dll": {},
@@ -7821,17 +7821,17 @@
         "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
-    "OpenCover/4.6.166": {
+    "OpenCover/4.6.261-rc": {
       "type": "package",
-      "sha512": "bor8lEgWH0upmsYg4/aj0CMOsczSwwGy6tBZRC26T1pBs1D2IkVQ/EHU/Shn5SjQ8M04cp8N4xiLFMzF8GzT6g==",
+      "sha512": "kTwzuRlHSuJjEPmadvsFobh8ky7H1rbrkt70mgwv5I+9iMegr2/m8VQTW90iWSXJBjFhH5JC8DCLQ6doY1B6Lg==",
       "files": [
         "docs/ReleaseNotes.txt",
         "docs/Usage.rtf",
         "License.rtf",
         "MSBuild/OpenCover.MSBuild.dll",
         "MSBuild/OpenCover.targets",
-        "OpenCover.4.6.166.nupkg",
-        "OpenCover.4.6.166.nupkg.sha512",
+        "OpenCover.4.6.261-rc.nupkg",
+        "OpenCover.4.6.261-rc.nupkg.sha512",
         "OpenCover.nuspec",
         "readme.txt",
         "Samples/x64/OpenCover.Simple.Target.exe",
@@ -7851,6 +7851,7 @@
         "SampleSln/packages/repositories.config",
         "tools/Autofac.Configuration.dll",
         "tools/Autofac.dll",
+        "tools/CrashReporter.NET.dll",
         "tools/Gendarme.Framework.dll",
         "tools/Gendarme.Rules.Maintainability.dll",
         "tools/log4net.config",
@@ -7871,14 +7872,14 @@
         "transform/transform.ps1"
       ]
     },
-    "ReportGenerator/2.3.4": {
+    "ReportGenerator/2.4.0-beta1": {
       "type": "package",
-      "sha512": "2H+u2UyswSd/ZFU76/OOK+KkWCqaBIFeot82CRD+08WPknUYVYZ2ujSx0nNYId0dkhCq4pSGa7TaXRvXDgdsMg==",
+      "sha512": "MhjaDe4adUDXJDu0CRosY5Hg/9V3Hnkovi1dhvXNMOTgAE5GpFBC7AsrVhOV7TjZQtuIZjKiHfYx4Mc6bnPTuA==",
       "files": [
         "LICENSE.txt",
         "Readme.txt",
-        "ReportGenerator.2.3.4.nupkg",
-        "ReportGenerator.2.3.4.nupkg.sha512",
+        "ReportGenerator.2.4.0-beta1.nupkg",
+        "ReportGenerator.2.4.0-beta1.nupkg.sha512",
         "ReportGenerator.nuspec",
         "tools/ICSharpCode.NRefactory.CSharp.dll",
         "tools/ICSharpCode.NRefactory.dll",
@@ -13388,8 +13389,8 @@
       "Microsoft.NETCore.TestHost >= 1.0.0-rc2-23530",
       "Microsoft.NETCore.Console >= 1.0.0-rc2-23530",
       "coveralls.io >= 1.4.0",
-      "OpenCover >= 4.6.166",
-      "ReportGenerator >= 2.3.4",
+      "OpenCover >= 4.6.261-rc",
+      "ReportGenerator >= 2.4.0-beta1",
       "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-alpha-build0025",
       "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-alpha-build0025",
       "xunit >= 2.1.0",


### PR DESCRIPTION
Our code coverage runs recently started failing consistently in CI, and it looks like there may be some related fixes in more recent releases.

cc: @mmitche, @weshaggard 