### PR TITLE
Add customizability to symbol packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -934,6 +934,8 @@
                ExcludeEmptyDirectories="true"
                PackSymbolPackage="true"
                SymbolPackageOutputDirectory="$(SymbolPackageOutputPath)"
+               AdditionalLibPackageExcludes="@(AdditionalLibPackageExcludes)"
+               AdditionalSymbolPackageExcludes="@(AdditionalSymbolPackageExcludes)"
                Condition="'$(_SkipCreatePackage)' != 'true'"/>
     <!-- Create a marker that records the path to the generated package -->
     <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(Version).nupkg;$(SymbolPackageOutputPath)$(Id).$(Version).symbols.nupkg"


### PR DESCRIPTION
Adds `AdditionalLibPackageExcludes` and `AdditionalSymbolPackageExcludes` that let packaging projects configure what belongs in their symbol packages. For example, an OSX native symbol project would add `**/*.dwarf` (escaped to `%2A%2A\%2A.dwarf` in MSBuild) to `AdditionalLibPackageExcludes`.

Also brings in an xplat path separator fix from NuGet's `_libPackageExcludes` and `_symbolPackageExcludes`.

/cc @weshaggard @ericstj @mikem8361 