### PR TITLE
Fix signing of build tools binaries.

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -148,10 +148,10 @@
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
     <!--
-      Delay signing with the ECMA key currently doesn't work.
-      https://github.com/dotnet/roslyn/issues/2444
+      Full signing with Open key doesn't work with Portable Csc.
+      https://github.com/dotnet/roslyn/issues/8210
     -->
-    <UseECMAKey>false</UseECMAKey>
+    <UseOpenKey>false</UseOpenKey>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OsEnvironment)'=='Unix'">
@@ -166,6 +166,11 @@
       Second, we aren't yet building pdbs, which the nuspecs specify.
     -->
     <SkipBuildPackages>true</SkipBuildPackages>
+  </PropertyGroup>
+
+  <!-- Set the default strong name sig to use the "open" key -->
+  <PropertyGroup Condition="'$(UseOpenKey)' == ''">
+    <UseOpenKey>true</UseOpenKey>
   </PropertyGroup>
 
   <!-- 

--- a/publishexe.targets
+++ b/publishexe.targets
@@ -9,7 +9,8 @@
     <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
   </PropertyGroup>
 
-  <Target Name="PublishFilesToRuntime" AfterTargets="CopyFilesToOutputDirectory"
+  <!-- this must happen after the binaries have been signed -->
+  <Target Name="PublishFilesToRuntime" AfterTargets="SignFiles"
           Condition="'$(OutputType)' == 'Exe' ">
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -16,7 +16,6 @@
     <FileAlignment>512</FileAlignment>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
-    <SkipSigning>true</SkipSigning>
     <ProjectGuid>{F01FAA6C-4EF1-4283-B9B5-4C1416FA7F50}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -11,7 +11,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <CLSCompliant>false</CLSCompliant>
-    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
@@ -9,7 +9,6 @@
     <RootNamespace>Microsoft.DotNet.Build.Tasks.Packaging.Tests</RootNamespace>
     <AssemblyName>Microsoft.DotNet.Build.Tasks.Packaging.Tests</AssemblyName>
     <CLSCompliant>false</CLSCompliant>
-    <SkipSigning>true</SkipSigning>
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
     <TaskProject Condition="'$(TaskProject)' == ''">..\src\Microsoft.DotNet.Build.Tasks.Packaging.csproj</TaskProject>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>Microsoft.DotNet.Build.Tasks</AssemblyName>
     <CLSCompliant>false</CLSCompliant>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -26,9 +26,6 @@
   -->
   <Import Project="$(MSBuildThisFileDirectory)toolruntime.targets" Condition="'$(ExcludeToolRuntimeImport)' != 'true'"/>
 
-  <!-- import the MicroBuild boot-strapper project (only relevant for shipping binaries) -->
-  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.targets" Condition="'$(IsTestProject)'!='true'" />
-
   <!--
     Import the reference assembly targets
     
@@ -189,7 +186,13 @@
       <VSDesignTimeBuild Condition="'$(BuildingInsideVisualStudio)'=='true' and '$(BuildingOutOfProcess)'=='false'">true</VSDesignTimeBuild>
     </PropertyGroup>
   </Target>
-  
+
+  <!--
+    import the MicroBuild boot-strapper project (only relevant for shipping binaries)
+    NOTE: we import this at the end as it will override some dummy targets (e.g. SignFiles)
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.targets" Condition="'$(IsTestProject)'!='true' and '$(SignType)' != 'oss'" />
+
   <!--
     Providing a definition for __BlockReflectionAttribute in an assembly is a signal to the .NET Native toolchain 
     to remove the metadata for all non-public APIs. This both reduces size and disables private reflection on those 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -23,6 +23,9 @@
     <SignType Condition="'$(SignType)' == ''">oss</SignType>
   </PropertyGroup>
 
+  <!-- stub for signing.  for official builds this is replaced with the real one -->
+  <Target Name="SignFiles" AfterTargets="AfterBuild" />
+
   <!--
     NOTE: This mechanism for wiring in the OpenSourceSign target can't be changed to any of the following:
 

--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -14,7 +14,6 @@
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <SkipSigning>true</SkipSigning>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>


### PR DESCRIPTION
In commit eca81d0 I changed how property SkipSigning is evaluated so that
when it's true no signing is performed.  Unfortunately we set this
property in most of the build tools projects and as a result they are no
longer Authenticode signed.  I have removed the SkipSigning property from
the offending projects.
Set the default strong name signing key to the "open" one.
The PublishFilesToRuntime task was running before real signing happens, as
a result we do not sign the renamed binary (e.g. GenAPI.exe ->
GenAPI.dll).  To fix this I sequenced this target after the SignFiles
target which is where the official signing happens.  To ensure this works
for dev builds I stubbed out this target in sign.targets.  It also
required me to re-order the import of the MicroBuild bootstrapper in
Build.Common.targets.