### PR TITLE
Fix issue #480 - GenerateAssemblyList task writes to exisiting output file without deleting previous contents.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Build.Tasks
             List<string> unmatched = new List<string>();
             bool foundDuplicates = false;
             Stream inputListLocationStream = File.OpenRead(InputListLocation);
-            Stream outputListLocationStream = File.OpenWrite(OutputListLocation);
+            Stream outputListLocationStream = new FileStream(OutputListLocation, FileMode.Create, FileAccess.Write, FileShare.None);
 
             using (StreamReader listReader = new StreamReader(inputListLocationStream))
             {


### PR DESCRIPTION
Fix Issue #480 - GenerateAssemblyList task writes to exisiting output file without deleting previous contents.