### PR TITLE
Specify specific version of S.R.Extensions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -20,11 +20,12 @@
     "Newtonsoft.Json": "7.0.1",
     "NuGet.Versioning": "3.4.0-beta-488",
     "NuGet.Client": "3.4.0-beta-488",
-    "System.IO.Compression": "4.1.0-rc2-23816",
-    "System.Dynamic.Runtime": "4.0.11-rc2-23816",
-    "System.Linq.Expressions": "4.0.11-rc2-23816",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23816",
+    "System.Dynamic.Runtime": "4.0.11-rc2-23816",
+    "System.IO.Compression": "4.1.0-rc2-23816",
     "System.IO.FileSystem": "4.0.1-rc2-23816",
+    "System.Linq.Expressions": "4.0.11-rc2-23816",
+    "System.Runtime.Extensions": "4.1.0-rc2-23816",
     "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23816"
   },
   "frameworks": {


### PR DESCRIPTION
In CI, the OS X builds are failing intermittently because restoring the tool
runtime is pulling down an old version of the runtime assemblies for
System.Runtime.Extensions. This version expects some exports from
System.Native which have been renamed.

Setting the correct version of System.Runtime.Extensions seems to
address this issue (I tried restoring the tool-runtime from this
project.json a bunch of times and each time the right thing happened,
whereas without this fix it only worked about a quarter of the time).

Obviously there is some larger issue at play here as I would not expect
this to be needed, but I would really like to unblock our CI runs so
here's a pragmatic change which should do that.