### PR TITLE
Adding Crossgen to the toolRuntime folder

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -9,7 +9,10 @@ set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
 set PORTABLETARGETS_VERSION=0.1.1-dev
 set ROSLYNCOMPILERS_VERSION=1.2.0-beta1-20160202-02
-set MSBUILD_CONTENT_JSON={"dependencies": { "MicroBuild.Core": "%MICROBUILD_VERSION%", "Microsoft.Portable.Targets": "%PORTABLETARGETS_VERSION%", "Microsoft.Net.Compilers": "%ROSLYNCOMPILERS_VERSION%"},"frameworks": {"dnxcore50": {},"net46": {}}}
+
+:: This version MUST match the one in tool-runtime/project.json
+set RUNTIME_CORECLR_VERSION=1.0.2-rc2-23907
+set MSBUILD_CONTENT_JSON={"dependencies": { "Microsoft.NETCore.Runtime.CoreCLR": "%RUNTIME_CORECLR_VERSION%","MicroBuild.Core": "%MICROBUILD_VERSION%", "Microsoft.Portable.Targets": "%PORTABLETARGETS_VERSION%", "Microsoft.Net.Compilers": "%ROSLYNCOMPILERS_VERSION%"},"frameworks": {"dnxcore50": {},"net46": {}}}
 
 if not exist "%PROJECT_DIR%" (
   echo ERROR: Cannot find project root path at [%PROJECT_DIR%]. Please pass in the source directory as the 1st parameter.
@@ -31,9 +34,10 @@ call "%DOTNET_CMD%" publish -f dnxcore50 -r %BUILDTOOLS_TARGET_RUNTIME% -o "%TOO
 if not exist "%BUILDTOOLS_PACKAGE_DIR%\portableTargets" mkdir "%BUILDTOOLS_PACKAGE_DIR%\portableTargets"
 echo %MSBUILD_CONTENT_JSON% > "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\project.json"
 cd "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\"
-call "%DOTNET_CMD%" restore --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json --packages "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages"
+call "%DOTNET_CMD%" restore --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json --packages "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages"
 Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\Microsoft.Portable.Targets\%PORTABLETARGETS_VERSION%\contentFiles\any\any\." "%TOOLRUNTIME_DIR%\." /E
 Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\MicroBuild.Core\%MICROBUILD_VERSION%\build\." "%TOOLRUNTIME_DIR%\." /E
+Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\runtime.%BUILDTOOLS_TARGET_RUNTIME%.Microsoft.NETCore.Runtime.CoreCLR\%RUNTIME_CORECLR_VERSION%\tools\." "%TOOLRUNTIME_DIR%\." /E
 
 :: Copy Roslyn Compilers Over to ToolRuntime
 Robocopy "%BUILDTOOLS_PACKAGE_DIR%\portableTargets\packages\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%TOOLRUNTIME_DIR%\net45\roslyn\." /E

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -6,7 +6,10 @@ __TOOLRUNTIME_DIR=$3
 __TOOLS_DIR=$(cd "$(dirname "$0")"; pwd -P)
 __MICROBUILD_VERSION=0.2.0
 __PORTABLETARGETS_VERSION=0.1.1-dev
-__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"MicroBuild.Core\": \"${__MICROBUILD_VERSION}\", \"Microsoft.Portable.Targets\": \"${__PORTABLETARGETS_VERSION}\"},\"frameworks\": {\"dnxcore50\": {},\"net46\": {}}}"
+
+# This version MUST match the one in tool-runtime/project.json
+__RUNTIME_CORECLR_VERSION=1.0.2-rc2-23907
+__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"Microsoft.NETCore.Runtime.CoreCLR\": \"${__RUNTIME_CORECLR_VERSION}\", \"MicroBuild.Core\": \"${__MICROBUILD_VERSION}\", \"Microsoft.Portable.Targets\": \"${__PORTABLETARGETS_VERSION}\"},\"frameworks\": {\"dnxcore50\": {},\"net46\": {}}}"
 
 __BUILDERRORLEVEL=0
 
@@ -73,9 +76,10 @@ fi
 mkdir "$__TOOLS_DIR/portableTargets"
 echo $__MSBUILD_CONTENT_JSON > "$__TOOLS_DIR/portableTargets/project.json"
 cd "$__TOOLS_DIR/portableTargets"
-"$__DOTNET_CMD" restore --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --packages "$__TOOLS_DIR/portableTargets/packages"
+"$__DOTNET_CMD" restore --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --packages "$__TOOLS_DIR/portableTargets/packages"
 cp -R "$__TOOLS_DIR/portableTargets/packages/Microsoft.Portable.Targets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
 cp -R "$__TOOLS_DIR/portableTargets/packages/MicroBuild.Core/${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
+cp -R "$__TOOLS_DIR/portableTargets/packages/runtime.${__PUBLISH_RID}.Microsoft.NETCore.Runtime.CoreCLR/${__RUNTIME_CORECLR_VERSION}/tools/." "$__TOOLRUNTIME_DIR/."
 
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages
 cp "$__TOOLRUNTIME_DIR/corerun" "$__TOOLRUNTIME_DIR/corerun.exe"


### PR DESCRIPTION
Even though I don't like this approach, we need crossgen to be dropped in the toolruntime folder as well if we want to crossgen the msbuild to make it build faster.

related: #487 

cc: @weshaggard