### PR TITLE
Update TestWithLocalLibraries support to understand AnyOS

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -76,15 +76,16 @@
          entries. -->
     <PropertyGroup Condition="'$(TestWithLocalLibraries)'=='true'">
       <BaseLocalLibrariesPath Condition="'$(BaseLocalLibrariesPath)'==''">$(BaseOutputPath)</BaseLocalLibrariesPath>
-      <LocalLibrariesPath Condition="'$(LocalLibrariesPath)'==''">$(BaseLocalLibrariesPath)$(OSPlatformConfig)</LocalLibrariesPath>
+      <AnyOSLocalLibrariesPath>$(BaseLocalLibrariesPath)/AnyOS.$(Platform).$(ConfigurationGroup)</AnyOSLocalLibrariesPath>
+      <OSGroupLocalLibrariesPath>$(BaseLocalLibrariesPath)/$(OSGroup).$(Platform).$(ConfigurationGroup)</OSGroupLocalLibrariesPath>
     </PropertyGroup>
     <ItemGroup Condition="'$(TestWithLocalLibraries)'=='true'">
       <!-- Replace some of the resolved libraries that came from nuget by exploring the list of files that we are going to copy
            and replacing them with local copies that were just built -->
-      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(LocalLibrariesPath)/%(filename)/%(filename).dll')" />
-      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(LocalLibrariesPath)/%(filename)/%(filename).pdb')" />
-      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(LocalLibrariesPath)/%(filename).CoreCLR/%(filename).dll')" />
-      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(LocalLibrariesPath)/%(filename).CoreCLR/%(filename).pdb')" />
+      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(AnyOSLocalLibrariesPath)/%(filename)/%(filename).dll')" />
+      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(AnyOSLocalLibrariesPath)/%(filename)/%(filename).pdb')" />
+      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(OSGroupLocalLibrariesPath)/%(filename)/%(filename).dll')" />
+      <_ReplacementCandidates Include="@(TestCopyLocal -> '$(OSGroupLocalLibrariesPath)/%(filename)/%(filename).pdb')" />
       <_ExistingReplacementCandidate Include="@(_ReplacementCandidates)" Condition="Exists('%(_ReplacementCandidates.FullPath)')" />
       <TestCopyLocal Include="@(_ExistingReplacementCandidate)" />
     </ItemGroup>


### PR DESCRIPTION
When TestWithLocalLibraries=true it will find local copied binaries
from AnyOS as well as from the matching OsGroup binary directory.

@stephentoub @ellismg 
