### PR TITLE
Allow build.revision mismatch in GenFacades

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
@@ -45,7 +45,7 @@
     <Error Text="No single matching contract found." Condition="'@(ResolvedMatchingContract->Count())' != '1'" />
 
     <PropertyGroup>
-      <GenFacadesArgs>-partialFacadeAssemblyPath:"$(GenFacadesInputAssembly)"</GenFacadesArgs>
+      <GenFacadesArgs>$(GenFacadesArgs) -partialFacadeAssemblyPath:"$(GenFacadesInputAssembly)"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -contracts:"%(ResolvedMatchingContract.Identity)"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -seeds:"@(GenFacadesSeeds, ';')"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -facadePath:"$(GenFacadesOutputPath.TrimEnd('/'))"</GenFacadesArgs>


### PR DESCRIPTION
Permit different build.revision in facade than contract to enable
https://github.com/dotnet/corefx/issues/7114