### PR TITLE
Create a common ruleset to be used at a repo level for changing analyzer behavior

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -54,6 +54,13 @@
   <Import Project="$(MSBuildThisFileDirectory)ReferenceAssemblies.targets" Condition="'$(ExcludeReferenceAssembliesImport)'!='true'" />
 
   <!-- 
+    Import the codeAnalysis.targets file to enable analyzer support during build. 
+    This should happen before we import the frameworkTargeting.targets because that import leads to computing a default
+    for the CodeAnalysisRuleset unless one is already specified
+  --> 
+  <Import Project="$(MSBuildThisFileDirectory)codeAnalysis.targets" />
+
+  <!-- 
     Import the default target framework targets.
     
     Inputs:
@@ -202,11 +209,6 @@
                              is true for reference assemblies, false for implementation.
    -->
   <Import Project="$(MSBuildThisFileDirectory)PackageLibs.targets" Condition="'$(ExclduePackageLibsImport)'!='true'"/>
-
-  <!-- 
-    Import the codeAnalysis.targets file to enable analyzer support during build.
-  --> 
-  <Import Project="$(MSBuildThisFileDirectory)codeAnalysis.targets" />
 
   <Target Name="CheckDesignTime">
     <!--

--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/Microsoft.DotNet.CodeAnalysis.ruleset
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/Microsoft.DotNet.CodeAnalysis.ruleset
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Common diagnostic rules" Description="Enables/disable rules for all projects." ToolsVersion="14.0">
+  <Rules AnalyzerId="Microsoft.DotNet.CodeAnalysis" RuleNamespace="Microsoft.DotNet.CodeAnalysis.Analyzers">
+    <!-- 
+        Use this section to globaly disable analyzers using the pattern below
+            <Rule Id="<ruleId>" Action="<Error|Warning|None>" />
+     -->
+  </Rules>
+</RuleSet>

--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
@@ -18,6 +18,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-  	<CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Microsoft.DotNet.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)'==''">$(MSBuildThisFileDirectory)Microsoft.DotNet.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
@@ -16,4 +16,8 @@
     <AdditionalFiles Include="$(MSBuildProjectDirectory)/*.analyzerdata" />
     <AdditionalFiles Include="$(MSBuildProjectDirectory)/*.analyzerdata.$(Platform)" />
   </ItemGroup>
+
+  <PropertyGroup>
+  	<CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Microsoft.DotNet.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
By default, all analyzers are going to be enabled and their default level (error, warning) will be specified by each analyzer as it sees fit.
If you need to change the default behavior at the repo level, you can update the Microsoft.DotNet.CodeAnalysis.ruleset file and modify the level as needed.

If individual projects need to change the defaults for analyzers they can do so in their own ruleset file.
Each project can also import the common ruleset file.

/cc @pallavit @joperezr @weshaggard 