### PR TITLE
Lower InteropServices baseline version

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/baseline.packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/baseline.packages.targets
@@ -261,7 +261,8 @@
       <Version>4.0.1</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Runtime.InteropServices">
-      <Version>4.1.0</Version>
+      <!-- intentionally lower than live to not lift up System.Runtime above baseline -->
+      <Version>4.0.21</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Runtime.InteropServices.PInvoke">
       <Version>4.0.0</Version>


### PR DESCRIPTION
Previously the baseline version for InteropServices was 4.1.0.  The
API surface in 4.1.0 requires a type forward to System.Runtime 4.1.0,
which breaks the baseline.

We were lifting all references of System.Runtime.InteropServices to
4.1.0 and only lifting System.Runtime to 4.0.21, essentially causing a
downgrade warning in all packages that referenced IS.

This lowers the baseline for IS to 4.0.21, which I restored in commit
https://github.com/dotnet/corefx/commit/c402f76ccbb649c6005882f5076dfd45b9251dad

Folks who must reference the latest version still can but we won't
artificially rase the version for folks that don't need to.

/cc @weshaggard 