### PR TITLE
Split package building into its own step.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <Project Include="src\dirs.proj" />
     <Project Include="src\sign.builds" />
+    <Project Include="src\packages.builds" />
   </ItemGroup>
 
   <Import Project="dir.targets" />

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -15,15 +15,7 @@
     <BuildToolsTaskDir>$(ToolsDir)</BuildToolsTaskDir>
   </PropertyGroup>
 
-  <Import Project="Microsoft.DotNet.Build.Tasks\PackageFiles\packages.targets" Condition="'$(ImportGetNuGetPackageVersions)' != 'false'" />
   <Import Project="$(ToolsDir)UpdateBuildValues.targets" Condition="Exists('$(ToolsDir)UpdateBuildValues.targets')" />
-
-  <PropertyGroup Condition="'$(ImportGetNuGetPackageVersions)' != 'false'">
-    <TraversalBuildDependsOn>
-      $(TraversalBuildDependsOn);
-      BuildPackages;
-    </TraversalBuildDependsOn>
-  </PropertyGroup>
 
   <PropertyGroup>
     <GenerateCodeCoverageReportForAll>true</GenerateCodeCoverageReportForAll>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+
+  <!-- packages.targets requires build values -->
+  <Import Project="BuildValues.props" />
+  <Import Project="Microsoft.DotNet.Build.Tasks\PackageFiles\packages.targets" Condition="'$(ImportGetNuGetPackageVersions)' != 'false'" />
+  
+  <Target Name="Build" DependsOnTargets="BuildPackages" />
+</Project>


### PR DESCRIPTION
Builds packages happens when building src\dirs.proj; this doesn't work
with the recent switch to batch signing as the binaries are now signed
after the packages are created.
Move the package build step into its own project packages.builds file to
be built after signing.