### PR TITLE
Restore Roslyn Compilers to Tools directory

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -6,7 +6,9 @@ set DOTNET_CMD=%~2
 set TOOLRUNTIME_DIR=%~3
 IF [%BUILDTOOLS_TARGET_RUNTIME%]==[] set BUILDTOOLS_TARGET_RUNTIME=win7-x64
 set BUILDTOOLS_PACKAGE_DIR=%~dp0
-set MSBUILD_CONTENT_JSON={"dependencies": {"Microsoft.Portable.Targets": "0.1.1-dev"},"frameworks": {"dnxcore50": {},"net46": {}}}
+set PORTABLETARGETS_VERSION=0.1.1-dev
+set ROSLYNCOMPILERS_VERSION=1.2.0-beta1-20160202-02
+set MSBUILD_CONTENT_JSON={"dependencies": {"Microsoft.Portable.Targets": "%PORTABLETARGETS_VERSION%", "Microsoft.Net.Compilers": "%ROSLYNCOMPILERS_VERSION%"},"frameworks": {"dnxcore50": {},"net46": {}}}
 
 if not exist "%PROJECT_DIR%" (
   echo ERROR: Cannot find project root path at [%PROJECT_DIR%]. Please pass in the source directory as the 1st parameter.
@@ -28,7 +30,10 @@ call "%DOTNET_CMD%" publish -f dnxcore50 -r %BUILDTOOLS_TARGET_RUNTIME% -o "%TOO
 mkdir "%BUILDTOOLS_PACKAGE_DIR%\portableTargets"
 echo %MSBUILD_CONTENT_JSON% > "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\project.json"
 cd "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\"
-call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-buildtools/ --packages "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\"
-Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\Microsoft.Portable.Targets\0.1.1-dev\contentFiles\any\any\." "%TOOLRUNTIME_DIR%\." /E
+call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-buildtools/ --source http://www.nuget.org/api/v2/ --packages "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\"
+Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\Microsoft.Portable.Targets\%PORTABLETARGETS_VERSION%\contentFiles\any\any\." "%TOOLRUNTIME_DIR%\." /E
+
+:: Copy Roslyn Compilers Over to ToolRuntime
+Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%TOOLRUNTIME_DIR%\net45\roslyn\." /E
 
 exit /b %ERRORLEVEL%

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -4,7 +4,8 @@ __PROJECT_DIR=$1
 __DOTNET_CMD=$2
 __TOOLRUNTIME_DIR=$3
 __TOOLS_DIR=$(cd "$(dirname "$0")"; pwd -P)
-__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"Microsoft.Portable.Targets\": \"0.1.1-dev\"},\"frameworks\": {\"dnxcore50\": {},\"net46\": {}}}"
+__PORTABLETARGETS_VERSION=0.1.1-dev
+__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"Microsoft.Portable.Targets\": \"${__PORTABLETARGETS_VERSION}\"},\"frameworks\": {\"dnxcore50\": {},\"net46\": {}}}"
 
 __BUILDERRORLEVEL=0
 
@@ -72,7 +73,7 @@ mkdir "$__TOOLS_DIR/portableTargets"
 echo $__MSBUILD_CONTENT_JSON > "$__TOOLS_DIR/portableTargets/project.json"
 cd "$__TOOLS_DIR/portableTargets"
 "$__DOTNET_CMD" restore --source https://www.myget.org/F/dotnet-buildtools/ --packages "$__TOOLS_DIR/portableTargets/packages/"
-cp -R "$__TOOLS_DIR/portableTargets/packages/Microsoft.Portable.Targets/0.1.1-dev/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
+cp -R "$__TOOLS_DIR/portableTargets/packages/Microsoft.Portable.Targets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
 
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages
 cp "$__TOOLRUNTIME_DIR/corerun" "$__TOOLRUNTIME_DIR/corerun.exe"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -9,7 +9,7 @@
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00017",
     "Microsoft.Build.Targets": "0.1.0-preview-00017",
     "Microsoft.Build": "0.1.0-preview-00017",
-    "Microsoft.Net.Compilers.NetCore": "1.2.0-beta1-20160122-02",
+    "Microsoft.Net.Compilers.NetCore": "1.2.0-beta1-20160202-02",
     "Microsoft.Net.Compilers.Targets.NetCore": "0.1.4-dev",
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23816",
     "Microsoft.NETCore.Console": "1.0.0-rc2-23816",


### PR DESCRIPTION
Restoring the full framework roslyn compilers to the Tools directory so that they may be consumed by corefx Windows builds.