### PR TITLE
Add Versioning control for Repos.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -13,8 +13,8 @@
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
 
     <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">-$(PreReleaseLabel)</VersionSuffix>
-    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)</VersionSuffix>
-
+    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor).$(BuildNumberMinor)</VersionSuffix>
+    
     <!--
       Empty out the project properties because we want configuration and platform to come from the individual
       projects instead of being overridden by the value the packages have.
@@ -476,7 +476,7 @@
   </Target>
 
   <Target Name="GetNuGetPackageDependencies"
-          DependsOnTargets="GetFilePackageReferences">
+          DependsOnTargets="CreateVersionFileDuringBuild;GetFilePackageReferences">
     <PropertyGroup>
       <!-- determine if we have any reference assets in the package (files in the ref folder) -->
       <_containsReferenceAsset Condition="'%(File.IsReferenceAsset)' == 'true'">true</_containsReferenceAsset>
@@ -544,7 +544,7 @@
   <!-- Calculates the package version including any prerelease suffix -->
   <Target Name="CalculatePackageVersion"
         BeforeTargets="GenerateNuSpec;GetPackageIdentity"
-        DependsOnTargets="GetAssemblyVersionFromProjects">
+        DependsOnTargets="CreateVersionFileDuringBuild;GetAssemblyVersionFromProjects">
 
     <Error Text="No version could be detected.  Either specify the Version property or provide at least one managed assembly."
            Condition="'$(Version)' == '' AND '$(_AssemblyVersion)' == ''"

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateCurrentVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateCurrentVersion.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Globalization;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class GenerateCurrentVersion : Task
+    {
+        /// <summary>
+        /// The passed in date that will be used to generate a version. (yyyy-MM-dd format)
+        /// </summary>
+        [Required]
+        public string SeedDate { get; set; }
+
+        /// <summary>
+        /// Optional parameter that sets the Padding for the version number. Must be 5 or bigger.
+        /// </summary>
+        public int Padding { get; set; }
+
+        /// <summary>
+        /// If basing off of internal builds version format is not required, this optional parameter lets you pass in a comparison date.
+        /// </summary>
+        public string ComparisonDate { get; set; }
+
+        /// <summary>
+        /// The Major Version that will be produced given a SeedDate.
+        /// </summary>
+        [Output]
+        public string GeneratedVersion { get; set; }
+
+        private const string DateFormat = "yyyy-MM-dd";
+        private const string LastModifiedTimeDateFormat = "yyyy-MM-dd HH:mm:ss.FFFFFFF";
+        private CultureInfo enUS = new CultureInfo("en-US");
+
+        public override bool Execute()
+        {
+            if (Padding == 0)
+            {
+                Padding = 5;
+            }
+            else if (Padding < 5)
+            {
+                Log.LogWarning("The specified Padding '{0}' has to be equal to or greater than 5. Using 5 as a default now.", Padding);
+                Padding = 5;
+            }
+            DateTime date;
+            GeneratedVersion = string.Empty;
+            if (!(DateTime.TryParseExact(SeedDate, DateFormat, enUS, DateTimeStyles.AssumeLocal, out date)))
+            {
+                // Check if the timestamp matches the LastModifiedTimeDateFormat
+                if (!(DateTime.TryParseExact(SeedDate, LastModifiedTimeDateFormat, enUS, DateTimeStyles.AssumeLocal, out date)))
+                {
+                    Log.LogError("The seed date '{0}' is not valid. Please specify a date in the short format.({1})", SeedDate, DateFormat);
+                    return false;
+                }
+            }
+            //Convert Date to UTC to converge
+            date = date.ToUniversalTime();
+            GeneratedVersion = GetCurrentVersionForDate(date, ComparisonDate);
+            if (string.IsNullOrEmpty(GeneratedVersion))
+            {
+                Log.LogError("The date '{0}' is not valid. Please pass in a date after {1}.", SeedDate, ComparisonDate);
+                return false;
+            }
+            return true;
+        }
+
+        public string GetCurrentVersionForDate(DateTime seedDate, string comparisonDate)
+        {
+            DateTime compareDate;
+            if (string.IsNullOrEmpty(comparisonDate))
+            {
+                /*
+                 * We need to ensure that our build numbers are higher that what we used to ship internal builds so this date
+                 * will make that possible.
+                 */
+                compareDate = new DateTime(1996, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+            }
+            else
+            {
+                bool isValidDate = DateTime.TryParseExact(comparisonDate, DateFormat, enUS, DateTimeStyles.AssumeLocal, out compareDate);
+                if (!isValidDate)
+                {
+                    Log.LogError("The comparison date '{0}' is not valid. Please specify a date in the short format.({1})", comparisonDate, DateFormat);
+                }
+                //Convert to UTC to converge
+                compareDate = compareDate.ToUniversalTime();
+            }
+            int months = (seedDate.Year - compareDate.Year) * 12 + seedDate.Month - compareDate.Month;
+            if (months > 0) //only allow dates after comparedate
+            {
+                return string.Format("{0}{1}", months.ToString("D" + (Padding -2)), seedDate.Day.ToString("D2"));
+            }
+            return string.Empty;
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -21,6 +21,7 @@
     <Compile Include="ExecWithMutex.cs" />
     <Compile Include="GatherFoldersToRestore.cs" />
     <Compile Include="GenerateAssemblyList.cs" />
+    <Compile Include="GenerateCurrentVersion.cs" />
     <Compile Include="GenerateResourcesCode.cs" />
     <Compile Include="GenerateEncodingTable.cs" />
     <Compile Include="GetPackageVersion.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BuildVersion.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BuildVersion.targets
@@ -1,0 +1,16 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <PropertyGroup>
+    <TodayTimeStamp>$([System.DateTime]::Now.ToString(yyyyMMdd))</TodayTimeStamp>
+    <BuildVersionFilePath>$(BaseIntermediateOutputPath)</BuildVersionFilePath>
+    <BuildVersionFile Condition="'$(BuildVersionFile)'==''">$(BuildVersionFilePath)BuildVersion-$(TodayTimeStamp).props</BuildVersionFile>
+  </PropertyGroup>
+
+  <!-- If BuildVersion.props exists already then import it to get BuildNumberMajor, else generate it and override props values. -->
+  <Import Condition="Exists('$(BuildVersionFile)')" Project="$(BuildVersionFile)" />
+
+  <PropertyGroup Condition="!Exists('$(BuildVersionFile)')">
+    <ShouldCreateVersionFileDuringBuild>true</ShouldCreateVersionFileDuringBuild>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -1,13 +1,15 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- Setup the default file version information -->
+  <UsingTask TaskName="GenerateCurrentVersion" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <!-- Setup the default file version information -->
   <PropertyGroup>
     <MajorVersion Condition="'$(MajorVersion)' == ''">1</MajorVersion>
     <MinorVersion Condition="'$(MinorVersion)' == ''">0</MinorVersion>
-    
+
     <!-- These should be set by importing the targets below but initializing to 0 for consistency -->
     <BuildNumberMajor Condition="'$(BuildNumberMajor)' == ''">0</BuildNumberMajor>
-    <BuildNumberMinor Condition="'$(BuildNumberMinor)' == ''">0</BuildNumberMinor>
+    <BuildNumberMinor Condition="'$(BuildNumberMinor)' == ''">00</BuildNumberMinor>
   </PropertyGroup>
 
   <!-- Import a build target that includes the build numbers -->
@@ -21,7 +23,7 @@
     <CLSCompliant Condition="'$(CLSCompliant)'==''">false</CLSCompliant>
     <AssemblyFileVersion Condition="'$(AssemblyFileVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</AssemblyFileVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup>
     <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">true</GenerateAssemblyInfo>
     <BuiltByString Condition="'$(BuiltByString)'==''">%20built by: $(COMPUTERNAME)-$(USERNAME)</BuiltByString>
@@ -40,7 +42,8 @@
   <Target Name="GenerateAssemblyInfo"
       Inputs="$(MSBuildProjectFile)"
       Outputs="$(AssemblyInfoFile)"
-      Condition="'$(GenerateAssemblyInfo)'=='true'">
+      Condition="'$(GenerateAssemblyInfo)'=='true'"
+      DependsOnTargets="CreateVersionFileDuringBuild">
 
     <Error Condition="!Exists('$(IntermediateOutputPath)')" Text="GenerateAssemblyInfo failed because IntermediateOutputPath isn't set to a valid directory" />
 
@@ -58,7 +61,7 @@
       <AssemblyInfoLines Include="[assembly:AssemblyInformationalVersion(@&quot;$(AssemblyFileVersion)$(BuiltByString)&quot;)]" />
       <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="[assembly:CLSCompliant(true)]" />
       <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="[assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))]" />
-      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'" 
+      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'"
         Include="[assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)]" />
     </ItemGroup>
 
@@ -76,7 +79,7 @@
       <AssemblyInfoLines Include="&lt;Assembly:AssemblyInformationalVersion(&quot;$(AssemblyFileVersion)$(BuiltByString)&quot;)&gt;" />
       <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="&lt;Assembly:CLSCompliant(True)&gt;" />
       <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="&lt;Assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))&gt;" />
-      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'" 
+      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'"
           Include="&lt;assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)&gt;" />
     </ItemGroup>
 
@@ -95,10 +98,10 @@
       Lines="@(AssemblyInfoUsings);@(AssemblyInfoLines)"
       Overwrite="true" />
 
-    <ItemGroup>  
-      <Compile Include="$(AssemblyInfoFile)" />  
-      <FileWrites Include="$(AssemblyInfoFile)" />  
-    </ItemGroup>  
+    <ItemGroup>
+      <Compile Include="$(AssemblyInfoFile)" />
+      <FileWrites Include="$(AssemblyInfoFile)" />
+    </ItemGroup>
 
   </Target>
 
@@ -125,7 +128,7 @@
       Inputs="$(MSBuildProjectFile)"
       Outputs="$(NativeVersionHeaderFile)"
       Condition="'$(NativeVersionHeaderFile)'!='' and '$(GenerateVersionHeader)'=='true'">
-      
+
     <ItemGroup>
       <NativeVersionLines Include="#define VER_COMPANYNAME_STR         &quot;Microsoft Corporation&quot;" />
       <NativeVersionLines Include="#define VER_FILEDESCRIPTION_STR     &quot;$(AssemblyName)&quot;" />
@@ -149,6 +152,92 @@
     <ItemGroup>
       <FileWrites Include="$(NativeVersionHeaderFile)" />
     </ItemGroup>
+  </Target>
+
+  <!-- #################################### -->
+  <!-- Generate BuildVersion.props -->
+  <!-- #################################### -->
+  <Target Name="CreateOrUpdateCurrentVersionFile" Condition="'$(SkipVersionGeneration)'!='true'" DependsOnTargets="GenerateCurrentVersion">
+    <!-- Error out if GeneratedBuildNumberMajor is empty since GenerateCurrentVersion should have calculated it already. -->
+    <Error Condition="'$(GeneratedBuildNumberMajor)'==''" Text="Error when generating current version." />
+
+    <PropertyGroup>
+      <VersionSeedSourceComment Condition="'$(VersionSeedSourceComment)'==''">VersionSeedData was produced by taking the timestamp of the last git commit.</VersionSeedSourceComment>
+    </PropertyGroup>
+      
+    <ItemGroup>
+      <CurrentVersionLines Include="%3C%3Fxml version=%221.0%22 encoding=%22utf-8%22%3F%3E" />
+      <CurrentVersionLines Include="%3C!-- This is a generated file. $(VersionSeedSourceComment) Seed Date is $(VersionSeedDate). --%3E" />
+      <CurrentVersionLines Include="%3CProject xmlns=%22http://schemas.microsoft.com/developer/msbuild/2003%22%3E" />
+      <CurrentVersionLines Include="%3CPropertyGroup%3E" />
+      <CurrentVersionLines Include="%3CBuildNumberMajor Condition=%22%27%24(BuildNumberMajor)%27==%27%27%22%3E$(GeneratedBuildNumberMajor)%3C/BuildNumberMajor%3E" />
+      <CurrentVersionLines Include="%3C/PropertyGroup%3E" />
+      <CurrentVersionLines Include="%3C/Project%3E" />
+    </ItemGroup>
+    
+    <!-- Since by default the file will get dropped at the obj dir, make sure that the dir is created already or else WriteLinesToFile will error. -->
+    <MakeDir Condition="!Exists('$(BuildVersionFilePath)')" Directories="$(BuildVersionFilePath)" />
+      
+    <WriteLinesToFile
+      ContinueOnError="WarnAndContinue"
+      Condition="!Exists('$(BuildVersionFile)')"
+      File="$(BuildVersionFile)"
+      Lines="@(CurrentVersionLines)"
+      Overwrite="true" />
+    
+    <!-- Delete old BuildVersion.props files -->
+    <ItemGroup>
+      <OldBuildVersionFiles Include="$(BuildVersionFilePath)BuildVersions-*.props" Exclude="$(BuildVersionFilePath)%(BuildVersionFileItem.Filename).props" />
+    </ItemGroup>
+    <Delete Files="@(OldBuildVersionFiles)" TreatErrorsAsWarnings="true"/>
+
+  </Target>
+
+  <Target Name="GenerateCurrentVersion" DependsOnTargets="GetVersionSeedDate">
+    <Error Condition="'$(VersionSeedDate)'==''" Text="A date is needed to Generate the current version." />
+
+    <!-- Setting default parameters in case that they are not set before. -->
+    <PropertyGroup>
+      <!-- Padding should be equal or greater to 5. Using 5 to align with internal build system. -->
+      <VersionPadding Condition="'$(VersionPadding)'==''">5</VersionPadding>
+      <!-- Using the following default comparison date will produce versions that align with our internal build system. -->
+      <VersionComparisonDate Condition="'$(VersionComparisonDate)'==''">1996-04-01 00:00:00 Z</VersionComparisonDate>
+    </PropertyGroup>
+      
+    <GenerateCurrentVersion SeedDate="$(VersionSeedDate)">
+      <Output PropertyName="GeneratedBuildNumberMajor" TaskParameter="GeneratedVersion" />
+    </GenerateCurrentVersion>
+  </Target>
+
+  <Target Name="GetVersionSeedDate" Condition="'$(VersionSeedDate)'==''">
+    <ItemGroup>
+      <VersionTargetsFile Include="$(MSBuildThisFileFullPath)" />
+    </ItemGroup>
+      
+    <!-- Windows Exec command requires DOS escaping for the percent sign since it secretly runs the process in a shell instead of calling createprocess. -->
+    <PropertyGroup>
+      <GitCommand Condition="'$(OsEnvironment)'=='Windows_NT'">git show -s --format=^%25%25cd --date=iso HEAD</GitCommand>
+      <GitCommand Condition="'$(OsEnvironment)'!='Windows_NT'">git show -s --format=%25cd --date=iso HEAD</GitCommand>
+    </PropertyGroup>
+      
+    <Exec Command="$(GitCommand)" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="VersionSeedDate" />
+      <Output TaskParameter="ExitCode" PropertyName="GitCommandExitCode" />
+    </Exec>
+    <PropertyGroup Condition="'$(GitCommandExitCode)'!='0'">
+      <VersionSeedDate>%(VersionTargetsFile.ModifiedTime)</VersionSeedDate>
+      <VersionSeedSourceComment>VersionSeedDate was produced by getting the timestamp of versioning.targets.</VersionSeedSourceComment>
+    </PropertyGroup>
+  </Target>
+
+  <!-- This target will only be executed if BuildVersion.props doesn't exist yet -->
+  <Target Name="CreateVersionFileDuringBuild" Condition="'$(SkipVersionGeneration)'!='true' AND '$(ShouldCreateVersionFileDuringBuild)'=='true'" DependsOnTargets="CreateOrUpdateCurrentVersionFile">
+    <PropertyGroup>
+      <BuildNumberMajor>$(GeneratedBuildNumberMajor)</BuildNumberMajor>
+      <AssemblyFileVersion>$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</AssemblyFileVersion>
+      <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">-$(PreReleaseLabel)</VersionSuffix>
+      <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor).$(BuildNumberMinor)</VersionSuffix>
+    </PropertyGroup>
   </Target>
 
   <Target Name="NativeResourceCompile" DependsOnTargets="$(BeforeResourceCompileTargets)" Inputs="$(MsBuildThisFileDirectory)NativeVersion.rc" Outputs="$(Win32Resource)">


### PR DESCRIPTION
CC: @weshaggard ~~The PR is not ready to be merged yet, but I wanted to send this out to you today so that if you have some time to take a look I can get early feedback. I plan to have this ready by tomorrow.~~ <- PR is ready to merge after feedback now.

FYI: @ericstj ~~We are still considering on adding another optional target that will generate a props file in the root of the repo, so that this doesn't need to be calculated over and over, which I know was more or less what you wanted.~~ <- I've changed the behavior now such that we will create a BuildVersion.props file which will contain the Build Version.

I'll send out a [sample corefx PR](https://github.com/dotnet/corefx/pull/6982) soon on how to consume this.

CC: @gkhanna79 
related: dotnet/coreclr#3559 dotnet/coreclr#3133