### PR TITLE
Xamarin FrameworkList.xml fixes

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoTouch,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoTouch,Version=v1.0/FrameworkList.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<FileList Redist="MonoTouch Base Class Libraries" Name="MonoTouch">
+<FileList Redist="MonoTouch" Name="MonoTouch Base Class Libraries">
   <File AssemblyName="Microsoft.CSharp" />
   <File AssemblyName="Microsoft.Win32.Primitives" />
   <File AssemblyName="System.AppContext" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<FileList Redist="Xamarin.TVOS Base Class Libraries" Name="Xamarin.TVOS">
+<FileList Redist="Xamarin.TVOS" Name="Xamarin.TVOS Base Class Libraries">
   <File AssemblyName="Microsoft.CSharp" />
   <File AssemblyName="Microsoft.Win32.Primitives" />
   <File AssemblyName="System.AppContext" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<FileList Redist="Xamarin.iOS Base Class Libraries" Name="Xamarin.TVOS">
+<FileList Redist="Xamarin.TVOS Base Class Libraries" Name="Xamarin.TVOS">
   <File AssemblyName="Microsoft.CSharp" />
   <File AssemblyName="Microsoft.Win32.Primitives" />
   <File AssemblyName="System.AppContext" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<FileList Redist="Xamarin.WatchOS Base Class Libraries" Name="Xamarin.WatchOS">
+<FileList Redist="Xamarin.WatchOS" Name="Xamarin.WatchOS Base Class Libraries">
   <File AssemblyName="Microsoft.CSharp" />
   <File AssemblyName="Microsoft.Win32.Primitives" />
   <File AssemblyName="System.AppContext" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<FileList Redist="Xamarin.iOS Base Class Libraries" Name="Xamarin.WatchOS">
+<FileList Redist="Xamarin.WatchOS Base Class Libraries" Name="Xamarin.WatchOS">
   <File AssemblyName="Microsoft.CSharp" />
   <File AssemblyName="Microsoft.Win32.Primitives" />
   <File AssemblyName="System.AppContext" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.iOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.iOS,Version=v1.0/FrameworkList.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<FileList Redist="Xamarin.iOS Base Class Libraries" Name="Xamarin.iOS">
+<FileList Redist="Xamarin.iOS" Name="Xamarin.iOS Base Class Libraries">
   <File AssemblyName="Microsoft.CSharp" />
   <File AssemblyName="Microsoft.Win32.Primitives" />
   <File AssemblyName="System.AppContext" />


### PR DESCRIPTION
- Fix typo in Xamarin TVOS and WatchOS Frameworklist.xml, they still referred to Xamarin.iOS.
- Fix Redist and Name in the Xamarin FrameworkList.xml. Name is supposed to be the display friendly string, but some of the profiles had that one in Redist instead.

/cc @ericstj 