### PR TITLE
Move signing to a post-build step so it batch signs.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -2,8 +2,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="dir.props" />
 
+  <!-- required to build the projects in their specified order -->
+  <PropertyGroup>
+    <SerializeProjects>true</SerializeProjects>
+  </PropertyGroup>
+
   <ItemGroup>
     <Project Include="src\dirs.proj" />
+    <Project Include="src\sign.builds" />
   </ItemGroup>
 
   <Import Project="dir.targets" />

--- a/publishexe.targets
+++ b/publishexe.targets
@@ -9,8 +9,7 @@
     <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
   </PropertyGroup>
 
-  <!-- this must happen after the binaries have been signed -->
-  <Target Name="PublishFilesToRuntime" AfterTargets="SignFiles"
+  <Target Name="PublishFilesToRuntime" AfterTargets="CopyFilesToOutputDirectory"
           Condition="'$(OutputType)' == 'Exe' ">
 
     <ItemGroup>
@@ -38,6 +37,10 @@
   <Target Name="FixUpCoreConsoleNames">
     <Move SourceFiles="$(Outdir)$(AssemblyName).exe" DestinationFiles="$(Outdir)$(AssemblyName).dll" />
     <Move SourceFiles="$(Outdir)CoreConsole.exe" DestinationFiles="$(Outdir)$(AssemblyName).exe" />
+    <!-- update TargetPath with the renamed file -->
+    <PropertyGroup>
+      <TargetPath>$(Outdir)$(AssemblyName).dll</TargetPath>
+    </PropertyGroup>
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -31,11 +31,14 @@
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="PreprocessFile.cs" />
+    <Compile Include="ReadSigningRequired.cs" />
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
+    <Compile Include="SignTypeItem.cs" />
     <Compile Include="UpdatePackageDependencyVersion.cs" />
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
+    <Compile Include="WriteSigningRequired.cs" />
     <Compile Include="ZipFileCreateFromDirectory.cs" />
     <Compile Include="Strings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <!-- metadata used for Authenticode and strong-name signing in official VSO builds -->
-  <ItemGroup Condition="'$(SkipSigning)' != 'true' and '$(IsTestProject)' != 'true' and '$(SignType)' != 'oss'">
-    <FilesToSign Include="$(TargetPath)">
-      <Authenticode>Microsoft</Authenticode>
-      <StrongName Condition="'$(SignType)' == 'real' and '$(UseOpenKey)' != 'true'">StrongName</StrongName>
-    </FilesToSign>
-  </ItemGroup>
+  <PropertyGroup>
+    <AuthenticodeSig Condition="'$(AuthenticodeSig)' == ''">Microsoft</AuthenticodeSig>
+    <StrongNameSig Condition="'$(StrongNameSig)' == '' and '$(SignType)' == 'real' and '$(UseOpenKey)' != 'true'">StrongName</StrongNameSig>
+  </PropertyGroup>
 
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="OpenSourceSign" />
+  <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="WriteSigningRequired" />
 
   <PropertyGroup Condition="'$(SkipSigning)'!='true'">
     <SignAssembly>true</SignAssembly>
@@ -25,6 +23,20 @@
 
   <!-- stub for signing.  for official builds this is replaced with the real one -->
   <Target Name="SignFiles" AfterTargets="AfterBuild" />
+
+  <!-- writes a signing marker file containing the required signatures -->
+  <Target Name="WriteSigningRequired"
+          AfterTargets="AfterBuild"
+          Condition="'$(SkipSigning)' != 'true' and '$(IsTestProject)' != 'true' and '$(SignType)' != 'oss'"
+          Inputs="$(TargetPath)"
+          Outputs="$(TargetPath).requires_signing">
+    <WriteSigningRequired AuthenticodeSig="$(AuthenticodeSig)"
+                          StrongNameSig="$(StrongNameSig)"
+                          MarkerFile="$(TargetPath).requires_signing" />
+    <ItemGroup>
+      <FileWrites Include="%(IntermediateAssembly.Identity).requires_signing" />
+    </ItemGroup>
+  </Target>
 
   <!--
     NOTE: This mechanism for wiring in the OpenSourceSign target can't be changed to any of the following:
@@ -45,7 +57,7 @@
     <OpenSourceSign AssemblyPath="%(IntermediateAssembly.Identity)" />
     <Touch Files="%(IntermediateAssembly.Identity).oss_signed" AlwaysCreate="true" />
     <ItemGroup>
-       <FileWrites Include="%(IntermediateAssembly.Identity).oss_signed" />
+      <FileWrites Include="%(IntermediateAssembly.Identity).oss_signed" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks/ReadSigningRequired.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ReadSigningRequired.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class ReadSigningRequired : Task
+    {
+        /// <summary>
+        /// Gets or sets the list of signing marker files.
+        /// </summary>
+        [Required]
+        public ITaskItem[] MarkerFiles { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of task items containing signing metadata.
+        /// </summary>
+        [Output]
+        public ITaskItem[] SigningMetadata { get; set; }
+
+        public override bool Execute()
+        {
+            // for each marker file, deserialize the JSON data and convert it to a task item
+            var signTypeItems = new List<Tuple<string, SignTypeItem>>();
+
+            foreach (var markerFile in MarkerFiles)
+            {
+                if (!File.Exists(markerFile.ItemSpec))
+                {
+                    Log.LogError("The specified marker file '{0}' doesn't exist.", markerFile.ItemSpec);
+                    return false;
+                }
+
+                using (var streamReader = new StreamReader(File.OpenRead(markerFile.ItemSpec)))
+                {
+                    using (var jsonReader = new JsonTextReader(streamReader))
+                    {
+                        JsonSerializer jsonSerializer = new JsonSerializer();
+                        var signTypeItem = jsonSerializer.Deserialize<SignTypeItem>(jsonReader);
+
+                        // the ItemSpec should be the name of the file to sign.  by convention the marker
+                        // file is the full path to the file plus a marker extension, so strip the extension.
+                        var itemSpec = markerFile.ItemSpec.Substring(0, markerFile.ItemSpec.LastIndexOf('.'));
+                        signTypeItems.Add(new Tuple<string, SignTypeItem>(itemSpec, signTypeItem));
+                    }
+                }
+            }
+
+            SigningMetadata = new ITaskItem[signTypeItems.Count];
+            for (int i = 0; i < signTypeItems.Count; ++i)
+            {
+                var taskItem = new TaskItem(signTypeItems[i].Item1);
+
+                if (!string.IsNullOrEmpty(signTypeItems[i].Item2.Authenticode))
+                    taskItem.SetMetadata("Authenticode", signTypeItems[i].Item2.Authenticode);
+                if (!string.IsNullOrEmpty(signTypeItems[i].Item2.StrongName))
+                    taskItem.SetMetadata("StrongName", signTypeItems[i].Item2.StrongName);
+
+                SigningMetadata[i] = taskItem;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/SignTypeItem.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/SignTypeItem.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Internal type used for JSON serialization of signing certificate data.
+    /// </summary>
+    internal sealed class SignTypeItem
+    {
+        /// <summary>
+        /// Gets or sets the name of the Authenticode signature to apply.
+        /// </summary>
+        public string Authenticode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the strong-name signature to apply.
+        /// </summary>
+        public string StrongName { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/WriteSigningRequired.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/WriteSigningRequired.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class WriteSigningRequired : Task
+    {
+        /// <summary>
+        /// Gets or sets the name of the Authenticode signature to apply.
+        /// </summary>
+        [Required]
+        public string AuthenticodeSig { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the strong-name signature to apply.
+        /// </summary>
+        public string StrongNameSig { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the signing marker file.
+        /// </summary>
+        [Required]
+        public string MarkerFile { get; set; }
+
+        public override bool Execute()
+        {
+            // serialize the settings to a JSON file
+
+            var signTypeItem = new SignTypeItem();
+            signTypeItem.Authenticode = AuthenticodeSig;
+            signTypeItem.StrongName = StrongNameSig;
+
+            using (var streamWriter = new StreamWriter(File.OpenWrite(MarkerFile)))
+            {
+                using (var jsonWriter = new JsonTextWriter(streamWriter))
+                {
+                    JsonSerializer jsonSerializer = new JsonSerializer();
+                    jsonSerializer.Serialize(jsonWriter, signTypeItem);
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/sign.builds
+++ b/src/sign.builds
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="dir.props" />
+  <Import Project="..\dir.targets" />
+
+  <PropertyGroup>
+    <OutDir>$(BinDir)</OutDir>
+  </PropertyGroup>
+
+  <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="ReadSigningRequired" />
+
+  <!-- populates item group FilesToSign with the list of files to sign -->
+  <Target Name="GetFilesToSignItems">
+    <!-- read all of the marker files and populate the FilesToSign item group -->
+    <ItemGroup>
+      <SignMarkerFile Include="$(OutDir)**\*.requires_signing" />
+    </ItemGroup>
+    <ReadSigningRequired MarkerFiles="@(SignMarkerFile)">
+      <Output TaskParameter="SigningMetadata" ItemName="FilesToSign" />
+    </ReadSigningRequired>
+  </Target>
+
+  <Target Name="Build"
+          Condition="'$(SkipSigning)' != 'true' and '$(SignType)' != 'oss'"
+          DependsOnTargets="GetFilesToSignItems">
+    <CallTarget Targets="SignFiles" />
+    <!-- now that the files have been signed delete the marker files -->
+    <Delete Files="@(SignMarkerFile)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
The current signing implementation signs files one by one which is
incredibly slow.  We can get better throughput by submitting all files for
signing in one item group.
If a file requires signing it will create a ".requires_signing" marker
file that will be read during a post build step; this post build step will
process all of the marker files and submit the signing job in one group.