### PR TITLE
Respect BUILDTOOLS_OVERRIDE_RUNTIME in init-tools.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -45,4 +45,9 @@ cd $__TOOLS_DIR/tool-runtime/
 $__DOTNET_CMD restore --source https://www.myget.org/F/dotnet-core/ --source https://www.myget.org/F/dotnet-buildtools/ --source https://www.nuget.org/api/v2/
 $__DOTNET_CMD publish -f dnxcore50 -r ${__PUBLISH_RID} -o $__TOOLRUNTIME_DIR
 
+if [ -n $BUILDTOOLS_OVERRIDE_RUNTIME ]; then
+    find $__TOOLRUNTIME_DIR -name *.ni.* | xargs rm 2>/dev/null
+    cp -R $BUILDTOOLS_OVERRIDE_RUNTIME/* $__TOOLRUNTIME_DIR
+fi
+
 exit $__BUILDERRORLEVEL


### PR DESCRIPTION
If the user has specified a value for BUILDTOOLS_OVERRIDE_RUNTIME
(e.g. if they are building on an OS or distro for which a package
is not available), copy the specified runtime into the necessary
locations for dotnet, dnx, etc.