### PR TITLE
Modify checks for IsOfficial CloudTest build

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
@@ -2,9 +2,12 @@
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
     "NuGet.Versioning": "3.4.0-beta-488",
-    "System.Reflection.Metadata": "1.0.22"
+    "System.Reflection.Metadata": "1.1.0"
   },
   "frameworks": {
     "net45": { }
+  },
+  "runtimes": {
+    "win": {}
   }
 }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -64,9 +64,9 @@
     <Error Condition="'$(EventHubPath)' == ''" Text="Missing required property EventHubPath." />
     <Error Condition="'$(EventHubSharedAccessKey)' == ''" Text="Missing required property EventHubSharedAccessKey." />
     <Error Condition="'$(EventHubSharedAccessKeyName)' == ''" Text="Missing required property EventHubSharedAccessKeyName." />
-    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(BuildIsOfficialConnection)' == ''" Text="Missing required property BuildIsOfficialConnection." />
-    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(DocumentDbKey)' == ''" Text="Missing required property DocumentDbKey." />
-    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(DocumentDbUri)' == ''" Text="Missing required property DocumentDbUri." />
+    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(BuildIsOfficialEventHubPath)' == ''" Text="Missing required property BuildIsOfficialEventHubPath." />
+    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(BuildIsOfficialEventHubSharedAccessKeyName)' == ''" Text="Missing required property BuildIsOfficialEventHubSharedAccessKeyName." />
+    <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(BuildIsOfficialEventHubSharedAccessKey)' == ''" Text="Missing required property BuildIsOfficialEventHubSharedAccessKey." />
     <!-- gather the test archives for upload -->
     <ItemGroup>
       <ForUpload Include="$(TestArchivesRoot)*.zip" />
@@ -310,8 +310,7 @@
       EventHubPath="$(BuildIsOfficialEventHubPath)"
       EventHubSharedAccessKeyName="$(BuildIsOfficialEventHubSharedAccessKeyName)"
       EventHubSharedAccessKey="$(BuildIsOfficialEventHubSharedAccessKey)"
-      EventData="%(TestListFile.OfficialBuildJson)"
-      PartitionKey="%(TestListFile.CorrelationId)"/>
+      EventData="%(TestListFile.OfficialBuildJson)"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
This is to update the checks on the properties passed in to allow builds to be marked as "official".
@ChadNedzlek 