### PR TITLE
Add a custom helper command to speed up restores

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GatherFoldersToRestore.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GatherFoldersToRestore.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class GatherDirectoriesToRestore : Task
+    {
+        [Required]
+        public string[] RootDirectories { get; set; }
+
+        [Output]
+        public string[] DirectoriesToRestore { get; set; }
+
+        private int directoryListLength = 7000;
+
+        public int DirectoryListLength
+        {
+            get { return directoryListLength; }
+            set { directoryListLength = value; }
+        }
+
+        public override bool Execute()
+        {
+            HashSet<string> directoriesToRestore = new HashSet<string>();
+
+            foreach (string rootDirectory in RootDirectories)
+            {
+                AddDirectoriesToRestore(rootDirectory, rootDirectory, directoriesToRestore);
+            }
+
+            List<string> resultBuilder = new List<string>();
+            StringBuilder sb = new StringBuilder(directoryListLength);
+
+            foreach (string directoryPath in directoriesToRestore)
+            {
+                sb.Append('"');
+                sb.Append(directoryPath);
+                sb.Append("\" ");
+
+                if (sb.Length >= directoryListLength)
+                {
+                    resultBuilder.Add(sb.ToString());
+                    sb.Clear();
+                }
+            }
+
+            if (sb.Length > 0)
+            {
+                resultBuilder.Add(sb.ToString());
+            }
+
+            DirectoriesToRestore = resultBuilder.ToArray();
+
+            return true;
+        }
+
+        public void AddDirectoriesToRestore(string directoryToExplore, string directoryToAdd, HashSet<string> directoriesToRestore)
+        {
+            bool hasProjectJson = File.Exists(Path.Combine(directoryToExplore, "project.json"));
+
+            if (hasProjectJson)
+            {
+                directoriesToRestore.Add(directoryToAdd);
+            }
+
+            foreach (string childDirectory in Directory.GetDirectories(directoryToExplore))
+            {
+                AddDirectoriesToRestore(childDirectory, hasProjectJson ? childDirectory : directoryToAdd, directoriesToRestore);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="Delegates.cs" />
     <Compile Include="ExecWithMutex.cs" />
+    <Compile Include="GatherFoldersToRestore.cs" />
     <Compile Include="GenerateAssemblyList.cs" />
     <Compile Include="GenerateResourcesCode.cs" />
     <Compile Include="GenerateEncodingTable.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -9,6 +9,7 @@
     "System.Xml.XDocument": "4.0.11-rc2-23712",
     "System.IO.Compression": "4.0.1-rc2-23712",
     "System.IO.Compression.ZipFile": "4.0.1-rc2-23712",
+    "System.IO.FileSystem": "4.0.1-rc2-23712",
     "System.Xml.ReaderWriter": "4.0.11-rc2-23712",
     "System.Xml.XPath.XmlDocument": "4.0.0",
     "System.Reflection": "4.1.0-rc2-23712",


### PR DESCRIPTION
In CoreFX we spend a bunch of time restoring packages, because we end up invoking
dotnet restore 300+ times to work around DNX bugs. This tool helps us batch up
these invocations which decreases the number of processes we have to launch and
should help dotnet restore do some additional caching

These problems may go away when we switch to a dotnet CLI which restores using
nuget, but for now this has a measurable impact on package restore.

In my measurements, package restore where the "packages" folder did not exist (but
the NuGet/DNX caches had not been cleared) dropped from ~20 mins to ~4.5 and a
package restore where everything had already been restored previously (e.g. calling
sync.cmd /p twice and measuring the second run) went from ~17 mins to ~50 seconds.