### PR TITLE
Support multiple conditions in [ConditionalFact] and [ConditionalTheory]

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/ConditionalFactAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ConditionalFactAttribute.cs
@@ -11,11 +11,11 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ConditionalFactAttribute : FactAttribute
     {
-        public string ConditionMemberName { get; private set; }
+        public string[] ConditionMemberNames { get; private set; }
 
-        public ConditionalFactAttribute(string conditionMemberName)
+        public ConditionalFactAttribute(params string[] conditionMemberNames)
         {
-            ConditionMemberName = conditionMemberName;
+            ConditionMemberNames = conditionMemberNames;
         }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/ConditionalTheoryAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ConditionalTheoryAttribute.cs
@@ -11,11 +11,11 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ConditionalTheoryAttribute : TheoryAttribute
     {
-        public string ConditionMemberName { get; private set; }
+        public string[] ConditionMemberNames { get; private set; }
 
-        public ConditionalTheoryAttribute(string conditionMemberName)
+        public ConditionalTheoryAttribute(params string[] conditionMemberNames)
         {
-            ConditionMemberName = conditionMemberName;
+            ConditionMemberNames = conditionMemberNames;
         }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.NetCore.Extensions
+{
+    // Internal helper class for code common to conditional test discovery through
+    // [ConditionalFact] and [ConditionalTheory]
+    internal class ConditionalTestDiscoverer
+    {
+        // This helper method evaluates the given condition member names for a given set of test cases.
+        // If any condition member evaluates to 'false', the test cases are marked to be skipped.
+        // The skip reason is the collection of all the condition members that evalated to 'false'.
+        internal static IEnumerable<IXunitTestCase> Discover(
+                                                        ITestFrameworkDiscoveryOptions discoveryOptions,
+                                                        IMessageSink diagnosticMessageSink,
+                                                        ITestMethod testMethod,
+                                                        IEnumerable<IXunitTestCase> testCases,
+                                                        IEnumerable<string> conditionMemberNames)
+        {
+            // A null or empty list of conditionMemberNames is treated as "no conditions".
+            // and the test cases will not be skipped.
+            // Example: [ConditionalFact()] or [ConditionalFact((string[]) null)]
+            int conditionCount = conditionMemberNames == null ? 0 : conditionMemberNames.Count();
+            if (conditionCount == 0)
+            {
+                return testCases;
+            }
+
+            MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
+            Type testMethodDeclaringType = testMethodInfo.DeclaringType;
+            List<string> falseConditions = new List<string>(conditionCount);
+
+            foreach (string entry in conditionMemberNames)
+            {
+                string conditionMemberName = entry;
+
+                // Null condition member names are silently tolerated
+                if (string.IsNullOrWhiteSpace(conditionMemberName))
+                {
+                    continue;
+                }
+
+                string[] symbols = conditionMemberName.Split('.');
+                Type declaringType = testMethodDeclaringType;
+
+                if (symbols.Length == 2)
+                {
+                    conditionMemberName = symbols[1];
+                    ITypeInfo type = testMethod.TestClass.Class.Assembly.GetTypes(false).Where(t => t.Name.Contains(symbols[0])).FirstOrDefault();
+                    if (type != null)
+                    {
+                        declaringType = type.ToRuntimeType();
+                    }
+                }
+
+                MethodInfo conditionMethodInfo;
+                if ((conditionMethodInfo = LookupConditionalMethod(declaringType, conditionMemberName)) == null)
+                {
+                    return new[] 
+                    {
+                        new ExecutionErrorTestCase(
+                            diagnosticMessageSink,
+                            discoveryOptions.MethodDisplayOrDefault(),
+                            testMethod,
+                            GetFailedLookupString(conditionMemberName))
+                    };
+                }
+
+                // In the case of multiple conditions, collect the results of all
+                // of them to produce a summary skip reason.
+                if (!(bool)conditionMethodInfo.Invoke(null, null))
+                {
+                    falseConditions.Add(conditionMemberName);
+                }
+            }
+
+            // Compose a summary of all conditions that returned false.
+            if (falseConditions.Count > 0)
+            {
+                string skippedReason = string.Format("Condition(s) not met: \"{0}\"", string.Join("\", \"", falseConditions));
+                return testCases.Select(tc => new SkippedTestCase(tc, skippedReason));
+            }
+
+            // No conditions returned false (including the absence of any conditions).
+            return testCases;
+        }
+
+        internal static string GetFailedLookupString(string name)
+        {
+            return
+                "An appropriate member \"" + name + "\" could not be found. " +
+                "The conditional method needs to be a static method or property on this or any ancestor type, " +
+                "of any visibility, accepting zero arguments, and having a return type of Boolean.";
+        }
+        
+        internal static MethodInfo LookupConditionalMethod(Type t, string name)
+        {
+            if (t == null || name == null)
+                return null;
+
+            TypeInfo ti = t.GetTypeInfo();
+
+            MethodInfo mi = ti.GetDeclaredMethod(name);
+            if (mi != null && mi.IsStatic && mi.GetParameters().Length == 0 && mi.ReturnType == typeof(bool))
+                return mi;
+
+            PropertyInfo pi = ti.GetDeclaredProperty(name);
+            if (pi != null && pi.PropertyType == typeof(bool) && pi.GetMethod != null && pi.GetMethod.IsStatic && pi.GetMethod.GetParameters().Length == 0)
+                return pi.GetMethod;
+
+            return LookupConditionalMethod(ti.BaseType, name);
+        }
+    }
+}

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -23,45 +23,9 @@ namespace Xunit.NetCore.Extensions
         public override IEnumerable<IXunitTestCase> Discover(
             ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
         {
-            MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
-
-            string conditionMemberName = theoryAttribute.GetConstructorArguments().FirstOrDefault() as string;
-            Type declaringType = testMethodInfo.DeclaringType;
-            string[] symbols = conditionMemberName.Split('.');
-
-            if (symbols.Length == 2)
-            {
-                conditionMemberName = symbols[1];
-                ITypeInfo type = testMethod.TestClass.Class.Assembly.GetTypes(false).Where(t => t.Name.Contains(symbols[0])).FirstOrDefault();
-                if (type != null)
-                {
-                    declaringType = type.ToRuntimeType();
-                }
-            }
-
-            MethodInfo conditionMethodInfo;
-            if (conditionMemberName == null ||
-                (conditionMethodInfo = ConditionalFactDiscoverer.LookupConditionalMethod(declaringType, conditionMemberName)) == null)
-            {
-                return new[] {
-                    new ExecutionErrorTestCase(
-                        _diagnosticMessageSink,
-                        discoveryOptions.MethodDisplayOrDefault(),
-                        testMethod,
-                        ConditionalFactDiscoverer.GetFailedLookupString(conditionMemberName))
-                };
-            }
-
+            string[] conditionMemberNames = theoryAttribute.GetConstructorArguments().FirstOrDefault() as string[];
             IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute);
-            if ((bool)conditionMethodInfo.Invoke(null, null))
-            {
-                return testCases;
-            }
-            else
-            {
-                string skippedReason = "\"" + conditionMemberName + "\" returned false.";
-                return testCases.Select(tc => new SkippedTestCase(tc, skippedReason));
-            }
+            return ConditionalFactDiscoverer.DiscoverConditionalTestCases(discoveryOptions, _diagnosticMessageSink, testMethod, testCases, conditionMemberNames);
         }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -25,7 +24,7 @@ namespace Xunit.NetCore.Extensions
         {
             string[] conditionMemberNames = theoryAttribute.GetConstructorArguments().FirstOrDefault() as string[];
             IEnumerable<IXunitTestCase> testCases = base.Discover(discoveryOptions, testMethod, theoryAttribute);
-            return ConditionalFactDiscoverer.DiscoverConditionalTestCases(discoveryOptions, _diagnosticMessageSink, testMethod, testCases, conditionMemberNames);
+            return ConditionalTestDiscoverer.Discover(discoveryOptions, _diagnosticMessageSink, testMethod, testCases, conditionMemberNames);
         }
     }
 }

--- a/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
+++ b/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
@@ -19,6 +19,7 @@
     <Compile Include="Attributes\ActiveIssueAttribute.cs" />
     <Compile Include="Attributes\PlatformSpecificAttribute.cs" />
     <Compile Include="Discoverers\ConditionalFactDiscoverer.cs" />
+    <Compile Include="Discoverers\ConditionalTestDiscoverer.cs" />
     <Compile Include="Discoverers\ConditionalTheoryDiscoverer.cs" />
     <Compile Include="Discoverers\ActiveIssueDiscoverer.cs" />
     <Compile Include="Attributes\OuterLoopAttribute.cs" />


### PR DESCRIPTION
Modifies [ConditionalFact] and [ConditionalTheory] attributes to accept
a variable number of condition member names.

Modifies ConditionalFactDiscoverer and ConditionalTheoryDiscoverer to
evaluate all of the conditions in the attributes.  Conditions are
logically "and'ed", so any condition returning false marks the test
to be skipped.

Existing tests using [ConditionalFact] or [ConditionalTheory] do not
need to be modified.  The only behavioral change is the phrasing of
the skip message which now begins "Conditions not met:..."

Fixes #610