### PR TITLE
Add support to xunit extensions for Windows Nano.

### DIFF
--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.IO;
 using System.Runtime.InteropServices;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -33,7 +34,8 @@ namespace Xunit.NetCore.Extensions
                 (platforms.HasFlag(PlatformID.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
                 (platforms.HasFlag(PlatformID.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
                 (platforms.HasFlag(PlatformID.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
-                (platforms.HasFlag(PlatformID.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+                (platforms.HasFlag(PlatformID.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ||
+                (platforms.HasFlag(PlatformID.WindowsNano) && !File.Exists("C:\\Windows\\regedit.exe")))
             {
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
                 yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);

--- a/src/xunit.netcore.extensions/Discoverers/PlatformSpecificDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/PlatformSpecificDiscoverer.cs
@@ -25,6 +25,8 @@ namespace Xunit.NetCore.Extensions
             PlatformID platform = (PlatformID)traitAttribute.GetConstructorArguments().First();
             if (!platform.HasFlag(PlatformID.Windows))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonWindowsTest);
+            if (!platform.HasFlag(PlatformID.WindowsNano))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonWindowsNanoTest);
             if (!platform.HasFlag(PlatformID.Linux))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonLinuxTest);
             if (!platform.HasFlag(PlatformID.OSX))

--- a/src/xunit.netcore.extensions/PlatformID.cs
+++ b/src/xunit.netcore.extensions/PlatformID.cs
@@ -15,6 +15,7 @@ namespace Xunit
         OSX = 4,
         FreeBSD = 8,
         NetBSD = 16,
+        WindowsNano = 32,
         AnyUnix = FreeBSD | Linux | NetBSD | OSX,
         Any = ~0
     }

--- a/src/xunit.netcore.extensions/XunitConstants.cs
+++ b/src/xunit.netcore.extensions/XunitConstants.cs
@@ -14,6 +14,7 @@ namespace Xunit.NetCore.Extensions
         internal const string NonNetBSDTest = "nonnetbsdtests";
         internal const string NonOSXTest = "nonosxtests";
         internal const string NonWindowsTest = "nonwindowstests";
+        internal const string NonWindowsNanoTest = "nonwindowsnanotests";
         internal const string Failing = "failing";
         internal const string ActiveIssue = "activeissue";
         internal const string OuterLoop = "outerloop";


### PR DESCRIPTION
cc @stephentoub @ellismg 

This is to allow skipping tests on winnano, and keeping builds green with tracking bugs, until fixed.