### PR TITLE
Don't promote reference depencies if inbox

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -519,7 +519,9 @@
     </ItemGroup>
     
     <!-- Promote reference dependencies to implementation TargetFrameworks -->
-    <PromoteReferenceDependencies Dependencies="@(FilePackageDependency)" Condition="'@(FilePackageDependency)' != ''">
+    <PromoteReferenceDependencies Dependencies="@(FilePackageDependency)"
+                                  FrameworkListsPath="$(FrameworkListsPath)"
+                                  Condition="'@(FilePackageDependency)' != ''">
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
     </PromoteReferenceDependencies>
       

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteReferenceDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteReferenceDependencies.cs
@@ -28,6 +28,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         [Required]
         public ITaskItem[] Dependencies { get; set; }
         
+        [Required]
+        public string FrameworkListsPath { get; set; }
+
         [Output]
         public ITaskItem[] PromotedDependencies { get; set; }
         
@@ -67,7 +70,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                         var promotedDependency = new TaskItem(reference.OriginalItem);
                         promotedDependency.SetMetadata(TargetFrameworkMetadataName, implementationFx);
 
-                        promotedDependencies.Add(promotedDependency);
+                        if (!Frameworks.IsInbox(FrameworkListsPath, implementationFx, reference.Id, reference.Version))
+                        {
+                            promotedDependencies.Add(promotedDependency);
+                        }
                     }
                 }
             }
@@ -82,6 +88,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             public Dependency(ITaskItem item)
             {
                 Id = item.ItemSpec;
+                Version = item.GetMetadata("Version");
                 bool isReference = false;
                 bool.TryParse(item.GetMetadata(IsReferenceMetadataName), out isReference);
                 IsReference = isReference;
@@ -90,6 +97,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             public string Id { get; }
+            public string Version { get; }
+
             public bool IsReference { get; }
             public string TargetFramework { get; }
 


### PR DESCRIPTION
We were already doing this similar filtering in SplitReferences.

The only package impacted by this change is System.Net.WinHttpHandler.