### PR TITLE
Harvest private package dependencies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -50,6 +50,9 @@
     <Compile Include="VersionUtility.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="PackageFiles\native.library.packages.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="PackageFiles\Generations.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -84,6 +84,7 @@
 
   <Import Project="stable.packages.targets" />
   <Import Project="baseline.packages.targets" />
+  <Import Project="native.library.packages.targets" />
 
   <!-- If this package explicitly sets the StableVersion then add it to the stable list -->
   <ItemGroup Condition="'$(StableVersion)' != ''">
@@ -485,6 +486,8 @@
     <GetAssemblyReferences Assemblies="@(File)" Condition="'%(File.HarvestDependencies)' == 'true' and '%(File.Extension)' == '.dll'">
       <Output TaskParameter="ReferencedAssemblies"
               ItemName="_FileReferencedAssemblies"/>
+      <Output TaskParameter="ReferencedNativeLibraries"
+              ItemName="_FileReferencedNativeLibraries"/>
     </GetAssemblyReferences>
 
     <PropertyGroup>
@@ -500,10 +503,12 @@
     
     <ItemGroup Condition="'@(_FilePackageReference)' != ''">
       <_FilePackageReference Remove="corefx;mscorlib;System;System.Core;System.Xml;Windows" />
-      <_FilePackageReference Remove="@(_FilePackageReference)"
-                             Condition="$([System.String]::new('%(Identity)').StartsWith('Internal.'))"/>
-      <_FilePackageReference Remove="@(_FilePackageReference)"
-                             Condition="$([System.String]::new('%(Identity)').StartsWith('System.Private.'))"/>
+
+      <_FilePackageReferencePrivate Include="@(_FilePackageReference)"
+                                    Condition="$([System.String]::new('%(Identity)').StartsWith('System.Private.'))"/>
+
+      <!-- exclude any System.Private dependencies that aren't known packages, where known packages are in BaseLinePackage -->
+      <PackageDependencyExclude Include="@(_FilePackageReferencePrivate)" Exclude="@(BaseLinePackage)" />
       <_FilePackageReference Remove="@(PackageDependencyExclude)"/>
 
       <!-- Projects may specify additional references by assembly name & identity that we'll process
@@ -513,6 +518,17 @@
       <_FilePackageReference Condition="'%(Identity)' == '@(FileRuntimeDependency)'">
         <TargetRuntime>@(FileRuntimeDependency->'%(TargetRuntime)')</TargetRuntime>
       </_FilePackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'@(_FileReferencedNativeLibraries)' != ''">
+      <!-- intersect with NativeLibrary and add Package metadata from NativeLibrary, preserving native lib file name in metadata -->
+      <_FileReferencedNativeLibrariesWithPackage Include="@(_FileReferencedNativeLibraries)"
+                                                 Condition="'@(_FileReferencedNativeLibraries)' == '@(NativeLibrary)' AND '%(Identity)' != ''">
+        <Package>@(NativeLibrary->'%(Package)')</Package>
+        <NativeLibrary>%(Identity)</NativeLibrary>
+      </_FileReferencedNativeLibrariesWithPackage>
+
+      <_FilePackageReference Include="@(_FileReferencedNativeLibrariesWithPackage->'%(Package)')" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/baseline.packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/baseline.packages.targets
@@ -412,5 +412,34 @@
     <BaseLinePackage Include="System.Xml.XPath.XmlDocument">
       <Version>4.0.1</Version>
     </BaseLinePackage>
+
+    <!-- private dependencies -->
+    <BaseLinePackage Include="runtime.native.System">
+      <Version>4.0.0</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="runtime.native.System.Data.SqlClient.sni">
+      <Version>4.0.0</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="runtime.native.System.IO.Compression">
+      <Version>4.1.0</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="runtime.native.System.Net.Http">
+      <Version>4.0.1</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="runtime.native.System.Net.Security">
+      <Version>4.0.1</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="runtime.native.System.Security.Cryptography">
+      <Version>4.0.0</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="System.Private.DataContractSerialization">
+      <Version>4.1.1</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="System.Private.ServiceModel">
+      <Version>4.1.0</Version>
+    </BaseLinePackage>
+    <BaseLinePackage Include="System.Private.Uri">
+      <Version>4.0.1</Version>
+    </BaseLinePackage>
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/native.library.packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/native.library.packages.targets
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!-- This file contains a map of native-library -> package so that we can harvest package dependencies from native references -->
+
+    <!-- runtime.native.System -->
+    <NativeLibrary Include="System.Native">
+      <Package>runtime.native.System</Package>
+    </NativeLibrary>
+
+    <!-- runtime.native.System.Data.SqlClient.sni -->
+    <NativeLibrary Include="sni.dll">
+      <Package>runtime.native.System.Data.SqlClient.sni</Package>
+    </NativeLibrary>
+    
+    <!-- runtime.native.System.IO.Compression -->
+    <NativeLibrary Include="clrcompression.dll">
+      <Package>runtime.native.System.IO.Compression</Package>
+    </NativeLibrary>
+    <NativeLibrary Include="System.IO.Compression.Native">
+      <Package>runtime.native.System.IO.Compression</Package>
+    </NativeLibrary>
+
+    <!-- runtime.native.System.Net.Http -->
+    <NativeLibrary Include="System.Net.Http.Native">
+      <Package>runtime.native.System.Net.Http</Package>
+    </NativeLibrary>
+
+    <!-- runtime.native.System.Net.Security -->
+    <NativeLibrary Include="System.Net.Security.Native">
+      <Package>runtime.native.System.Net.Security</Package>
+    </NativeLibrary>
+
+    <!-- runtime.native.System.Security.Cryptography -->
+    <NativeLibrary Include="System.Security.Cryptography.Native">
+      <Package>runtime.native.System.Security.Cryptography</Package>
+    </NativeLibrary>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Currently we don't automatically harvest package dependencies for
private packages.  Instead we exclude them completely.

This change adds harvesting for private packages, including those that
come from native dependencies.

Corresponding changes to
CoreFx: https://github.com/ericstj/corefx/commit/b76ac1c538506a41719a13bcb5ff38e3b28e5247
WCF: https://github.com/ericstj/wcf/commit/6f1b85067628c37439cccbf4ff98480bc13f4de0

/cc @weshaggard @chcosta 