### PR TITLE
Add framework import to test-runtime making xunit.abstractions compatible with DNXCore

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -16,7 +16,9 @@
       "xunit.runner.utility": "2.1.0"
     },
     "frameworks": {
-       "dnxcore50": { }
+      "dnxcore50": {
+        "imports": "portable-net45+win8"
+      }
     },
     "runtimes": {
        "win7-x64": { },


### PR DESCRIPTION
Applies the workaround mentioned here: https://github.com/dotnet/corefx/issues/4448#issuecomment-156255106

Fixes these errors I'm hitting when restoring test-runtime\project.json with xplat nuget:

	EXEC : warning : xunit.abstractions 2.0.0 is not compatible with DNXCore,Version=v5.0 (win7-x64).
	EXEC : warning : xunit.abstractions 2.0.0 is not compatible with DNXCore,Version=v5.0 (win7-x86).
	EXEC : warning : xunit.abstractions 2.0.0 is not compatible with DNXCore,Version=v5.0.

cc @weshaggard @ericstj 