### PR TITLE
Update prerelease versions, add pre-restore dependency validation

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -12,6 +12,7 @@
 
   <PropertyGroup>
     <TraversalBuildDependsOn>
+      ValidateAllProjectDependencies;
       BatchRestorePackages;
       $(TraversalBuildDependsOn);
     </TraversalBuildDependsOn>
@@ -27,6 +28,33 @@
       <_allPackagesConfigs Include="$(MSBuildProjectDirectory)\src\**\packages.config"/>
     </ItemGroup>
     <Exec Condition="'@(_allPackagesConfigs)' != ''" Command="$(NugetRestoreCommand) &quot;%(_allPackagesConfigs.FullPath)&quot;" StandardOutputImportance="Low" />
+  </Target>
+
+  <!-- Task from buildtools that validates dependencies contained in project.json files. -->
+  <UsingTask TaskName="ValidateProjectDependencyVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <Target Name="ValidateAllProjectDependencies"
+          Condition="'$(ValidatePackageVersions)'=='true' and '@(ProjectJsonFiles)'!=''">
+    <ValidateProjectDependencyVersions ProjectJsons="@(ProjectJsonFiles)"
+                                       ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
+                                       ValidationPatterns="@(ValidationPattern)" />
+  </Target>
+
+  <Target Name="UpdateInvalidPackageVersions">
+    <ValidateProjectDependencyVersions ProjectJsons="@(ProjectJsonFiles)"
+                                       ProhibitFloatingDependencies="$(ProhibitFloatingDependencies)"
+                                       ValidationPatterns="@(ValidationPattern)"
+                                       UpdateInvalidDependencies="true" />
+  </Target>
+
+  <!-- Tasks from buildtools for easy project.json dependency updates -->
+  <UsingTask TaskName="UpdatePackageDependencyVersion" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <Target Name="UpdatePackageDependencyVersion">
+    <UpdatePackageDependencyVersion ProjectJsons="@(ProjectJsonFiles)"
+                                    PackageId="$(PackageId)"
+                                    OldVersion="$(OldVersion)"
+                                    NewVersion="$(NewVersion)" />
   </Target>
 
   <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->

--- a/dir.props
+++ b/dir.props
@@ -59,6 +59,21 @@
     <TestRuntimeProjectLockJson Condition="'$(TestRuntimeProjectLockJson)' == ''">$(SourceDir)Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.lock.json</TestRuntimeProjectLockJson>
   </PropertyGroup>
 
+  <!-- Package dependency validation -->
+  <PropertyGroup>
+    <ValidatePackageVersions>true</ValidatePackageVersions>
+    <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ValidationPattern Include="^((System\..%2A)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
+      <ExpectedPrerelease>rc3-23811</ExpectedPrerelease>
+    </ValidationPattern>
+    <ValidationPattern Include="^xunit$">
+      <ExpectedVersion>2.1.0</ExpectedVersion>
+    </ValidationPattern>
+  </ItemGroup>
+
   <!-- list of nuget package sources passed to nuget.exe -->
   <ItemGroup>
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools" />
@@ -110,6 +125,11 @@
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
   </PropertyGroup>
+
+  <!-- Create a collection of all project.json files for dependency updates. -->
+  <ItemGroup>
+    <ProjectJsonFiles Include="$(SourceDir)**/project.json" />
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">
     <!-- When we do a traversal build we get all packages up front, don't restore them again -->

--- a/src/BinaryRewriting/BclRewriter/project.json
+++ b/src/BinaryRewriting/BclRewriter/project.json
@@ -1,16 +1,16 @@
-﻿{
+{
   "dependencies": {
     "Microsoft.Cci": "4.0.0-rc2-23712",
-    "System.Console": "4.0.0-rc2-23712",
+    "System.Console": "4.0.0-rc3-23811",
     "System.Xml.ReaderWriter": "4.0.10",
     "System.Linq": "4.0.0",
     "System.Reflection.TypeExtensions": "4.0.0",
-    "System.Reflection.Extensions": "4.0.0",
+    "System.Reflection.Extensions": "4.0.0"
   },
-    "frameworks": {
-       "dnxcore50": { }
-    },
-    "runtimes": {
-       "win7-x64": { }
-    }
+  "frameworks": {
+    "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
 }

--- a/src/GenAPI.Desktop/project.json
+++ b/src/GenAPI.Desktop/project.json
@@ -1,16 +1,16 @@
-﻿{
-    "dependencies": {
-        "Microsoft.Cci": "4.0.0-rc2-23712",
-        "System.Console": "4.0.0-rc2-23712",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23712",
-        "System.Diagnostics.TraceSource" : "4.0.0-rc2-23712",
-        "System.Linq": "4.0.0",
-        "System.Reflection": "4.0.10",
-        "System.Reflection.Extensions": "4.0.0",
-        "System.Reflection.TypeExtensions": "4.0.0",
-        "System.Runtime": "4.0.20"
-    },
-    "frameworks": {
-       "net46": { }
-    }
+{
+  "dependencies": {
+    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "System.Console": "4.0.0-rc3-23811",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-23811",
+    "System.Diagnostics.TraceSource": "4.0.0-rc3-23811",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.0.0",
+    "System.Runtime": "4.0.20"
+  },
+  "frameworks": {
+    "net46": {}
+  }
 }

--- a/src/GenAPI/project.json
+++ b/src/GenAPI/project.json
@@ -1,22 +1,22 @@
-﻿{
-    "dependencies": {
-        "Microsoft.Cci": "4.0.0-rc2-23712",
-        "System.Console": "4.0.0-rc2-23712",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23712",
-        "System.Diagnostics.TraceSource" : "4.0.0-rc2-23712",
-        "System.Linq": "4.0.0",
-        "System.Reflection": "4.0.10",
-        "System.Reflection.Extensions": "4.0.0",
-        "System.Reflection.TypeExtensions": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Text.Encoding": "4.0.10",
-        "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
-        "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23712"
-    },
-    "frameworks": {
-       "dnxcore50": { }
-    },
-    "runtimes": {
-       "win7-x64": { }
-    }
+{
+  "dependencies": {
+    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "System.Console": "4.0.0-rc3-23811",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-23811",
+    "System.Diagnostics.TraceSource": "4.0.0-rc3-23811",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Text.Encoding": "4.0.10",
+    "Microsoft.NETCore.Runtime": "1.0.1-rc3-23811",
+    "Microsoft.NETCore.ConsoleHost": "1.0.0-rc3-23811"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
 }

--- a/src/GenFacades.Desktop/project.json
+++ b/src/GenFacades.Desktop/project.json
@@ -1,19 +1,19 @@
-﻿{
-    "dependencies": {
-        "Microsoft.Cci": "4.0.0-rc2-23712",
-        "System.Collections": "4.0.10",
-        "System.Console": "4.0.0-rc2-23712",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23712",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23712",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-23712",
-        "System.IO.FileSystem": "4.0.0",
-        "System.Linq": "4.0.0",
-        "System.Reflection": "4.0.10",
-        "System.Reflection.TypeExtensions": "4.0.0",
-        "System.Text.Encoding": "4.0.10",
-    },
-    "frameworks": {
-       "net46": { }
-    }
+{
+  "dependencies": {
+    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "System.Collections": "4.0.10",
+    "System.Console": "4.0.0-rc3-23811",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.FileVersionInfo": "4.0.0-rc3-23811",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-23811",
+    "System.Diagnostics.TraceSource": "4.0.0-rc3-23811",
+    "System.IO.FileSystem": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Reflection.TypeExtensions": "4.0.0",
+    "System.Text.Encoding": "4.0.10"
+  },
+  "frameworks": {
+    "net46": {}
+  }
 }

--- a/src/GenFacades/project.json
+++ b/src/GenFacades/project.json
@@ -1,25 +1,25 @@
-﻿{
-    "dependencies": {
-        "Microsoft.Cci": "4.0.0-rc2-23712",
-        "System.Collections": "4.0.10",
-        "System.Console": "4.0.0-rc2-23712",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23712",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23712",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-23712",
-        "System.IO.FileSystem": "4.0.0",
-        "System.Linq": "4.0.0",
-        "System.Reflection": "4.0.10",
-        "System.Reflection.Extensions": "4.0.0",
-        "System.Reflection.TypeExtensions": "4.0.0",
-        "System.Text.Encoding": "4.0.10",
-        "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
-        "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23712"
-    },
-    "frameworks": {
-       "dnxcore50": { }
-    },
-    "runtimes": {
-       "win7-x64": { }
-    }
+{
+  "dependencies": {
+    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "System.Collections": "4.0.10",
+    "System.Console": "4.0.0-rc3-23811",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.FileVersionInfo": "4.0.0-rc3-23811",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-23811",
+    "System.Diagnostics.TraceSource": "4.0.0-rc3-23811",
+    "System.IO.FileSystem": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.0.0",
+    "System.Text.Encoding": "4.0.10",
+    "Microsoft.NETCore.Runtime": "1.0.1-rc3-23811",
+    "Microsoft.NETCore.ConsoleHost": "1.0.0-rc3-23811"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
 }

--- a/src/Microsoft.Cci.Extensions/project.json
+++ b/src/Microsoft.Cci.Extensions/project.json
@@ -1,18 +1,18 @@
-﻿{
-    "dependencies": {
-        "Microsoft.Cci": "4.0.0-rc2-23712",
-        "Microsoft.Composition": "1.0.30",
-        "System.Collections": "4.0.10",
-        "System.Collections.NonGeneric": "4.0.0",
-        "System.Console": "4.0.0-rc2-23712",
-        "System.Diagnostics.Contracts": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-23712",
-        "System.IO.FileSystem": "4.0.0",
-        "System.Linq": "4.0.0",
-        "System.Reflection": "4.0.10",
-        "System.Text.RegularExpressions": "4.0.10",
-        "System.Threading": "4.0.10",
-        "System.Xml.XDocument": "4.0.10",
-    }
+{
+  "dependencies": {
+    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.Composition": "1.0.30",
+    "System.Collections": "4.0.10",
+    "System.Collections.NonGeneric": "4.0.0",
+    "System.Console": "4.0.0-rc3-23811",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.TraceSource": "4.0.0-rc3-23811",
+    "System.IO.FileSystem": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Text.RegularExpressions": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Xml.XDocument": "4.0.10"
+  }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
@@ -4,12 +4,12 @@
     "Newtonsoft.Json": "7.0.1",
     "NuGet.Client": "3.4.0-beta-488",
     "System.Reflection.Metadata": "1.0.22",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23712"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23811"
   },
   "frameworks": {
-    "net45": { }
+    "net45": {}
   },
   "runtimes": {
-    "win": { }
+    "win": {}
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00005",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00005",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00005",
-    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23712",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-23811",
     "Newtonsoft.Json": "7.0.1",
     "NuGet.Client": "3.4.0-beta-488",
     "System.Collections": "4.0.10",
@@ -19,10 +19,10 @@
     "System.Xml.XDocument": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": { }
+    "dnxcore50": {}
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { }
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -1,27 +1,24 @@
 {
-    "dependencies": {
-      "Microsoft.NETCore.Platforms": "1.0.1-rc2-23712",
-      "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712",
-      "Microsoft.NETCore.Console": "1.0.0-rc2-23712",
-
-      "coveralls.io": "1.4",
-      "OpenCover": "4.6.476-rc",
-      "ReportGenerator": "2.4.0-beta2",
-
-      "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0028",
-      "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0028",
-
-      "xunit": "2.1.0",
-      "xunit.console.netcore": "1.0.2-prerelease-00101",
-      "xunit.runner.utility": "2.1.0"
-    },
-    "frameworks": {
-      "dnxcore50": {
-        "imports": "portable-net45+win8"
-      }
-    },
-    "runtimes": {
-       "win7-x64": { },
-       "win7-x86": { }
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-23811",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc3-23811",
+    "Microsoft.NETCore.Console": "1.0.0-rc3-23811",
+    "coveralls.io": "1.4",
+    "OpenCover": "4.6.476-rc",
+    "ReportGenerator": "2.4.0-beta2",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0028",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0028",
+    "xunit": "2.1.0",
+    "xunit.console.netcore": "1.0.2-prerelease-00101",
+    "xunit.runner.utility": "2.1.0"
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
     }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {}
+  }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -11,19 +11,19 @@
     "Microsoft.Build": "0.1.0-preview-00017",
     "Microsoft.Net.Compilers.NetCore": "1.2.0-beta1-20160122-02",
     "Microsoft.Net.Compilers.Targets.NetCore": "0.1.4-dev",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23712",
-    "Microsoft.NETCore.Console": "1.0.0-rc2-23712",
-    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23712",
-    "Microsoft.NETCore.Runtime": "1.0.1-rc2-23712",
-    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc3-23811",
+    "Microsoft.NETCore.Console": "1.0.0-rc3-23811",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc3-23811",
+    "Microsoft.NETCore.Runtime": "1.0.1-rc3-23811",
+    "Microsoft.Cci": "4.0.0-rc3-23811",
     "MSBuild": "0.1.0-preview-00017",
     "Newtonsoft.Json": "7.0.1",
     "NuGet.Versioning": "3.4.0-beta-488",
     "NuGet.Client": "3.4.0-beta-488",
-    "System.IO.Compression": "4.1.0-rc2-23712",
-    "System.Dynamic.Runtime": "4.0.11-rc2-23712",
-    "System.Linq.Expressions": "4.0.11-rc2-23712",
-    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23712"
+    "System.IO.Compression": "4.1.0-rc3-23811",
+    "System.Dynamic.Runtime": "4.0.11-rc3-23811",
+    "System.Linq.Expressions": "4.0.11-rc3-23811",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-23811"
   },
   "frameworks": {
     "dnxcore50": { 

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -4,26 +4,26 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00005",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00005",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00005",
-    "Microsoft.CSharp": "4.0.1-rc2-23712",
-    "System.Linq": "4.0.1-rc2-23712",
-    "System.Xml.XDocument": "4.0.11-rc2-23712",
-    "System.IO.Compression": "4.0.1-rc2-23712",
-    "System.IO.Compression.ZipFile": "4.0.1-rc2-23712",
-    "System.IO.FileSystem": "4.0.1-rc2-23712",
-    "System.Xml.ReaderWriter": "4.0.11-rc2-23712",
+    "Microsoft.CSharp": "4.0.1-rc3-23811",
+    "System.Linq": "4.0.1-rc3-23811",
+    "System.Xml.XDocument": "4.0.11-rc3-23811",
+    "System.IO.Compression": "4.0.1-rc3-23811",
+    "System.IO.Compression.ZipFile": "4.0.1-rc3-23811",
+    "System.IO.FileSystem": "4.0.1-rc3-23811",
+    "System.Xml.ReaderWriter": "4.0.11-rc3-23811",
     "System.Xml.XPath.XmlDocument": "4.0.0",
-    "System.Reflection": "4.1.0-rc2-23712",
+    "System.Reflection": "4.1.0-rc3-23811",
     "System.Reflection.Metadata": "1.1.0",
     "Newtonsoft.Json": "7.0.1",
     "NuGet.Versioning": "3.4.0-beta-488"
   },
   "frameworks": {
-    "dnxcore50": { }
+    "dnxcore50": {}
   },
   "runtimes": {
-    "win7-x64": { },
-    "win7-x86": { },
-    "ubuntu.14.04-x64": { },
-    "osx.10.10-x64": { }
+    "win7-x64": {},
+    "win7-x86": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {}
   }
 }

--- a/src/xunit.console.netcore/project.json
+++ b/src/xunit.console.netcore/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "System.Collections.Concurrent": "4.0.10",
-    "System.Console": "4.0.0-rc2-23712",
+    "System.Console": "4.0.0-rc3-23811",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Diagnostics.Tools": "4.0.0",

--- a/src/xunit.netcore.extensions/project.json
+++ b/src/xunit.netcore.extensions/project.json
@@ -9,9 +9,9 @@
     "System.Reflection": "4.0.10",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime.Extensions": "4.0.10",
-    "System.Runtime.InteropServices.RuntimeInformation":"4.0.0-rc2-23712",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23811",
     "xunit": "2.1.0"
-    },
+  },
   "frameworks": {
     "dnxcore50": {}
   }


### PR DESCRIPTION
NuGet restore couldn't find rhel.7-x64 runtimes for old packages, so I updated the tool-runtime project.json.

After that, to finish https://github.com/dotnet/buildtools/issues/402, I added the dependency validation task to the build and upgraded the other project.jsons in `src\`.

/cc @ericstj 