### PR TITLE
Force explicit qualifier usage of required parameter in GenAPI

### DIFF
--- a/src/GenAPI.Desktop/Microsoft.DotNet.BuildTools.GenAPI.targets
+++ b/src/GenAPI.Desktop/Microsoft.DotNet.BuildTools.GenAPI.targets
@@ -24,7 +24,7 @@
       <_referencePathDirectories Include="%(_referencePathDirectoriesWithDuplicates.Identity)" />
     </ItemGroup>
 
-    <Exec Command="&quot;$(_GenAPIPath)&quot; &quot;$(TargetPath)&quot; -libPath:&quot;@(_referencePathDirectories)&quot; -out:&quot;$(GenAPITargetPath)&quot; $(GenAPIAdditionalParameters)" />
+    <Exec Command="&quot;$(_GenAPIPath)&quot; -assembly:&quot;$(TargetPath)&quot; -libPath:&quot;@(_referencePathDirectories)&quot; -out:&quot;$(GenAPITargetPath)&quot; $(GenAPIAdditionalParameters)" />
 
     <ItemGroup>
       <FileWrites Include="$(GenAPITargetPath)"/>

--- a/src/GenAPI/Program.cs
+++ b/src/GenAPI/Program.cs
@@ -201,7 +201,7 @@ namespace GenAPI
                 parser.DefineOptionalQualifier("hightlightInterfaceMembers", ref s_hightlightInterfaceMembers, "(-him) [CSDecl] Highlight interface implementation members.");
                 parser.DefineAliases("throw", "t");
                 parser.DefineOptionalQualifier("throw", ref s_throw, "(-t) Method bodies should throw PlatformNotSupportedException.");
-                parser.DefineParameter<string>("", ref s_assembly, "Path for an specific assembly or a directory to get all assemblies.");
+                parser.DefineQualifier("assembly", ref s_assembly, "Path for an specific assembly or a directory to get all assemblies.");
             }, args);
         }
     }


### PR DESCRIPTION
CommandLineParser chokes on unix-style paths for positional parameters.

@Priya91 , @ericstj 

After this fix is published to NuGet, we need to update the version grabbed by the tool runtime, and update notsupported.targets slightly (to pass this qualifier).