### PR TITLE
Remove framework attributes and signing from test projects

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -14,15 +14,6 @@
     <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
   </PropertyGroup>
 
-  <ItemGroup>
-    <AssemblyMetadata Include=".NETFrameworkAssembly">
-      <Value></Value>
-    </AssemblyMetadata>
-    <AssemblyMetadata Include="Serviceable">
-      <Value>True</Value>
-    </AssemblyMetadata>
-  </ItemGroup>
-
   <!--
     Switching to the .NET Core version of the BuildTools tasks seems to break numerous scenarios, such as VS intellisense and resource designer
     as well as runnning the build on mono. Until we can get these sorted out we will continue using the .NET 4.5 version of the tasks.

--- a/dir.targets
+++ b/dir.targets
@@ -10,6 +10,15 @@
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
+  
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'" >
+    <AssemblyMetadata Include=".NETFrameworkAssembly">
+      <Value></Value>
+    </AssemblyMetadata>
+    <AssemblyMetadata Include="Serviceable">
+      <Value>True</Value>
+    </AssemblyMetadata>
+  </ItemGroup>  
 
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="'$(UseLiveBuildTools)' != 'true'" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -8,6 +8,11 @@
 
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="OpenSourceSign" />
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="WriteSigningRequired" />
+  
+  <!-- Don't sign test assemblies -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'" >
+    <SkipSigning>true</SkipSigning>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(SkipSigning)'!='true'">
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Removes platform-specific assembly metadata from test-built assemblies and turns off signing them.  This allows the .NET Native toolchain to process them correctly.

This is to support https://github.com/dotnet/corefx/issues/6945 