### PR TITLE
Fix discovery logic in perf tests

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/GetPerfTestAssemblies.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/GetPerfTestAssemblies.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Microsoft.Build.Framework;
@@ -68,7 +69,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
             if (perfTests.Count > 0)
             {
-                PerfTestAssemblies = perfTests.ToArray();
+                PerfTestAssemblies = perfTests.Distinct().ToArray();
                 Log.LogMessage(MessageImportance.High, "Found {0} assemblies containing performance tests.", perfTests.Count);
             }
             else

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -221,9 +221,9 @@
     </GetPerfTestAssemblies>
     <!-- don't add any items to the group if no perf tests were found -->
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
-      <PerfTest Include="$(TestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
-      <PerfTest Include="$(AnyOSTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
-      <PerfTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
+      <PerfTest Condition="Exists('$(TestArchivesRoot)%(PerfTestAssembly.Identity).zip')" Include="$(TestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
+      <PerfTest Condition="Exists('$(AnyOSTestArchivesRoot)%(PerfTestAssembly.Identity).zip')" Include="$(AnyOSTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
+      <PerfTest Condition="'$(TargetsUnix)' == 'true' And Exists('$(UnixTestArchivesRoot)%(PerfTestAssembly.Identity).zip')" Include="$(UnixTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
     </ItemGroup>
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest>


### PR DESCRIPTION
Fix issue reported by @dsgouda . @lt72  as FYI.

There were two bugs here:
- The build task that discovers whether tests are perf tests doesn't do duplicate checking... added a Distinct() call to fix that.
- The .targets file section that brings in perf tests could not have worked for > 1 output directory due to trying to resolve just the name of every perf test found without checking for the existence of the archives.

Note that in CoreFX, System.Globalization.Calendars.Tests.zip and System.Globalization.Tests.zip currently will still cause duplication specifically because they literally do build both for AnyOS and WIndows_NT builds.  However, there also really are two test archives.

