### PR TITLE
Package fixes

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
@@ -28,7 +28,12 @@ namespace Microsoft.Cci.Writers.CSharp
                     WriteKeyword("unsafe");
 
                 if (field.IsCompileTimeConstant)
+                {
+                    if (field.GetHiddenBaseField(_filter) != Dummy.Field)
+                        WriteKeyword("new");
+
                     WriteKeyword("const");
+                }
                 else
                 {
                     if (field.IsStatic)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -213,7 +213,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                                {
                                    Id = d.ItemSpec,
                                    Version = d.GetVersion(),
-                                   TargetFramework = d.GetTargetFramework(),
+                                   TargetFramework = d.GetTargetFramework() ?? NuGetFramework.AnyFramework,
                                    Include = d.GetValueList("Include"),
                                    Exclude = d.GetValueList("Exclude")
                                };

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -73,12 +73,21 @@
   <Import Project="$(MSBuildThisFileDirectory)packageresolve.targets" Condition="'$(ExcludePackageResolveImport)'!='true'" />
 
   <!-- 
+    Import the partial facade generation targets
+    
+      Inputs:
+        GeneratePlatformNotSupportedAssembly - Determines wether to generate not-supported API for this assembly
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)notsupported.targets" Condition="'$(ExcludePartialFacadesImport)' != 'true'"/>
+
+  <!-- 
     Import the default SR resource generation targets 
   
       Inputs:
         ResourcesSourceOutputDirectory - If not set defaults to $(MSBuildProjectDirectory)\Resources.
         StringResourcesPath - If not set defaults to $(ResourcesSourceOutputDirectory\Strings.resx if it exists. If the file exists
           then the targets generates the strongly typed $(ResourcesSourceOutputDirectory)\SR.cs/vb file based on resource strings.  
+        OmitResources - If set to true will skip resource inclusion even if StringResourcesPath exists.
   -->
   <Import Project="$(MSBuildThisFileDirectory)resources.targets" Condition="'$(ExcludeResourcesImport)'!='true'" />
 
@@ -105,14 +114,6 @@
     Import the localization target
   -->
   <Import Project="$(MSBuildThisFileDirectory)localization.targets" Condition="'$(ExcludeLocalizationImport)'!='true'" />
-
-  <!-- 
-    Import the partial facade generation targets
-    
-      Inputs:
-        GeneratePlatformNotSupportedAssembly - Determines wether to generate not-supported API for this assembly
-  -->
-  <Import Project="$(MSBuildThisFileDirectory)notsupported.targets" Condition="'$(ExcludePartialFacadesImport)' != 'true'"/>
   
   <!-- 
     Import the partial facade generation targets

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-
   <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true'">
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
     <NotSupportedSourceFile>$(IntermediateOutputPath)$(TargetName).notsupported.cs</NotSupportedSourceFile>
     <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateNotSupportedSource</CoreCompileDependsOn>
+    <OmitResources>true</OmitResources>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true'">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -9,6 +9,12 @@
     <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateNotSupportedSource</CoreCompileDependsOn>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true'">
+    <AssemblyMetadata Include="NotSupported">
+      <Value>True</Value>
+    </AssemblyMetadata>
+  </ItemGroup>
+
   <!-- GenerateNotSupportedSource
        Inputs:
          * A contract assembly

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateResourcesSource"
-          Condition="'$(StringResourcesPath)'!=''"
+          Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'"
           Inputs="$(StringResourcesPath)"
           Outputs="$(IntermediateResOutputFileFullPath)">
     
@@ -39,14 +39,14 @@
     </ItemGroup>
   </Target>
   
-  <ItemGroup Condition="'$(StringResourcesPath)'!=''">
+  <ItemGroup Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'">
     <EmbeddedResource Include="$(StringResourcesPath)">
       <Visible>true</Visible>
       <LogicalName>FxResources.$(AssemblyName).SR.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   
-  <ItemGroup Condition="Exists('$(StringResourcesPath)') And '$(SkipCommonResourcesIncludes)'==''">
+  <ItemGroup Condition="Exists('$(StringResourcesPath)') And '$(SkipCommonResourcesIncludes)'=='' AND '$(OmitResources)'!='true'">
     <Compile Condition="'$(MSBuildProjectExtension)' == '.csproj'" Include="$(CommonPath)/System/SR.cs">
       <Visible>true</Visible>
       <Link>Resources/Common/SR.cs</Link>


### PR DESCRIPTION
Default dependency groups to "any" to avoid exception in nuget 3.4 update.

Clean up "NotSupported" assembly contents and add a metadata attribute.

/cc @weshaggard 