### PR TITLE
Workaround to copy native artifacts to the tools dir (for CLI upgrade)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -26,6 +26,12 @@ cd "%BUILDTOOLS_PACKAGE_DIR%\tool-runtime\"
 call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-core/ --source https://www.myget.org/F/dotnet-buildtools/ --source https://www.nuget.org/api/v2/
 call "%DOTNET_CMD%" publish -f dnxcore50 -r %BUILDTOOLS_TARGET_RUNTIME% -o "%TOOLRUNTIME_DIR%"
 
+:: Temporary workaround for CLI #1528: copy native artifacts that weren't during dotnet publish.
+set TOOL_RUNTIME_PACKAGE_DIR=%BUILDTOOLS_PACKAGE_DIR%\tool-runtime\packages
+call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-core/ --source https://www.myget.org/F/dotnet-buildtools/ --source https://www.nuget.org/api/v2/ --packages "%TOOL_RUNTIME_PACKAGE_DIR%"
+copy "%TOOL_RUNTIME_PACKAGE_DIR%\Microsoft.Build.Targets\0.1.0-preview-00017\runtimes\any\native\*" "%TOOLRUNTIME_DIR%"
+copy "%TOOL_RUNTIME_PACKAGE_DIR%\MSBuild\0.1.0-preview-00017\runtimes\any\native\*" "%TOOLRUNTIME_DIR%"
+
 :: Copy Portable Targets Over to ToolRuntime
 mkdir "%BUILDTOOLS_PACKAGE_DIR%\portableTargets"
 echo %MSBUILD_CONTENT_JSON% > "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\project.json"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -68,6 +68,12 @@ if [ -n "$BUILDTOOLS_OVERRIDE_RUNTIME" ]; then
     cp -R $BUILDTOOLS_OVERRIDE_RUNTIME/* $__TOOLRUNTIME_DIR
 fi
 
+# Temporary workaround for CLI #1528: copy native artifacts that weren't during dotnet publish.
+__TOOL_RUNTIME_PACKAGE_DIR="$__TOOLS_DIR/tool-runtime/packages"
+"$__DOTNET_CMD" restore --source https://www.myget.org/F/dotnet-core/ --source https://www.myget.org/F/dotnet-buildtools/ --source https://www.nuget.org/api/v2/ --packages "$__TOOL_RUNTIME_PACKAGE_DIR"
+cp "${__TOOL_RUNTIME_PACKAGE_DIR}/Microsoft.Build.Targets/0.1.0-preview-00017/runtimes/any/native/"* "$__TOOLRUNTIME_DIR"
+cp "${__TOOL_RUNTIME_PACKAGE_DIR}/MSBuild/0.1.0-preview-00017/runtimes/any/native/"* "$__TOOLRUNTIME_DIR"
+
 # Copy Portable Targets Over to ToolRuntime
 mkdir "$__TOOLS_DIR/portableTargets"
 echo $__MSBUILD_CONTENT_JSON > "$__TOOLS_DIR/portableTargets/project.json"


### PR DESCRIPTION
In init-tools.sh we expect dotnet publish to copy the native artifacts in `tool-runtime/project.json` packages into the Tools dir. If we upgrade the version of dotnet CLI that we use, native artifact copy doesn't happen due to ~~https://github.com/dotnet/cli/issues/710~~ https://github.com/dotnet/cli/issues/1528.

This works around it by manually copying the expected native artifacts to the Tools dir.

**Open question**: hardcoding the path feels really bad. Another option is to restore `tool-runtime/project.json` *again* into a folder under the tool runtime dir and copy the files out from there. This also would mean that we can use better wildcards rather than hardcoding the path, because we know only the packages we want are in the folder. This would slow down the init though. Is it worth it?

(A reason to use `~/.nuget/packages` in the first place is that dotnet CLI doesn't support specifying a packages dir for publish. https://github.com/dotnet/cli/issues/1075 / https://github.com/dotnet/cli/issues/261)

/cc @weshaggard 