### PR TITLE
Add support for ValidationPatternsFile.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
@@ -21,7 +21,15 @@ namespace Microsoft.DotNet.Build.Tasks
 
             public ValidationPattern(ITaskItem item, TaskLoggingHelper log)
             {
-                _idPattern = new Regex(item.ItemSpec);
+                string idRegex = item.GetMetadata("IdentityRegex");
+                if (string.IsNullOrEmpty(idRegex))
+                {
+                    // Temporarily support reading the regex from the Include/ItemSpec for backwards compatibility
+                    // when the IdentityRegex isn't specified. This can be removed once all consumers are using IdentityRegex.
+                    idRegex = item.ItemSpec;
+                }
+
+                _idPattern = new Regex(idRegex);
                 _expectedVersion = item.GetMetadata("ExpectedVersion");
                 _expectedPrerelease = item.GetMetadata("ExpectedPrerelease");
                 _log = log;


### PR DESCRIPTION
In order to support easier maintenance of the valid dependency versions, allow the version information to be specified in a text file. This allows automated tools to update the version numbers easier than updating MSBuild files. It also removes having to put regular expressions in MSBuild files (which requires non-trivial work arounds).

@dagood @weshaggard 