### PR TITLE
Support Desktop test Build and Run

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -67,6 +67,15 @@
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </PrereleaseResolveNuGetPackageAssets>
 
+    <ItemGroup Condition="'$(TestWithCore)' != 'true'">
+      <!-- Filter out the copy-local set of references coming from the targeting pack packages -->
+      <TestCopyLocalToRemove Include="@(TestCopyLocal)"
+        Condition="$([System.String]::new('%(TestCopyLocal.NuGetPackageId)').StartsWith('$(_TargetingPackPrefix)'))" />
+      <TestCopyLocal Remove="@(TestCopyLocalToRemove)" />
+      
+      <TestCopyLocal Include="$(PackagesDir)xunit.runner.console/2.1.0/tools/*.*" />
+    </ItemGroup>
+
     <!-- We may have an indirect package reference that we want to replace with a project reference.
           Those are part of RunTestsForProjectInputs. The order that we append to TestCopyLocal is
           significant, later entries override earlier entries. -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -1,20 +1,27 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23923",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23923",
-    "Microsoft.NETCore.Console": "1.0.0-rc2-23923",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",
     "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0028",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0028",
     "xunit": "2.1.0",
-    "xunit.console.netcore": "1.0.2-prerelease-00101",
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
     "dnxcore50": {
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-rc2-23923",
+        "Microsoft.NETCore.TestHost": "1.0.0-rc2-23923",
+        "Microsoft.NETCore.Console": "1.0.0-rc2-23923",
+        "xunit.console.netcore": "1.0.2-prerelease-00101"
+      },
       "imports": "portable-net45+win8"
+    },
+    "net462": {
+      "dependencies": {
+        "xunit.runner.console":"2.1.0"
+      }
     }
   },
   "runtimes": {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -20,6 +20,10 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net45'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net46'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net461'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net462'">false</TestWithCore>
     <TestWithCore Condition="'$(TestWithCore)' == ''">true</TestWithCore>
   </PropertyGroup>
 
@@ -50,7 +54,16 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestWithCore)' != 'true'">
-    <TestTargetFramework Include=".NETFramework,Version=v4.5">
+    <TestTargetFramework Include=".NETFramework,Version=v4.6.2" Condition="'$(TargetGroup)' == 'net462'">
+      <Folder>net462</Folder>
+    </TestTargetFramework>
+    <TestTargetFramework Include=".NETFramework,Version=v4.6.1" Condition="'$(TargetGroup)' == 'net461'">
+      <Folder>net461</Folder>
+    </TestTargetFramework>
+    <TestTargetFramework Include=".NETFramework,Version=v4.6" Condition="'$(TargetGroup)' == 'net46'">
+      <Folder>net46</Folder>
+    </TestTargetFramework>
+    <TestTargetFramework Include=".NETFramework,Version=v4.5" Condition="'$(TargetGroup)' == 'net45'">
       <Folder>net45</Folder>
     </TestTargetFramework>
   </ItemGroup>


### PR DESCRIPTION
This change is to add the necessary test publishing filters and restore the xunit desktop runner pack to allow compiling and running the tests against the desktop