### PR TITLE
Add logic for local Content to correctly binplace to the tests directory

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -102,7 +102,8 @@
         <NugetPackageId>%(TestCopyLocal.NugetPackageId)</NugetPackageId>
         <SourcePath>%(Identity)</SourcePath>
       </_TestCopyLocalByFileName>
-    </ItemGroup>      
+    </ItemGroup>
+
     <RemoveDuplicatesWithLastOneWinsPolicy Inputs="@(_TestCopyLocalByFileName)">
       <Output TaskParameter="Filtered" ItemName="_TestCopyLocalByFileNameWithoutDuplicates" />
     </RemoveDuplicatesWithLastOneWinsPolicy>
@@ -113,10 +114,21 @@
     <PropertyGroup>
       <CreateHardLinksForCopyTestToTestDirectoryIfPossible Condition="'$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)'=='' and '$(OS)' == 'Windows_NT'">true</CreateHardLinksForCopyTestToTestDirectoryIfPossible>
       <CreateHardLinksForCopyTestToTestDirectoryIfPossible Condition="'$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)'==''">$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)</CreateHardLinksForCopyTestToTestDirectoryIfPossible>
-   </PropertyGroup>
+    </PropertyGroup>
+    
+    <PropertyGroup>
+      <TestTargetFrameworkFolder>%(TestTargetFramework.Folder)</TestTargetFrameworkFolder>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SourcesWithoutContent Include="@(_TestCopyLocalByFileNameWithoutDuplicates)" Exclude="@(ContentWithTargetPath->'%(FileName)%(Extension)')" />
+      <SourcesToCopyToTestDir Include="@(SourcesWithoutContent->'%(SourcePath)');@(ContentWithTargetPath)" />
+      <DestinationsForTestDir Include="@(SourcesWithoutContent->'$(TestPath)$(TestTargetFrameworkFolder)\%(Filename)%(Extension)');@(ContentWithTargetPath->'$(TestPath)$(TestTargetFrameworkFolder)\%(TargetPath)')" />
+    </ItemGroup>
+
     <Copy
-      SourceFiles="@(_TestCopyLocalByFileNameWithoutDuplicates->'%(SourcePath)')"
-      DestinationFolder="$(TestPath)%(TestTargetFramework.Folder)"
+      SourceFiles="@(SourcesToCopyToTestDir)"
+      DestinationFiles="@(DestinationsForTestDir)"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"


### PR DESCRIPTION
Content files from the test csproj weren't considered as special in the publishing to the tests directory. For all dependencies we take the file name and extension, append that to the tests directory and call it a day. Sub-directories are never considered, regardless of the type of the item (content, none, etc.).

We do something special for restoring supplemental test data from a nuget package (i.e. testdata), but do not do anything along those lines for content within the csproj directly.

This commit adds logic to respect the subdirectories of Content items.

@mellinoe 