### PR TITLE
Adding target that generates version.c

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -155,6 +155,30 @@
     </ItemGroup>
   </Target>
 
+  <!-- Non Windows versioning requires to generate a source file and include it on the compilation. -->
+  <Target Name="GenerateVersionSourceFile"
+      Inputs="$(MSBuildProjectFile)"
+      Outputs="$(NativeVersionSourceFile)"
+      DependsOnTargets="CreateVersionFileDuringBuild"
+      Condition="'$(NativeVersionSourceFile)'!='' and '$(GenerateVersionSourceFile)'=='true'">
+
+    <ItemGroup>
+      <SourceFileLines />
+      <SourceFileLines Include="static char sccsid%5B%5D %5F%5Fattribute%5F%5F%28%28used%29%29 %3D %22%40%28%23%29Version $(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)%22%3B" />
+      <!-- Since this is a source file, compiler will complain if there is no new line at end of file, so adding one bellow. -->
+      <SourceFileLines Include=" " />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(NativeVersionSourceFile)"
+      Lines="@(SourceFileLines)"
+      Overwrite="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(NativeVersionSourceFile)" />
+    </ItemGroup>
+  </Target>
+
   <!-- #################################### -->
   <!-- Generate BuildVersion.props -->
   <!-- #################################### -->


### PR DESCRIPTION
This target generates a version source file which contains one line like:
```c
static char sccsid[] __attribute__((used)) = "@(#)Version 1.0.12345.0";
```
When adding this source file to any compilation, we will be able to get the version of native binaries built in non-Windows platforms by using either `what(1)` or `strings+grep`

related: dotnet/coreclr#3133
cc: @ellismg @weshaggard 
FYI: @gkhanna79 