### PR TITLE
Fixes to cloud test targets.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -10,6 +10,16 @@
   <UsingTask TaskName="WriteTestBuildStatsJson" AssemblyFile="$(ToolsDir)net45/Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
+  <!-- set Helix environment vars based on target platform -->
+  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
+    <HelixPythonPath>%HELIX_PYTHONPATH%</HelixPythonPath>
+    <HelixScriptRoot>%HELIX_SCRIPT_ROOT%\</HelixScriptRoot>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
+    <HelixPythonPath>$HELIX_PYTHONPATH</HelixPythonPath>
+    <HelixScriptRoot>$HELIX_SCRIPT_ROOT/</HelixScriptRoot>
+  </PropertyGroup>
+
   <PropertyGroup>
     <ContainerName>$(TestProduct)-$(Branch)-$(BuildMoniker)</ContainerName>
     <ContainerName>$(ContainerName.ToLower())</ContainerName>
@@ -22,7 +32,7 @@
     <FuncTestListFile>$(TestWorkingDir)$(OSPlatformConfig)/$(FuncTestListFilename)</FuncTestListFile>
     <PerfTestListFile>$(TestWorkingDir)$(OSPlatformConfig)/$(PerfTestListFilename)</PerfTestListFile>
     <BuildStatsJsonFile>$(TestWorkingDir)$(OSPlatformConfig)/BuildStats.json</BuildStatsJsonFile>
-    <RunnerScript Condition="'$(RunnerScript)' == ''">%HELIX_SCRIPT_ROOT%\xunitrunner.py</RunnerScript>
+    <RunnerScript Condition="'$(RunnerScript)' == ''">$(HelixScriptRoot)xunitrunner.py</RunnerScript>
     <SupplementalPayloadDir Condition="'$(SupplementalPayloadDir)' == ''">$(TestWorkingDir)SupplementalPayload/</SupplementalPayloadDir>
     <SupplementalPayloadFilename>SupplementalPayload.zip</SupplementalPayloadFilename>
     <SupplementalPayloadFile>$(ArchivesRoot)$(SupplementalPayloadFilename)</SupplementalPayloadFile>
@@ -131,7 +141,7 @@
     </ItemGroup>
     <ItemGroup>
       <FunctionalTest>
-        <Command>%HELIX_PYTHONPATH% $(RunnerScript) --dll %(Filename).dll -- $(XunitArgs)</Command>
+        <Command>$(HelixPythonPath) $(RunnerScript) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
         <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>FunctionalTest.%(Filename)</WorkItemId>
@@ -155,6 +165,9 @@
   </Target>
 
   <Target Name="CreatePerfTestListJson" DependsOnTargets="CreateAzureStorage" Condition="'$(Performance)' == 'true'">
+    <PropertyGroup>
+      <OtherRunnerScriptArgs>--perf-runner Microsoft.DotNet.xunit.performance.runner.Windows $(OtherRunnerScriptArgs)</OtherRunnerScriptArgs>
+    </PropertyGroup>
     <!-- now gather the perf tests -->
     <ItemGroup>
       <TestBinary Include="$(BinDir)$(OSPlatformConfig)/**/*Tests.dll" />
@@ -168,7 +181,7 @@
     </ItemGroup>
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest>
-        <Command>%HELIX_PYTHONPATH% $(RunnerScript) --dll %(Filename).dll --perf-runner Microsoft.DotNet.xunit.performance.runner.Windows -- $(XunitArgs)</Command>
+        <Command>$(HelixPythonPath) $(RunnerScript) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
         <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>PerfTest.%(Filename)</WorkItemId>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -183,19 +183,19 @@
   </Target>
 
   <Target Name="CreateAssemblyListTxt" DependsOnTargets="CopyTestToTestDirectory">
-    <Message Text="Generating $(OutDir)AssemblyList.txt" />
+    <Message Text="Generating $(OutDir)assemblylist.txt" />
     <ItemGroup>
       <!-- Using String.Replace instead of MSBuild MakeRelativePath since there is a bug in NetCore MSBuild where it doesn't recognize paths in linux -->
       <AssemblyPaths Include="$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').Replace('$(PackagesDir)',''))" Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.NugetPackageId)' != ''" />
     </ItemGroup>
     <WriteLinesToFile
-      File="$(OutDir)AssemblyList.flat.txt"
+      File="$(OutDir)assemblylist.flat.txt"
       Lines="@(AssemblyPaths)"
       Overwrite="true"
       Encoding="Ascii" />
     <GenerateAssemblyList
-      InputListLocation="$(OutDir)AssemblyList.flat.txt"
-      OutputListLocation="$(OutDir)AssemblyList.txt"
+      InputListLocation="$(OutDir)assemblylist.flat.txt"
+      OutputListLocation="$(OutDir)assemblylist.txt"
      />
   </Target>
 


### PR DESCRIPTION
Added property OtherRunnerScriptArgs allowing additional runner script
args to be specified at build time.
Replaced hard-coded Windows-specific Helix python root path environment
variable with a dynamic property supporting Windows and Unix variants.
Change assembly list file name to all lower case to avoid issues on case-sensitive
file systems.