### PR TITLE
Fix issues from Pull Request 555

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -10,15 +10,6 @@
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
   <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
-  
-  <ItemGroup Condition="'$(IsTestProject)' == 'true'" >
-    <AssemblyMetadata Include=".NETFrameworkAssembly">
-      <Value></Value>
-    </AssemblyMetadata>
-    <AssemblyMetadata Include="Serviceable">
-      <Value>True</Value>
-    </AssemblyMetadata>
-  </ItemGroup>  
 
   <Import Project="$(ToolsDir)/Build.Common.targets" Condition="'$(UseLiveBuildTools)' != 'true'" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -16,7 +16,19 @@
       a project is localized in German, then it is localized in all languages.
     -->
     <ExcludeLocalizationImport Condition="'$(ExcludeLocalizationImport)'=='' And !Exists('$(MSBuildProjectDirectory)/MultilingualResources/$(MSBuildProjectName).de.xlf')">true</ExcludeLocalizationImport>
+    
   </PropertyGroup>
+
+  <!-- Assembly metadata indicating that an assembly is a framework (as opposed to user) assembly:
+       Test projects need to not have this because of the way "IsFrameworkAssembly" APIs work to check this. -->
+  <ItemGroup Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' AND '$(IsTestProject)' != 'true'" >
+    <AssemblyMetadata Include=".NETFrameworkAssembly">
+      <Value></Value>
+    </AssemblyMetadata>
+    <AssemblyMetadata Include="Serviceable">
+      <Value>True</Value>
+    </AssemblyMetadata>
+  </ItemGroup>  
 
   <!--
     Import the provides support for EnsureBuildToolsRuntime target which will restore a .NET Core based 


### PR DESCRIPTION
Discussed this with @weshaggard, and made his suggested change.  The previous change to dir.targets was irrelevant as I should have made this change in the CoreFX dir.targets.

Now, this functionality is in Build.Common.targets and only included if IsDotNetFrameworkProductAssembly is explicitly set to true.  This same functionality exists in CoreFX today (sans check for IsTestProject).  

Once this goes in, I have another change ready that would remove the corresponding snippet from CoreFX repo and add IsDotNetFrameworkProductAssembly.