### PR TITLE
More robust UnsupportedPlatform handling

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -169,8 +169,9 @@
           AfterTargets="Test"
           Condition="'$(TestDisabled)'!='true'">
     <PropertyGroup>
-      <IsWindowsAssembly Condition="'$(OS)'=='Windows_NT' And '%(UnsupportedPlatformsItems.Identity)'=='Windows_NT'">false</IsWindowsAssembly>
-      <TestDisabled Condition="'$(IsWindowsAssembly)'=='false'">true</TestDisabled>
+      <TestDisabled Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(OSGroup)'">true</TestDisabled>
     </PropertyGroup>
+    <Message Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(OSGroup)'"
+      Text="Skipping tests in $(AssemblyName) because it is not supported on $(OSGroup)" />
   </Target>
 </Project>


### PR DESCRIPTION
This was previously hard-coded to only consider things that were not supported on Windows. Instead, I'm just comparing the identities of the unsupported platforms with the current OSGroup. This should fix all of the unsupported tests being run in x-plat builds (outside of run-tests.sh).

@weshaggard , @Priya91 