### PR TITLE
Split updating and committing of build number into separate files.

### DIFF
--- a/src/BuildValues.props
+++ b/src/BuildValues.props
@@ -8,6 +8,6 @@
       prerelease version number and without the leading zeroes foo-20 is
       smaller than foo-4.
     -->
-    <RevisionNumber>00203</RevisionNumber>
+    <RevisionNumber>00204</RevisionNumber>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CommitBuildValues.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CommitBuildValues.targets
@@ -1,0 +1,40 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <GitWorkingBranch Condition="'$(GitWorkingBranch)' == ''">master</GitWorkingBranch>
+    <GitPushRemote Condition="'$(GitPushRemote)' == ''">origin</GitPushRemote>
+  </PropertyGroup>
+
+  <Target Name="CommitBuildValues"
+    AfterTargets="BuildPackages"
+    Condition="'$(UpdateBuildValues)' == 'true'"
+    >
+    <!-- configure the commit to show up as the dotnet bot -->
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git config user.name &quot;dotnet-bot&quot;" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git config user.email &quot;dotnet-bot@microsoft.com&quot;" />
+
+    <!-- commit and push to origin -->
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git checkout $(GitWorkingBranch)" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git commit -m &quot;Automated commit of revision number value $(RevisionNumber).&quot; $(SourceDir)BuildValues.props" />
+
+    <Exec
+      WorkingDirectory="$(SourceDir)"
+      StandardOutputImportance="Low"
+      Command="git push $(GitPushRemote) $(GitWorkingBranch)" />
+
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/UpdateBuildValues.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/UpdateBuildValues.targets
@@ -1,10 +1,6 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="GetNextRevisionNumber" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
-  <PropertyGroup>
-    <GitWorkingBranch Condition="'$(GitWorkingBranch)' == ''">master</GitWorkingBranch>
-    <GitPushRemote Condition="'$(GitPushRemote)' == ''">origin</GitPushRemote>
-  </PropertyGroup>
+  <UsingTask TaskName="GetNextRevisionNumber" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <Target Name="GetNextRevisionNumber"
     BeforeTargets="Build;BuildAllProjects"
@@ -16,36 +12,4 @@
     </GetNextRevisionNumber>
   </Target>
 
-  <Target Name="CommitBuildValues"
-    AfterTargets="BuildPackages"
-    Condition="'$(UpdateBuildValues)' == 'true'"
-    >
-    <!-- configure the commit to show up as the dotnet bot -->
-    <Exec
-      WorkingDirectory="$(SourceDir)"
-      StandardOutputImportance="Low"
-      Command="git config user.name &quot;dotnet-bot&quot;" />
-
-    <Exec
-      WorkingDirectory="$(SourceDir)"
-      StandardOutputImportance="Low"
-      Command="git config user.email &quot;dotnet-bot@microsoft.com&quot;" />
-
-    <!-- commit and push to origin -->
-    <Exec
-      WorkingDirectory="$(SourceDir)"
-      StandardOutputImportance="Low"
-      Command="git checkout $(GitWorkingBranch)" />
-
-    <Exec
-      WorkingDirectory="$(SourceDir)"
-      StandardOutputImportance="Low"
-      Command="git commit -m &quot;Automated commit of revision number value $(RevisionNumber).&quot; $(SourceDir)BuildValues.props" />
-
-    <Exec
-      WorkingDirectory="$(SourceDir)"
-      StandardOutputImportance="Low"
-      Command="git push $(GitPushRemote) $(GitWorkingBranch)" />
-
-  </Target>
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
+  <Import Project="$(ToolsDir)CommitBuildValues.targets" Condition="Exists('$(ToolsDir)CommitBuildValues.targets')" />
+
   <!-- packages.targets requires build values -->
   <Import Project="BuildValues.props" />
   <Import Project="Microsoft.DotNet.Build.Tasks\PackageFiles\packages.targets" Condition="'$(ImportGetNuGetPackageVersions)' != 'false'" />


### PR DESCRIPTION
In commit e89c9d2 I split packaging into its own build step; this had the
unintended side-effect of causing the automated commit of build numbers to
stop.  To fix this I have moved the automated commit into
CommitBuildValues.targets which is imported by packages.builds causing the
commit to happen post building of packages.
I have also bumped the build number to match the latest built package.