### PR TITLE
Fixes for cloud testing targets.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CreateAzureContainer.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CreateAzureContainer.cs
@@ -85,6 +85,11 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
             StorageUri = newContainer.Uri.ToString();
 
+            // to keep with the msbuild convention of having a path end with
+            // a directory separator char append a '/' to the end of the URI
+            if (!StorageUri.EndsWith("/"))
+                StorageUri = string.Format("{0}/", StorageUri);
+
             if (ReadOnlyTokenDaysValid > 0)
             {
                 var sasRO = new SharedAccessBlobPolicy();

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -94,13 +94,9 @@
       AccountName="$(CloudDropAccountName)"
       ContainerName="$(ContainerName)"
       ReadOnlyTokenDaysValid="30">
-        <Output TaskParameter="StorageUri" PropertyName="DropUriRoot" />
+        <Output TaskParameter="StorageUri" PropertyName="DropUri" />
         <Output TaskParameter="ReadOnlyToken" PropertyName="DropUriReadOnlyToken" />
     </CreateAzureContainer>
-    <!-- append the build arch and type to the root URI -->
-    <CreateProperty Value="$(DropUriRoot)/$(BuildArch)$(BuildType)">
-      <Output TaskParameter="Value" PropertyName="DropUri" />
-    </CreateProperty>
     <!-- now that we have a drop URI create the list of correlation payloads -->
     <ItemGroup>
       <CorrelationPayloadUri Include="$(DropUri)$(Platform)$(ConfigurationGroup)/Packages.zip$(DropUriReadOnlyToken)" />


### PR DESCRIPTION
In the CreateAzureContainer task, append a '/' to the storage URI if one
doesn't exist.
Don't append $(BuildArch) and $(BuildType) properties to the root of the
URI as not all repos define these properties.  It's also redundant as
architecture-specific content is already copied to the appropriate
subdirectories in the container.

This fixes the bug mentioned in issue https://github.com/dotnet/buildtools/issues/460.