### PR TITLE
Add targets file to be used for publishing build artifacts.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
@@ -1,0 +1,44 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="CreateAzureContainer" AssemblyFile="$(ToolsDir)net45/Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="UploadToAzure" AssemblyFile="$(ToolsDir)net45/Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+
+  <PropertyGroup>
+    <OverwriteOnPublish Condition="'$(OverwriteOnPublish)' == ''">false</OverwriteOnPublish>
+  </PropertyGroup>
+
+  <!-- gathers the items to be published -->
+  <Target Name="GatherItemsForPattern">
+    <Error Condition="'$(PublishPattern)' == ''" Text="Please specify a value for PublishPattern using standard msbuild 'include' syntax." />
+    <ItemGroup>
+      <ForPublishing Include="$(PublishPattern)" />
+    </ItemGroup>
+    <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />
+  </Target>
+
+  <!-- publishes items to blob storage in Azure -->
+  <Target Name="UploadToAzure" DependsOnTargets="GatherItemsForPattern">
+    <Error Condition="'$(ContainerName)' == ''" Text="Missing property ContainerName." />
+    <Error Condition="'$(CloudDropAccountName)' == ''" Text="Missing property CloudDropAccountName." />
+    <Error Condition="'$(CloudDropAccessToken)' == ''" Text="Missing property CloudDropAccessToken." />
+    <!-- create the container if it doesn't exist -->
+    <CreateAzureContainer
+      AccountKey="$(CloudDropAccessToken)"
+      AccountName="$(CloudDropAccountName)"
+      ContainerName="$(ContainerName)" />
+    <!-- add relative blob path metadata -->
+    <ItemGroup>
+      <ForPublishing>
+        <RelativeBlobPath>%(RecursiveDir)%(Filename)%(Extension)</RelativeBlobPath>
+      </ForPublishing>
+    </ItemGroup>
+    <!-- now upload the items -->
+    <UploadToAzure
+      AccountKey="$(CloudDropAccessToken)"
+      AccountName="$(CloudDropAccountName)"
+      ContainerName="$(ContainerName)"
+      Items="@(ForPublishing)"
+      Overwrite="$(OverwriteOnPublish)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
The build pipeline requires the ability to publish build artifacts to
various endpoints.  This change adds a targets file that will contain
various publishing targets.  At present the only endpoint we need is Azure
blob storage.