### PR TITLE
Add MicroBuild.Core restore to init-tools.sh

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -4,8 +4,9 @@ __PROJECT_DIR=$1
 __DOTNET_CMD=$2
 __TOOLRUNTIME_DIR=$3
 __TOOLS_DIR=$(cd "$(dirname "$0")"; pwd -P)
+__MICROBUILD_VERSION=0.2.0
 __PORTABLETARGETS_VERSION=0.1.1-dev
-__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"Microsoft.Portable.Targets\": \"${__PORTABLETARGETS_VERSION}\"},\"frameworks\": {\"dnxcore50\": {},\"net46\": {}}}"
+__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"MicroBuild.Core\": \"${__MICROBUILD_VERSION}\", \"Microsoft.Portable.Targets\": \"${__PORTABLETARGETS_VERSION}\"},\"frameworks\": {\"dnxcore50\": {},\"net46\": {}}}"
 
 __BUILDERRORLEVEL=0
 
@@ -74,6 +75,7 @@ echo $__MSBUILD_CONTENT_JSON > "$__TOOLS_DIR/portableTargets/project.json"
 cd "$__TOOLS_DIR/portableTargets"
 "$__DOTNET_CMD" restore --source https://www.myget.org/F/dotnet-buildtools/ --packages "$__TOOLS_DIR/portableTargets/packages"
 cp -R "$__TOOLS_DIR/portableTargets/packages/Microsoft.Portable.Targets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
+cp -R "$__TOOLS_DIR/portableTargets/packages/MicroBuild.Core/${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
 
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages
 cp "$__TOOLRUNTIME_DIR/corerun" "$__TOOLRUNTIME_DIR/corerun.exe"


### PR DESCRIPTION
Fixes a break introduced by https://github.com/dotnet/buildtools/commit/d852b602fc85b463defafbd6cf2e4ed62cc2c092

/cc @jhendrixMSFT @iamjasonp 