### PR TITLE
Fixes for cloud testing tasks.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -26,6 +26,7 @@
     <SupplementalPayloadDir Condition="'$(SupplementalPayloadDir)' == ''">$(TestWorkingDir)SupplementalPayload/</SupplementalPayloadDir>
     <SupplementalPayloadFilename>SupplementalPayload.zip</SupplementalPayloadFilename>
     <SupplementalPayloadFile>$(ArchivesRoot)$(SupplementalPayloadFilename)</SupplementalPayloadFile>
+    <OverwriteOnUpload Condition="'$(OverwriteOnUpload)' == ''">false</OverwriteOnUpload>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)CloudTest.Perf.targets" Condition="'$(Performance)' == 'true'" />
@@ -222,13 +223,13 @@
       AccountName="$(CloudDropAccountName)"
       ContainerName="$(ContainerName)"
       Items="@(ForUpload)"
-      Overwrite="true" />
+      Overwrite="$(OverwriteOnUpload)" />
     <UploadToAzure
       AccountKey="$(CloudDropAccessToken)"
       AccountName="$(CloudDropAccountName)"
       ContainerName="$(ContainerName)"
       Items="@(SupplementalPayload)"
-      Overwrite="true"
+      Overwrite="$(OverwriteOnUpload)"
       Condition="'@(SupplementalPayload)' != ''" />
   </Target>
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -60,16 +60,25 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
             CloudBlobContainer container = blobClient.GetContainerReference(ContainerName);
 
-            System.Threading.Tasks.Parallel.ForEach(Items, (item) =>
+            bool result = true;
+            System.Threading.Tasks.Parallel.ForEach(Items, (item, loopState) =>
             {
                 var relativeBlobPath = item.GetMetadata("RelativeBlobPath");
                 if (string.IsNullOrEmpty(relativeBlobPath))
-                    throw new ArgumentException(string.Format("Metadata 'RelativeBlobPath' is missing for item '{0}'.", item.ItemSpec));
+                {
+                    Log.LogError(string.Format("Metadata 'RelativeBlobPath' is missing for item '{0}'.", item.ItemSpec));
+                    result = false;
+                    loopState.Stop();
+                }
 
                 CloudBlockBlob blockBlob = container.GetBlockBlobReference(relativeBlobPath);
 
                 if (!Overwrite && blockBlob.Exists())
-                    throw new InvalidOperationException(string.Format("The blob '{0}' already exists.", blockBlob.Uri));
+                {
+                    Log.LogError(string.Format("The blob '{0}' already exists.", blockBlob.Uri));
+                    result = false;
+                    loopState.Stop();
+                }
 
                 using (var fileStream = File.OpenRead(item.ItemSpec))
                 {
@@ -78,8 +87,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 }
             });
 
-            Log.LogMessage(MessageImportance.High, "Upload to Azure is complete, a total of {0} items were uploaded.", Items.Length);
-            return true;
+            if (result)
+                Log.LogMessage(MessageImportance.High, "Upload to Azure is complete, a total of {0} items were uploaded.", Items.Length);
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
Add a new property, FailIfExists, to task CreateAzureContainer that when
set to true will cause the task to fail if it attempts to create a
container that already exists.
In the UploadToAzure task, if the operation fails don't simply let an
exception go unhandled.  Instead, log an error message and have the task
return false.
Disable overwriting of upload content by default.  To overwrite, set
property OverwriteOnUpload to true.