### PR TITLE
Minor Fix

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -155,12 +155,12 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <_DesktopParameter Condition="'$(TargetGroup)' == 'net46'">--xunit-test-type=desktop</_DesktopParameter>
+        <OtherRunnerScriptArgs Condition="'$(TargetGroup)' == 'net46'">$(OtherRunnerScriptArgs) --xunit-test-type=desktop </OtherRunnerScriptArgs>
     </PropertyGroup>
 
     <ItemGroup>
       <FunctionalTest>
-        <Command>$(HelixPythonPath) $(RunnerScript) $(_DesktopParameter) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
+        <Command>$(HelixPythonPath) $(RunnerScript) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
         <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>FunctionalTest.%(Filename)</WorkItemId>


### PR DESCRIPTION
This change uses OtherRunnerScriptArgs property instead of using extra property to pass the needed arguments to Helix.