### PR TITLE
Project Reference to package dependency conversion fixes for corefx and build pipeline

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -16,7 +16,6 @@
       a project is localized in German, then it is localized in all languages.
     -->
     <ExcludeLocalizationImport Condition="'$(ExcludeLocalizationImport)'=='' And !Exists('$(MSBuildProjectDirectory)/MultilingualResources/$(MSBuildProjectName).de.xlf')">true</ExcludeLocalizationImport>
-    
   </PropertyGroup>
 
   <!-- Assembly metadata indicating that an assembly is a framework (as opposed to user) assembly:
@@ -98,6 +97,12 @@
 
   <Import Project="$(MSBuildThisFileDirectory)Packaging.targets" Condition="'$(ExcludePackagingImport)'!='true' AND '$(MSBuildProjectExtension)' == '.pkgproj'" />
 
+  <!-- Property which signals whether to import buildagainstpackages.targets.  This target contains 
+       the targets necessary to build tests with project references converted to package dependencies.
+  -->
+  <PropertyGroup>
+    <_BuildAgainstPackages Condition="'$(KeepAllProjectReferences)' != 'true' and '$(IsTestProject)' == 'true' and '$(MSBuildProjectExtension)' != '.builds'">$(BuildTestsAgainstPackages)</_BuildAgainstPackages>
+  </PropertyGroup>
   <!-- 
     Import the default package restore and resolve targets 
   

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -10,6 +10,11 @@
     <_PackagesDrops Include="$(PackagesDrops)" />
   </ItemGroup>
   <PropertyGroup>
+    <PackageNameRegex Condition="'$(PackageNameRegex)' == ''">(.*)\.(\d+\.\d+\.\d+)-([^-]+-\d+-\d+)</PackageNameRegex>
+    <VersionStructureRegex Condition="'$(VersionStructureRegex)' == ''">(\d+\.\d+\.\d+)-((beta|rc2|rc3)-?(\d+(-\d+)?)?)</VersionStructureRegex>
+    <BuildNumberOverrideStructureRegex Condition="'$(BuildNumberOverrideStructureRegex)' == ''">([^-]+)?-?(\d+(-\d+)?)?</BuildNumberOverrideStructureRegex>
+  </PropertyGroup>
+  <PropertyGroup>
     <!-- overridden in repo -->
     <GeneratedProjectJsonDir Condition="'$(GeneratedProjectJsonDir)' == ''">$(ObjDir)generated</GeneratedProjectJsonDir>
   </PropertyGroup>
@@ -90,7 +95,7 @@
       </_PackageDropAssembly>
     </ItemGroup>
     <ParsePackageNames PackageDrops="@(_PackagesDrops)"
-                                           PackageNameRegex="([^\\]+)\.(\d+\.\d+\.\d+)-([^\.]+)">
+                       PackageNameRegex="$(PackageNameRegex)">
        <Output TaskParameter="PackageNames" ItemName="_PackageVersionList" />                                                  
     </ParsePackageNames>                                           
   </Target>
@@ -106,7 +111,7 @@
       <!-- determine the version of the assembly in the project reference by looking at the packages in "PackagesDrops".  -->
       <!-- If an alternate packagereferencename was specified, then look for that version number instead of the version number for the project reference. -->
       <_AssemblyVersion Condition="'$(_PackageReferenceName)' != '' and '%(_PackageVersionList.PackageName)' == '$(_PackageReferenceName)'">%(_PackageVersionList.PackageVersion)</_AssemblyVersion>
-      <_AssemblyVersion Condition="'$(_AssemblyVersion)' == '' and '%(_PackageVersionList.AssemblyName)' == '$(_InjectProjectReference)'">%(_PackageVersionList.PackageVersion)</_AssemblyVersion>
+      <_AssemblyVersion Condition="'$(_AssemblyVersion)' == '' and '%(_PackageVersionList.PackageName)' == '$(_InjectProjectReference)'">%(_PackageVersionList.PackageVersion)</_AssemblyVersion>
     </PropertyGroup>
 
     <Message Condition="'$(_AssemblyVersion)' != ''" Text="Derived version number from packages drop." />   
@@ -155,21 +160,23 @@
     <Error Condition="'$(ErrorNoVersion)' == 'true'" Text="Unable to determine version number for project reference dependency '%(_InjectProjectReferenceDependency.Name)'" />
   </Target>
   
+  
   <Target Name="AddDependenciesToProjectJson"
           DependsOnTargets="GatherProjectReferenceForProjectJson;DetermineProjectJsonPath"
           Condition="'@(_InjectProjectReferenceDependency)' != ''">
     
     <Message Condition="'$(PackageBuildNumberOverride)' != ''" Text="Setting package version to '$(PackageBuildNumberOverride)'" />
-    <GetPackageNumberFromPackageDrop Condition="'@(_PackagesDrops)' != ''"
-                                     PackageDrops="@(_PackagesDrops)">
-      <Output TaskParameter="PackageNumber" PropertyName="_DerivedPackageNumber" />
-    </GetPackageNumberFromPackageDrop>
-    
+    <ParsePackageNames Condition="'@(_PackagesDrops)' != '' and '$(_DerivedPackageNumber)' == ''"
+                       PackageDrops="@(_PackagesDrops)"
+                       PackageNameRegex="$(PackageNameRegex)">
+      <Output TaskParameter="PackageNames" ItemName="_ParsedPackages" />
+    </ParsePackageNames>
+    <PropertyGroup>
+      <_DerivedPackageNumber Condition="'$(_DerivedPackageNumber)' == '' and '%(_ParsedPackages.PrereleaseVersion)' != ''">%(_ParsedPackages.PrereleaseVersion)</_DerivedPackageNumber>
+    </PropertyGroup>
     <Message Condition="'$(PackageBuildNumberOverride)' == '' and '$(_DerivedPackageNumber)' != ''" Text="Derived package version from packagedrops.  Setting package version to '$(_DerivedPackageNumber)'" />
     <PropertyGroup>
         <PackageBuildNumberOverride Condition="'$(PackageBuildNumberOverride)' == '' and '$(_DerivedPackageNumber)' != ''">$(_DerivedPackageNumber)</PackageBuildNumberOverride>
-        <VersionStructureRegex Condition="'$(VersionStructureRegex)' == ''">(\d+\.\d+\.\d+)-((beta|rc2|rc3)-?(\d+(-\d+)?)?)</VersionStructureRegex>
-        <BuildNumberOverrideStructureRegex Condition="'$(BuildNumberOverrideStructureRegex)' == ''">([^-]+)?-?(\d+(-\d+)?)?</BuildNumberOverrideStructureRegex>
     </PropertyGroup>
     <AddDependenciesToProjectJson Condition="'$(ErrorNoVersion)' == ''"
                                   VersionStructureRegex="$(VersionStructureRegex)"

--- a/src/Microsoft.DotNet.Build.Tasks/ParsePackageNames.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ParsePackageNames.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     Log.LogWarning("PackageDrop does not exist - '{0}'", packageDrop);
                     continue;
                 }
-                IEnumerable<ITaskItem> packages = Directory.GetFiles(packageDrop)?.Select(f => new TaskItem(f));
+                IEnumerable<ITaskItem> packages = Directory.GetFiles(packageDrop).Select(f => new TaskItem(Path.GetFileNameWithoutExtension(f)));
 
 
                 foreach (ITaskItem package in packages)


### PR DESCRIPTION
- Move _BuildAgainstPackages property into buildtools common targets

- Project Reference to package dependency fixes
    - Use ParsePackageNames task to determine assembly version (I know this is "bad" and is on 
      the list of things to fix)
    - A couple of tasks were eliminated in favor of the ParsePackageNames before previous PR's 
      were merged, one fallout was that determining a version number broke because it wasn't 
      updated correctly to use the ParsePackageNames task
    - PackageNameRegEx explicitly looks for the "buildnumber-buildminor" instead of just grabbing 
      the rest of the package name as the Prerelease version because I noticed a bug in some of 
      the packages being produced on xplatforms where the package names 
      where "buildnumber.buildminor" instead of "-"
    - Move RegEx up to the top of the file where it is easy to see / edit / fix.

/cc @weshaggard 