### PR TITLE
Add Unix to folders to search for test archives

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -31,7 +31,11 @@
     <AnyOSPlatformConfig>AnyOS.AnyCPU.$(ConfigurationGroup)</AnyOSPlatformConfig>    
     <AnyOsArchivesRoot>$(TestWorkingDir)$(AnyOSPlatformConfig)/archive/</AnyOsArchivesRoot>
     <AnyOSTestArchivesRoot>$(AnyOsArchivesRoot)tests/</AnyOSTestArchivesRoot>
-    <!-- These archives represent the zips of tests that are OSPlatform specific -->
+    <!-- Additionally, *NIX variations may need to include their own root folders -->    
+    <UnixPlatformConfig>Unix.$(Platform).$(ConfigurationGroup)</UnixPlatformConfig>    
+    <UnixArchivesRoot>$(TestWorkingDir)$(UnixPlatformConfig)/archive/</UnixArchivesRoot>
+    <UnixTestArchivesRoot>$(UnixArchivesRoot)tests/</UnixTestArchivesRoot>
+    <!-- Finally, these archives represent the zips of tests that are OSPlatform specific -->
     <ArchivesRoot>$(TestWorkingDir)$(OSPlatformConfig)/archive/</ArchivesRoot>
     <TestArchivesRoot>$(ArchivesRoot)tests/</TestArchivesRoot>
     <PackagesArchiveFilename>Packages.zip</PackagesArchiveFilename>
@@ -46,7 +50,7 @@
     <OverwriteOnUpload Condition="'$(OverwriteOnUpload)' == ''">false</OverwriteOnUpload>
     <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
   </PropertyGroup>
-
+  
   <Import Project="$(MSBuildThisFileDirectory)CloudTest.Perf.targets" Condition="'$(Performance)' == 'true'" />
 
   <!-- main entrypoint -->
@@ -76,11 +80,16 @@
     <ItemGroup>
       <ForUpload Include="$(TestArchivesRoot)*.zip" />
       <ForUpload Include="$(AnyOSTestArchivesRoot)*.zip" />
+      <!-- Only include Unix folders if supported by the current target OS --> 
+      <ForUpload Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />      
     </ItemGroup>   
+    
     <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" /> 
     <Message Text="Using AnyOS test archives from: $(AnyOSTestArchivesRoot)" />
+    <Message Condition="'$(TargetsUnix)' == 'true'"  Text="Using Unix test archives from: $(UnixTestArchivesRoot)" />
+    
     <!-- verify the test archives were created -->
-    <Error Condition="'@(ForUpload->Count())' == '0'" Text="Didn't find any test archives in '$(TestArchivesRoot)' or $(AnyOSTestArchivesRoot)." />
+    <Error Condition="'@(ForUpload->Count())' == '0'" Text="Didn't find any test archives in supplied folders." />
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForUpload>
@@ -152,6 +161,7 @@
     <ItemGroup>
       <FunctionalTest Include="$(TestArchivesRoot)*.zip" />
       <FunctionalTest Include="$(AnyOSTestArchivesRoot)*.zip" />
+      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />  
     </ItemGroup>
 
     <PropertyGroup>
@@ -195,6 +205,10 @@
       <TestBinary Include="$(BinDir)$(AnyOSPlatformConfig)/**/*.dll" />
       <TestBinary Include="$(BinDir)$(AnyOSPlatformConfig)/**/*.exe" />
     </ItemGroup>
+    <ItemGroup Condition="'$(TargetsUnix)' == 'true'" >
+      <TestBinary Include="$(BinDir)$(UnixPlatformConfig)/**/*.dll" />
+      <TestBinary Include="$(BinDir)$(UnixPlatformConfig)/**/*.exe" />
+    </ItemGroup>
     <GetPerfTestAssemblies TestBinaries="@(TestBinary)" GetFullPaths="false">
       <Output TaskParameter="PerfTestAssemblies" ItemName="PerfTestAssembly" />
     </GetPerfTestAssemblies>
@@ -202,6 +216,7 @@
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest Include="$(TestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
       <PerfTest Include="$(AnyOSTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
+      <PerfTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
     </ItemGroup>
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest>
@@ -302,6 +317,7 @@
     <ItemGroup>
       <BuiltSuccessfully Include="$(TestArchivesRoot)*.zip" />
       <BuiltSuccessfully Include="$(AnyOSTestArchivesRoot)*.zip" />      
+      <BuiltSuccessfully Condition="'$(TargetsUnix)' == 'true'"  Include="$(UnixTestArchivesRoot)*.zip" />      
     </ItemGroup>
     <WriteTestBuildStatsJson
       CorrelationIds="@(TestListFile->'%(CorrelationId)')"


### PR DESCRIPTION
Changes to support picking up test archives from the Unix.* folder if the target platform supports Unix.  This includes OSX and all flavors of Linux.

@jhendrixMSFT  @sokket @joshfree 

For Helix folks:
OSX run id: 540452dd-bf28-46fe-be14-86b4b9320f74 
Ubuntu Run id: 314b42dd-0514-4b33-b420-90165c905dfa