### PR TITLE
Update notsupported.targets to use required qualifier

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -37,7 +37,7 @@
     <Error Text="No single matching contract found." Condition="'@(ResolvedMatchingContract->Count())' != '1'" />
 
     <PropertyGroup>
-      <GenAPIArgs>"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
+      <GenAPIArgs>-assembly:"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -libPath:"@(_referencePathDirectories)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -out:"$(NotSupportedSourceFile)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -throw</GenAPIArgs>


### PR DESCRIPTION
Didn't realize that this program was included directly in buildtools. We need this change to use GenAPI.exe, which is already merged.

@Priya91 