### PR TITLE
Update System.Reflection.Metadata to 1.3.0

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -29,6 +29,7 @@
     "System.IO.Compression": "4.1.0-rc2-23907",
     "System.IO.FileSystem": "4.0.1-rc2-23907",
     "System.Linq.Expressions": "4.0.11-rc2-23907",
+    "System.Reflection.Metadata": "1.3.0-rc2-23907",
     "System.Runtime.Extensions": "4.1.0-rc2-23907",
     "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23907"
   },


### PR DESCRIPTION
System.Reflection.Metadata 1.2.0 removed some types from a previous
build.  See https://github.com/dotnet/corefx/commit/7152971f4a940aa897c29fcdbed8934a692a928e.

Roslyn depended on those types.

The rc2-23907 references the stable 1.2.0 build of Metadata (and so does
rc2-23908 and rc2-23909).  The rc2-23910 build of the packages that
comes out tonight will have the fix to reference 1.3.0, but we don't
want to wait for that.  For now reference 1.3.0-rc2-23907 directly.

We can remove the direct reference when we update the baseline,
and in fact should remove lots of these direct references at that point

/cc @dagood @mellinoe 