### PR TITLE
Adding Perf tests support for CoreCLR

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/GetPerfTestAssemblies.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/GetPerfTestAssemblies.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         [Required]
         public ITaskItem[] TestBinaries { get; set; }
 
+        public bool GetFullPaths { get; set; }
+
         /// <summary>
         /// An item group containing performance test binaries.  Can be empty if no performance tests were found.
         /// </summary>
@@ -39,7 +41,11 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {
                     using (var peFile = new PEReader(stream))
                     {
+                        if(!peFile.HasMetadata){
+                            continue;
+                        }
                         var mdReader = peFile.GetMetadataReader();
+
                         foreach (var asmRefHandle in mdReader.AssemblyReferences)
                         {
                             var asmRef = mdReader.GetAssemblyReference(asmRefHandle);
@@ -50,9 +56,9 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
                             if (string.Compare(asmRefName, "xunit.performance.core", StringComparison.OrdinalIgnoreCase) == 0)
                             {
-                                var fileNameShort = Path.GetFileNameWithoutExtension(testBinary.ItemSpec);
-                                perfTests.Add(new TaskItem(fileNameShort));
-                                Log.LogMessage("+ Assembly {0} contains one or more performance tests.", fileNameShort);
+                                var fileName = (GetFullPaths) ? Path.GetFullPath(testBinary.ItemSpec) : Path.GetFileNameWithoutExtension(testBinary.ItemSpec);
+                                perfTests.Add(new TaskItem(fileName));
+                                Log.LogMessage("+ Assembly {0} contains one or more performance tests.", fileName);
                                 break;
                             }
                         }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -14,7 +14,7 @@
   <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
     <HelixPythonPath>%HELIX_PYTHONPATH%</HelixPythonPath>
     <HelixScriptRoot>%HELIX_SCRIPT_ROOT%\</HelixScriptRoot>
-    <FuncTestRunnerScript>%HELIX_CORRELATION_PAYLOAD%\RunnerScripts\xunitrunner-func\xunitrunner-func.py</FuncTestRunnerScript>    
+    <FuncTestRunnerScript>%HELIX_CORRELATION_PAYLOAD%\RunnerScripts\xunitrunner-func\xunitrunner-func.py</FuncTestRunnerScript>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
     <HelixPythonPath>$HELIX_PYTHONPATH</HelixPythonPath>
@@ -150,7 +150,7 @@
         <WorkItemId>FunctionalTest.%(Filename)</WorkItemId>
         <TimeoutInSeconds>$(TimeoutInSeconds)</TimeoutInSeconds>
       </FunctionalTest>
-    </ItemGroup> 
+    </ItemGroup>
     <WriteItemsToJson JsonFileName="$(FuncTestListFile)" Items="@(FunctionalTest)" />
     <!-- add test lists to the list of items for upload -->
     <ItemGroup>
@@ -174,9 +174,10 @@
     </PropertyGroup>
     <!-- now gather the perf tests -->
     <ItemGroup>
-      <TestBinary Include="$(BinDir)$(OSPlatformConfig)/**/*Tests.dll" />
+      <TestBinary Include="$(BinDir)$(OSPlatformConfig)/**/*.dll" />
+      <TestBinary Include="$(BinDir)$(OSPlatformConfig)/**/*.exe" />
     </ItemGroup>
-    <GetPerfTestAssemblies TestBinaries="@(TestBinary)">
+    <GetPerfTestAssemblies TestBinaries="@(TestBinary)" GetFullPaths="false">
       <Output TaskParameter="PerfTestAssemblies" ItemName="PerfTestAssembly" />
     </GetPerfTestAssemblies>
     <!-- don't add any items to the group if no perf tests were found -->

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/csvjsonconvertor.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/csvjsonconvertor.py
@@ -24,6 +24,7 @@ def add_row(test, value, csvdict):
         [System, ComponentModel, Tests, Perf_TypeDescriptorTests, GetConverter(typeToConvert: typeof(bool), expectedConverter: typeof(System.ComponentModel.BooleanConverter))]
     """
 
+    test = test.strip('\"')
     funcMeta = test.split('(')
     funcMeta = funcMeta[1:]
     test = test.split('(')[0]
@@ -34,7 +35,7 @@ def add_row(test, value, csvdict):
 
     identifiers[-1] = funcName
     currdict = csvdict
-    for identifier in identifiers[:-2]:
+    for identifier in identifiers[:-1]:
         if identifier not in currdict:
             currdict[identifier] = dict()
 
@@ -97,7 +98,7 @@ def generate_json(opts, csvdict):
     rootTests = list()
 
     # recursively build nodes from the csvdict
-    rootTest = generate_test_object(opts, csvdict, 'CoreFX Perf Test')
+    rootTest = generate_test_object(opts, csvdict, opts['--branch']+' Perf Test Results')
     rootTests.append(rootTest)
 
     # populate the root level meta info

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -23,6 +23,7 @@
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.metrics.dll" />
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.logger.exe" />
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.core.dll" />
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.runner.utility.desktop.dll" >
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/ProcDomain.dll" />
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll" />
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/*/*.*" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -4,7 +4,6 @@
   <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="RemoveDuplicatesWithLastOneWinsPolicy" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileCreateFromDirectory" Condition="'$(ArchiveTests)' == 'true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-
   <UsingTask TaskName="GenerateAssemblyList" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="GetTargetMachineInfo" Condition="'$(TestWithLocalLibraries)'=='true'" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
@@ -50,7 +49,8 @@
   </Target>
 
   <Target Name="CopyTestToTestDirectory"
-          DependsOnTargets="DiscoverTestInputs">
+          DependsOnTargets="DiscoverTestInputs" Condition="'$(DisableCopyTestToTestDirectory)'!='true'">
+
     <ItemGroup>
       <TestNugetProjectLockFile Include="$(ProjectLockJson)" Condition="Exists($(ProjectLockJson))"/>
       <TestNugetProjectLockFile Include="$(TestRuntimeProjectLockJson)" Condition="Exists($(TestRuntimeProjectLockJson))"/>
@@ -73,7 +73,7 @@
     <ItemGroup>
       <TestCopyLocal Include="@(RunTestsForProjectInputs)" Exclude="@(PackagesConfigs)" />
     </ItemGroup>
-    
+
     <GetTargetMachineInfo Condition="'$(TestWithLocalLibraries)'=='true'">
       <Output Condition="'$(TargetArch)'==''" TaskParameter="TargetArch" PropertyName="TargetArch" />
       <Output Condition="'$(TargetOS)'==''" TaskParameter="TargetOS" PropertyName="TargetOS" />
@@ -106,8 +106,8 @@
       <TestCopyLocal Include="$(BUILDTOOLS_OVERRIDE_RUNTIME)/*.*" />
     </ItemGroup>
 
-    <!-- Remove duplicates. Note that we musn't just copy in sequence and let 
-         the last one win that way because it will cause copies to occur on 
+    <!-- Remove duplicates. Note that we musn't just copy in sequence and let
+         the last one win that way because it will cause copies to occur on
          every incremental build. -->
     <ItemGroup>
       <_TestCopyLocalByFileName Include="@(TestCopyLocal->'%(FileName)%(Extension)')">
@@ -216,10 +216,14 @@
     <PropertyGroup>
       <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(TestProjectName)'==''">
+      <TestProjectName>$(MSBuildProjectName)</TestProjectName>
+    </PropertyGroup>
+
     <!-- the project json files need to be included in the archive -->
     <Copy SourceFiles="$(ProjectJson);$(ProjectLockJson)" DestinationFolder="$(OutDir)" />
     <MakeDir Directories="$(TestArchiveDir)" />
-    <ZipFileCreateFromDirectory SourceDirectory="$(OutDir)" DestinationArchive="$(TestArchiveDir)$(MSBuildProjectName).zip" OverwriteDestination="true" />
+    <ZipFileCreateFromDirectory SourceDirectory="$(OutDir)" DestinationArchive="$(TestArchiveDir)$(TestProjectName).zip" OverwriteDestination="true" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -6,8 +6,8 @@
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0028",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0028",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0029",
     "xunit": "2.1.0",
     "xunit.console.netcore": "1.0.2-prerelease-00101",
     "xunit.runner.utility": "2.1.0"


### PR DESCRIPTION
Changes to allow packaging and running building perf tests for CoreCLR via Helix
•Gathering full paths of test binaries instead of relative paths since we need it to mitigate for perf tests in subdirectories under CoreCLR
•Adding support for different xunit performance versions in xunit perf runner
•Conditional AssemblyList creation and CopyTestToTestDirectory since CoreCLR currently does not support running individual tests in isolation in an automated manner
•Fixing mismatch in xunit performance versions and copying proper execution assemblies for xunit performance

@MattGal @brianrob @lt72 @jhendrixMSFT @rahku 
