### PR TITLE
Fix dependency versions after automatic prerelease upgrade

### DIFF
--- a/src/ApiCompat/project.json
+++ b/src/ApiCompat/project.json
@@ -17,7 +17,7 @@
     "System.Reflection.TypeExtensions": "4.0.0",
     "System.Threading.Thread": "4.0.0-rc2-23907",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23907",
-    "Microsoft.NETCore.Runtime": "1.0.1-rc2-23907",
+    "Microsoft.NETCore.Runtime": "1.0.2-rc2-23907",
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23907"
   },
   "frameworks": {

--- a/src/GenAPI/project.json
+++ b/src/GenAPI/project.json
@@ -3,7 +3,7 @@
     "Microsoft.Cci": "4.0.0-rc2-23712",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23907",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23907",
-    "Microsoft.NETCore.Runtime": "1.0.1-rc2-23907",
+    "Microsoft.NETCore.Runtime": "1.0.2-rc2-23907",
     "System.Console": "4.0.0-rc2-23907",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23907",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-23907",

--- a/src/GenFacades/project.json
+++ b/src/GenFacades/project.json
@@ -3,7 +3,7 @@
     "Microsoft.Cci": "4.0.0-rc2-23712",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23907",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23907",
-    "Microsoft.NETCore.Runtime": "1.0.1-rc2-23907",
+    "Microsoft.NETCore.Runtime": "1.0.2-rc2-23907",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc2-23907",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -14,7 +14,7 @@
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23907",
     "Microsoft.NETCore.Console": "1.0.0-rc2-23907",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23907",
-    "Microsoft.NETCore.Runtime": "1.0.1-rc2-23907",
+    "Microsoft.NETCore.Runtime": "1.0.2-rc2-23907",
     "Microsoft.Cci": "4.0.0-rc3-23811",
     "Microsoft.Win32.Registry": { 
       "version": "4.0.0-rc2-23907",

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -12,7 +12,7 @@
     "Newtonsoft.Json": "7.0.1",
     "NuGet.Versioning": "3.4.0-beta-488",
     "NuProj": "0.10.4-beta-gf7fc34e7d8",
-    "System.IO.Compression": "4.0.1-rc2-23907",
+    "System.IO.Compression": "4.1.0-rc2-23907",
     "System.IO.Compression.ZipFile": "4.0.1-rc2-23907",
     "System.IO.FileSystem": "4.0.1-rc2-23907",
     "System.Linq": "4.0.1-rc2-23907",


### PR DESCRIPTION
The auto-upgrade in https://github.com/dotnet/buildtools/pull/515 resulted in some dependencies not existing due to the minor/patch versions changing. Corrected throughout the repository.

/cc @ericstj @stephentoub 