### PR TITLE
Disable delay signing for Desktop tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -20,6 +20,15 @@
 
     <DelaySign>true</DelaySign>
     <DelaySign Condition="'$(UseOpenKey)' == 'true'">false</DelaySign>
+    <!--
+      We enable the signing for the test projects only on Windows because Roslyn not supporting full signing on non-Windows platforms.
+      Issue: https://github.com/dotnet/roslyn/issues/8210
+    -->
+    <DelaySign Condition="'$(OSEnvironment)' == 'Windows_NT' And '$(IsTestProject)' == 'true'">false</DelaySign>
+
+    <SignType Condition="'$(SignType)'=='' And '$(UseOpenKey)' == 'true'">real</SignType>
+    <SignType Condition="'$(SignType)'=='' And '$(IsTestProject)' == 'true'">real</SignType>
+
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <!-- applicable values for SignType are oss, test or real -->
     <SignType Condition="'$(SignType)' == ''">oss</SignType>


### PR DESCRIPTION
To run the desktop test we need to have the test assembly get signed with the test.snk. Currently we have some workaround in some of the test projects to disable the delay signing. The change here is to centerline this in the tools and avoid duplicating the workaround in every test project

https://github.com/dotnet/buildtools/issues/596
