### PR TITLE
Fix Issue 474 were ToolRuntime dir wasn't getting deleted

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -29,6 +29,8 @@ if exist "%BUILD_TOOLS_SEMAPHORE%" (
   goto :EOF
 )
 
+if exist "%TOOLRUNTIME_DIR%" rmdir /S /Q "%TOOLRUNTIME_DIR%"
+
 :: Download nuget
 if NOT exist "%PACKAGES_DIR%\NuGet.exe" (
   if NOT exist "PACKAGES_DIR" mkdir "%PACKAGES_DIR%"


### PR DESCRIPTION
ToolRuntime dir was not being cleaned correctly when a new version of BuildTools was selected. This fixes that issue.