### PR TITLE
Update PrereleaseResolveNugetPackageAssets to support project references, use project reference for test-runtime

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExceptionFromResource.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExceptionFromResource.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    internal sealed class ExceptionFromResource : Exception
+    {
+        public string ResourceName { get; private set; }
+        public object[] MessageArgs { get; private set; }
+
+        public ExceptionFromResource(string resourceName, params object[] messageArgs)
+        {
+            ResourceName = resourceName;
+            MessageArgs = messageArgs;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ExceptionFromResource.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExceptionFromResource.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace Microsoft.DotNet.Build.Tasks
 {

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <Compile Include="BinClashLogger.cs" />
     <Compile Include="Delegates.cs" />
+    <Compile Include="ExceptionFromResource.cs" />
     <Compile Include="ExecWithMutex.cs" />
     <Compile Include="GatherFoldersToRestore.cs" />
     <Compile Include="GenerateAssemblyList.cs" />
@@ -33,9 +34,11 @@
     <Compile Include="LocatePreviousContract.cs" />
     <Compile Include="NormalizePaths.cs" />
     <Compile Include="GetDoItemsIntersect.cs" />
+    <Compile Include="NuGetPackageObject.cs" />
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="PreprocessFile.cs" />
+    <Compile Include="Preprocessor.cs" />
     <Compile Include="ReadSigningRequired.cs" />
     <Compile Include="RemoveDuplicatesWithLastOneWinsPolicy.cs" />
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/NuGetPackageObject.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/NuGetPackageObject.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Metedata and information for a package listed in the lock file.
+    /// </summary>
+    internal sealed class NuGetPackageObject
+    {
+        /// <summary>
+        /// A Lazy to get the full path to the package. In some cases we want to represent packages where we don't actually have
+        /// a path to it, but we don't care about that fact until we try getting assets to it. Thus we won't force us to have
+        /// a package path until we actually need it.
+        /// </summary>
+        private readonly Lazy<string> _fullPackagePath;
+
+        public NuGetPackageObject(string id, string version, bool isProject, Func<string> fullPackagePathGenerator, JObject targetObject, JObject libraryObject)
+        {
+            Id = id;
+            Version = version;
+            IsProject = isProject;
+            _fullPackagePath = new Lazy<string>(fullPackagePathGenerator);
+            TargetObject = targetObject;
+            LibraryObject = libraryObject;
+        }
+
+        public string Id { get; }
+        public string Version { get; }
+        public bool IsProject { get; }
+
+        /// <summary>
+        /// The JSON object from the "targets" section in the project.lock.json for this package.
+        /// </summary>
+        public JObject TargetObject { get; }
+
+        /// <summary>
+        /// The JSON object from the "libraries" section in the project.lock.json for this package.
+        /// </summary>
+        public JObject LibraryObject { get; }
+
+        public string GetFullPathToFile(string relativePath)
+        {
+            relativePath = relativePath.Replace('/', '\\');
+            return Path.Combine(_fullPackagePath.Value, relativePath);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/depProj.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/depProj.targets
@@ -23,7 +23,7 @@ See the LICENSE file in the project root for more information.
        
        NuGetTargetMoniker - determined by the TargetFramework* and TargetPlatform* 
                             properties of the project, can be overidden.
-       NuGetRuntimeIdentifier - defaults to win-$(PlatformTarget), can be overidden
+       NuGetRuntimeIdentifier - defaults to <empty> (""), can be overidden.
        NuGetDeploySourceItem - defaults to ReferenceCopyLocalPaths, can be overidden to
                                specify Reference (for compile assets) or Analyzer(for
                                analyzer assets)
@@ -32,12 +32,16 @@ See the LICENSE file in the project root for more information.
        TargetName and TargetExt to match one of the files that will be copied
        from the packages.
   -->
-  
+
   <PropertyGroup>
     <NuGetDeploySourceItem Condition="'$(NuGetDeploySourceItem)' == ''">ReferenceCopyLocalPaths</NuGetDeploySourceItem>
 
     <!-- suppress the attempt to copy build output. -->
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+
+    <!-- Unless overridden, use no runtime identifier. This is transformed in packageresolve.targets. 
+         We specify "None" here to avoid being assigned the default runtime for projects which set CopyNuGetImplementations=true. -->
+    <NuGetRuntimeIdentifier Condition="'$(NuGetRuntimeIdentifier)' == ''">None</NuGetRuntimeIdentifier>
 
     <!-- make sure we tell nuget targets to copy, even if output type would not by default -->
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
@@ -45,7 +49,7 @@ See the LICENSE file in the project root for more information.
     <!-- by default there shouldn't be any assets in depproj files that require signing -->
     <SkipSigning Condition="'$(SkipSigning)' == ''">true</SkipSigning>
   </PropertyGroup>
-  
+
   <Target Name="CoreCompile">
 
     <Error Condition="'$(NuGetDeploySourceItem)' != 'ReferenceCopyLocalPaths' AND
@@ -56,13 +60,13 @@ See the LICENSE file in the project root for more information.
     <ItemGroup>
       <!-- Don't set IntermediateAssembly since this is not produced -->
       <IntermediateAssembly Remove="@(IntermediateAssembly)" />
-      
+
       <NuGetDeploy Include="@($(NuGetDeploySourceItem))" />
       <!-- filter to only items that came from packages -->
       <!-- the following condition must be applied after the include because msbuild doesn't seem
            to support property-defined-item-names in a metadata statement -->
       <NuGetDeploy Remove="@(NuGetDeploy)" Condition="'%(NugetDeploy.NuGetPackageId)' == ''" />
-      
+
       <!-- remove all existing items from NuGet packages we'll be defining these in our own item -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''"/>
       <Reference Remove="@(Reference)" Condition="'%(Reference.NuGetPackageId)' != ''"/>
@@ -74,17 +78,17 @@ See the LICENSE file in the project root for more information.
 
     <Error Condition="'@(NuGetDeploy)' == ''" Text="Error no assets were resolved from NuGet packages." />
     <Message Importance="High" Text="%(FullPath) (%(NuGetPackageId).%(NuGetPackageVersion)) -&gt; @(NuGetDeploy->'%(FileName)%(Extension)')" />
-    
+
     <!-- Include marker files if an extension has been provided -->
     <!-- internal builds use this to distinguish files which have already been signed -->
     <Touch Condition="'$(DeployMarkerExtension)' != ''" Files="@(NuGetDeploy->'$(TargetDir)%(FileName)$(DeployMarkerExtension)')" AlwaysCreate="true">
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites"/>
     </Touch>
   </Target>
-  
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
   <!-- Required by Common.Targets but not used for depproj -->
   <Target Name="CreateManifestResourceNames" />
-  
+
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -40,11 +40,11 @@
       ResolveNuGetPackages;
       ValidatePackageVersions;
     </ResolveAssemblyReferencesDependsOn>
- </PropertyGroup>
+  </PropertyGroup>
 
- <Import Condition="'$(_BuildAgainstPackages)' == 'true'" Project="buildagainstpackages.targets" />
+  <Import Condition="'$(_BuildAgainstPackages)' == 'true'" Project="buildagainstpackages.targets" />
 
- <PropertyGroup>
+  <PropertyGroup>
     <!-- temporarily accept the old name NuGetTargetFrameworkMoniker until all projects are moved forward -->
     <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">$(NuGetTargetFrameworkMoniker)</NuGetTargetMoniker>
     <UseTargetPlatformAsNuGetTargetMoniker Condition="'$(UseTargetPlatformAsNuGetTargetMoniker)' == '' AND '$(TargetFrameworkMoniker)' == '.NETCore,Version=v5.0'">true</UseTargetPlatformAsNuGetTargetMoniker>
@@ -60,6 +60,11 @@
     <_NuGetRuntimeIdentifierWithoutAot>$(BaseNuGetRuntimeIdentifier)-$(PlatformTarget.ToLower())</_NuGetRuntimeIdentifierWithoutAot>
     <NuGetRuntimeIdentifier>$(_NuGetRuntimeIdentifierWithoutAot)</NuGetRuntimeIdentifier>
     <NuGetRuntimeIdentifier Condition="'$(UseDotNetNativeToolchain)' == 'true'">$(_NuGetRuntimeIdentifierWithoutAot)-aot</NuGetRuntimeIdentifier>
+  </PropertyGroup>
+
+  <!-- Some projects want to explicitly use no runtime identifier, and do not want to receive any default value provided by other targets. -->
+  <PropertyGroup Condition="'$(NuGetRuntimeIdentifier)' == 'None'">
+    <NuGetRuntimeIdentifier></NuGetRuntimeIdentifier>
   </PropertyGroup>
 
   <Target Name="ResolveNuGetPackages"
@@ -154,7 +159,7 @@
       <ReferenceCopyLocalPaths Remove="@(PackageCopyLocalToRemove)" />
     </ItemGroup>
 
-    <Message Importance="Low" 
+    <Message Importance="Low"
              Text="Removed all ResolvedTagetingPackReferences that were not specified explicitly as a TargetingPackReference=[@(TargetingPackReference)]. PackageReferencesToRemove=[@(PackageReferencesToRemove)]." />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -12,12 +12,6 @@
     <TargetOS Condition="'$(OSGroup)'!='AnyOS'">$(OSGroup)</TargetOS>
   </PropertyGroup>
 
-  <Target Name="RestoreTestRuntimePackage"
-          BeforeTargets="ResolveNuGetPackages"
-          Condition="'$(RestorePackages)'=='true' AND '$(IsTestProject)' == 'true' AND '$(TestRuntimeProjectJson)' != ''">
-    <Exec Command="$(DnuRestoreCommand) &quot;$(TestRuntimeProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
-  </Target>
-
   <PropertyGroup>
     <PrepareForRunDependsOn Condition="'$(IsTestProject)'=='true'">$(PrepareForRunDependsOn);CopyTestToTestDirectory;CreateTestNuGetPackage;CreateAssemblyListTxt</PrepareForRunDependsOn>
     <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
@@ -51,18 +45,13 @@
   <Target Name="CopyTestToTestDirectory"
           DependsOnTargets="DiscoverTestInputs" Condition="'$(DisableCopyTestToTestDirectory)'!='true'">
 
-    <ItemGroup>
-      <TestNugetProjectLockFile Include="$(ProjectLockJson)" Condition="Exists($(ProjectLockJson))"/>
-      <TestNugetProjectLockFile Include="$(TestRuntimeProjectLockJson)" Condition="Exists($(TestRuntimeProjectLockJson))"/>
-    </ItemGroup>
-
-    <PrereleaseResolveNuGetPackageAssets Condition="'@(TestNugetProjectLockFile)' != ''"
+    <PrereleaseResolveNuGetPackageAssets Condition="Exists($(ProjectLockJson))"
                                AllowFallbackOnTargetSelection="true"
                                IncludeFrameworkReferences="false"
                                NuGetPackagesDirectory="$(PackagesDir)"
                                RuntimeIdentifier="$(TestNugetRuntimeId)"
                                ProjectLanguage="$(Language)"
-                               ProjectLockFile="%(TestNugetProjectLockFile.FullPath)"
+                               ProjectLockFile="$(ProjectLockJson)"
                                TargetMonikers="@(TestTargetFramework)">
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </PrereleaseResolveNuGetPackageAssets>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -28,8 +28,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestWithCore)' == 'true'">
-    <TestRuntimeProjectJson Condition="'$(TestRuntimeProjectJson)' == ''">$(MSBuildThisFileDirectory)test-runtime/project.json</TestRuntimeProjectJson>
-    <TestRuntimeProjectLockJson Condition="'$(TestRuntimeProjectLockJson)' == ''">$(MSBuildThisFileDirectory)test-runtime/project.lock.json</TestRuntimeProjectLockJson>
     <!-- Invoke with the correct casing of corerun per-OS.  There are some process tests
          that check the invoked process name against known casing which fail under code coverage.
          This is probably because the code coverage target invocation does not canonicalize the

--- a/src/Microsoft.DotNet.Build.Tasks/Preprocessor.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Preprocessor.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public static class Preprocessor
+    {
+        private const char PreprocessorDelimiter = '$';
+
+        public static void Preprocess(TextReader reader, TextWriter writer, IReadOnlyDictionary<string, string> values)
+        {
+            // $$ is the escape for a $, which we can just replicate in the algorithm by giving the empty replacement the known value
+            var maximumKeyLength = values.Keys.Max<string, int?>(k => k.Length).GetValueOrDefault(0);
+            char[] buffer = new char[Math.Max(4096, maximumKeyLength + 2)];
+
+            int charsInBuffer = reader.ReadBlock(buffer, 0, buffer.Length);
+
+            while (charsInBuffer != 0)
+            {
+                int indexOfDelimiter = Array.IndexOf(buffer, PreprocessorDelimiter, 0, charsInBuffer);
+
+                if (indexOfDelimiter == -1)
+                {
+                    // If the buffer doesn't contain any delimiters, then we can immediately write it out and move on
+                    writer.Write(buffer, 0, charsInBuffer);
+                    charsInBuffer = reader.ReadBlock(buffer, 0, buffer.Length);
+                }
+                else
+                {
+                    // Write whatever is before the $ and advance up to the $
+                    writer.Write(buffer, 0, indexOfDelimiter);
+                    Advance(reader, buffer, ref charsInBuffer, charsToAdvance: indexOfDelimiter);
+
+                    // Let's read in the token name
+                    var token = new StringBuilder();
+                    int position = 1;
+
+                    while (true)
+                    {
+                        if (position == buffer.Length)
+                        {
+                            Advance(reader, buffer, ref charsInBuffer, buffer.Length);
+                            position = 0;
+                        }
+
+                        // If at end, we'll want to fall through to the last case
+                        var c = position < charsInBuffer ? buffer[position] : '\0';
+
+                        if (c == PreprocessorDelimiter)
+                        {
+                            position++;
+
+                            // Is it the escape case?
+                            string value;
+                            if (token.Length == 0)
+                            {
+                                writer.Write(PreprocessorDelimiter);
+                            }
+                            else if (values.TryGetValue(token.ToString(), out value))
+                            {
+                                writer.Write(value);
+                            }
+                            else
+                            {
+                                throw new ExceptionFromResource(nameof(Strings.UnspecifiedToken), PreprocessorDelimiter + token.ToString() + PreprocessorDelimiter);
+                            }
+
+                            break;
+                        }
+                        else if (IsTokenCharacter(c))
+                        {
+                            token.Append(c);
+                            position++;
+                        }
+                        else
+                        {
+                            // The token ended prematurely, so we just treat it verbatim and write it out
+                            writer.Write(PreprocessorDelimiter);
+                            writer.Write(token);
+
+                            break;
+                        }
+                    }
+
+                    // Advance to the next position to start all over
+                    Advance(reader, buffer, ref charsInBuffer, position);
+                }
+            }
+        }
+
+        private static bool IsTokenCharacter(char c)
+        {
+            var category = CharUnicodeInfo.GetUnicodeCategory(c);
+            return category == UnicodeCategory.LowercaseLetter ||
+                   category == UnicodeCategory.UppercaseLetter ||
+                   category == UnicodeCategory.TitlecaseLetter ||
+                   category == UnicodeCategory.OtherLetter ||
+                   category == UnicodeCategory.ModifierLetter ||
+                   category == UnicodeCategory.DecimalDigitNumber ||
+                   category == UnicodeCategory.ConnectorPunctuation;
+
+        }
+
+        private static void Advance(TextReader reader, char[] buffer, ref int charsInBuffer, int charsToAdvance)
+        {
+            Debug.Assert(charsToAdvance <= charsInBuffer);
+
+            // Move the remaining characters in the buffer forward
+            Array.Copy(sourceArray: buffer, sourceIndex: charsToAdvance, destinationArray: buffer, destinationIndex: 0, length: charsInBuffer - charsToAdvance);
+            charsInBuffer -= charsToAdvance;
+            charsInBuffer += reader.ReadBlock(buffer, charsInBuffer, buffer.Length - charsInBuffer);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
@@ -8,11 +8,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata;
-using System.Reflection.PortableExecutable;
 using System.Text;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
+using System.Security.Cryptography;
+using System.Reflection.PortableExecutable;
+using System.Reflection.Metadata;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
@@ -23,6 +24,11 @@ namespace Microsoft.DotNet.Build.Tasks
     {
         internal const string NuGetPackageIdMetadata = "NuGetPackageId";
         internal const string NuGetPackageVersionMetadata = "NuGetPackageVersion";
+        internal const string NuGetIsFrameworkReference = "NuGetIsFrameworkReference";
+        internal const string NuGetSourceType = "NuGetSourceType";
+        internal const string NuGetSourceType_Project = "Project";
+        internal const string NuGetSourceType_Package = "Package";
+
         internal const string ReferenceImplementationMetadata = "Implementation";
         internal const string ReferenceImageRuntimeMetadata = "ImageRuntime";
         internal const string ReferenceWinMDFileMetadata = "WinMDFile";
@@ -34,16 +40,20 @@ namespace Microsoft.DotNet.Build.Tasks
         internal const string NuGetAssetTypeRuntime = "runtime";
         internal const string NuGetAssetTypeResource = "resource";
 
-
         private readonly List<ITaskItem> _analyzers = new List<ITaskItem>();
         private readonly List<ITaskItem> _copyLocalItems = new List<ITaskItem>();
         private readonly List<ITaskItem> _references = new List<ITaskItem>();
         private readonly List<ITaskItem> _referencedPackages = new List<ITaskItem>();
+        private readonly List<ITaskItem> _contentItems = new List<ITaskItem>();
+        private readonly List<ITaskItem> _fileWrites = new List<ITaskItem>();
+
+        private readonly Dictionary<string, string> _projectReferencesToOutputBasePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         #region UnitTestSupport
         private readonly DirectoryExists _directoryExists = new DirectoryExists(Directory.Exists);
         private readonly FileExists _fileExists = new FileExists(File.Exists);
         private readonly TryGetRuntimeVersion _tryGetRuntimeVersion = new TryGetRuntimeVersion(TryGetRuntimeVersion);
+        private readonly bool _reportExceptionsToMSBuildLogger = true;
 
         internal PrereleaseResolveNuGetPackageAssets(DirectoryExists directoryExists, FileExists fileExists, TryGetRuntimeVersion tryGetRuntimeVersion)
             : this()
@@ -62,6 +72,8 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 _tryGetRuntimeVersion = tryGetRuntimeVersion;
             }
+
+            _reportExceptionsToMSBuildLogger = false;
         }
         #endregion
 
@@ -70,6 +82,7 @@ namespace Microsoft.DotNet.Build.Tasks
         /// </summary>
         public PrereleaseResolveNuGetPackageAssets()
         {
+            Log.TaskResources = Strings.ResourceManager;
         }
 
         /// <summary>
@@ -106,6 +119,44 @@ namespace Microsoft.DotNet.Build.Tasks
         public ITaskItem[] ReferencedPackages
         {
             get { return _referencedPackages.ToArray(); }
+        }
+
+        /// <summary>
+        /// Additional content items provided from NuGet packages.
+        /// </summary>
+        [Output]
+        public ITaskItem[] ContentItems => _contentItems.ToArray();
+
+        /// <summary>
+        /// Files written to during the generation process.
+        /// </summary>
+        [Output]
+        public ITaskItem[] FileWrites => _fileWrites.ToArray();
+
+        /// <summary>
+        /// Items specifying the tokens that can be substituted into preprocessed content files. The ItemSpec of each item is
+        /// the name of the token, without the surrounding $$, and the Value metadata should specify the replacement value.
+        /// </summary>
+        public ITaskItem[] ContentPreprocessorValues
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// A list of project references that are creating packages as listed in the lock file. The OutputPath metadata should
+        /// set on each of these items, which is used by the task to construct full output paths to assets.
+        /// </summary>
+        public ITaskItem[] ProjectReferencesCreatingPackages
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// The base output directory where the temporary, preprocessed files should be written to.
+        /// </summary>
+        public string ContentPreprocessorOutputDirectory
+        {
+            get; set;
         }
 
         /// <summary>
@@ -153,21 +204,21 @@ namespace Microsoft.DotNet.Build.Tasks
         /// </summary>
         public override bool Execute()
         {
-            Log.TaskResources = Strings.ResourceManager;
-
             try
             {
                 ExecuteCore();
                 return true;
             }
-            catch (ExceptionFromResource e)
+            catch (ExceptionFromResource e) when (_reportExceptionsToMSBuildLogger)
             {
                 Log.LogErrorFromResources(e.ResourceName, e.MessageArgs);
                 return false;
             }
-            catch (Exception e)
+            catch (Exception e) when (_reportExceptionsToMSBuildLogger)
             {
-                Log.LogErrorFromException(e);
+                // Any user-visible exceptions we throw should be ExceptionFromResource, so here we should dump stacks because
+                // something went very wrong.
+                Log.LogErrorFromException(e, showStackTrace: true);
                 return false;
             }
         }
@@ -176,7 +227,7 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             if (!_fileExists(ProjectLockFile))
             {
-                throw new ExceptionFromResource("LockFileNotFound", ProjectLockFile);
+                throw new ExceptionFromResource(nameof(Strings.LockFileNotFound), ProjectLockFile);
             }
 
             JObject lockFile;
@@ -184,11 +235,30 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 lockFile = JObject.Load(new JsonTextReader(streamReader));
             }
-            
+
+            PopulateProjectReferenceMaps();
             GetReferences(lockFile);
             GetCopyLocalItems(lockFile);
             GetAnalyzers(lockFile);
             GetReferencedPackages(lockFile);
+            ProduceContentAssets(lockFile);
+        }
+
+        private void PopulateProjectReferenceMaps()
+        {
+            foreach (var projectReference in ProjectReferencesCreatingPackages ?? new ITaskItem[] { })
+            {
+                var fullPath = GetAbsolutePathFromProjectRelativePath(projectReference.ItemSpec);
+                if (_projectReferencesToOutputBasePaths.ContainsKey(fullPath))
+                {
+                    Log.LogWarningFromResources(nameof(Strings.DuplicateProjectReference), fullPath, nameof(ProjectReferencesCreatingPackages));
+                }
+                else
+                {
+                    var outputPath = projectReference.GetMetadata("OutputBasePath");
+                    _projectReferencesToOutputBasePaths.Add(fullPath, outputPath);
+                }
+            }
         }
 
         private void GetReferences(JObject lockFile)
@@ -197,16 +267,9 @@ namespace Microsoft.DotNet.Build.Tasks
             var frameworkReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var fileNamesOfRegularReferences = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var package in target)
+            foreach (var package in GetPackagesFromTarget(lockFile, target))
             {
-                var packageNameParts = package.Key.Split('/');
-                var packageName = packageNameParts[0];
-                var packageVersion = packageNameParts[1];
-
-
-                Log.LogMessageFromResources(MessageImportance.Low, "ResolvedReferencesFromPackage", packageName);
-
-                foreach (var referenceItem in CreateItems(packageName, packageVersion, package.Value, NuGetAssetTypeCompile))
+                foreach (var referenceItem in CreateItems(package, NuGetAssetTypeCompile, includePdbs: false))
                 {
                     _references.Add(referenceItem);
 
@@ -215,7 +278,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 if (IncludeFrameworkReferences)
                 {
-                    var frameworkAssembliesArray = package.Value["frameworkAssemblies"] as JArray;
+                    var frameworkAssembliesArray = package.TargetObject["frameworkAssemblies"] as JArray;
                     if (frameworkAssembliesArray != null)
                     {
                         foreach (var frameworkAssembly in frameworkAssembliesArray.OfType<JToken>())
@@ -228,7 +291,10 @@ namespace Microsoft.DotNet.Build.Tasks
 
             foreach (var frameworkReference in frameworkReferences.Except(fileNamesOfRegularReferences, StringComparer.OrdinalIgnoreCase))
             {
-                _references.Add(new TaskItem(frameworkReference));
+                var item = new TaskItem(frameworkReference);
+                item.SetMetadata(NuGetIsFrameworkReference, "true");
+                item.SetMetadata(NuGetSourceType, NuGetSourceType_Package);
+                _references.Add(item);
             }
         }
 
@@ -246,15 +312,9 @@ namespace Microsoft.DotNet.Build.Tasks
             HashSet<string> candidateNativeImplementations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             List<ITaskItem> runtimeWinMDItems = new List<ITaskItem>();
 
-            foreach (var package in target)
+            foreach (var package in GetPackagesFromTarget(lockFile, target))
             {
-                var packageNameParts = package.Key.Split('/');
-                var packageName = packageNameParts[0];
-                var packageVersion = packageNameParts[1];
-
-                Log.LogMessageFromResources(MessageImportance.Low, "ResolvedReferencesFromPackage", packageName);
-
-                foreach(var nativeItem in CreateItems(packageName, packageVersion, package.Value, NuGetAssetTypeNative))
+                foreach (var nativeItem in CreateItems(package, NuGetAssetTypeNative))
                 {
                     if (Path.GetExtension(nativeItem.ItemSpec).Equals(".dll", StringComparison.OrdinalIgnoreCase))
                     {
@@ -264,7 +324,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     _copyLocalItems.Add(nativeItem);
                 }
 
-                foreach (var runtimeItem in CreateItems(packageName, packageVersion, package.Value, NuGetAssetTypeRuntime))
+                foreach (var runtimeItem in CreateItems(package, NuGetAssetTypeRuntime))
                 {
                     if (Path.GetExtension(runtimeItem.ItemSpec).Equals(".winmd", StringComparison.OrdinalIgnoreCase))
                     {
@@ -274,7 +334,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     _copyLocalItems.Add(runtimeItem);
                 }
 
-                foreach (var resourceItem in CreateItems(packageName, packageVersion, package.Value, NuGetAssetTypeResource))
+                foreach (var resourceItem in CreateItems(package, NuGetAssetTypeResource))
                 {
                     _copyLocalItems.Add(resourceItem);
                 }
@@ -289,37 +349,28 @@ namespace Microsoft.DotNet.Build.Tasks
             // scenario where somebody has a library but on .NET Native might have some specific restrictions that need to be enforced.
             var target = GetTargetOrAttemptFallback(lockFile, needsRuntimeIdentifier: !string.IsNullOrEmpty(RuntimeIdentifier));
 
-            var libraries = (JObject)lockFile["libraries"];
-
-            foreach (var package in target.Children())
+            foreach (var package in GetPackagesFromTarget(lockFile, target))
             {
-                var name = (package is JProperty) ? ((JProperty)package).Name : null;
-                var packageNameParts = name != null ? name.Split('/') : null;
-                if (packageNameParts == null)
+                var files = package.LibraryObject["files"];
+
+                if (files != null)
                 {
-                    continue;
-                }
-
-                var packageId = packageNameParts[0];
-                var packageVersion = packageNameParts[1];
-
-                var librariesPackage = libraries[name];
-
-                foreach (var file in librariesPackage["files"].Children()
-                                    .Select(x => x.ToString())
-                                    .Where(x => x.StartsWith("analyzers")))
-                {
-                    if (Path.GetExtension(file).Equals(".dll", StringComparison.OrdinalIgnoreCase))
+                    foreach (var file in files.Children()
+                                        .Select(x => x.ToString())
+                                        .Where(x => x.StartsWith("analyzers")))
                     {
-                        string path;
-                        if (TryGetFile(packageId, packageVersion, file, out path))
+                        if (Path.GetExtension(file).Equals(".dll", StringComparison.OrdinalIgnoreCase))
                         {
-                            var analyzer = new TaskItem(path);
+                            string path;
+                            if (TryGetFile(package.Id, package.Version, file, out path))
+                            {
+                                var analyzer = new TaskItem(path);
 
-                            analyzer.SetMetadata(NuGetPackageIdMetadata, packageId);
-                            analyzer.SetMetadata(NuGetPackageVersionMetadata, packageVersion);
+                                analyzer.SetMetadata(NuGetPackageIdMetadata, package.Id);
+                                analyzer.SetMetadata(NuGetPackageVersionMetadata, package.Version);
 
-                            _analyzers.Add(analyzer);
+                                _analyzers.Add(analyzer);
+                            }
                         }
                     }
                 }
@@ -328,7 +379,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private void SetWinMDMetadata(IEnumerable<ITaskItem> runtimeWinMDs, ICollection<string> candidateImplementations)
         {
-            foreach(var winMD in runtimeWinMDs.Where(w => _fileExists(w.ItemSpec)))
+            foreach (var winMD in runtimeWinMDs.Where(w => _fileExists(w.ItemSpec)))
             {
                 string imageRuntimeVersion = _tryGetRuntimeVersion(winMD.ItemSpec);
 
@@ -402,12 +453,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private bool IsFileValid(string file, string expectedLanguage, string unExpectedLanguage)
         {
-
-            if(ProjectLanguage == null)
-            {
-                throw new ExceptionFromResource("NoProgrammingLanguageSpecified");
-            }
-
             var expectedProjectLanguage = expectedLanguage;
             expectedLanguage = expectedLanguage == "C#" ? "cs" : expectedLanguage;
             unExpectedLanguage = unExpectedLanguage == "C#" ? "cs" : unExpectedLanguage;
@@ -420,6 +465,175 @@ namespace Microsoft.DotNet.Build.Tasks
         private string GetPath(string packageName, string packageVersion, string file)
         {
             return Path.Combine(GetNuGetPackagePath(packageName, packageVersion), file.Replace('/', '\\'));
+        }
+
+        /// <summary>
+        /// Produces a string hash of the key/values in the dictionary. This hash is used to put all the
+        /// preprocessed files into a folder with the name so we know to regenerate when any of the
+        /// inputs change.
+        /// </summary>
+        private string BuildPreprocessedContentHash(IReadOnlyDictionary<string, string> values)
+        {
+            using (var stream = new MemoryStream())
+            {
+                using (var streamWriter = new StreamWriter(stream, Encoding.UTF8, bufferSize: 4096, leaveOpen: true))
+                {
+                    foreach (var pair in values.OrderBy(v => v.Key))
+                    {
+                        streamWriter.Write(pair.Key);
+                        streamWriter.Write('\0');
+                        streamWriter.Write(pair.Value);
+                        streamWriter.Write('\0');
+                    }
+                }
+
+                stream.Position = 0;
+
+                return SHA1.Create().ComputeHash(stream).Aggregate("", (s, b) => s + b.ToString("x2"));
+            }
+        }
+
+        private void ProduceContentAssets(JObject lockFile)
+        {
+            string valueSpecificPreprocessedOutputDirectory = null;
+            var preprocessorValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            // If a preprocessor directory isn't set, then we won't have a place to generate.
+            if (!string.IsNullOrEmpty(ContentPreprocessorOutputDirectory))
+            {
+                // Assemble the preprocessor values up-front
+                var duplicatedPreprocessorKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var preprocessorValueItem in ContentPreprocessorValues ?? Enumerable.Empty<ITaskItem>())
+                {
+                    if (preprocessorValues.ContainsKey(preprocessorValueItem.ItemSpec))
+                    {
+                        duplicatedPreprocessorKeys.Add(preprocessorValueItem.ItemSpec);
+                    }
+
+                    preprocessorValues[preprocessorValueItem.ItemSpec] = preprocessorValueItem.GetMetadata("Value");
+                }
+
+                foreach (var duplicatedPreprocessorKey in duplicatedPreprocessorKeys)
+                {
+                    Log.LogWarningFromResources(nameof(Strings.DuplicatePreprocessorToken), duplicatedPreprocessorKey, preprocessorValues[duplicatedPreprocessorKey]);
+                }
+
+                valueSpecificPreprocessedOutputDirectory = Path.Combine(ContentPreprocessorOutputDirectory, BuildPreprocessedContentHash(preprocessorValues));
+            }
+
+            // For shared content, it does not depend upon the RID so we should ignore it
+            var target = GetTargetOrAttemptFallback(lockFile, needsRuntimeIdentifier: false);
+
+            foreach (var package in GetPackagesFromTarget(lockFile, target))
+            {
+                var contentFiles = package.TargetObject["contentFiles"] as JObject;
+                if (contentFiles != null)
+                {
+                    // Is there an asset with our exact language? If so, we use that. Otherwise we'll simply collect "any" assets.
+                    string codeLanguageToSelect;
+
+                    if (string.IsNullOrEmpty(ProjectLanguage))
+                    {
+                        codeLanguageToSelect = "any";
+                    }
+                    else
+                    {
+                        string nuGetLanguageName = GetNuGetLanguageName(ProjectLanguage);
+                        if (contentFiles.Properties().Any(a => (string)a.Value["codeLanguage"] == nuGetLanguageName))
+                        {
+                            codeLanguageToSelect = nuGetLanguageName;
+                        }
+                        else
+                        {
+                            codeLanguageToSelect = "any";
+                        }
+                    }
+
+                    foreach (var contentFile in contentFiles.Properties())
+                    {
+                        // Ignore magic _._ placeholder files. We couldn't ignore them during the project language
+                        // selection, since you could imagine somebody might have a package that puts assets under
+                        // "any" but then uses _._ to opt some languages out of it
+                        if (Path.GetFileName(contentFile.Name) != "_._")
+                        {
+                            if ((string)contentFile.Value["codeLanguage"] == codeLanguageToSelect)
+                            {
+                                ProduceContentAsset(package, contentFile, preprocessorValues, valueSpecificPreprocessedOutputDirectory);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string GetNuGetLanguageName(string projectLanguage)
+        {
+            switch (projectLanguage)
+            {
+                case "C#": return "cs";
+                case "F#": return "fs";
+                default: return projectLanguage.ToLowerInvariant();
+            }
+        }
+
+        /// <summary>
+        /// Produces the asset for a single shared asset. All applicablility checks have already been completed.
+        /// </summary>
+        private void ProduceContentAsset(NuGetPackageObject package, JProperty sharedAsset, IReadOnlyDictionary<string, string> preprocessorValues, string preprocessedOutputDirectory)
+        {
+            string pathToFinalAsset = package.GetFullPathToFile(sharedAsset.Name);
+
+            if (sharedAsset.Value["ppOutputPath"] != null)
+            {
+                if (preprocessedOutputDirectory == null)
+                {
+                    throw new ExceptionFromResource(nameof(Strings.PreprocessedDirectoryNotSet), nameof(ContentPreprocessorOutputDirectory));
+                }
+
+                // We need the preprocessed output, so let's run the preprocessor here
+                pathToFinalAsset = Path.Combine(preprocessedOutputDirectory, package.Id, package.Version, (string)sharedAsset.Value["ppOutputPath"]);
+
+                if (!File.Exists(pathToFinalAsset))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(pathToFinalAsset));
+
+                    using (var input = new StreamReader(new FileStream(package.GetFullPathToFile(sharedAsset.Name), FileMode.Open, FileAccess.Read, FileShare.Read), detectEncodingFromByteOrderMarks: true))
+                    using (var output = new StreamWriter(new FileStream(pathToFinalAsset, FileMode.OpenOrCreate, FileAccess.Write, FileShare.Write), encoding: input.CurrentEncoding))
+                    {
+                        Preprocessor.Preprocess(input, output, preprocessorValues);
+                    }
+
+                    _fileWrites.Add(new TaskItem(pathToFinalAsset));
+                }
+            }
+
+            if ((bool)sharedAsset.Value["copyToOutput"])
+            {
+                string outputPath = (string)sharedAsset.Value["outputPath"] ?? (string)sharedAsset.Value["ppOutputPath"];
+
+                if (outputPath != null)
+                {
+                    var item = CreateItem(package, pathToFinalAsset, targetPath: outputPath);
+                    _copyLocalItems.Add(item);
+                }
+            }
+
+            string buildAction = (string)sharedAsset.Value["buildAction"];
+            if (!string.Equals(buildAction, "none", StringComparison.OrdinalIgnoreCase))
+            {
+                var item = CreateItem(package, pathToFinalAsset);
+
+                // We'll put additional metadata on the item so we can convert it back to the real item group in our targets
+                item.SetMetadata("NuGetItemType", buildAction);
+
+                // If this is XAML, the build targets expect Link metadata to construct the relative path
+                if (string.Equals(buildAction, "Page", StringComparison.OrdinalIgnoreCase))
+                {
+                    item.SetMetadata("Link", Path.Combine("NuGet", package.Id, package.Version, Path.GetFileName(sharedAsset.Name)));
+                }
+
+                _contentItems.Add(item);
+            }
         }
 
         /// <summary>
@@ -444,19 +658,33 @@ namespace Microsoft.DotNet.Build.Tasks
                 }
             }
 
-            var preferredForErrorMessages = GetTargetMonikerWithOptionalRuntimeIdentifier(TargetMonikers.First(), needsRuntimeIdentifier);
-            if (!AllowFallbackOnTargetSelection)
+            // If we need a runtime identifier, let's see if we have the framework targeted. If we do,
+            // then we can give a better error message.
+            bool onlyNeedsRuntimeInProjectJson = false;
+            if (needsRuntimeIdentifier)
             {
-                // If we're not falling back then abort the build
-                throw new ExceptionFromResource("MissingEntryInLockFile", preferredForErrorMessages);
+                foreach (var targetMoniker in TargetMonikers)
+                {
+                    var targetMonikerWithoutRuntimeIdentifier = GetTargetMonikerWithOptionalRuntimeIdentifier(targetMoniker, needsRuntimeIdentifier: false);
+                    if (targets[targetMonikerWithoutRuntimeIdentifier] != null)
+                    {
+                        // We do have a TXM being targeted, so we just are missing the runtime
+                        onlyNeedsRuntimeInProjectJson = true;
+                        break;
+                    }
+                }
             }
 
-            // We are allowing fallback, so we'll still give a warning but allow us to continue
-            // In production ResolveNuGetPackageAssets, this call is LogWarningFromResources.
-            // In our current use in dotnet\buildtools, we rely on the fallback behavior, so we just log
-            // this as a message.
-            Log.LogMessageFromResources("MissingEntryInLockFile", preferredForErrorMessages);
+            if (onlyNeedsRuntimeInProjectJson)
+            {
+                GiveErrorForMissingRuntimeIdentifier();
+            }
+            else
+            {
+                ThrowExceptionIfNotAllowingFallback(nameof(Strings.MissingFramework), TargetMonikers.First().ItemSpec);
+            }
 
+            // If we're still here, that means we're allowing fallback, so let's try
             foreach (var fallback in TargetMonikers)
             {
                 var target = (JObject)targets[GetTargetMonikerWithOptionalRuntimeIdentifier(fallback, needsRuntimeIdentifier: false)];
@@ -472,10 +700,53 @@ namespace Microsoft.DotNet.Build.Tasks
             var firstTarget = (JObject)enumerableTargets.FirstOrDefault().Value;
             if (firstTarget == null)
             {
-                throw new ExceptionFromResource("NoTargetsInLockFile");
+                throw new ExceptionFromResource(nameof(Strings.NoTargetsInLockFile));
             }
 
             return firstTarget;
+        }
+
+        private void GiveErrorForMissingRuntimeIdentifier()
+        {
+            string runtimePiece = '"' + RuntimeIdentifier + "\": { }";
+
+            bool hasRuntimesSection;
+            try
+            {
+                using (var streamReader = new StreamReader(new FileStream(ProjectLockFile.Replace(".lock.json", ".json"), FileMode.Open, FileAccess.Read, FileShare.Read)))
+                {
+                    var jsonFile = JObject.Load(new JsonTextReader(streamReader));
+                    hasRuntimesSection = jsonFile["runtimes"] != null;
+                }
+            }
+            catch
+            {
+                // User has a bad file, locked file, no file at all, etc. We'll just assume they have one.
+                hasRuntimesSection = true;
+            }
+
+            if (hasRuntimesSection)
+            {
+                ThrowExceptionIfNotAllowingFallback(nameof(Strings.MissingRuntimeInRuntimesSection), RuntimeIdentifier, runtimePiece);
+            }
+            else
+            {
+                var runtimesSection = "\"runtimes\": { " + runtimePiece + " }";
+                ThrowExceptionIfNotAllowingFallback(nameof(Strings.MissingRuntimesSection), runtimesSection);
+            }
+        }
+
+        private void ThrowExceptionIfNotAllowingFallback(string resourceName, params string[] messageArgs)
+        {
+            if (!AllowFallbackOnTargetSelection)
+            {
+                throw new ExceptionFromResource(resourceName, messageArgs);
+            }
+            else
+            {
+                // We are allowing fallback, so we'll still give a warning but allow us to continue
+                Log.LogWarningFromResources(resourceName, messageArgs);
+            }
         }
 
         private string GetTargetMonikerWithOptionalRuntimeIdentifier(ITaskItem preferredTargetMoniker, bool needsRuntimeIdentifier)
@@ -483,9 +754,9 @@ namespace Microsoft.DotNet.Build.Tasks
             return needsRuntimeIdentifier ? preferredTargetMoniker.ItemSpec + "/" + RuntimeIdentifier : preferredTargetMoniker.ItemSpec;
         }
 
-        private IEnumerable<ITaskItem> CreateItems(string packageId, string packageVersion, JToken packageObject, string key)
+        private IEnumerable<ITaskItem> CreateItems(NuGetPackageObject package, string key, bool includePdbs = true)
         {
-            var values = packageObject[key] as JObject;
+            var values = package.TargetObject[key] as JObject;
             var items = new List<ITaskItem>();
 
             if (values == null)
@@ -493,97 +764,84 @@ namespace Microsoft.DotNet.Build.Tasks
                 return items;
             }
 
-            var nugetPackage = GetNuGetPackagePath(packageId, packageVersion);
-
-            foreach (string file in values.Properties().Select(p => p.Name))
+            foreach (var file in values.Properties())
             {
-                if (Path.GetFileName(file) == "_._")
+                if (Path.GetFileName(file.Name) == "_._")
                 {
                     continue;
                 }
 
-                var sanitizedFile = file.Replace('/', '\\');
-                var nugetPath = Path.Combine(nugetPackage, sanitizedFile);
-                var item = new TaskItem(nugetPath);
+                string targetPath = null;
+                string culture = file.Value["locale"]?.ToString();
 
-                item.SetMetadata(NuGetPackageIdMetadata, packageId);
-                item.SetMetadata(NuGetPackageVersionMetadata, packageVersion);
-                item.SetMetadata("Private", "false");
-
-                string targetPath = TryGetTargetPath(sanitizedFile);
-
-                if (targetPath != null)
+                if (culture != null)
                 {
-                    var destinationSubDirectory = Path.GetDirectoryName(targetPath);
-
-                    if (!string.IsNullOrEmpty(destinationSubDirectory))
-                    {
-                        item.SetMetadata("DestinationSubDirectory", destinationSubDirectory + "\\");
-                    }
-
-                    item.SetMetadata("TargetPath", targetPath);
+                    targetPath = Path.Combine(culture, Path.GetFileName(file.Name));
                 }
 
+                var item = CreateItem(package, package.GetFullPathToFile(file.Name), targetPath);
+
+                item.SetMetadata("Private", "false");
+                item.SetMetadata(NuGetIsFrameworkReference, "false");
+                item.SetMetadata(NuGetSourceType, package.IsProject ? NuGetSourceType_Project : NuGetSourceType_Package);
+
                 items.Add(item);
+
+                // If there's a PDB alongside the implementation, we should copy that as well
+                if (includePdbs)
+                {
+                    var pdbFileName = Path.ChangeExtension(item.ItemSpec, ".pdb");
+
+                    if (_fileExists(pdbFileName))
+                    {
+                        var pdbItem = new TaskItem(pdbFileName);
+
+                        // CopyMetadataTo also includes an OriginalItemSpec that will point to our original item, as we want
+                        item.CopyMetadataTo(pdbItem);
+
+                        items.Add(pdbItem);
+                    }
+                }
             }
 
             return items;
         }
 
-        private static string TryGetTargetPath(string file)
+        private static ITaskItem CreateItem(NuGetPackageObject package, string itemSpec, string targetPath = null)
         {
-            var foldersAndFile = file.Split('\\').ToArray();
-#if TODO // Not sure if we support culture specific directories yet...
-            for (int i = foldersAndFile.Length - 1; i > -1; i--)
+            var item = new TaskItem(itemSpec);
+
+            item.SetMetadata(NuGetPackageIdMetadata, package.Id);
+            item.SetMetadata(NuGetPackageVersionMetadata, package.Version);
+
+            if (targetPath != null)
             {
-                if (CultureStringUtilities.IsValidCultureString(foldersAndFile[i]))
+                item.SetMetadata("TargetPath", targetPath);
+
+                var destinationSubDirectory = Path.GetDirectoryName(targetPath);
+
+                if (!string.IsNullOrEmpty(destinationSubDirectory))
                 {
-                    return Path.Combine(foldersAndFile.Skip(i).ToArray());
+                    item.SetMetadata("DestinationSubDirectory", destinationSubDirectory + "\\");
                 }
             }
-#endif
-            // There is no culture-specific directory, so it'll go in the root
-            return null;
+
+            return item;
         }
 
         private void GetReferencedPackages(JObject lockFile)
         {
             var projectFileDependencyGroups = (JObject)lockFile["projectFileDependencyGroups"];
+            var projectFileDependencies = (JArray)projectFileDependencyGroups[""];
 
-            // find whichever target we will have selected
-            var actualTarget = GetTargetOrAttemptFallback(lockFile, needsRuntimeIdentifier: false)?.Parent as JProperty;
-            string targetMoniker = null;
-            if (actualTarget != null)
+            foreach (var packageDependency in projectFileDependencies.Select(v => (string)v))
             {
-                targetMoniker = actualTarget.Name.Split('/').FirstOrDefault();
-            }
+                int firstSpace = packageDependency.IndexOf(' ');
 
-            foreach (var dependencyGroup in projectFileDependencyGroups.Values<JProperty>())
-            {
-                if (dependencyGroup.Name.Length == 0 || dependencyGroup.Name == targetMoniker)
+                if (firstSpace > -1)
                 {
-                    foreach (var packageDependency in dependencyGroup.Value.Values<string>())
-                    {
-                        int firstSpace = packageDependency.IndexOf(' ');
-
-                        if (firstSpace > -1)
-                        {
-                            _referencedPackages.Add(new TaskItem(packageDependency.Substring(0, firstSpace)));
-                        }
-                    }
+                    _referencedPackages.Add(new TaskItem(packageDependency.Substring(0, firstSpace)));
                 }
-            }
-        }
-
-        private sealed class ExceptionFromResource : Exception
-        {
-            public string ResourceName { get; private set; }
-            public object[] MessageArgs { get; private set; }
-
-            public ExceptionFromResource(string resourceName, params object[] messageArgs)
-            {
-                ResourceName = resourceName;
-                MessageArgs = messageArgs;
             }
         }
 
@@ -594,7 +852,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
             if (!_directoryExists(packagePath))
             {
-                throw new ExceptionFromResource("PackageFolderNotFound", packageId, packageVersion, packagesFolder);
+                throw new ExceptionFromResource(nameof(Strings.PackageFolderNotFound), packageId, packageVersion, packagesFolder);
             }
 
             return packagePath;
@@ -616,7 +874,58 @@ namespace Microsoft.DotNet.Build.Tasks
 
             return string.Empty;
         }
-        
+
+        private IEnumerable<NuGetPackageObject> GetPackagesFromTarget(JObject lockFile, JObject target)
+        {
+            foreach (var package in target)
+            {
+                var nameParts = package.Key.Split('/');
+                var id = nameParts[0];
+                var version = nameParts[1];
+                bool isProject = false;
+
+                var libraryObject = (JObject)lockFile["libraries"][package.Key];
+
+                Func<string> fullPackagePathGenerator;
+
+                // If this is a project then we need to figure out it's relative output path
+                if ((string)libraryObject["type"] == "project")
+                {
+                    isProject = true;
+
+                    fullPackagePathGenerator = () =>
+                    {
+                        var relativeMSBuildProjectPath = (string)libraryObject["msbuildProject"];
+
+                        if (string.IsNullOrEmpty(relativeMSBuildProjectPath))
+                        {
+                            throw new ExceptionFromResource(nameof(Strings.MissingMSBuildPathInProjectPackage), id);
+                        }
+
+                        var absoluteMSBuildProjectPath = GetAbsolutePathFromProjectRelativePath(relativeMSBuildProjectPath);
+                        string fullPackagePath;
+                        if (!_projectReferencesToOutputBasePaths.TryGetValue(absoluteMSBuildProjectPath, out fullPackagePath))
+                        {
+                            throw new ExceptionFromResource(nameof(Strings.MissingProjectReference), absoluteMSBuildProjectPath, nameof(ProjectReferencesCreatingPackages));
+                        }
+
+                        return fullPackagePath;
+                    };
+                }
+                else
+                {
+                    fullPackagePathGenerator = () => GetNuGetPackagePath(id, version);
+                }
+
+                yield return new NuGetPackageObject(id, version, isProject, fullPackagePathGenerator, (JObject)package.Value, libraryObject);
+            }
+        }
+
+        private string GetAbsolutePathFromProjectRelativePath(string path)
+        {
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(ProjectLockFile)), path));
+        }
+
         /// <summary>
         /// Parse the imageRuntimeVersion from COR header
         /// </summary>

--- a/src/Microsoft.DotNet.Build.Tasks/Strings.Designer.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Strings.Designer.cs
@@ -62,6 +62,24 @@ namespace Microsoft.DotNet.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The preprocessor token &apos;{0}&apos; has been given more than one value. Choosing &apos;{1}&apos; as the value..
+        /// </summary>
+        internal static string DuplicatePreprocessorToken {
+            get {
+                return ResourceManager.GetString("DuplicatePreprocessorToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project &apos;{0}&apos; was referenced more than once in the {1} property. Ignoring all but the first..
+        /// </summary>
+        internal static string DuplicateProjectReference {
+            get {
+                return ResourceManager.GetString("DuplicateProjectReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The dependency section {0} from the project.lock.json could not be parsed..
         /// </summary>
         internal static string InvalidDependencyFormat {
@@ -85,6 +103,51 @@ namespace Microsoft.DotNet.Build.Tasks {
         internal static string MissingEntryInLockFile {
             get {
                 return ResourceManager.GetString("MissingEntryInLockFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project is not referencing the &quot;{0}&quot; framework. Add a reference to &quot;{0}&quot; in the &quot;frameworks&quot; section of your project.json, and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingFramework {
+            get {
+                return ResourceManager.GetString("MissingFramework", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project is consuming assets from the project &apos;{0}&apos; but no MSBuild project is found in the project.lock.json. Check the project references in your project file, and re-run NuGet restore..
+        /// </summary>
+        internal static string MissingMSBuildPathInProjectPackage {
+            get {
+                return ResourceManager.GetString("MissingMSBuildPathInProjectPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project.json is referencing the project &apos;{0}&apos;, but an output path was not specified on an item in the {1} property..
+        /// </summary>
+        internal static string MissingProjectReference {
+            get {
+                return ResourceManager.GetString("MissingProjectReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project.json doesn&apos;t list &apos;{0}&apos; as a targeted runtime. You should add &apos;{1}&apos; inside your &quot;runtimes&quot; section in your project.json, and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingRuntimeInRuntimesSection {
+            get {
+                return ResourceManager.GetString("MissingRuntimeInRuntimesSection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your project.json doesn&apos;t have a runtimes section. You should add &apos;{0}&apos; to your project.json and then re-run NuGet restore..
+        /// </summary>
+        internal static string MissingRuntimesSection {
+            get {
+                return ResourceManager.GetString("MissingRuntimesSection", resourceCulture);
             }
         }
         
@@ -125,11 +188,29 @@ namespace Microsoft.DotNet.Build.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The {0} property must be set in order to consume preprocessed content..
+        /// </summary>
+        internal static string PreprocessedDirectoryNotSet {
+            get {
+                return ResourceManager.GetString("PreprocessedDirectoryNotSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Resolved references from {0}:.
         /// </summary>
         internal static string ResolvedReferencesFromPackage {
             get {
                 return ResourceManager.GetString("ResolvedReferencesFromPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The token &apos;{0}&apos; is unrecognized..
+        /// </summary>
+        internal static string UnspecifiedToken {
+            get {
+                return ResourceManager.GetString("UnspecifiedToken", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks/Strings.resx
+++ b/src/Microsoft.DotNet.Build.Tasks/Strings.resx
@@ -141,4 +141,31 @@
   <data name="NoProgrammingLanguageSpecified" xml:space="preserve">
     <value>"The ProjectLanguage task parameter cannot be null."</value>
   </data>
+  <data name="DuplicateProjectReference" xml:space="preserve">
+    <value>The project '{0}' was referenced more than once in the {1} property. Ignoring all but the first.</value>
+  </data>
+  <data name="DuplicatePreprocessorToken" xml:space="preserve">
+    <value>The preprocessor token '{0}' has been given more than one value. Choosing '{1}' as the value.</value>
+  </data>
+  <data name="MissingFramework" xml:space="preserve">
+    <value>Your project is not referencing the "{0}" framework. Add a reference to "{0}" in the "frameworks" section of your project.json, and then re-run NuGet restore.</value>
+  </data>
+  <data name="MissingMSBuildPathInProjectPackage" xml:space="preserve">
+    <value>Your project is consuming assets from the project '{0}' but no MSBuild project is found in the project.lock.json. Check the project references in your project file, and re-run NuGet restore.</value>
+  </data>
+  <data name="MissingProjectReference" xml:space="preserve">
+    <value>The project.json is referencing the project '{0}', but an output path was not specified on an item in the {1} property.</value>
+  </data>
+  <data name="MissingRuntimeInRuntimesSection" xml:space="preserve">
+    <value>Your project.json doesn't list '{0}' as a targeted runtime. You should add '{1}' inside your "runtimes" section in your project.json, and then re-run NuGet restore.</value>
+  </data>
+  <data name="MissingRuntimesSection" xml:space="preserve">
+    <value>Your project.json doesn't have a runtimes section. You should add '{0}' to your project.json and then re-run NuGet restore.</value>
+  </data>
+  <data name="PreprocessedDirectoryNotSet" xml:space="preserve">
+    <value>The {0} property must be set in order to consume preprocessed content.</value>
+  </data>
+  <data name="UnspecifiedToken" xml:space="preserve">
+    <value>The token '{0}' is unrecognized.</value>
+  </data>
 </root>

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateProjectDependencyVersions.cs
@@ -163,6 +163,12 @@ namespace Microsoft.DotNet.Build.Tasks
             string version;
             if (package.Value is JObject)
             {
+                JToken target = package.Value["target"];
+                if (target != null && target.Value<string>() == "project")
+                {
+                    return false;
+                }
+
                 version = package.Value["version"].Value<string>();
             }
             else if (package.Value is JValue)


### PR DESCRIPTION
This updates the fork we have of PrereleaseResolveNugetPackageAssets in order to support the use of project references in dependencies. This will allow us to reference the test-runtime project in corefx from the dependencies of each test project. This will allow nuget to do proper resolution of the combined set of dependencies, which is an improvement over the error-prone way we are currently combining the two. It will also allow us to more easily reference a different test-runtime, for example.

Includes the following changes:

* Updated fork of Nuget code. This is mostly verbatim from the nuget sources, but does include some changes to maintain compatibility with our build system. Long-term we need to move off of having a fork of this code.
* Update ValidateProjectDependencyVersions to handle previously-unexpected values in the project.json file.
* Update publishtest.targets. We no longer restore both the test-runtime project.json and the test's project.json. We only restore the test's project.json and resolve assets from it. The test project.json must now have a reference to a test-runtime to use, or more specifically must include references to all of the runtime dependencies that it needs to run tests.

Don't merge this yet, I need to prepare and test changes to go along with this in corefx and WCF.

@ericstj , @weshaggard