### PR TITLE
Lifting XUnit's dependencies to latest.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
@@ -12,12 +12,8 @@
     <PackagesBasePath Condition="'$(PackagesBasePath)' == ''">$(OutDir)</PackagesBasePath>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <NuGetExe>&quot;$(NuGetToolPath)&quot;</NuGetExe>
-    <NuGetBasePath>&quot;$(PackagesBasePath.TrimEnd('\'))&quot;</NuGetBasePath>
-    <NuGetOutputDirectory>&quot;$(PackagesOutDir.TrimEnd('\'))&quot;</NuGetOutputDirectory>
-  </PropertyGroup>
-
+  <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  
   <Target Name="BuildPackages"
     DependsOnTargets="GetNuGetPackageVersions"
     Condition="'$(SkipBuildPackages)' != 'true'">
@@ -26,17 +22,13 @@
     <MakeDir Directories="$(PackagesOutDir)" />
 
     <!-- Make package -->
-    <!-- We ignore warnings because NuGet will warn when libraries are not placed
-         in framework specific subfolders.  Our build tools do this because the
-         libraries are used during build, and do not depend on the framework being
-         targeted by the build -->
-    <!-- We trim the last backslash from properties which could end with one,
-         to prevent it from escaping the closing quote -->
-    <Exec
+    <NugetPack
       Condition="'@(PackagesNuSpecFiles)'!=''"
-      IgnoreStandardErrorWarningFormat="true"
-      StandardOutputImportance="Low"
-      Command="$(NuGetExe) pack &quot;%(PackagesNuSpecFiles.FullPath)&quot; -BasePath $(NuGetBasePath) -OutputDirectory $(NuGetOutputDirectory) %(PackagesNuSpecFiles.PackageVersion) -NoPackageAnalysis -NoDefaultExcludes -ExcludeEmptyDirectories" />
+      Nuspecs="%(PackagesNuSpecFiles.FullPath)"
+      OutputDirectory="$(PackagesOutDir)"
+      BaseDirectory="$(PackagesBasePath)"
+      PackageVersion="%(PackagesNuSpecFiles.PackageVersion)"
+      ExcludeEmptyDirectories="true"/>
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"
@@ -68,7 +60,7 @@
     
     <ItemGroup>
       <PackagesNuSpecFiles Condition="'%(PackagesNuSpecFiles.Identity)' == '%(Identity)'">
-        <PackageVersion>-Version $(_TempPackageVersion)</PackageVersion>
+        <PackageVersion>$(_TempPackageVersion)</PackageVersion>
       </PackagesNuSpecFiles>
     </ItemGroup>
 

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -22,21 +22,4 @@
   </PropertyGroup>
   <Import Project="$(ToolsDir)CodeCoverage.targets" Condition="Exists('$(ToolsDir)CodeCoverage.targets')" />
   <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets')" />
-
-<!--  Temporary Removing this since NugetPack doesn't support passing in a version number, so falling back to Nuget.exe temporarily.
-      Issue: https://github.com/dotnet/buildtools/issues/430
-  Overriding BuildPackages Target to use NuGet-independent version instead
-  <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-
-  <Target Name="BuildPackages">
-    <MakeDir Directories="$(PackagesOutDir)" />
-
-    <NugetPack Nuspecs="%(PackagesNuSpecFiles.FullPath)"
-             OutputDirectory="$(PackagesOutDir)%(PackagesNuSpecFiles.Filename).%(PackagesNuSpecFiles.PackageVersion).nupkg"
-             BaseDirectory="$(PackagesBasePath)"
-             ExcludeEmptyDirectories="true"
-             Condition="'$(_SkipCreatePackage)' != 'true'"/>
-  </Target>
--->
-
 </Project>

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -54,6 +54,9 @@
         <dependency id="System.Threading.Tasks" version="4.0.11-rc2-23921" />
         <dependency id="System.Xml.XDocument" version="4.0.11-rc2-23921" />
         <dependency id="xunit.runner.utility" version="2.1.0" />
+        <!-- xunit.runner.utility 2.1.0 has some older packages referenced that are not listed here -->
+        <dependency id="System.Reflection" version="4.1.0-rc2-23921" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1-rc2-23921" />
       </group>
     </dependencies>
   </metadata>

--- a/src/nuget/xunit.netcore.extensions.nuspec
+++ b/src/nuget/xunit.netcore.extensions.nuspec
@@ -46,6 +46,10 @@
         <dependency id="System.Threading" version="4.0.11-rc2-23921" />
         <dependency id="System.Threading.Tasks" version="4.0.11-rc2-23921" />
         <dependency id="xunit" version="2.1.0" />
+        <!-- xunit 2.1.0 has some older packages referenced that are not listed here -->
+        <dependency id="System.ObjectModel" version="4.0.12-rc2-23921" />
+        <dependency id="System.Linq.Expressions" version="4.0.11-rc2-23921" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1-rc2-23921" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
XUnit was referencing old versions of packages without support for
latest TFMs.  Now that we don't lift dependencies with the lineup we
need to reference newer packages.

Continuation of https://github.com/dotnet/buildtools/pull/559