### PR TITLE
Fix dependency projection

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Framework.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Framework.cs
@@ -192,6 +192,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static bool IsInbox(string frameworkListsPath, string framework, string assemblyName, string assemblyVersion)
         {
+            NuGetFramework fx = NuGetFramework.Parse(framework);
+            return IsInbox(frameworkListsPath, fx, assemblyName, assemblyVersion);
+        }
+
+        public static bool IsInbox(string frameworkListsPath, NuGetFramework framework, string assemblyName, string assemblyVersion)
+        {
             // if no version is specified just use 0.0.0.0 to evaluate for any version of the contract
             Version version = FrameworkUtilities.Ensure4PartVersion(String.IsNullOrEmpty(assemblyVersion) ? new Version(0, 0, 0, 0) : new Version(assemblyVersion));
             FrameworkSet fxs = GetInboxFrameworks(frameworkListsPath);
@@ -202,15 +208,15 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             foreach (var fxVersions in fxs.Frameworks.Values)
             {
                 // Get the nearest compatible framework from this set of frameworks.
-                var nearest = FrameworkUtilities.GetNearest(NuGetFramework.Parse(framework), fxVersions.Select(fx => NuGetFramework.Parse(fx.ShortName)).ToArray());
+                var nearest = FrameworkUtilities.GetNearest(framework, fxVersions.Select(fx => NuGetFramework.Parse(fx.ShortName)).ToArray());
                 // If there are not compatible frameworks in the current framework set, there is not going to be a match.
                 if (nearest == null)
                 {
                     continue;
                 }
-                var origFramework = NuGetFramework.Parse(framework);
+
                 // if the nearest compatible frameworks version is greater than the version of the framework we are looking for, this is not going to be a match.
-                if (nearest.Version > origFramework.Version)
+                if (nearest.Version > framework.Version)
                 {
                     continue;
                 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -490,13 +490,6 @@
         <Exclude Condition="'%(FilePackageDependency.IsReferenceAsset)' != 'true'">Compile</Exclude>
       </FilePackageDependency>
     </ItemGroup>
-    
-    <!-- Promote reference dependencies to implementation TargetFrameworks -->
-    <PromoteReferenceDependencies Dependencies="@(FilePackageDependency)"
-                                  FrameworkListsPath="$(FrameworkListsPath)"
-                                  Condition="'@(FilePackageDependency)' != ''">
-      <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
-    </PromoteReferenceDependencies>
       
     
    <!-- We can reduce the number of dependencies listed for any framework that has
@@ -505,12 +498,18 @@
         packages.config based projects.  -->
     <CreateTrimDependencyGroups Dependencies="@(FilePackageDependency);@(Dependency)"
                       FrameworkListsPath="$(FrameworkListsPath)"
-                      TrimFrameworks="@(InboxOnTargetFramework);@(NotSupportedOnTargetFramework);@(ExternalOnTargetFramework)"
                       Files="@(File)"
                       UseNetPlatform="$(UseNetPlatform)"
                       Condition="'@(FilePackageDependency)' != '' AND '$(PackageTargetRuntime)' == ''">
       <Output TaskParameter="TrimmedDependencies" ItemName="FilePackageDependency" />
     </CreateTrimDependencyGroups>
+
+    <!-- Promote reference dependencies to implementation TargetFrameworks -->
+    <PromoteReferenceDependencies Dependencies="@(FilePackageDependency)"
+                                  FrameworkListsPath="$(FrameworkListsPath)"
+                                  Condition="'@(FilePackageDependency)' != ''">
+      <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
+    </PromoteReferenceDependencies>
 
     <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" BaseLinePackages="@(BaseLinePackage)" Condition="'$(BaseLinePackageDependencies)' != 'false'">
       <Output TaskParameter="BaseLinedDependencies" ItemName="_BaseLinedDependencies" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteReferenceDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteReferenceDependencies.cs
@@ -38,10 +38,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         {
             List<ITaskItem> promotedDependencies = new List<ITaskItem>();
 
+            var implementationFxs = Dependencies.Select(d => d.GetMetadata("TargetFramework")).Distinct();
+
             var actualDependencies = Dependencies.Where(d => d.ItemSpec != "_._").Select(d => new Dependency(d)).ToArray();
-
-            var implementationFxs = actualDependencies.Where(d => !d.IsReference).Select(d => d.TargetFramework).Distinct();
-
             var referenceSets = actualDependencies.Where(d => d.IsReference).GroupBy(d => d.TargetFramework).ToDictionary(g => NuGetFramework.Parse(g.Key), g => g.ToArray());
             var candidateFxs = referenceSets.Keys.ToArray();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/CreateTrimDependencyGroupsTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/CreateTrimDependencyGroupsTests.cs
@@ -36,6 +36,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateFileItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/wpa81", "wpa81"),
                 CreateFileItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/xamarinios10", "xamarinios10"),
                 CreateFileItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/xamarinmac20", "xamarinmac20"),
+                CreateFileItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/xamarintvos10", "xamarintvos10"),
+                CreateFileItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/xamarinwatchos10", "xamarinwatchos10"),
                 CreateFileItem(@"E:\ProjectK\binaries\x86ret\NETCore\Libraries\System.Collections.Immutable.dll", "lib/netstandard1.0", "netstandard1.0"),
                 CreateFileItem(@"E:\ProjectK\binaries\x86ret\Open\CoreFx\Windows_NT.x86.Release\System.Collections.Immutable\System.Collections.Immutable.xml", "lib/netstandard1.0", "netstandard1.0"),
                 CreateFileItem(@"E:\ProjectK\binaries\x86ret\Open\CoreFx\Windows_NT.x86.Release\System.Collections.Immutable\System.Collections.Immutable.xml", "lib/portable-net45+win8+wp8+wpa81", "portable-net45+win8+wp8+wpa81"),
@@ -53,6 +55,16 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             };
             ITaskItem[] dependencies = new[]
             {
+                CreateDependencyItem(@"_._", null, "MonoAndroid10"),
+                CreateDependencyItem(@"_._", null, "MonoTouch10"),
+                CreateDependencyItem(@"_._", null, "net45"),
+                CreateDependencyItem(@"_._", null, "win8"),
+                CreateDependencyItem(@"_._", null, "wp8"),
+                CreateDependencyItem(@"_._", null, "wpa81"),
+                CreateDependencyItem(@"_._", null, "xamarinios10"),
+                CreateDependencyItem(@"_._", null, "xamarinmac20"),
+                CreateDependencyItem(@"_._", null, "xamarintvos10"),
+                CreateDependencyItem(@"_._", null, "xamarinwatchos10"),
                 CreateDependencyItem(@"System.Runtime", "4.0.0", "netstandard1.0"),
                 CreateDependencyItem(@"System.Resources.ResourceManager", "4.0.0", "netstandard1.0"),
                 CreateDependencyItem(@"System.Collections", "4.0.0", "netstandard1.0"),
@@ -138,31 +150,42 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         {
             ITaskItem[] files = new[]
             {
-                CreateFileItem(@"E:\ProjectK\binaries\x86ret\NETCore\Libraries\System.ComponentModel.dll", "lib/netstandard1.3", "netstandard1.3"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "lib/MonoAndroid10", "MonoAndroid10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "lib/MonoTouch10", "MonoTouch10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\net45.dll", "lib/net45", "net45"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "lib/win8", "win8"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "lib/wp80", "wp80"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "lib/wpa81", "wpa81"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "lib/xamarinios10", "xamarinios10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "lib/xamarinmac20", "xamarinmac20"),
-                CreateFileItem(@"E:\ProjectK\binaries\x86ret\NETCore\Libraries\System.ComponentModel.dll", "lib/netcore50/System.ComponentModel.dll", "netcore50"),
-                CreateFileItem(@"E:\ProjectK\binaries\x86ret\Contracts\System.ComponentModel\4.0.1.0\System.ComponentModel.dll", "lib/ref/netstandard1.0", "netstandard1.0"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/MonoAndroid10", "MonoAndroid10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/MonoTouch10", "MonoTouch10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\net45.dll", "ref/net45", "net45"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/win8", "win8"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/wp80", "wp80"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/wpa81", "wpa81"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/xamarinios10", "xamarinios10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/xamarintvos10", "xamarintvos10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/xamarinwatchos10", "xamarinwatchos10"),
-                CreateFileItem(@"E:\ProjectK\src\NDP\FxCore\src\Packages\_._", "ref/xamarinmac20", "xamarinmac20"),
-                CreateFileItem(@"E:\ProjectK\binaries\x86ret\Contracts\System.ComponentModel\4.0.1.0\System.ComponentModel.dll", "ref/netcore50/System.ComponentModel.dll", "netcore50")
+                CreateFileItem(@"C:\bin\System.ComponentModel.dll", "lib/netstandard1.3", "netstandard1.3"),
+                CreateFileItem(@"C:\bin\System.ComponentModel.dll", "lib/netcore50/System.ComponentModel.dll", "netcore50"),
+                CreateFileItem(@"C:\bin\ns10\System.ComponentModel.dll", "lib/netstandard1.0", "netstandard1.0"),
+                CreateFileItem(@"C:\bin\_._", "lib/MonoAndroid10", "MonoAndroid10"),
+                CreateFileItem(@"C:\bin\_._", "lib/MonoTouch10", "MonoTouch10"),
+                CreateFileItem(@"C:\bin\_._", "lib/win8", "win8"),
+                CreateFileItem(@"C:\bin\_._", "lib/wp80", "wp80"),
+                CreateFileItem(@"C:\bin\_._", "lib/wpa81", "wpa81"),
+                CreateFileItem(@"C:\bin\_._", "lib/xamarinios10", "xamarinios10"),
+                CreateFileItem(@"C:\bin\_._", "lib/xamarinmac20", "xamarinmac20"),
+                CreateFileItem(@"C:\bin\_._", "lib/xamarintvos10", "xamarintvos10"),
+                CreateFileItem(@"C:\bin\_._", "lib/xamarinwatchos10", "xamarinwatchos10"),
+                CreateFileItem(@"C:\bin\ref\System.ComponentModel.dll", "ref/netstandard1.3", "netstandard1.3"),
+                CreateFileItem(@"C:\bin\ref\System.ComponentModel.dll", "ref/netcore50/System.ComponentModel.dll", "netcore50"),
+                CreateFileItem(@"C:\bin\ref\ns10\System.ComponentModel.dll", "ref/netstandard1.0", "netstandard1.0"),
+                CreateFileItem(@"C:\bin\_._", "ref/MonoAndroid10", "MonoAndroid10"),
+                CreateFileItem(@"C:\bin\_._", "ref/MonoTouch10", "MonoTouch10"),
+                CreateFileItem(@"C:\bin\_._", "ref/win8", "win8"),
+                CreateFileItem(@"C:\bin\_._", "ref/wp80", "wp80"),
+                CreateFileItem(@"C:\bin\_._", "ref/wpa81", "wpa81"),
+                CreateFileItem(@"C:\bin\_._", "ref/xamarinios10", "xamarinios10"),
+                CreateFileItem(@"C:\bin\_._", "ref/xamarintvos10", "xamarintvos10"),
+                CreateFileItem(@"C:\bin\_._", "ref/xamarinwatchos10", "xamarinwatchos10"),
+                CreateFileItem(@"C:\bin\_._", "ref/xamarinmac20", "xamarinmac20"),
             };
             ITaskItem[] dependencies = new[]
             {
+                CreateDependencyItem(@"_._", null, "MonoAndroid10"),
+                CreateDependencyItem(@"_._", null, "MonoTouch10"),
+                CreateDependencyItem(@"_._", null, "win8"),
+                CreateDependencyItem(@"_._", null, "wp8"),
+                CreateDependencyItem(@"_._", null, "wpa81"),
+                CreateDependencyItem(@"_._", null, "xamarinios10"),
+                CreateDependencyItem(@"_._", null, "xamarinmac20"),
+                CreateDependencyItem(@"_._", null, "xamarintvos10"),
+                CreateDependencyItem(@"_._", null, "xamarinwatchos10"),
                 CreateDependencyItem(@"System.Runtime", "4.0.0", "netstandard1.0"),
                 CreateDependencyItem(@"System.Runtime", "4.0.20", "netstandard1.3"),
                 // Make up some dependencies which are not inbox on net45, net451, net46
@@ -188,7 +211,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
 
             // System.Collections.Immutable is not inbox and we've specified different versions for netstandard1.0 and netstandard1.3, so
             // we're expecting those dependencies to both be present for the net45 and net46 target frameworks.
-            Assert.Equal(3, task.TrimmedDependencies.Length);
+            Assert.Equal(2, task.TrimmedDependencies.Length);
             Assert.Equal(1, task.TrimmedDependencies.Where(f => f.GetMetadata("TargetFramework").Equals("net45") && f.ItemSpec.Equals("System.Collections.Immutable", StringComparison.OrdinalIgnoreCase)).Count());
             Assert.Equal(1, task.TrimmedDependencies.Where(f => f.GetMetadata("TargetFramework").Equals("net451") && f.ItemSpec.Equals("System.Collections.Immutable", StringComparison.OrdinalIgnoreCase)).Count());
         }
@@ -305,7 +328,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         public static ITaskItem CreateDependencyItem(string sourcePath, string version, string targetFramework)
         {
             TaskItem item = new TaskItem(sourcePath);
-            item.SetMetadata("Version", version);
+
+            if (version != null)
+            {
+                item.SetMetadata("Version", version);
+            }
+
             item.SetMetadata("TargetFramework", targetFramework);
             return item;
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/6813

The CreateTrimDependencyGroups task was incorrectly projecting
implementation dependencies to dependency groups that had a different
implementation assembly.

For example:
	NETStandard1.0 implementation dll
	NET45 facade dll

We were copying the portable implementation's dependencies into the
facade's dependency group.

This was happening because the task wasn't considering all existing
dependency goups.  Instead it was just considering the placeholder
groups "specially" via the TrimFrameworks parameter.

I removed this parameter and refactored the algorithm a bit to
consider any dependency group, which includes the placeholders
as well as any dependency group created by harvesting the references.

This fixed the projection problem, but now we no longer were getting
compile references copied.  We need to preserve compile references
because they are part of the package's compat contract.  If someone
builds a portable library against one of our packages they may depend on
the packages transitive dependencies rather than directly referencing
those.

For example:
 - System.Data.SqlClient's reference assembly depends on S.Data.Common
 - Neither S.Data.SqlClient nor S.Data.Common are inbox on desktop.
 - S.Data.SqlClient's desktop implementation does not depend on
S.Data.Common since it is a facade that only depends on S.Data and
mscorlib
 - A PCL might reference just S.Data.SqlClient but will have assembly
refs to both S.Data.SqlClient and S.Data.Common.
 - We must deploy the S.Data.Common facade on desktop.

To fix this problem I made sure that PromoteReferenceDependencies always
copies the references, even for empty dependency groups (as would be the
case for a facade).  My previous change to add this task simply
overlooked the fact that an empty dependency group needed to be treated
as a supported framework to promote to as opposed to one to skip over.

/cc @weshaggard @chcosta 