### PR TITLE
Check Microsoft.Cci dependency version with validation

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -57,10 +57,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ValidationPattern Include="^((System\..%2A)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
+    <ValidationPattern Include="^(?i)((System\..%2A)|(Microsoft\.Cci)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
       <ExpectedPrerelease>rc2-23923</ExpectedPrerelease>
     </ValidationPattern>
-    <ValidationPattern Include="^xunit$">
+    <ValidationPattern Include="^(?i)xunit$">
       <ExpectedVersion>2.1.0</ExpectedVersion>
     </ValidationPattern>
   </ItemGroup>

--- a/src/ApiCompat/project.json
+++ b/src/ApiCompat/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc2-23816",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "Microsoft.Composition": "1.0.30",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc2-23923",

--- a/src/BinaryRewriting/BclRewriter/project.json
+++ b/src/BinaryRewriting/BclRewriter/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23923",
     "System.Console": "4.0.0-rc2-23923",
     "System.Linq": "4.0.0",

--- a/src/GenAPI.Desktop/project.json
+++ b/src/GenAPI.Desktop/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "System.Console": "4.0.0-rc2-23923",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23923",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-23923",

--- a/src/GenAPI/project.json
+++ b/src/GenAPI/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23923",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23923",
     "Microsoft.NETCore.Runtime": "1.0.2-rc2-23923",

--- a/src/GenFacades.Desktop/project.json
+++ b/src/GenFacades.Desktop/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc2-23923",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/GenFacades/project.json
+++ b/src/GenFacades/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23923",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23923",
     "Microsoft.NETCore.Runtime": "1.0.2-rc2-23923",

--- a/src/Microsoft.Cci.Extensions/project.json
+++ b/src/Microsoft.Cci.Extensions/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc2-23712",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "Microsoft.Composition": "1.0.30",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23923",
     "System.Collections": "4.0.10",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -15,7 +15,7 @@
     "Microsoft.NETCore.Console": "1.0.0-rc2-23923",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23923",
     "Microsoft.NETCore.Runtime": "1.0.2-rc2-23923",
-    "Microsoft.Cci": "4.0.0-rc3-23811",
+    "Microsoft.Cci": "4.0.0-rc2-23923",
     "Microsoft.Win32.Registry": {
       "version": "4.0.0-rc2-23923",
       "exclude": "Compile"


### PR DESCRIPTION
Validate Microsoft.Cci package with the rest of the prerelease packages. Fixes https://github.com/dotnet/buildtools/issues/451.

Also minor fix of changing validation regex to case-insensitive.

/cc @joperezr