### PR TITLE
Remove trailing slash from package directories.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -36,7 +36,7 @@ copy "%TOOL_RUNTIME_PACKAGE_DIR%\MSBuild\0.1.0-preview-00017\runtimes\any\native
 mkdir "%BUILDTOOLS_PACKAGE_DIR%\portableTargets"
 echo %MSBUILD_CONTENT_JSON% > "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\project.json"
 cd "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\"
-call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-buildtools/ --source http://www.nuget.org/api/v2/ --packages "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\"
+call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-buildtools/ --source http://www.nuget.org/api/v2/ --packages "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages"
 Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\Microsoft.Portable.Targets\%PORTABLETARGETS_VERSION%\contentFiles\any\any\." "%TOOLRUNTIME_DIR%\." /E
 
 :: Copy Roslyn Compilers Over to ToolRuntime

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -78,7 +78,7 @@ cp "${__TOOL_RUNTIME_PACKAGE_DIR}/MSBuild/0.1.0-preview-00017/runtimes/any/nativ
 mkdir "$__TOOLS_DIR/portableTargets"
 echo $__MSBUILD_CONTENT_JSON > "$__TOOLS_DIR/portableTargets/project.json"
 cd "$__TOOLS_DIR/portableTargets"
-"$__DOTNET_CMD" restore --source https://www.myget.org/F/dotnet-buildtools/ --packages "$__TOOLS_DIR/portableTargets/packages/"
+"$__DOTNET_CMD" restore --source https://www.myget.org/F/dotnet-buildtools/ --packages "$__TOOLS_DIR/portableTargets/packages"
 cp -R "$__TOOLS_DIR/portableTargets/packages/Microsoft.Portable.Targets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
 
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages


### PR DESCRIPTION
The `\"` in init-tools.cmd was causing a `error: Illegal characters in path.` error with new dotnet CLI. Edited .cmd and .sh for symmetry.

Here's DNU (old) behavior vs xplat nuget (new) behavior:

	> dotnet000973\bin\dotnet.exe restore --packages "packages\"
	Microsoft .NET Development Utility CoreClr-x64-1.0.0-rc1-16231
	...
	Restoring packages for E:\temp\toolruntimepublish\tool-runtime\project.json
	...
	
	> dotnet001496\bin\dotnet.exe restore --packages "packages\"
	log  : Restoring packages for E:\temp\toolruntimepublish\tool-runtime\project.json...
	error: Illegal characters in path.
	error: Parameter name: path

/cc @ericstj @joperezr 