### PR TITLE
Falling back to using NuGet.exe for package creation temporary to fix no revision in packages bug.

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -29,6 +29,12 @@ if exist "%BUILD_TOOLS_SEMAPHORE%" (
   goto :EOF
 )
 
+:: Download nuget
+if NOT exist "%PACKAGES_DIR%\NuGet.exe" (
+  if NOT exist "PACKAGES_DIR" mkdir "%PACKAGES_DIR%"
+  powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadFile('https://www.nuget.org/nuget.exe', '%PACKAGES_DIR%\NuGet.exe')
+)
+
 if NOT exist "%PROJECT_JSON_PATH%" mkdir "%PROJECT_JSON_PATH%"
 echo %PROJECT_JSON_CONTENTS% > %PROJECT_JSON_FILE%
 echo Running %0 > %INIT_TOOLS_LOG%

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -31,7 +31,9 @@
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
   <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets')" />
 
-  <!-- Overriding BuildPackages Target to use NuGet-independent version instead -->
+<!--  Temporary Removing this since NugetPack doesn't support passing in a version number, so falling back to Nuget.exe temporarily.
+      Issue: https://github.com/dotnet/buildtools/issues/430
+  Overriding BuildPackages Target to use NuGet-independent version instead
   <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
   <Target Name="BuildPackages">
@@ -43,5 +45,6 @@
              ExcludeEmptyDirectories="true"
              Condition="'$(_SkipCreatePackage)' != 'true'"/>
   </Target>
+-->
 
 </Project>


### PR DESCRIPTION
This is a temporary fix to unblock folks. The right fix is comming which is adding support to overriding Versions in NugetPack task.