### PR TITLE
Use TagetGroup Filtering property instead of TargetGroup

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -165,7 +165,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <OtherRunnerScriptArgs Condition="'$(TargetGroup)' == 'net46'">$(OtherRunnerScriptArgs) --xunit-test-type=desktop </OtherRunnerScriptArgs>
+        <OtherRunnerScriptArgs Condition="'$(FilterToTargetGroup)' == 'net46'">$(OtherRunnerScriptArgs) --xunit-test-type=desktop </OtherRunnerScriptArgs>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
FilterToTargetGroup is the property we'll use to filter on TargetGroup. for the desktop we'll have FilterToTargetGroup=net46