### PR TITLE
Fixed a property for running ApiCompat on ref assemblies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
@@ -85,7 +85,7 @@
     <LocatePreviousContract CurrentContractProjectPath="$(MSBuildProjectFullPath)" AssemblyVersion="$(AssemblyVersion)">
       <Output TaskParameter="PreviousContractVersion" PropertyName="_PreviousContractVersion" />
     </LocatePreviousContract>
-    <PropertyGroup Condition="'$(PreviousContractVersion)'!=''">
+    <PropertyGroup Condition="'$(_PreviousContractVersion)'!=''">
       <!-- The folder names are obtained by truncating the AssemblyVersion after the last '.' So we add it back -->
       <_PreviousContractAssemblyVersion>$(_PreviousContractVersion).0</_PreviousContractAssemblyVersion>    
       <_PreviousContractProjectPath>$(MSBuildProjectDirectory)/$(_PreviousContractVersion)</_PreviousContractProjectPath>
@@ -95,7 +95,7 @@
 
   <!-- Get the set of directories where the current contract's dependencies can be found -->
   <Target Name="GetCurrentContractDependencies"
-          Returns="@(_CurrentContractDependencies)">          
+          Returns="@(_CurrentContractDependencies)">
     <ItemGroup>
       <_CurrentContractDependencies Include="@(ReferencePath->'%(RootDir)%(Directory)')" />      
     </ItemGroup>
@@ -106,11 +106,11 @@
           Returns="@(_PreviousContractDependencyDirectories)"
           DependsOnTargets="GetPreviousContractProjectPath"
            >
-    <PropertyGroup Condition="'$(PreviousContractVersion)'!=''">
+    <PropertyGroup Condition="'$(_PreviousContractVersion)'!=''">
       <PreviousContractProjectJson Condition="'$(PreviousContractProjectJson)'=='' and Exists('$(_PreviousContractProjectPath)/project.json')">$(_PreviousContractProjectPath)/project.json</PreviousContractProjectJson>
       <PreviousContractProjectLockJson Condition="Exists('$(PreviousContractProjectJson)') and '$(PreviousContractProjectLockJson)'==''">$(_PreviousContractProjectPath)/project.lock.json</PreviousContractProjectLockJson>    
     </PropertyGroup>
-    <Warning Condition="!Exists('$(PreviousContractProjectLockJson)') AND '$(PreviousContractVersion)'!=''" Text=" The project.lock.json was not found for : $(_PreviousContractProjectPath)" />          
+    <Warning Condition="!Exists('$(PreviousContractProjectLockJson)') AND '$(_PreviousContractVersion)'!=''" Text=" The project.lock.json was not found for : $(_PreviousContractProjectPath)" />
     <PrereleaseResolveNuGetPackageAssets Condition="Exists('$(PreviousContractProjectLockJson)')"
                                AllowFallbackOnTargetSelection="true"
                                IncludeFrameworkReferences="false"


### PR DESCRIPTION
ApiCompat needed a minor fix that needed to be checked in. The property _PreviousContractVersion was not referenced correctly in a few conditions