### PR TITLE
Add infrastructure to support IsNotSupportedAssembly 

### DIFF
--- a/src/GenAPI/GenAPI.csproj
+++ b/src/GenAPI/GenAPI.csproj
@@ -42,6 +42,5 @@
     <ProjectReference Include="..\Microsoft.CCI.Extensions\Microsoft.CCI.Extensions.csproj" />
   </ItemGroup>
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), publishexe.targets))\publishexe.targets" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/GenAPI/Program.cs
+++ b/src/GenAPI/Program.cs
@@ -93,6 +93,7 @@ namespace GenAPI
                         writer.HighlightBaseMembers = s_hightlightBaseMembers;
                         writer.HighlightInterfaceMembers = s_hightlightInterfaceMembers;
                         writer.PutBraceOnNewLine = true;
+                        writer.ThrowPlatformNotSupportedForCompilation = s_throw;
                         return writer;
                     }
             }
@@ -171,6 +172,7 @@ namespace GenAPI
         private static bool s_hightlightBaseMembers;
         private static bool s_hightlightInterfaceMembers;
         private static bool s_all;
+        private static bool s_throw;
 
         private static void ParseCommandLine(string[] args)
         {
@@ -197,6 +199,8 @@ namespace GenAPI
                 parser.DefineOptionalQualifier("hightlightBaseMembers", ref s_hightlightBaseMembers, "(-hbm) [CSDecl] Highlight overridden base members.");
                 parser.DefineAliases("hightlightInterfaceMembers", "him");
                 parser.DefineOptionalQualifier("hightlightInterfaceMembers", ref s_hightlightInterfaceMembers, "(-him) [CSDecl] Highlight interface implementation members.");
+                parser.DefineAliases("throw", "t");
+                parser.DefineOptionalQualifier("throw", ref s_throw, "(-t) Method bodies should throw PlatformNotSupportedException.");
                 parser.DefineParameter<string>("", ref s_assembly, "Path for an specific assembly or a directory to get all assemblies.");
             }, args);
         }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -186,9 +186,16 @@ namespace Microsoft.Cci.Writers.CSharp
 
             WriteOutParameterInitializations(method);
 
-            // Structs cannot have empty constructors so we need to output this dummy body
-            if (method.ContainingTypeDefinition.IsValueType && method.IsConstructor)
+            if (_forCompilationThrowPlatformNotSupported)
             {
+                Write("throw new ");
+                if (_forCompilationIncludeGlobalprefix)
+                    Write("global::");
+                Write("System.PlatformNotSupportedException(); ");
+            }
+            else if (method.ContainingTypeDefinition.IsValueType && method.IsConstructor)
+            {
+                // Structs cannot have empty constructors so we need to output this dummy body
                 Write("throw new ");
                 if (_forCompilationIncludeGlobalprefix)
                     Write("global::");

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Cci.Writers.CSharp
         private readonly ICciFilter _filter;
         private bool _forCompilation;
         private bool _forCompilationIncludeGlobalprefix;
+        private bool _forCompilationThrowPlatformNotSupported;
         private bool _includeFakeAttributes;
 
         public CSDeclarationWriter(ISyntaxWriter writer)
@@ -36,6 +37,7 @@ namespace Microsoft.Cci.Writers.CSharp
             _filter = filter;
             _forCompilation = forCompilation;
             _forCompilationIncludeGlobalprefix = false;
+            _forCompilationThrowPlatformNotSupported = false;
             _includeFakeAttributes = false;
         }
 
@@ -55,6 +57,11 @@ namespace Microsoft.Cci.Writers.CSharp
         {
             get { return _forCompilationIncludeGlobalprefix; }
             set { _forCompilationIncludeGlobalprefix = value; }
+        }
+        public bool ForCompilationThrowPlatformNotSupported
+        {
+            get { return _forCompilationThrowPlatformNotSupported; }
+            set { _forCompilationThrowPlatformNotSupported = value; }
         }
 
         public ISyntaxWriter SyntaxtWriter { get { return _writer; } }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Cci.Writers
             get { return _declarationWriter.ForCompilationIncludeGlobalPrefix; }
             set { _declarationWriter.ForCompilationIncludeGlobalPrefix = value; }
         }
+        public bool ThrowPlatformNotSupportedForCompilation
+        {
+            get { return _declarationWriter.ForCompilationThrowPlatformNotSupported; }
+            set { _declarationWriter.ForCompilationThrowPlatformNotSupported = value; }
+        }
 
         public void WriteAssemblies(IEnumerable<IAssembly> assemblies)
         {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -110,16 +110,30 @@
     Import the partial facade generation targets
     
       Inputs:
+        GeneratePlatformNotSupportedAssembly - Determines wether to generate not-supported API for this assembly
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)notsupported.targets" Condition="'$(ExcludePartialFacadesImport)' != 'true'"/>
+  
+  <!-- 
+    Import the partial facade generation targets
+    
+      Inputs:
         IsPartialFacadeAssembly - Determines whether the partial facade generation targets will be as a post-processing step on the
           assembly. Also invokes special logic for determining References.
-        AssemblyName - Needed to determine which contract name to map to
-        AssemblyVersion - Needed to determine which contract version to map to
   -->
   <Import Project="$(MSBuildThisFileDirectory)partialfacades.targets" Condition="'$(ExcludePartialFacadesImport)' != 'true'"/>
   
    <!-- Import the ApiCompat targets. -->
   <Import Project="$(MSBuildThisFileDirectory)ApiCompat.targets" />
   
+  <!-- 
+    Import the contract resolution targets
+    
+      Inputs:
+        AssemblyName - Needed to determine which contract name to map to
+        AssemblyVersion - Needed to determine which contract version to map to
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)resolveContract.targets" Condition="'$(ExcludeResolveContractImport)' != 'true'"/>
   <!-- 
     Import the default signing targets which will setup the authenticode properties and do OpenSourceSigning
     

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+
+  <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true'">
+    <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
+    <ResolveMatchingContract>true</ResolveMatchingContract>
+    <NotSupportedSourceFile>$(IntermediateOutputPath)$(TargetName).notsupported.cs</NotSupportedSourceFile>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateNotSupportedSource</CoreCompileDependsOn>
+  </PropertyGroup>
+
+  <!-- GenerateNotSupportedSource
+       Inputs:
+         * A contract assembly
+         * Reference assemblies
+
+       Generates source for the contract that throws PlatformNotSupportedException
+  -->
+  <Target Name="GenerateNotSupportedSource" 
+          DependsOnTargets="ResolveMatchingContract"
+          Inputs="@(ReferencePath);@(ResolvedMatchingContract)"
+          Outputs="$(NotSupportedSourceFile)">
+
+    <ItemGroup>
+      <!-- build out a list of directories where dependencies are located -->
+      <_referencePathDirectoriesWithDuplicates Include="@(ReferencePath->'%(RootDir)%(Directory)'->TrimEnd('\'))" />
+      <!-- strip metadata, removing duplicates -->
+      <_referencePathDirectories Include="%(_referencePathDirectoriesWithDuplicates.Identity)" />
+    </ItemGroup>
+
+    <Error Text="No single matching contract found." Condition="'@(ResolvedMatchingContract->Count())' != '1'" />
+
+    <PropertyGroup>
+      <GenAPIArgs>"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
+      <GenAPIArgs>$(GenAPIArgs) -libPath:"@(_referencePathDirectories)"</GenAPIArgs>
+      <GenAPIArgs>$(GenAPIArgs) -out:"$(NotSupportedSourceFile)"</GenAPIArgs>
+      <GenAPIArgs>$(GenAPIArgs) -throw</GenAPIArgs>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <GenAPICmd>$(ToolHostCmd) "$(ToolsDir)GenAPI.exe"</GenAPICmd>
+    </PropertyGroup>
+
+    <Exec Command="$(GenAPICmd) $(GenAPIArgs)" WorkingDirectory="$(ToolRuntimePath)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(NotSupportedSourceFile)" />
+      <Compile Include="$(NotSupportedSourceFile)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-
   <!-- Hook both partial-facade-related targets into TargetsTriggeredByCompilation. This will cause them
           to only be invoked upon a successful compilation; they can conceptualized as an extension
           of the assembly compilation process.
@@ -12,39 +10,11 @@
       $(TargetsTriggeredByCompilation);FillPartialFacade
     </TargetsTriggeredByCompilation>
   </PropertyGroup>
-  
-  <!-- If a reference assembly project exists for the partial facade, prefer that over the package  -->
+
   <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
-    <ResolveReferencesDependsOn>
-      FindPartialFacadeProjectReference;
-      $(ResolveReferencesDependsOn)
-    </ResolveReferencesDependsOn>
-    <CleanDependsOn>
-      FindPartialFacadeProjectReference;
-      $(CleanDependsOn);
-    </CleanDependsOn>
+    <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
+    <ResolveMatchingContract>true</ResolveMatchingContract>
   </PropertyGroup>
-  
-  <Target Name="FindPartialFacadeProjectReference">
-    <PropertyGroup>
-      <_referenceAssemblyProject>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'ref/$(AssemblyName).csproj'))/ref/$(AssemblyName).csproj</_referenceAssemblyProject>
-      <_versionReferenceAssemblyProject>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'ref/$(APIVersion)/$(AssemblyName).csproj'))/ref/$(APIVersion)/$(AssemblyName).csproj</_versionReferenceAssemblyProject>
-    </PropertyGroup>
-    <ItemGroup>
-      <!-- first check for a specific version -->
-      <ProjectReference Include="$(_versionReferenceAssemblyProject)" Condition="Exists('$(_versionReferenceAssemblyProject)')">
-        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-        <OutputItemType>ResolvedMatchingContract</OutputItemType>
-        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
-      </ProjectReference>
-      <!-- fall back to 'current' version -->
-      <ProjectReference Include="$(_referenceAssemblyProject)" Condition="!Exists('$(_versionReferenceAssemblyProject)') AND Exists('$(_referenceAssemblyProject)')">
-        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-        <OutputItemType>ResolvedMatchingContract</OutputItemType>
-        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
-      </ProjectReference>
-    </ItemGroup>
-  </Target>
 
   <!-- Inputs and outputs of FillPartialFacade -->
   <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
@@ -65,7 +35,7 @@
        Fills the "input assembly" by finding types in the contract assembly that are missing from it, and adding type-forwards
          to those matching types in the seed assemblies.
   -->
-  <Target Name="FillPartialFacade" DependsOnTargets="EnsureBuildToolsRuntime">
+  <Target Name="FillPartialFacade" DependsOnTargets="EnsureBuildToolsRuntime;ResolveMatchingContract">
 
     <ItemGroup>
       <!-- References used for compilation are automatically included as seed assemblies -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resolveContract.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resolveContract.targets
@@ -13,19 +13,15 @@
   </PropertyGroup>
   
   <Target Name="ResolveMatchingContract">
-    <PropertyGroup>
-      <_referenceAssemblyProject>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'ref/$(AssemblyName).csproj'))/ref/$(AssemblyName).csproj</_referenceAssemblyProject>
-      <_versionReferenceAssemblyProject>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'ref/$(APIVersion)/$(AssemblyName).csproj'))/ref/$(APIVersion)/$(AssemblyName).csproj</_versionReferenceAssemblyProject>
+    <PropertyGroup Condition="`$(ContractProject)` == ''">
+      <ContractProject>$(SourceDir)/$(AssemblyName)/ref/$(APIVersion)/$(AssemblyName).csproj</ContractProject>
+      <!-- fall back to 'current' version if specific version does not exist -->
+      <ContractProject Condition="!(Exists('$(ContractProject)')">$(SourceDir)/$(AssemblyName)/ref/$(AssemblyName).csproj</ContractProject>
+      <!-- don't add a project if one can't be found-->
+      <ContractProject Condition="!(Exists('$(ContractProject)')"></ContractProject>
     </PropertyGroup>
     <ItemGroup>
-      <!-- first check for a specific version -->
-      <ProjectReference Include="$(_versionReferenceAssemblyProject)" Condition="Exists('$(_versionReferenceAssemblyProject)')">
-        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-        <OutputItemType>ResolvedMatchingContract</OutputItemType>
-        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
-      </ProjectReference>
-      <!-- fall back to 'current' version -->
-      <ProjectReference Include="$(_referenceAssemblyProject)" Condition="!Exists('$(_versionReferenceAssemblyProject)') AND Exists('$(_referenceAssemblyProject)')">
+      <ProjectReference Include="$(ContractProject)" Condition="'$(ContractProject)' != ''">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <OutputItemType>ResolvedMatchingContract</OutputItemType>
         <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resolveContract.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resolveContract.targets
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="'$(ResolveMatchingContract)' == 'true'">
+    <ResolveReferencesDependsOn>
+      ResolveMatchingContract;
+      $(ResolveReferencesDependsOn)
+    </ResolveReferencesDependsOn>
+    <CleanDependsOn>
+      ResolveMatchingContract;
+      $(CleanDependsOn);
+    </CleanDependsOn>
+  </PropertyGroup>
+  
+  <Target Name="ResolveMatchingContract">
+    <PropertyGroup>
+      <_referenceAssemblyProject>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'ref/$(AssemblyName).csproj'))/ref/$(AssemblyName).csproj</_referenceAssemblyProject>
+      <_versionReferenceAssemblyProject>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'ref/$(APIVersion)/$(AssemblyName).csproj'))/ref/$(APIVersion)/$(AssemblyName).csproj</_versionReferenceAssemblyProject>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- first check for a specific version -->
+      <ProjectReference Include="$(_versionReferenceAssemblyProject)" Condition="Exists('$(_versionReferenceAssemblyProject)')">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <OutputItemType>ResolvedMatchingContract</OutputItemType>
+        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
+      </ProjectReference>
+      <!-- fall back to 'current' version -->
+      <ProjectReference Include="$(_referenceAssemblyProject)" Condition="!Exists('$(_versionReferenceAssemblyProject)') AND Exists('$(_referenceAssemblyProject)')">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <OutputItemType>ResolvedMatchingContract</OutputItemType>
+        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -37,6 +37,7 @@
     <file src="Microsoft.DotNet.Build.Tasks\NuProj\**\*.*" target="lib\NuProj" />
     <file src="BclRewriter\BclRewriter.exe" target="lib" />
     <file src="GenFacades\GenFacades.exe" target="lib" />
+    <file src="GenAPI\GenAPI.exe" target="lib" />
     <file src="ApiCompat\ApiCompat.exe" target="lib" />
     <file src="Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib" />


### PR DESCRIPTION
This adds infrastructure to buildtools to create NotSupported assemblies.

These assemblies expose API described by the contract and throw PlatformNotSupported from every method.