### PR TITLE
Remove hard-coded repository for "git push" when updating build values.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/UpdateBuildValues.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/UpdateBuildValues.targets
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <GitWorkingBranch Condition="'$(GitWorkingBranch)' == ''">master</GitWorkingBranch>
+    <GitPushRemote Condition="'$(GitPushRemote)' == ''">origin</GitPushRemote>
   </PropertyGroup>
 
   <Target Name="GetNextRevisionNumber"
@@ -44,7 +45,7 @@
     <Exec
       WorkingDirectory="$(SourceDir)"
       StandardOutputImportance="Low"
-      Command="git push origin $(GitWorkingBranch)" />
+      Command="git push $(GitPushRemote) $(GitWorkingBranch)" />
 
   </Target>
 </Project>


### PR DESCRIPTION
Add property GitPushRemote that allows the repository to be specified
when pushing the commit of the automated build value change.