### PR TITLE
Remove workaround for dotnet publish not copying native artifacts

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -26,12 +26,6 @@ cd "%BUILDTOOLS_PACKAGE_DIR%\tool-runtime\"
 call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-core/ --source https://www.myget.org/F/dotnet-buildtools/ --source https://www.nuget.org/api/v2/
 call "%DOTNET_CMD%" publish -f dnxcore50 -r %BUILDTOOLS_TARGET_RUNTIME% -o "%TOOLRUNTIME_DIR%"
 
-:: Temporary workaround for CLI #1528: copy native artifacts that weren't during dotnet publish.
-set TOOL_RUNTIME_PACKAGE_DIR=%BUILDTOOLS_PACKAGE_DIR%\tool-runtime\packages
-call "%DOTNET_CMD%" restore --source https://www.myget.org/F/dotnet-core/ --source https://www.myget.org/F/dotnet-buildtools/ --source https://www.nuget.org/api/v2/ --packages "%TOOL_RUNTIME_PACKAGE_DIR%"
-copy "%TOOL_RUNTIME_PACKAGE_DIR%\Microsoft.Build.Targets\0.1.0-preview-00017\runtimes\any\native\*" "%TOOLRUNTIME_DIR%"
-copy "%TOOL_RUNTIME_PACKAGE_DIR%\MSBuild\0.1.0-preview-00017\runtimes\any\native\*" "%TOOLRUNTIME_DIR%"
-
 :: Copy Portable Targets Over to ToolRuntime
 mkdir "%BUILDTOOLS_PACKAGE_DIR%\portableTargets"
 echo %MSBUILD_CONTENT_JSON% > "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\project.json"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -68,12 +68,6 @@ if [ -n "$BUILDTOOLS_OVERRIDE_RUNTIME" ]; then
     cp -R $BUILDTOOLS_OVERRIDE_RUNTIME/* $__TOOLRUNTIME_DIR
 fi
 
-# Temporary workaround for CLI #1528: copy native artifacts that weren't during dotnet publish.
-__TOOL_RUNTIME_PACKAGE_DIR="$__TOOLS_DIR/tool-runtime/packages"
-"$__DOTNET_CMD" restore --source https://www.myget.org/F/dotnet-core/ --source https://www.myget.org/F/dotnet-buildtools/ --source https://www.nuget.org/api/v2/ --packages "$__TOOL_RUNTIME_PACKAGE_DIR"
-cp "${__TOOL_RUNTIME_PACKAGE_DIR}/Microsoft.Build.Targets/0.1.0-preview-00017/runtimes/any/native/"* "$__TOOLRUNTIME_DIR"
-cp "${__TOOL_RUNTIME_PACKAGE_DIR}/MSBuild/0.1.0-preview-00017/runtimes/any/native/"* "$__TOOLRUNTIME_DIR"
-
 # Copy Portable Targets Over to ToolRuntime
 mkdir "$__TOOLS_DIR/portableTargets"
 echo $__MSBUILD_CONTENT_JSON > "$__TOOLS_DIR/portableTargets/project.json"


### PR DESCRIPTION
Reverses https://github.com/dotnet/buildtools/pull/463 because https://github.com/dotnet/cli/issues/1528 has been fixed. Native artifacts like `MSBuild.exe` and `Microsoft.CSharp.targets` are now correctly copied by dotnet publish.

(The fix is available starting with CLI `1.0.0.001504`.)

/cc @ericstj @weshaggard @joperezr 