### PR TITLE
Add check to GenFacades command so that if DebugType is Portable we disable the rewrite in genfacades.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
@@ -79,7 +79,7 @@
       <GenFacadesArgs>$(GenFacadesArgs) -contracts:"%(ResolvedMatchingContract.Identity)"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -seeds:"@(GenFacadesSeeds, ';')"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -facadePath:"$(GenFacadesOutputPath.TrimEnd('/'))"</GenFacadesArgs>
-      <GenFacadesArgs Condition="'$(DebugSymbols)' == 'false'">$(GenFacadesArgs) -producePdb:false</GenFacadesArgs>
+      <GenFacadesArgs Condition="'$(DebugSymbols)' == 'false' OR '$(DebugType)'=='Portable'">$(GenFacadesArgs) -producePdb:false</GenFacadesArgs>
       <GenFacadesArgs Condition="'@(SeedTypePreference)' != ''">$(GenFacadesArgs) -preferSeedType:"@(SeedTypePreference->'%(Identity)=%(Assembly)', ',')"</GenFacadesArgs>
     </PropertyGroup>
 
@@ -91,7 +91,7 @@
     <!-- Move the PDB into a subdirectory for GenFacades if we are producing PDBs -->
     <Move SourceFiles="$(PartialFacadeSymbols)"
           DestinationFolder="$(GenFacadesInputPath)"
-          Condition="'$(DebugSymbols)' != 'false'"
+          Condition="'$(DebugSymbols)' != 'false' AND '$(DebugType)'!='Portable'"
     />
 
     <PropertyGroup>


### PR DESCRIPTION
Given that we have moved to using .Net Core MSBuild in non-Windows corefx builds, we are now able to produce Portable PDBs as part of the build. The problem is that CCI doesn't support Portable PDB reading yet, so GenFacades can't rewrite them as part of the build. This change is to disable the PDB rewriting for now when the PDBs are portable and will be removed once CCI supports it.