### PR TITLE
We should only overwrite the CodeAnalysisRuleSet property if the analyzers are enabled

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
@@ -17,7 +17,7 @@
     <AdditionalFiles Include="$(MSBuildProjectDirectory)/*.analyzerdata.$(Platform)" />
   </ItemGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(EnableDotnetAnalyzers)' == 'true'">
     <CodeAnalysisRuleSet Condition="'$(CodeAnalysisRuleSet)'==''">$(MSBuildThisFileDirectory)Microsoft.DotNet.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When enabling the analyzers I missed a condition that would not overwrite the CodeAnalysisRuleset if the analyzers were not enabled.