### PR TITLE
Make baseline errors less aggressive & include RID graph

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -61,11 +61,12 @@
   <PropertyGroup>
     <ValidatePackageVersions>true</ValidatePackageVersions>
     <ProhibitFloatingDependencies>true</ProhibitFloatingDependencies>
+    <CoreFxExpectedPrerelease>rc2-23923</CoreFxExpectedPrerelease>
   </PropertyGroup>
 
   <ItemGroup>
     <ValidationPattern Include="^(?i)((System\..%2A)|(Microsoft\.Cci)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
-      <ExpectedPrerelease>rc2-23923</ExpectedPrerelease>
+      <ExpectedPrerelease>$(CoreFxExpectedPrerelease)</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="^(?i)xunit$">
       <ExpectedVersion>2.1.0</ExpectedVersion>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -55,6 +55,7 @@
     </None>
     <None Include="PackageFiles\Packaging.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </None>
     <None Include="PackageFiles\PackageLibs.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -67,7 +68,8 @@
       <Link>FrameworkLists\%(RecursiveDir)%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(PackagesDir)Microsoft.NETCore.Platforms\1.0.1-rc2-23923\runtime.json">
+    <None Include="$(PackagesDir)Microsoft.NETCore.Platforms\1.0.1-$(CoreFxExpectedPrerelease)\runtime.json">
+      <Link>PackageFiles\runtime.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
@@ -79,6 +81,17 @@
     <Folder Include="FrameworkLists\.NETFramework,Version=v4.6.1\" />
     <Folder Include="FrameworkLists\.NETFramework,Version=v4.6.2\" />
     <Folder Include="FrameworkLists\.NETFramework,Version=v4.6\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.5,Profile=Profile111\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.5,Profile=Profile259\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.5,Profile=Profile49\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.5,Profile=Profile78\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.5,Profile=Profile7\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.6,Profile=Profile151\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.6,Profile=Profile157\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.6,Profile=Profile31\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.6,Profile=Profile32\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.6,Profile=Profile44\" />
+    <Folder Include="FrameworkLists\.NETPortable,Version=v4.6,Profile=Profile84\" />
     <Folder Include="FrameworkLists\MonoAndroid,Version=v1.0\" />
     <Folder Include="FrameworkLists\MonoTouch,Version=v1.0\" />
     <Folder Include="FrameworkLists\WindowsPhone,Version=v8.0\" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -549,15 +549,11 @@
         <Exclude Condition="'%(FilePackageDependency.IsReferenceAsset)' != 'true'">Compile</Exclude>
       </FilePackageDependency>
     </ItemGroup>
-    
-    <Error Condition="'@(BaseLinePackage)' == ''" Text="The BaseLinePackage item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
-    <Error Condition="'@(StablePackage)' == ''" Text="The StablePackage item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
-    <Error Condition="'$(BaseLinePropsFile)' == ''" Text="The BaseLinePropsFile property is not defined: ensure you have set this to your repositories props file that contains BaseLinePackage items." />
-    
-   <!-- We can reduce the number of dependencies listed for any framework that has
-        inbox implementations since that framework doesn't need the packages for
-        compile/runtime.  This reduces the noise when consuming our packages in
-        packages.config based projects.  -->
+
+    <!-- We can reduce the number of dependencies listed for any framework that has
+         inbox implementations since that framework doesn't need the packages for
+         compile/runtime.  This reduces the noise when consuming our packages in
+         packages.config based projects.  -->
     <CreateTrimDependencyGroups Dependencies="@(FilePackageDependency);@(Dependency)"
                       FrameworkListsPath="$(FrameworkListsPath)"
                       Files="@(File)"
@@ -572,7 +568,9 @@
                                   Condition="'@(FilePackageDependency)' != ''">
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
     </PromoteReferenceDependencies>
-
+    
+    <Error Condition="'@(BaseLinePackage)' == '' AND '@(FilePackageDependency)' != '' AND '$(BaseLinePackageDependencies)' != 'false'" 
+           Text="The BaseLinePackage item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
     <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" BaseLinePackages="@(BaseLinePackage)" Condition="'$(BaseLinePackageDependencies)' != 'false'">
       <Output TaskParameter="BaseLinedDependencies" ItemName="_BaseLinedDependencies" />
     </ApplyBaseLine>
@@ -582,10 +580,10 @@
       <_BaseLinedDependencies Include="@(FilePackageDependency)" />
     </ItemGroup>
 
+    <Error Condition="@(_BaseLinedDependencies)' != '' AND '@(StablePackage)' == ''" Text="The StablePackage item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
     <ApplyPreReleaseSuffix Condition="'@(_BaseLinedDependencies)' != ''" StablePackages="@(StablePackage)" OriginalPackages="@(_BaseLinedDependencies)" PreReleaseSuffix="$(VersionSuffix)" RevStableToPrerelease="$(DependencyRevStableToPrerelease)">
       <Output TaskParameter="UpdatedPackages" ItemName="Dependency"/>
     </ApplyPreReleaseSuffix>
-
   </Target>
 
   <!-- Walks every project gathering its AssemblyVersion, choosing the highest -->
@@ -949,9 +947,11 @@
     <PropertyGroup>
       <_VersionWithoutPreRelease>$(Version)</_VersionWithoutPreRelease>
       <_VersionWithoutPreRelease Condition="$(Version.Contains('-'))">$(Version.SubString(0, $(Version.IndexOf('-'))))</_VersionWithoutPreRelease>
+      <BaseLinePropsUpdateMessage Condition="'$(BaseLinePropsFile)' == ''">  Please update '$(BaseLinePropsFile)'.</BaseLinePropsUpdateMessage>
     </PropertyGroup>
+    
     <Error Condition="'$(SkipBaseLineCheck)' != 'true' AND '@(_thisPackageBaseLine)' != '' AND '@(_thisPackageBaseLine->WithMetadataValue('Version', '$(_VersionWithoutPreRelease)'))' == ''"
-           Text="This package's version '$(_VersionWithoutPreRelease)' is not part of any BaseLine '@(_thisPackageBaseLine->'%(Version)')'.  Please update '$(BaseLinePropsFile)'." />
+           Text="This package's version '$(_VersionWithoutPreRelease)' is not part of any BaseLine '@(_thisPackageBaseLine->'%(Version)')'.$(BaseLinePropsUpdateMessage)" />
   </Target>
 
   <Target Name="ValidateMetaPackageFramework"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -75,6 +75,7 @@
     <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)/runtime.json</RuntimeFilePath>
     <PlaceholderFile>$(MSBuildThisFileDirectory)_._</PlaceholderFile>
     <PackageDescriptionFile Condition="'$(PackageDescriptionFile)' == ''">path to descriptions.json must be specified</PackageDescriptionFile>
+    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == '' AND Exists('$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json')">$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
     <FrameworkListsPath Condition="'$(FrameworkListsPath)' == ''">$(MSBuildThisFileDirectory)FrameworkLists</FrameworkListsPath>
     <ValidationSuppressionFile Condition="'$(ValidationSuppressionFile)' == ''">ValidationSuppression.txt</ValidationSuppressionFile>


### PR DESCRIPTION
Per previous PR feedback softening the baseline error messages.

Also fixing an old bug where we were missing the runtime.json from buildtools.  I also added a condition to search for it in the repo in order to help us remove some repo-configuration from corefx.

/cc @weshaggard 