### PR TITLE
Work around to MSBuild issue were Exec task doesn't read exit code correctly

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -146,6 +146,7 @@
 
     <Exec Command="$(TestCommandLine)"
           WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          CustomErrorRegularExpression="Failed: [^0]"
           ContinueOnError="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
     </Exec>


### PR DESCRIPTION
Working around the issue in .Net Core MSBuild Exec task where the return code is not processed correctly. This will basically check if there were any failures in the run, and if so, then it will fail the exec call.

related: dotnet/corefx#7362 , microsoft/msbuild#566

cc: @weshaggard 
FYI: @mellinoe 