### PR TITLE
Exclude the PackageFiles project.json files from dependency validation

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -126,7 +126,7 @@
   <!-- Create a collection of all project.json files for dependency updates. -->
   <ItemGroup>
     <!-- Exclude PackageFiles tool-runtime and test-runtime project.json files. -->
-    <ProjectJsonFiles Include="$(SourceDir)**/project.json"
+    <ProjectJsonFiles Include="$(SourceDir)**\project.json"
                       Exclude="$(SourceDir)Microsoft.DotNet.Build.Tasks\PackageFiles\**\project.json" />
   </ItemGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -125,7 +125,9 @@
 
   <!-- Create a collection of all project.json files for dependency updates. -->
   <ItemGroup>
-    <ProjectJsonFiles Include="$(SourceDir)**/project.json" />
+    <!-- Exclude PackageFiles tool-runtime and test-runtime project.json files. -->
+    <ProjectJsonFiles Include="$(SourceDir)**/project.json"
+                      Exclude="$(SourceDir)Microsoft.DotNet.Build.Tasks\PackageFiles\**\project.json" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildAllProjects)'=='true'">


### PR DESCRIPTION
Validation had been set up to keep every project.json in the repository in sync, but tool-runtime and test-runtime need to change independently.

Fixes build error in https://github.com/dotnet/buildtools/pull/509

/cc @stephentoub @weshaggard 