### PR TITLE
Add a simple preprocessor task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -31,6 +31,7 @@
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
+    <Compile Include="PreprocessFile.cs" />
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
     <Compile Include="UpdatePackageDependencyVersion.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PreprocessFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PreprocessFile.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class PreprocessFile : Task
+    {
+        [Required]
+        public string SourceFile { get; set; }
+
+        [Required]
+        public string OutputFile { get; set; }
+
+        public string[] Defines { get; set; }
+
+        public override bool Execute()
+        {
+            HashSet<string> defineSet = new HashSet<string>(Defines ?? new string[] { }, StringComparer.Ordinal);
+            Stack<bool> preprocessorStack = new Stack<bool>();
+
+            preprocessorStack.Push(true);
+
+            using (StreamWriter outputStream = new StreamWriter(File.Open(OutputFile, FileMode.Create, FileAccess.Write, FileShare.None), Encoding.UTF8))
+            {
+                foreach (string line in File.ReadLines(SourceFile))
+                {
+                    string trimmedLine = line.Trim();
+
+                    if (trimmedLine.StartsWith("#if ", StringComparison.Ordinal))
+                    {
+                        string defineName = trimmedLine.Substring(3).Trim();
+
+                        if (defineName == "")
+                        {
+                            Log.LogError("Malformed #if, missing symbol name");
+                            return false;
+                        }
+
+                        if (defineName[0] != '!')
+                        {
+                            preprocessorStack.Push(preprocessorStack.Peek() && defineSet.Contains(defineName));
+                        }
+                        else
+                        {
+                            preprocessorStack.Push(preprocessorStack.Peek() && !defineSet.Contains(defineName.Substring(1)));
+                        }
+                    }
+                    else if (trimmedLine.StartsWith("#endif", StringComparison.Ordinal))
+                    {
+                        preprocessorStack.Pop();
+
+                        if (preprocessorStack.Count == 0)
+                        {
+                            Log.LogError("Extra #endif detected.");
+                            return false;
+                        }
+                    }
+                    else if (preprocessorStack.Peek())
+                    {
+                        outputStream.WriteLine(line);
+                    }
+                    else
+                    {
+                        // Exclued by defines.
+                    }
+                }
+
+                if (preprocessorStack.Count != 1)
+                {
+                    Log.LogError("Missing #endif detected.");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Add a very simple task that understands the limited form of #if/#endif
used by mscorlib.txt used for mscorlib's resources. This will allow us
to preprocess the file to generate a new .txt file that has only the
resources mscorlib needs (based on what FEATURE_ flags are defined)
and then use that as the .txt file MSBuild will use to generate
resources.

This will be used to resolve dotnet/coreclr#3090.