### PR TITLE
Make sure code analyzers can be correctly loaded on all supported platforms.

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(EnableDotnetAnalyzers)' == 'true'">
     <!-- Enable the Microsoft.Dotnet.CodeAnalysis.dll analyzer --> 
-    <Analyzer Include="$(BuildToolsTaskDir)Microsoft.Dotnet.CodeAnalysis.dll"/>
+    <Analyzer Include="$(BuildToolsTaskDir)analyzers\Microsoft.Dotnet.CodeAnalysis.dll"/>
 
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\*.analyzerdata" />
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\*.analyzerdata.$(Platform)" />

--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- 
+    We should be using $(BuildToolsTaskDir) for this, however we are currently forcing that property to 
+    always be net45 (because we use Mono to run our tests and Mono needs to load the net45 version)
+-->
+  <PropertyGroup>
+    <CodeAnalyzerDir Condition="'$(CodeAnalyzerDir)'=='' and '$(OSEnvironment)'=='Windows_NT'">$(ToolsDir)net45/analyzers/</CodeAnalyzerDir>
+    <CodeAnalyzerDir Condition="'$(CodeAnalyzerDir)'=='' and '$(OSEnvironment)'!='Windows_NT'">$(ToolsDir)analyzers/</CodeAnalyzerDir>
+  </PropertyGroup>
+  
   <ItemGroup Condition="'$(EnableDotnetAnalyzers)' == 'true'">
     <!-- Enable the Microsoft.Dotnet.CodeAnalysis.dll analyzer --> 
-    <Analyzer Include="$(BuildToolsTaskDir)analyzers\Microsoft.Dotnet.CodeAnalysis.dll"/>
+    <Analyzer Include="$(CodeAnalyzerDir)Microsoft.DotNet.CodeAnalysis.dll"/>
 
-    <AdditionalFiles Include="$(MSBuildProjectDirectory)\*.analyzerdata" />
-    <AdditionalFiles Include="$(MSBuildProjectDirectory)\*.analyzerdata.$(Platform)" />
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)/*.analyzerdata" />
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)/*.analyzerdata.$(Platform)" />
   </ItemGroup>
 </Project>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools</id>
@@ -39,8 +39,8 @@
     <file src="GenFacades\GenFacades.exe" target="lib" />
     <file src="GenAPI\GenAPI.exe" target="lib" />
     <file src="ApiCompat\ApiCompat.exe" target="lib" />
-    <file src="Microsoft.DotNet.CodeAnalysis\Microsoft.DotNet.CodeAnalysis.dll" target="lib" />
-    <file src="Microsoft.DotNet.CodeAnalysis.net45\Microsoft.DotNet.CodeAnalysis.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.CodeAnalysis\Microsoft.DotNet.CodeAnalysis.dll" target="lib\analyzers" />
+    <file src="Microsoft.DotNet.CodeAnalysis.net45\Microsoft.DotNet.CodeAnalysis.dll" target="lib\net45\analyzers" />
     <file src="Microsoft.DotNet.CodeAnalysis\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib" />


### PR DESCRIPTION
There were a couple of issues with the way analyzers were enabled:
- The net core version of the analyzer was placed in the root of the Tools directory. This meant that it became part of the TPA (Trusted Platform Assemblies) list when the net core compiler was run with corerun. 
 - This lead to a very mysterious issue where the runtime complained that it could not load the analyzer file because it could not find its dependencies.
 - In reality, this was caused by the fact that the assembly was part of the TPA list and the way the Roslyn compiler loads assemblies.
 - **Fix: Move the analyzer in a separate folder under Tools to prevent it from showing up in the TPA list.**
- The property that was used to decide the path where the assembly should be loaded from was `$(BuildToolsTaskDir)`
 - This property however is fixed to be net45. This was needed at the time because we still depended on Mono to build our binaries on non Windows platform. 
 - This is still required today because we still use Mono to run our tests.
 - **Fix: Temporarily introduce a new property that uses `$(OSEnvironment)` to decide if it should use the net45 version or the net core version for the analyzer**

Note: During the investigation I noticed that the way that we load the `Microsoft.DotNet.Build.Tasks.dll` happens to work because of an implementation detail in how assemblies are being loaded.
What happens is that when we are running on the net core msbuild, we still pass it the path to the net45 assembly. However, because there is already a file with the same simple name next to corerun, we are going to end up loading that assembly instead of the one we specified. 
This is something we need to address in the future.
