### PR TITLE
Add symbol package creation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -17,6 +17,14 @@
       <PackageIncludeDocs Condition="'$(PackageIncludeDocs)' == '' AND '$(DocumentationFile)' != ''">true</PackageIncludeDocs>
     </PropertyGroup>
 
+    <!-- Find a root directory that is an ancestor of every possible source file, including
+         ones in bin and Tools. Allow configuration, otherwise prefer TFS root. -->
+    <PropertyGroup>
+      <ProjectRoot Condition="'$(ProjectRoot)'==''">$(SourcesRootPath)</ProjectRoot>
+      <ProjectRoot Condition="'$(ProjectRoot)'==''">$(ProjectDir)</ProjectRoot>
+      <ProjectRootLength>$(ProjectRoot.Length)</ProjectRootLength>
+    </PropertyGroup>
+
     <!-- XmlDocFileRoot should be defined externally since these are currently not
          part of the corefx repo. -->
     <!-- This isn't a straight mapping to an algorithm using CultureInfo.
@@ -116,8 +124,13 @@
 
     <!-- *** include assets *** -->
     <ItemGroup>
+      <!-- Include symbols output -->
+      <SymbolFileToPackage Include="$(PackagePath.Replace('.dll', '.pdb'))" Condition="Exists($(PackagePath.Replace('.dll', '.pdb')))">
+        <IsSymbolFile>true</IsSymbolFile>
+      </SymbolFileToPackage>
+
       <!-- Include primary output -->
-      <FilesToPackage Include="$(PackagePath)">
+      <FilesToPackage Include="$(PackagePath);@(SymbolFileToPackage)">
         <AssemblyVersion>$(AssemblyVersion)</AssemblyVersion>
         <TargetFramework>%(PackageDestination.TargetFramework)</TargetFramework>
         <TargetPath>%(PackageDestination.Identity)</TargetPath>
@@ -139,6 +152,13 @@
       </FilesToPackage>
       <FilesToPackage Condition="'%(FilesToPackage.SubFolder)' != ''">
         <TargetPath>%(TargetPath)%(FilesToPackage.SubFolder)</TargetPath>
+      </FilesToPackage>
+
+      <!-- Include source files for symbol packages. -->
+      <FilesToPackage Include="@(Compile->'%(FullPath)')">
+        <TargetPath>src</TargetPath>
+        <TargetPath Condition="$([System.String]::new('%(FullPath)').StartsWith('$(ProjectRoot)'))">src\$([System.String]::new('%(FullPath)').Substring('$(ProjectRootLength)'))</TargetPath>
+        <IsSourceCodeFile>true</IsSourceCodeFile>
       </FilesToPackage>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -63,6 +63,7 @@
   <!-- Shared properties -->
   <PropertyGroup>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>
+    <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(BaseOutputPath)symbolpkg/</SymbolPackageOutputPath>
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
@@ -330,6 +331,8 @@
                       '%(File.SkipPackageFileCheck)' != 'true' AND
                       '%(File.FileName)' != '_' AND
                       '%(File.FileName)%(File.Extension)' != 'runtime.json' AND
+                      '%(File.Extension)' != '.cs' AND
+                      '%(File.Extension)' != '.vb' AND
                       !$(ID.Contains('%(File.FileName)'))"
            Text="Package $(ID) contains file with name %(File.FileName).  If this is expected you can disable this filename checking for this item or package by setting SkipPackageFileCheck = true"
            ContinueOnError="ErrorAndContinue" />
@@ -413,11 +416,25 @@
           Returns="@(PackageFile)"
           DependsOnTargets="GetFiles;EnsureOOBFramework;$(VersionDependsOn)">
     <ItemGroup>
-      <PackageFile Include="@(File)" />
+      <!-- Include all files except source files. Sources need to be deduplicated. -->
+      <PackageFile Include="@(File)" Condition="'%(File.IsSourceCodeFile)'!='true'" />
       <PackageFile Condition="'%(PackageFile.PackageId)' == ''">
         <PackageId>$(Id)</PackageId>
         <PackageVersion>$(Version)</PackageVersion>
       </PackageFile>
+
+      <!-- Include Sources. Deduplicate so the nuspec doesn't contain multiple entries for each source file. -->
+      <PackageSources Include="@(File)"
+                      KeepMetadata="TargetPath;IsSourceCodeFile"
+                      KeepDuplicates="false"
+                      Condition="'%(File.IsSourceCodeFile)'=='true'" />
+      <!-- Add a placeholder source file if there are symbols but no sources. -->
+      <PackageSymbolFiles Include="@(File)" Condition="'%(File.IsSymbolFile)'=='true'" />
+      <PackageSources Include="$(PlaceholderFile)" Condition="'@(PackageSymbolFiles)'!='' AND '@(PackageSources)'==''">
+        <IsSourceCodeFile>true</IsSourceCodeFile>
+        <TargetPath>src</TargetPath>
+      </PackageSources>
+      <PackageFile Include="@(PackageSources)" />
 
       <!-- Nuget will treat TargetPath as a directory if the extensions dont match,
            however we need to package files without an extension (Unix exectuables).
@@ -846,10 +863,25 @@
       <Output TaskParameter="TargetOutputs" ItemName="RuntimeFile" />
     </MSBuild>
 
+    <ItemGroup>
+      <EveryUnfilteredFile Include="@(RuntimeFile);@(PackageFile)" />
+      
+      <!-- Include all files except source files. Sources need to be deduplicated. -->
+      <EveryFile Include="@(EveryUnfilteredFile)"
+                 Condition="'%(EveryUnfilteredFile.IsSourceCodeFile)'!='true'" />
+
+      <!-- Include Sources. Deduplicate so they pass package validation. -->
+      <SourceFile Include="@(EveryUnfilteredFile)"
+                  KeepMetadata="TargetPath;IsSourceCodeFile"
+                  KeepDuplicates="false"
+                  Condition="'%(EveryUnfilteredFile.IsSourceCodeFile)'=='true'" />
+      <EveryFile Include="@(SourceFile)" />
+    </ItemGroup>
+
     <ValidatePackage ContractName="$(BaseId)"
                      PackageId="$(Id)"
                      PackageVersion="$(Version)"
-                     Files="@(PackageFile);@(RuntimeFile)"
+                     Files="@(EveryFile)"
                      SupportedFrameworks="@(SupportedFramework)"
                      Frameworks="@(ValidateFramework)"
                      RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
@@ -900,9 +932,11 @@
     <NugetPack Nuspecs="$(NuSpecPath)"
                OutputDirectory="$(PackageOutputPath)"
                ExcludeEmptyDirectories="true"
+               PackSymbolPackage="true"
+               SymbolPackageOutputDirectory="$(SymbolPackageOutputPath)"
                Condition="'$(_SkipCreatePackage)' != 'true'"/>
     <!-- Create a marker that records the path to the generated package -->
-    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(Version).nupkg"
+    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(Version).nupkg;$(SymbolPackageOutputPath)$(Id).$(Version).symbols.nupkg"
                       File="$(NuSpecPath).pkgpath"
                       Overwrite="true"
                       Condition="'$(_SkipCreatePackage)' != 'true'"/>


### PR DESCRIPTION
Symbol packages include pdb files for each dll and any source files inside the project root that are referenced in `<Compile>` items. The nuspec contains all these files and the `NuGetPack` task filters using the same logic as the `nuget pack` command.

This is enabled by default in corefx and wcf but will require a change in TFS to turn on (and a change to add a placeholder to a manually-created nuspec that has symbols but no source.)

Tested successfully on Windows with corefx, wcf, and TFS.

On OSX with corefx no symbol packages are created, presumably because the source file paths aren't handled correctly. Looking into it. I might create an issue and get to it later because getting symbols published from TFS to MyGet seems like the higher priority.

For an example of source and symbol indexing at work, check out https://www.myget.org/feed/dagood-test-dotnet-core/package/nuget/System.Linq.Parallel. (You will need to log in to see it, but you shouldn't need any special permissions.) MyGet should have a symbol source for the feed that can be used from VS--I don't have the newest dotnet core VS tooling set up so I'm still working on testing that out.

/cc @weshaggard @ericstj @gkhanna79 

(Sorry about the NuGetPack diff--I moved some code out into another method and unindented as part of my changes. :cry:)