### PR TITLE
Add validation report and doc generation task.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNetStandardSupportTable.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNetStandardSupportTable.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class GenerateNetStandardSupportTable : PackagingTask
+    {
+        [Required]
+        public ITaskItem[] Reports
+        {
+            get;
+            set;
+        }
+
+        [Required]
+        public string DocFilePath
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Generates a table in markdown that lists the API version supported by 
+        /// various packages at all levels of NETStandard.
+        /// </summary>
+        /// <returns></returns>
+        public override bool Execute()
+        {
+            if (Reports == null || Reports.Length == 0)
+            {
+                Log.LogError("Reports argument must be specified");
+                return false;
+            }
+
+            if (String.IsNullOrEmpty(DocFilePath))
+            {
+                Log.LogError("DocFilePath argument must be specified");
+                return false;
+            }
+
+            string docDir = Path.GetDirectoryName(DocFilePath);
+            if (!Directory.Exists(docDir))
+            {
+                Directory.CreateDirectory(docDir);
+            }
+
+            SortedSet<Version> knownNetStandardVersions = new SortedSet<Version>();
+            List<SupportRow> rows = new List<SupportRow>(Reports.Length);
+
+            foreach (var report in Reports.Select(r => r.GetMetadata("FullPath")))
+            {
+                SupportRow row = new SupportRow();
+                row.Name = Path.GetFileNameWithoutExtension(report);
+                row.SuportedVersions = new SortedSet<NETStandardApiVersion>();
+
+                using (var file = File.OpenText(report))
+                using (var reader = new JsonTextReader(file))
+                {
+                    var doc = JObject.Load(reader);
+                    var supportedFrameworks = doc["supportedFrameworks"] as JObject;
+
+                    foreach(var supportedFramework in supportedFrameworks.Properties())
+                    {
+                        var fx = NuGetFramework.Parse(supportedFramework.Name);
+
+                        if (fx.Framework == FrameworkConstants.FrameworkIdentifiers.NetStandard)
+                        {
+                            row.SuportedVersions.Add(new NETStandardApiVersion(fx.Version, new Version(supportedFramework.Value.ToString())));
+                            knownNetStandardVersions.Add(fx.Version);
+                        }
+                    }
+                }
+                rows.Add(row);
+            }
+
+            using (var docFile = File.CreateText(DocFilePath))
+            {
+                docFile.WriteLine($"| Contract | {String.Join(" | ", knownNetStandardVersions.Select(v => v.ToString(2)))} |");
+                docFile.WriteLine($"| -------- | {String.Join(" | ", Enumerable.Repeat("---", knownNetStandardVersions.Count))}");
+
+                foreach(var row in rows.OrderBy(r => r.Name))
+                {
+                    if (row.SuportedVersions.Count == 0)
+                    {
+                        Log.LogMessage($"Skipping {row.Name} since it has no supported NETStandard versions");
+                        continue;
+                    }
+
+                    docFile.Write($"| {row.Name} |");
+                    
+                    foreach (var netStandardVersion in knownNetStandardVersions)
+                    {
+                        var apiVersion = row.SuportedVersions.LastOrDefault(a => a.NETStandardVersion <= netStandardVersion);
+
+                        docFile.Write(" ");
+                        if (apiVersion != null)
+                        {
+                                docFile.Write(apiVersion.APIVersion.ToString(3));
+                        }
+                        docFile.Write(" |");
+                    }
+                    docFile.WriteLine();
+                }
+            }
+            return !Log.HasLoggedErrors;
+        }
+
+        private class SupportRow
+        {
+            public string Name { get; set; }
+            public SortedSet<NETStandardApiVersion> SuportedVersions { get; set; }
+        }
+
+        private class NETStandardApiVersion : IComparable<NETStandardApiVersion>
+        {
+            public NETStandardApiVersion(Version netStandardVersion, Version apiVersion)
+            {
+                NETStandardVersion = netStandardVersion;
+                APIVersion = apiVersion;
+            }
+
+            public Version NETStandardVersion { get; }
+            public Version APIVersion {get;}
+
+            public int CompareTo(NETStandardApiVersion other)
+            {
+                return NETStandardVersion.CompareTo(other.NETStandardVersion);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GenerateNetStandardSupportTable.cs" />
     <Compile Include="PromoteReferenceDependencies.cs" />
     <Compile Include="CreateTrimDependencyGroups.cs" />
     <Compile Include="ApplyBaseLine.cs" />
@@ -80,6 +81,7 @@
     <Folder Include="FrameworkLists\.NETFramework,Version=v4.5.1\" />
     <Folder Include="FrameworkLists\.NETFramework,Version=v4.5\" />
     <Folder Include="FrameworkLists\.NETFramework,Version=v4.6.1\" />
+    <Folder Include="FrameworkLists\.NETFramework,Version=v4.6.2\" />
     <Folder Include="FrameworkLists\.NETFramework,Version=v4.6\" />
     <Folder Include="FrameworkLists\MonoAndroid,Version=v1.0\" />
     <Folder Include="FrameworkLists\MonoTouch,Version=v1.0\" />
@@ -87,6 +89,8 @@
     <Folder Include="FrameworkLists\WindowsPhoneApp,Version=v8.1\" />
     <Folder Include="FrameworkLists\Xamarin.iOS,Version=v1.0\" />
     <Folder Include="FrameworkLists\Xamarin.Mac,Version=v2.0\" />
+    <Folder Include="FrameworkLists\Xamarin.TVOS,Version=v1.0\" />
+    <Folder Include="FrameworkLists\Xamarin.WatchOS,Version=v1.0\" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -66,6 +66,8 @@
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
+    <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(PackageOutputPath)reports/</PackageReportDir>
+    <PackageReportPath>$(PackageReportDir)$(Id)$(NuspecSuffix).json</PackageReportPath>
     <TargetPath>$(NuSpecPath)</TargetPath>
     <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)/runtime.json</RuntimeFilePath>
     <PlaceholderFile>$(MSBuildThisFileDirectory)_._</PlaceholderFile>
@@ -846,6 +848,7 @@
 
     <ValidatePackage ContractName="$(BaseId)"
                      PackageId="$(Id)"
+                     PackageVersion="$(Version)"
                      Files="@(PackageFile);@(RuntimeFile)"
                      SupportedFrameworks="@(SupportedFramework)"
                      Frameworks="@(ValidateFramework)"
@@ -855,6 +858,7 @@
                      SkipSupportCheck="$(SkipSupportCheck)"
                      SuppressionFile="$(ValidationSuppressionFile)"
                      UseNetPlatform="$(UseNetPlatform)"
+                     ValidationReport="$(PackageReportPath)"
                      ContinueOnError="ErrorAndContinue"/>
   </Target>
 


### PR DESCRIPTION
Add functionality to emit some of the results from package validation to
use for generating documentation.

I'm not currently using the emitted AllSupportedFrameworks items but we
could use this in the future to append a list of supported frameworks to
the package description.  Folks have various opinions about what is the
right amount of data to show here, until we have some concensus I'm
going to avoid shoving more data into the publicly facing package
description.

I'll follow up to a pointer of the CoreFx change that consumes this.