### PR TITLE
Fix package versioning break

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -13,7 +13,7 @@
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
 
     <VersionSuffix Condition="'$(PreReleaseLabel)' != ''">-$(PreReleaseLabel)</VersionSuffix>
-    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor).$(BuildNumberMinor)</VersionSuffix>
+    <VersionSuffix Condition="'$(IncludeBuildNumberInPackageVersion)' == 'true'">$(VersionSuffix)-$(BuildNumberMajor)-$(BuildNumberMinor)</VersionSuffix>
     
     <!--
       Empty out the project properties because we want configuration and platform to come from the individual

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -52,8 +52,6 @@
         APIVersion - Major.Minor assembly version for the project
   -->
   <Import Project="$(MSBuildThisFileDirectory)ReferenceAssemblies.targets" Condition="'$(ExcludeReferenceAssembliesImport)'!='true'" />
-  
-  <Import Project="$(MSBuildThisFileDirectory)Packaging.targets" Condition="'$(ExcludePackagingImport)'!='true' AND '$(MSBuildProjectExtension)' == '.pkgproj'" />
 
   <!-- 
     Import the default target framework targets.
@@ -67,6 +65,27 @@
   -->
   <Import Project="$(MSBuildThisFileDirectory)FrameworkTargeting.targets" Condition="'$(ExcludeFrameworkTargetingImport)'!='true'" />
   
+  <!-- 
+    Import the default assembly info generation targets
+    
+      Inputs:
+        GenerateAssemblyInfo - Controls whether or not to generate the assembly info file and defaults to true if not set.
+        AssemblyVersion - If not set defaults to 1.0.0.0 but it is expected to be set in csproj files.
+        CLSCompliant - If not set defaults to true and if it is true then adds the assembly level CLSCompliant(true) attribute.
+
+      File Version Inputs:
+        MajorVersion - If not set defaults to 1.
+        MinorVersion - If not set defaults to 0.
+        BuildNumberMajor - If not set defaults to 0.
+        BuildNumberMinor - If not set defaults to 0. 
+        AssemblyFileVersion - If not set defaults to $(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor). 
+        
+      BuildNumberTarget - If this property is set it will try to import the file which allows for it to override the properties above.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)versioning.targets" Condition="'$(ExcludeVersioningImport)'!='true'" />
+
+  <Import Project="$(MSBuildThisFileDirectory)Packaging.targets" Condition="'$(ExcludePackagingImport)'!='true' AND '$(MSBuildProjectExtension)' == '.pkgproj'" />
+
   <!-- 
     Import the default package restore and resolve targets 
   
@@ -102,25 +121,6 @@
         OmitResources - If set to true will skip resource inclusion even if StringResourcesPath exists.
   -->
   <Import Project="$(MSBuildThisFileDirectory)resources.targets" Condition="'$(ExcludeResourcesImport)'!='true'" />
-
-  <!-- 
-    Import the default assembly info generation targets
-    
-      Inputs:
-        GenerateAssemblyInfo - Controls whether or not to generate the assembly info file and defaults to true if not set.
-        AssemblyVersion - If not set defaults to 1.0.0.0 but it is expected to be set in csproj files.
-        CLSCompliant - If not set defaults to true and if it is true then adds the assembly level CLSCompliant(true) attribute.
-
-      File Version Inputs:
-        MajorVersion - If not set defaults to 1.
-        MinorVersion - If not set defaults to 0.
-        BuildNumberMajor - If not set defaults to 0.
-        BuildNumberMinor - If not set defaults to 0. 
-        AssemblyFileVersion - If not set defaults to $(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor). 
-        
-      BuildNumberTarget - If this property is set it will try to import the file which allows for it to override the properties above.
-  -->
-  <Import Project="$(MSBuildThisFileDirectory)versioning.targets" Condition="'$(ExcludeVersioningImport)'!='true'" />
 
   <!--
     Import the localization target


### PR DESCRIPTION
Change https://github.com/dotnet/buildtools/commit/daac863e9ea367338d6295c42264a58f4eb5bf1e
broke package build.  Two problems: BuildNumberMinor was not defined,
and NuGet didn't like a dash followed by a 2-part version (eg -00001.00)

For now I've changed to use a hyphen instead of a dash.  We may want to
file a bug on NuGet for this.

/cc @joperezr @weshaggard @Priya91 