### PR TITLE
Packaging fixes/features for open meta-packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetMinimumNETStandard.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetMinimumNETStandard.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class GetMinimumNETStandard : PackagingTask
+    {
+        [Required]
+        public ITaskItem[] Frameworks
+        {
+            get;
+            set;
+        }
+
+        [Output]
+        public string MinimumNETStandard
+        {
+            get;
+            private set;
+        }
+
+        public override bool Execute()
+        {
+            var minNETStandard = Frameworks.Select(fx => NuGetFramework.Parse(fx.ItemSpec))
+                .Where(fx => fx.Framework == FrameworkConstants.FrameworkIdentifiers.NetStandard)
+                .OrderBy(fx => fx.Version)
+                .FirstOrDefault();
+
+            if (minNETStandard == null)
+            {
+                minNETStandard = FrameworkConstants.CommonFrameworks.NetStandard10;
+                Log.LogMessage($"Could not find any NETStandard frameworks, defaulting to {minNETStandard}.");
+            }
+            
+            MinimumNETStandard = minNETStandard.ToString();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -18,6 +18,8 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GetMinimumNETStandard.cs" />
+    <Compile Include="SplitDependenciesBySupport.cs" />
     <Compile Include="GenerateNetStandardSupportTable.cs" />
     <Compile Include="PromoteReferenceDependencies.cs" />
     <Compile Include="CreateTrimDependencyGroups.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -106,6 +106,8 @@
   <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="ApplyBaseLine" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="PromoteReferenceDependencies" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetMinimumNETStandard" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="SplitDependenciesBySupport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms
@@ -346,11 +348,22 @@
   <Target Name="GetPackageIdentity"
           Returns="@(_PackageIdentity)"
           DependsOnTargets="$(VersionDependsOn)">
+
+    <ItemGroup>
+      <_referenceFrameworks Include="%(File.TargetFramework)" Condition="'%(File.IsReferenceAsset)' == 'true'" />
+    </ItemGroup>
+
+    <GetMinimumNETStandard Condition="'$(MinimumNETStandard)' == ''"
+                           Frameworks="@(_referenceFrameworks)">
+      <Output TaskParameter="MinimumNETStandard" PropertyName="MinimumNETStandard"/>
+    </GetMinimumNETStandard>
+    
     <ItemGroup>
       <_PackageIdentity Include="$(Id)">
         <Version>$(Version)</Version>
         <TargetFramework Condition="'$(PackageTargetFramework)' != ''">$(PackageTargetFramework)</TargetFramework>
         <TargetRuntime Condition="'$(PackageTargetRuntime)' != ''">$(PackageTargetRuntime)</TargetRuntime>
+        <MinimumNETStandard Condition="'$(MinimumNETStandard)' != ''">$(MinimumNETStandard)</MinimumNETStandard>
       </_PackageIdentity>
     </ItemGroup>
   </Target>
@@ -396,6 +409,16 @@
 
   <Target Name="AssignPkgProjPackageDependenciesTargetFramework"
           DependsOnTargets="GetPkgProjPackageDependencies;GetFiles;EnsureOOBFramework">
+
+    <SplitDependenciesBySupport Condition="'$(SplitDependenciesBySupport)' == 'true'"
+                                OriginalDependencies="@(PkgProjDependency)">
+      <Output TaskParameter="SplitDependencies" ItemName="_SplitPkgProjDependency" />
+    </SplitDependenciesBySupport>
+
+    <ItemGroup Condition="'@(_SplitPkgProjDependency)' != ''">
+      <PkgProjDependency Remove="@(PkgProjDependency)" />
+      <PkgProjDependency Include="@(_SplitPkgProjDependency)" />
+    </ItemGroup>
 
     <ItemGroup>
       <!-- ensure that unconstrained dependencies are also expanded in constrained TFM groups -->

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -26,6 +26,8 @@
 
     <!-- By default we'll build libraries referenced by packages -->
     <BuildPackageLibraryReferences Condition="'$(BuildPackageLibraryReferences)' == ''">true</BuildPackageLibraryReferences>
+
+    <BuildInParallel Condition="'$(BuildInParallel)' == '' AND '$(MSBuildNodeCount)' > '1'">true</BuildInParallel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsRuntimePackage)' == 'true' or '$(PackageTargetRuntime)' != ''">
@@ -182,6 +184,7 @@
           Outputs="fake"
           DependsOnTargets="SplitProjectReferences">
     <MSBuild Targets="GetPackageIdentity"
+             BuildInParallel="$(BuildInParallel)"
              Projects="@(_PkgProjProjectReferenceClosure)"
              Properties="%(_PkgProjProjectReferenceClosure.SetConfiguration); %(_PkgProjProjectReferenceClosure.SetPlatform)">
       <Output TaskParameter="TargetOutputs"
@@ -304,6 +307,7 @@
 
     <!-- Only rebuild project references when specified -->
     <MSBuild Targets="Build"
+             BuildInParallel="$(BuildInParallel)"
              Condition="'$(BuildPackageLibraryReferences)' == 'true'"
              Projects="@(_NonPkgProjProjectReference)"
              Properties="$(ProjectProperties)"
@@ -718,7 +722,11 @@
     </ItemGroup>
 
     <!-- Lineups need to have all runtime dependencies to ensure that they are part of the compile graph -->
-    <MSBuild Projects="@(LineupProjectReference)" Targets="DetermineRuntimeDependencies" Condition="'$(IsLineupPackage)' == 'true'" Properties="$(ProjectProperties)">
+    <MSBuild Projects="@(LineupProjectReference)" 
+             Targets="DetermineRuntimeDependencies" 
+             Condition="'$(IsLineupPackage)' == 'true'"
+             BuildInParallel="$(BuildInParallel)"
+             Properties="$(ProjectProperties)">
       <Output TaskParameter="TargetOutputs" ItemName="_indirectRuntimeDependencies" />
     </MSBuild>
 
@@ -859,7 +867,10 @@
     </ItemGroup>
 
     <!-- Get all the files from runtime implementation packages to include in reference path-->
-    <MSBuild Projects="@(RuntimeProjectReference)" Targets="GetPackageFiles" Properties="$(ProjectProperties)">
+    <MSBuild Projects="@(RuntimeProjectReference)" 
+             Targets="GetPackageFiles" 
+             BuildInParallel="$(BuildInParallel)"
+             Properties="$(ProjectProperties)">
       <Output TaskParameter="TargetOutputs" ItemName="RuntimeFile" />
     </MSBuild>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitDependenciesBySupport.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/SplitDependenciesBySupport.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    /// <summary>
+    /// Examines all dependencies 
+    /// </summary>
+    public class SplitDependenciesBySupport : PackagingTask
+    {
+        [Required]
+        public ITaskItem[] OriginalDependencies { get; set; }
+
+        [Output]
+        public ITaskItem[] SplitDependencies { get; set; }
+        
+        public override bool Execute()
+        {
+            var dependencies = OriginalDependencies.Select(od => new Dependency(od)).ToArray();
+
+            // preserve all of the TFM-specific dependencies that are not NETStandard.
+            List<ITaskItem> splitDependencies = new List<ITaskItem>(dependencies.Where(d => d.TargetFramework != null && d.TargetFramework.Framework != FrameworkConstants.FrameworkIdentifiers.NetStandard).Select(d => d.OriginalItem));
+
+            // for any dependency with unspecified TFM, get it's minimum supported netstandard version
+            // and treat it as targeting that.
+            var unspecDeps = dependencies.Where(d => d.TargetFramework == null).ToArray();
+            foreach (var unspecDep in unspecDeps)
+            {
+                unspecDep.TargetFramework = unspecDep.MinimumNETStandard;
+            }
+
+            // get all distinct netstandard TFMs
+            var netStandardGroups = dependencies.Select(d => d.TargetFramework)
+                                     .Where(fx => fx != null && fx.Framework == FrameworkConstants.FrameworkIdentifiers.NetStandard)
+                                     .Distinct()
+                                     .OrderBy(fx => fx.Version)
+                                     .ToArray();
+
+            // for every netstandard group include all dependencies that support that version of NETStandard or lower
+            foreach (var netStandardGroup in netStandardGroups)
+            {
+                var applicableDependencies = dependencies.Where(d => d.TargetFramework != null &&
+                                                              d.TargetFramework.Framework == FrameworkConstants.FrameworkIdentifiers.NetStandard &&
+                                                              d.TargetFramework.Version <= netStandardGroup.Version);
+                splitDependencies.AddRange(applicableDependencies.Select(d => d.GetItemWithTargetFramework(netStandardGroup)));
+            }
+
+            SplitDependencies = splitDependencies.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private class Dependency
+        {
+            public Dependency(ITaskItem originalItem)
+            {
+                OriginalItem = originalItem;
+                Name = originalItem.ItemSpec;
+                string fx = originalItem.GetMetadata("TargetFramework");
+                if (!String.IsNullOrEmpty(fx))
+                {
+                    TargetFramework = NuGetFramework.Parse(fx);
+                }
+                else
+                {
+                    TargetFramework = null;
+                }
+
+                string minNSFx = originalItem.GetMetadata("MinimumNETStandard");
+                if (!String.IsNullOrEmpty(minNSFx))
+                {
+                    MinimumNETStandard = NuGetFramework.Parse(minNSFx);
+                }
+                else
+                {
+                    MinimumNETStandard = null;
+                }
+            }
+
+            public ITaskItem OriginalItem { get; }
+            public string Name { get; }
+            public NuGetFramework TargetFramework { get; set; }
+            public NuGetFramework MinimumNETStandard { get; }
+
+            public ITaskItem GetItemWithTargetFramework(NuGetFramework framework)
+            {
+                var newItem = new TaskItem(OriginalItem);
+                newItem.SetMetadata("TargetFramework", framework.GetShortFolderName());
+                return newItem;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR does the following:
- Fix perf for building package project references to use all cores
- Preserve supports section in runtime.json (a bug I noticed when examining the generated runtime.json)
- Feature for splitting pkgproj dependencies by minimum netstandard version, needed to fix https://github.com/dotnet/corefx/issues/6561.

For the last feature I initially coded it to use the validation report but this created unnecessary complexity and sequencing restrictions, so I changed to plumb it through as meta-data on the resolved pkgproj reference.

/cc @weshaggard @chcosta 