### PR TITLE
Fixes to support real-signed builds in CoreFx.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/depProj.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/depProj.targets
@@ -41,6 +41,9 @@ See the LICENSE file in the project root for more information.
 
     <!-- make sure we tell nuget targets to copy, even if output type would not by default -->
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
+
+    <!-- by default there shouldn't be any assets in depproj files that require signing -->
+    <SkipSigning Condition="'$(SkipSigning)' == ''">true</SkipSigning>
   </PropertyGroup>
   
   <Target Name="CoreCompile">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -2,10 +2,10 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- metadata used for Authenticode and strong-name signing in official VSO builds -->
-  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
+  <ItemGroup Condition="'$(SkipSigning)' != 'true' and '$(IsTestProject)' != 'true' and '$(SignType)' != 'oss'">
     <FilesToSign Include="$(TargetPath)">
       <Authenticode>Microsoft</Authenticode>
-      <StrongName Condition="'$(SkipSigning)' != 'true'">StrongName</StrongName>
+      <StrongName Condition="'$(SignType)' == 'real' and '$(UseOpenKey)' != 'true'">StrongName</StrongName>
     </FilesToSign>
   </ItemGroup>
 
@@ -19,7 +19,8 @@
     <DelaySign>true</DelaySign>
     <DelaySign Condition="'$(UseOpenKey)' == 'true'">false</DelaySign>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
-    <UseOpenSourceSign Condition="'$(UseOpenSourceSign)' == ''">true</UseOpenSourceSign>
+    <!-- applicable values for SignType are oss, test or real -->
+    <SignType Condition="'$(SignType)' == ''">oss</SignType>
   </PropertyGroup>
 
   <!--
@@ -34,7 +35,7 @@
   </PropertyGroup>
 
   <Target Name="OpenSourceSign"
-          Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != '' and '$(SkipSigning)' != 'true' and '$(UseOpenSourceSign)' == 'true'"
+          Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != '' and '$(SkipSigning)' != 'true' and '$(SignType)' == 'oss'"
           Inputs="@(IntermediateAssembly)"
           Outputs="%(IntermediateAssembly.Identity).oss_signed"
           >


### PR DESCRIPTION
By default skip signing when building depproj projects.
Renamed property UseOpenSourceSign to SignType to better align with real
signing requirements.
Disable Authenticode signing when doing OSS signing.
For real-signed builds that don't use the "open" key add build metadata so
the assembly gets a real strong name.