### PR TITLE
Replace built-in source command with cat command for better compatibility for Linux distributions.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -36,14 +36,13 @@ case $OSName in
         ;;
 
     Linux)
-        source /etc/os-release
-        if [ "$ID" == "centos" ]; then
+        if [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
             __PUBLISH_RID=centos.7-x64
-        elif [ "$ID" == "rhel" ]; then
+        elif [ "$(cat /etc/*-release | grep -cim1 rhel)" -eq 1 ]; then
             __PUBLISH_RID=rhel.7-x64
-        elif [ "$ID" == "ubuntu" ]; then
+        elif [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then
             __PUBLISH_RID=ubuntu.14.04-x64
-        elif [ "$ID" == "debian" ]; then
+        elif [ "$(cat /etc/*-release | grep -cim1 debian)" -eq 1 ]; then
             __PUBLISH_RID=debian.8.2-x64
         else
             echo "Unsupported Linux distribution '$ID' detected. Downloading ubuntu-x64 tools."


### PR DESCRIPTION
The **source**  command is a bash build-in command. It is not a program - like ls or grep.
On up-to-date Ubuntu distribution, /bin/sh calls /bin/dash. Traditionally, /bin/sh
called /bin/bash for supporting compatibility mode. Let's use **cat** command instead of
**source** command to support better compatibility.

Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
Signed-off-by: Prajwal A N an.prajwal@samsung.com
Signed-off-by: MyungJoo Ham myungjoo.ham@samsung.com
