### PR TITLE
Upgrade to OpenCover v4.6.476-rc

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -5,7 +5,7 @@
     Code coverage package versions go here and in the test-runtime-packages.config
   -->
   <PropertyGroup>
-    <OpenCoverVersion>4.6.434-rc</OpenCoverVersion>
+    <OpenCoverVersion>4.6.476-rc</OpenCoverVersion>
     <ReportGeneratorVersion>2.4.0-beta2</ReportGeneratorVersion>
     <CoverallsUploaderVersion>1.4</CoverallsUploaderVersion>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -5,7 +5,7 @@
       "Microsoft.NETCore.Console": "1.0.0-rc2-23712",
 
       "coveralls.io": "1.4",
-      "OpenCover": "4.6.434-rc",
+      "OpenCover": "4.6.476-rc",
       "ReportGenerator": "2.4.0-beta2",
 
       "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0025",


### PR DESCRIPTION
To workaround an OpenCover regression around filters.