### PR TITLE
Clean up required flags

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
     <GenerationDefinitionFile Condition="'$(GenerationDefinitionFile)' == ''">$(MSBuildThisFileDirectory)Generations.json</GenerationDefinitionFile>
-    <!-- turn off dotnet > netstandard rename until ready -->
-    <UseNetPlatform Condition="'$(UseNetPlatform)' == ''">true</UseNetPlatform>
   </PropertyGroup>
 
   <UsingTask TaskName="ValidatePackageTargetFramework" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -26,9 +26,6 @@
 
     <!-- By default we'll build libraries referenced by packages -->
     <BuildPackageLibraryReferences Condition="'$(BuildPackageLibraryReferences)' == ''">true</BuildPackageLibraryReferences>
-    
-    <!-- turn off dotnet > netstandard rename until ready -->
-    <UseNetPlatform Condition="'$(UseNetPlatform)' == ''">true</UseNetPlatform>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsRuntimePackage)' == 'true' or '$(PackageTargetRuntime)' != ''">
@@ -80,7 +77,7 @@
   </PropertyGroup>
 
   <Import Project="stable.packages.targets" />
-  <Import Condition="'$(BaseLinePackageDependencies)' == 'true'" Project="baseline.packages.targets" />
+  <Import Project="baseline.packages.targets" />
 
   <!-- If this package explicitly sets the StableVersion then add it to the stable list -->
   <ItemGroup Condition="'$(StableVersion)' != ''">
@@ -477,30 +474,6 @@
       <FrameworkReference Condition="$(_TargetFramework.StartsWith('net4'))" Include="@(_FileFrameworkReference)" KeepDuplicates="false" />
     </ItemGroup>
   </Target>
-  
-  <Target Name="GetNuGetPackageDependencies"
-          DependsOnTargets="GetFilePackageReferences">
-   <!-- We can reduce the number of dependencies listed for any framework that has
-        inbox implementations since that framework doesn't need the packages for
-        compile/runtime.  This reduces the noise when consuming our packages in
-        packages.config based projects.  -->
-    <CreateTrimDependencyGroups Dependencies="@(FilePackageDependency);@(Dependency)"
-                      FrameworkListsPath="$(FrameworkListsPath)"
-                      TrimFrameworks="@(InboxOnTargetFramework);@(NotSupportedOnTargetFramework);@(ExternalOnTargetFramework)"
-                      Files="@(File)"
-                      Condition="'@(FilePackageDependency)' != '' AND '$(PackageTargetRuntime)' == ''">
-      <Output TaskParameter="TrimmedDependencies" ItemName="FilePackageDependency" />
-    </CreateTrimDependencyGroups>
-
-    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" BaseLinePackages="@(BaseLinePackage)">
-      <Output TaskParameter="BaseLinedDependencies" ItemName="_BaseLinedDependencies" />
-    </ApplyBaseLine>
-
-    <ApplyPreReleaseSuffix Condition="'@(_BaseLinedDependencies)' != ''" StablePackages="@(StablePackage)" OriginalPackages="@(_BaseLinedDependencies)" PreReleaseSuffix="$(VersionSuffix)" RevStableToPrerelease="$(DependencyRevStableToPrerelease)">
-      <Output TaskParameter="UpdatedPackages" ItemName="Dependency"/>
-    </ApplyPreReleaseSuffix>
-
-  </Target>
 
   <Target Name="GetNuGetPackageDependencies"
           DependsOnTargets="GetFilePackageReferences">
@@ -537,7 +510,7 @@
       <Output TaskParameter="TrimmedDependencies" ItemName="FilePackageDependency" />
     </CreateTrimDependencyGroups>
 
-    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" BaseLinePackages="@(BaseLinePackage)">
+    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" BaseLinePackages="@(BaseLinePackage)" Condition="'$(BaseLinePackageDependencies)' != 'false'">
       <Output TaskParameter="BaseLinedDependencies" ItemName="_BaseLinedDependencies" />
     </ApplyBaseLine>
 
@@ -610,7 +583,8 @@
       <RuntimeFileSource Condition="'%(File.FileName)%(File.Extension)' == 'runtime.json'">%(File.Identity)</RuntimeFileSource>
     </PropertyGroup>
 
-    <ItemGroup Condition="'@(RuntimeDependency)' != '' AND '$(ExcludeRuntimeJson)' != 'true'">
+    <!-- only include runtime.json in lineup packages -->
+    <ItemGroup Condition="'$(IsLineupPackage)' == 'true' OR '$(IncludeRuntimeJson)' == 'true'">
       <!-- if we are updating, remove it from the file group, we'll replace it with the generated version -->
       <PackageFile Condition="'$(RuntimeFileSource)' != ''" Remove="$(RuntimeFileSource)"/>
       <PackageFile Include="$(RuntimeFilePath)">


### PR DESCRIPTION
Cleaning up the feature flags I added for nestandard rename, baselining,
and runtime.json exclusion now that all branches set these flags.

To summarize:
1. Repos no longer need to set UseNetPlatform to false in order to build/validate as `NETStandard` instead of `dotnet`.  `NETStandard` is now the default.  Set UseNetPlatform=true to use `dotnet`.
2. Baselining is now on by default.  To opt out of package baselining folks can set BaseLinePackageDependencies=false.
3. Runtime.jsons will be excluded by default from normal packages.  Only lineup packages (IsLineupPackage=true) or packages explicitly opting in (IncludeRuntimeJson=true) will get runtime.jsons.