### PR TITLE
Add support for microsoft.netcore.targets lineup package

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -368,6 +368,20 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="FindProjectsForMetaPackages" BeforeTargets="ConvertCommonMetadataToAdditionalProperties">
+    <ItemGroup>
+      <_packageToProject Include="@(Package)" />
+      <_packageToProject Condition="'$(IsLineupPackage)' == 'true'" Include="@(LineupPackage)" />
+      
+      <!-- first try and find any open-source package that exists -->
+      <_projectForPackage Include="@(_packageToProject->'$(ProjectDir)src\%(Identity)\pkg\%(Version)\%(Identity).pkgproj')" />
+      <_projectForPackage Include="@(_packageToProject->'$(ProjectDir)src\Native\pkg\%(Identity)\%(Version)\%(Identity).pkgproj')" />
+      <_projectForPackageExists Include="@(_projectForPackage)" Condition="Exists('%(Identity)')" />
+
+      <LineupProjectReference Include="@(_projectForPackageExists)" Condition="'$(IsLineupPackage)' == 'true'" />
+    </ItemGroup>
+  </Target>
+
   <!-- Don't actually walk the closure all the time, conditioned on GetClosure metadata on ProjectReference.
        Walking the closure is very expensive for many of our packages and is unecessary since we are very
        strict about assets that are included in the package.  -->


### PR DESCRIPTION
Porting change to support building lineup package in the open.  I considered changing the name of this target to reflect that the meta packages are no longer part of the work performed by this target, but I left it as-is so that this target (imported before our internal definition) will be overridden when building internally.

I need to verify that this does not have any unexpected side-affects internally.  Please review, but don't merge.  I'll merge this change after further validation and sign-off.

/cc @weshaggard @ericstj 