### PR TITLE
Support running test against desktop on Helix

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -153,9 +153,14 @@
       <FunctionalTest Include="$(TestArchivesRoot)*.zip" />
       <FunctionalTest Include="$(AnyOSTestArchivesRoot)*.zip" />
     </ItemGroup>
+
+    <PropertyGroup>
+        <_DesktopParameter Condition="'$(TargetGroup)' == 'net46'">--xunit-test-type=desktop</_DesktopParameter>
+    </PropertyGroup>
+
     <ItemGroup>
       <FunctionalTest>
-        <Command>$(HelixPythonPath) $(RunnerScript) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
+        <Command>$(HelixPythonPath) $(RunnerScript) $(_DesktopParameter) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
         <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>FunctionalTest.%(Filename)</WorkItemId>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -73,7 +73,14 @@
         Condition="$([System.String]::new('%(TestCopyLocal.NuGetPackageId)').StartsWith('$(_TargetingPackPrefix)'))" />
       <TestCopyLocal Remove="@(TestCopyLocalToRemove)" />
       
-      <TestCopyLocal Include="$(PackagesDir)xunit.runner.console/2.1.0/tools/*.*" />
+      <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.exe" />
+      <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.dll" />
+
+      <TestCopyLocal Include="@(_TestCopyLocalXunitFiles)" >
+        <NuGetPackageId>%(FileName)</NuGetPackageId>
+        <NuGetPackageVersion>2.1.0</NuGetPackageVersion>
+        <Private>false</Private>
+      </TestCopyLocal>
     </ItemGroup>
 
     <!-- We may have an indirect package reference that we want to replace with a project reference.


### PR DESCRIPTION
This change enable running the test against the desktop on Helix. the change add missed entries in the file assemblylist.txt so Helix can restore the right list of assemblies. also it add the needed parameters for the test runner command to enable the desktop