### PR TITLE
Various packaging fixes

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -66,6 +66,7 @@
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
+    <TargetPath>$(NuSpecPath)</TargetPath>
     <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)/runtime.json</RuntimeFilePath>
     <PlaceholderFile>$(MSBuildThisFileDirectory)_._</PlaceholderFile>
     <PackageDescriptionFile Condition="'$(PackageDescriptionFile)' == ''">path to descriptions.json must be specified</PackageDescriptionFile>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -746,8 +746,8 @@
 
     <PropertyGroup>
       <Description Condition="'$(UseRuntimePackageDescription)' == 'true' AND '$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer)</Description>
-      <Description Condition="'$(UseRuntimePackageDescription)' != 'true' AND '$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer) \r\n $(Description)</Description>
-      <Description Condition="'@(SyncInfoLines)' != ''">$(Description) \r\n %(SyncInfoLines.Identity)</Description>
+      <Description Condition="'$(UseRuntimePackageDescription)' != 'true' AND '$(RuntimeDisclaimer)' != ''">$(RuntimeDisclaimer) %0A$(Description)</Description>
+      <Description Condition="'@(SyncInfoLines)' != ''">$(Description) %0A%(SyncInfoLines.Identity)</Description>
     </PropertyGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -890,7 +890,7 @@
       <_SkipCreatePackage Condition="'$(SkipCreatePackageOnMissingFiles)' == 'true' AND '@(_missingFiles)' != ''">true</_SkipCreatePackage>
     </PropertyGroup>
 
-    <Warning Condition="'$(_SkipCreatePackage)' == 'true'" Text="Skipping package creation for $(NuSpecPath) because the following files do not exist: @(_missingFiles)" />
+    <Message Condition="'$(_SkipCreatePackage)' == 'true'" Text="Skipping package creation for $(NuSpecPath) because the following files do not exist: @(_missingFiles)" />
 
     <NugetPack Nuspecs="$(NuSpecPath)"
                OutputDirectory="$(PackageOutputPath)"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/baseline.packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/baseline.packages.targets
@@ -91,6 +91,9 @@
     <BaseLinePackage Include="System.Diagnostics.Tracing">
       <Version>4.1.0</Version>
     </BaseLinePackage>
+    <BaseLinePackage Include="System.Drawing.Primitives">
+      <Version>4.0.0</Version>
+    </BaseLinePackage>
     <BaseLinePackage Include="System.Dynamic.Runtime">
       <Version>4.0.11</Version>
     </BaseLinePackage>
@@ -311,6 +314,9 @@
       <Version>4.0.0</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Security.Cryptography.Primitives">
+      <Version>4.0.0</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="System.Security.Cryptography.ProtectedData">
       <Version>4.0.0</Version>
     </BaseLinePackage>
     <BaseLinePackage Include="System.Security.Cryptography.X509Certificates">


### PR DESCRIPTION
Fix the annoying \r\n from our package descriptions
Update the baseline list.
Don't warn when folks have opted to skip missing files.
Set targetpath so that binclashlogger can catch package bin-clashes.