### PR TITLE
xplat: Adds NetBSD support

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -195,6 +195,7 @@
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('NetBSD'))">NetBSD</OSGroup>
     <OSGroup Condition="'$(OSGroup)'==''">AnyOS</OSGroup>
   </PropertyGroup>
 
@@ -253,8 +254,9 @@
     <TargetsLinux Condition="'$(OSGroup)' == 'Linux'">true</TargetsLinux>
     <TargetsOSX Condition="'$(OSGroup)' == 'OSX'">true</TargetsOSX>
     <TargetsFreeBSD Condition="'$(OSGroup)' == 'FreeBSD'">true</TargetsFreeBSD>
+    <TargetsNetBSD Condition="'$(OSGroup)' == 'NetBSD'">true</TargetsNetBSD>
 
-    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true'">true</TargetsUnix>
+    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true' or '$(TargetsNetBSD)' == 'true'">true</TargetsUnix>
   </PropertyGroup>
 
   <Import Project="$(RoslynPropsFile)"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -63,6 +63,7 @@
     <XunitOptions Condition="'$(OSGroup)'=='Linux'">$(XunitOptions) -notrait category=nonlinuxtests</XunitOptions>
     <XunitOptions Condition="'$(OSGroup)'=='OSX'">$(XunitOptions) -notrait category=nonosxtests</XunitOptions>
     <XunitOptions Condition="'$(OSGroup)'=='FreeBSD'">$(XunitOptions) -notrait category=nonfreebsdtests</XunitOptions>
+    <XunitOptions Condition="'$(OSGroup)'=='NetBSD'">$(XunitOptions) -notrait category=nonnetbsdtests</XunitOptions>
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -31,6 +31,7 @@ namespace Xunit.NetCore.Extensions
             PlatformID platforms = (PlatformID)ctorArgs.Last();
             if ((platforms.HasFlag(PlatformID.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
                 (platforms.HasFlag(PlatformID.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+                (platforms.HasFlag(PlatformID.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
                 (platforms.HasFlag(PlatformID.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
                 (platforms.HasFlag(PlatformID.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
             {

--- a/src/xunit.netcore.extensions/Discoverers/PlatformSpecificDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/PlatformSpecificDiscoverer.cs
@@ -31,6 +31,8 @@ namespace Xunit.NetCore.Extensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonOSXTest);
             if (!platform.HasFlag(PlatformID.FreeBSD))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonFreeBSDTest);
+            if (!platform.HasFlag(PlatformID.NetBSD))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetBSDTest);
         }
     }
 }

--- a/src/xunit.netcore.extensions/PlatformID.cs
+++ b/src/xunit.netcore.extensions/PlatformID.cs
@@ -14,7 +14,8 @@ namespace Xunit
         Linux = 2,
         OSX = 4,
         FreeBSD = 8,
-        AnyUnix = FreeBSD | Linux | OSX,
+        NetBSD = 16,
+        AnyUnix = FreeBSD | Linux | NetBSD | OSX,
         Any = ~0
     }
 }

--- a/src/xunit.netcore.extensions/XunitConstants.cs
+++ b/src/xunit.netcore.extensions/XunitConstants.cs
@@ -11,6 +11,7 @@ namespace Xunit.NetCore.Extensions
     {
         internal const string NonFreeBSDTest = "nonfreebsdtests";
         internal const string NonLinuxTest = "nonlinuxtests";
+        internal const string NonNetBSDTest = "nonnetbsdtests";
         internal const string NonOSXTest = "nonosxtests";
         internal const string NonWindowsTest = "nonwindowstests";
         internal const string Failing = "failing";


### PR DESCRIPTION
NetBSD support has been added to CoreCLR, CoreRT and CoreFX (native).
In order to proceed with managed code port, buildtools support is
required.