### PR TITLE
Remove dotnet-corefx feed since it no longer exists

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -75,7 +75,6 @@
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-core/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-coreclr/" />
-    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefx/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxtestdata/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/nugetbuild/" />


### PR DESCRIPTION
/cc @weshaggard @markwilkie 
FYI to anyone who breaks with 
```
Error: FindPackagesById: <packageId>
  Response status code does not indicate success: 404 (Not Found).
```
This is the error you'll get whenever any feed in your source list cannot be resolved.  NuGet/DNX fails rather than just skipping that feed.