### PR TITLE
Add ability to run OuterLoop and InnerLoop tests simultaneously

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -145,7 +145,7 @@
 
     <!-- Default behavior is to disable OuterLoop and failing tests if not specified in WithCategories. -->
     <ItemGroup>
-      <DefaultNoCategories Include="OuterLoop" />
+      <DefaultNoCategories Condition="'$(Outerloop)'!='true'" Include="OuterLoop" />
       <DefaultNoCategories Include="failing" />
       <WithoutCategoriesItems Include="@(DefaultNoCategories)" Exclude="@(WithCategoriesItems)" />
       <WithoutCategoriesItemsDistinct Include="@(WithoutCategoriesItems->Distinct())" />


### PR DESCRIPTION
The current test targets will always add "-notrait category=outerloop" to the xunit runner, so you can only ever run just innerloop or just outerloop. I added a simple check to the "Outerloop" property before the default notrait is added.

To run innerloop alongside outerloop, just pass "/p:Outerloop=true" to msbuild.

affects https://github.com/dotnet/corefx/issues/1477 and provides a resolution path to https://github.com/dotnet/corefx/issues/1742 pending a corefx PR to modify the properties passed in the coverage build.

@Priya91 @stephentoub 