### PR TITLE
Split references by FrameworkAssembly/Dependency

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetAssemblyReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetAssemblyReferences.cs
@@ -55,6 +55,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                             TaskItem referenceItem = new TaskItem(reader.GetString(reference.Name));
                             assemblyItem.CopyMetadataTo(referenceItem);
                             referenceItem.SetMetadata("Version", reference.Version.ToString());
+                            referenceItem.SetMetadata("AssemblyVersion", reference.Version.ToString());
                             references.Add(referenceItem);
                         }
                     }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -61,6 +61,7 @@
     <Compile Include="PackageItem.cs" />
     <Compile Include="PackageMetadata.cs" />
     <Compile Include="PackagingTask.cs" />
+    <Compile Include="SplitReferences.cs" />
     <Compile Include="ValidatePackage.cs" />
     <Compile Include="ValidatePackageTargetFramework.cs" />
     <Compile Include="VersionUtility.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -91,6 +91,7 @@
 
   <UsingTask TaskName="ApplyPreReleaseSuffix" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetAssemblyReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="SplitReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GenerateRuntimeDependencies" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetPackageDescription" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetInboxFrameworks" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
@@ -442,18 +443,18 @@
     </GetAssemblyReferences>
 
     <PropertyGroup>
-      <_IsClassicAssembly>false</_IsClassicAssembly>
-      <_IsClassicAssembly Condition="'%(_FileReferencedAssemblies.FileName)' == 'mscorlib'">true</_IsClassicAssembly>
-      <_IsClassicAssembly Condition="'%(_FileReferencedAssemblies.FileName)' == 'System.Private.Corelib'">true</_IsClassicAssembly>
       <_TargetFramework>%(File.TargetFramework)</_TargetFramework>
     </PropertyGroup>
 
-    <ItemGroup Condition="'@(_FileReferencedAssemblies)' != ''">
-      <_FilePackageReference Include="@(_FileReferencedAssemblies)"
-                             Exclude="corefx;mscorlib;System;System.Core;System.Xml;Windows">
-        <AssemblyVersion>%(Version)</AssemblyVersion>
-      </_FilePackageReference>
-
+    <SplitReferences References="@(_FileReferencedAssemblies)"
+                     TargetFramework="$(_TargetFramework)"
+                     FrameworkListsPath="$(FrameworkListsPath)">
+      <Output TaskParameter="FrameworkReferences" ItemName="_FileFrameworkReference"/>
+      <Output TaskParameter="PackageReferences" ItemName="_FilePackageReference"/>
+    </SplitReferences>
+    
+    <ItemGroup Condition="'@(_FilePackageReference)' != ''">
+      <_FilePackageReference Remove="corefx;mscorlib;System;System.Core;System.Xml;Windows" />
       <_FilePackageReference Remove="@(_FilePackageReference)"
                              Condition="$([System.String]::new('%(Identity)').StartsWith('Internal.'))"/>
       <_FilePackageReference Remove="@(_FilePackageReference)"
@@ -470,12 +471,9 @@
     </ItemGroup>
     
     <ItemGroup>
-      <FilePackageDependency Condition="'$(_IsClassicAssembly)' != 'true' OR !$(_TargetFramework.StartsWith('net4'))"  Include="@(_FilePackageReference)">
-        <TargetFramework Condition="'$(_TargetFramework)' != ''" >$(_TargetFramework)</TargetFramework>
-      </FilePackageDependency>
-      <FrameworkReference Condition="'$(_IsClassicAssembly)' == 'true' AND $(_TargetFramework.StartsWith('net4'))" Include="%(_FileReferencedAssemblies.Identity)">
-        <TargetFramework>$(_TargetFramework)</TargetFramework>
-      </FrameworkReference>
+      <FilePackageDependency Include="@(_FilePackageReference)" />
+      <!-- Only add framework references for desktop frameworks -->
+      <FrameworkReference Condition="$(_TargetFramework.StartsWith('net4'))" Include="@(_FileFrameworkReference)" KeepDuplicates="false" />
     </ItemGroup>
   </Target>
   

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitReferences.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitReferences.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class SplitReferences : PackagingTask
+    {
+        [Required]
+        public ITaskItem[] References
+        {
+            get;
+            set;
+        }
+
+        public string TargetFramework
+        {
+            get;
+            set;
+        }
+
+        [Required]
+        public string FrameworkListsPath
+        {
+            get;
+            set;
+        }
+
+        [Output]
+        public ITaskItem[] PackageReferences
+        {
+            get;
+            set;
+        }
+
+        [Output]
+        public ITaskItem[] FrameworkReferences
+        {
+            get;
+            set;
+        }
+
+        public override bool Execute()
+        {
+            if (References == null || References.Length == 0)
+                return true;
+            
+            Dictionary<string, ITaskItem> packageReferences = new Dictionary<string, ITaskItem>();
+            Dictionary<string, ITaskItem> assemblyReferences = new Dictionary<string, ITaskItem>();
+
+            bool referencesMscorlib = false;
+
+            NuGetFramework targetFx = NuGetFramework.Parse(TargetFramework);
+            bool isOobFramework = targetFx.Equals(FrameworkConstants.CommonFrameworks.NetCore50) || targetFx.Framework == FrameworkConstants.FrameworkIdentifiers.UAP;
+
+            foreach (var reference in References)
+            {
+                string referenceName = reference.ItemSpec;
+                referencesMscorlib |= referenceName.Equals("mscorlib");
+                string referenceVersion = reference.GetMetadata("Version");
+                reference.SetMetadata("TargetFramework", TargetFramework);
+                if (!string.IsNullOrEmpty(TargetFramework) && !isOobFramework && Frameworks.IsInbox(FrameworkListsPath, TargetFramework, referenceName, referenceVersion))
+                {
+                    AddReference(assemblyReferences, reference);
+                }
+                else
+                {
+                    AddReference(packageReferences, reference);
+                }
+            }
+
+            if (referencesMscorlib)
+            {
+                // only add framework references for mscorlib-based assemblies.
+                FrameworkReferences = assemblyReferences.Values.ToArray();
+            }
+
+            if (packageReferences.Count == 0)
+            {
+                var emptyItem = new TaskItem("_._");
+                emptyItem.SetMetadata("TargetFramework", TargetFramework);
+                packageReferences.Add(emptyItem.ItemSpec, emptyItem);
+            }
+
+            PackageReferences = packageReferences.Values.ToArray();
+
+
+            return true;
+        }
+
+        private static void AddReference(Dictionary<string, ITaskItem> collection, ITaskItem item)
+        {
+            ITaskItem existingItem;
+
+            if (collection.TryGetValue(item.ItemSpec, out existingItem))
+            {
+                Version existingVersion = Version.Parse(existingItem.GetMetadata("Version"));
+                Version newVersion = Version.Parse(existingItem.GetMetadata("Version"));
+
+                if (newVersion > existingVersion)
+                {
+                    collection[item.ItemSpec] = item;
+                }
+            }
+            else
+            {
+                collection[item.ItemSpec] = item;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Previously we'd try to determine if an assembly was mscorlib-based
or System.Runtime-based.  If mscorlib-based we assumed all
dependencies were framework assemblies.  This was incorrect, partial
facades may still reference packages and those packages may have an
OOB implementation.  This was recently the case for
System.IO.Compression's reference to System.Buffers.
https://github.com/dotnet/corefx/issues/5941
/cc @sokket @weshaggard @chcosta 