### PR TITLE
Add additional clean targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/clean.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/clean.targets
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <UserLocalFolder Condition="'$(OsEnvironment)'!='Unix'">$(LocalAppData)/</UserLocalFolder>
+    <UserLocalFolder Condition="'$(OsEnvironment)'=='Unix'">$(HOME)/.local/share/</UserLocalFolder>
+  </PropertyGroup>
+
+  <Target Name="CleanPackages">
+    <RemoveDir Directories="$(PackagesDir)" />
+  </Target>
+
+  <Target Name="CleanPackagesCache">
+    <RemoveDir Directories="$(UserLocalFolder)NuGet/Cache/;$(UserLocalFolder)NuGet/v3-cache/;$(UserLocalFolder)dnu/cache/" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
Based on the feedback for https://github.com/dotnet/corefx/pull/4643,
I've decided to add clean targets to BuildTools so that they can be
shared between clean.sh and clean.cmd, and used for both CoreFX and
CoreCLR.  Note that these targets are in addition to the Clean target
which is defined in build.proj in CoreFX and removes the bin directory.