### PR TITLE
Add lockfile validation for exact nuget restores

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -44,6 +44,7 @@
     <Compile Include="PrereleaseResolveNuGetPackageAssets.cs" />
     <Compile Include="SignTypeItem.cs" />
     <Compile Include="UpdatePackageDependencyVersion.cs" />
+    <Compile Include="ValidateExactRestore.cs" />
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="WriteSigningRequired.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateExactRestore.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateExactRestore.cs
@@ -1,0 +1,84 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json.Linq;
+using NuGet.Versioning;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class ValidateExactRestore : Task
+    {
+        [Required]
+        public ITaskItem[] ProjectLockJsons { get; set; }
+
+        private HashSet<string> _errors = new HashSet<string>();
+
+        public override bool Execute()
+        {
+            foreach (var projectLockItem in ProjectLockJsons)
+            {
+                ValidateLockFile(projectLockItem.ItemSpec);
+            }
+            return !Log.HasLoggedErrors;
+        }
+
+        private void ValidateLockFile(string lockFilePath)
+        {
+            var lockfile = VisitProjectDependencies.ReadJsonFile(lockFilePath);
+
+            var lockedDependencyVersions = lockfile["libraries"]
+                .Children<JProperty>()
+                .Select(p => p.Name.Split('/'))
+                .ToLookup(libParts => libParts[0], libParts => NuGetVersion.Parse(libParts[1]));
+
+            // Look at dependencies for all frameworks.
+            var requestedDependencies = lockfile["projectFileDependencyGroups"]
+                .Children<JProperty>()
+                .SelectMany(group => group.Value.Value<JArray>().Values<string>());
+
+            foreach (var dependency in requestedDependencies)
+            {
+                string[] dependencyParts = dependency.Split(' ');
+                string requestedId = dependencyParts[0];
+                if (dependencyParts.Length < 3)
+                {
+                    // Some dependencies have no versions, e.g. 'test-runtime' and 'net46-test-runtime'.
+                    continue;
+                }
+
+                string requestedVersion = dependencyParts[2];
+                NuGetVersion requestedNuGetVersion = NuGetVersion.Parse(requestedVersion);
+
+                IEnumerable<NuGetVersion> restoredVersions = lockedDependencyVersions[requestedId];
+
+                // Check if the requested package is exactly included in the "libraries" section.
+                if (!restoredVersions.Contains(requestedNuGetVersion))
+                {
+                    HandleNonExistentDependency(requestedId, requestedVersion, restoredVersions, lockFilePath);
+                }
+            }
+        }
+
+        protected virtual void HandleNonExistentDependency(
+            string name,
+            string version,
+            IEnumerable<NuGetVersion> libraryVersionsRestored,
+            string lockFilePath)
+        {
+            string errorMessage = string.Format(
+                "Exact package '{0} {1}' was not restored: found '{2}'",
+                name,
+                version,
+                string.Join(", ", libraryVersionsRestored));
+
+            // Only output message once per combination.
+            if (_errors.Add(errorMessage))
+            {
+                Log.LogError(errorMessage);
+            }
+
+            Log.LogMessage(MessageImportance.Low, $"{errorMessage} in '{lockFilePath}'");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
@@ -14,11 +14,11 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public ITaskItem[] ProjectJsons { get; set; }
 
-        private static JObject ReadProject(string projectJsonPath)
+        public static JObject ReadJsonFile(string projectJsonPath)
         {
-            using (TextReader projectFileReader = File.OpenText(projectJsonPath))
+            using (TextReader reader = File.OpenText(projectJsonPath))
             {
-                var projectJsonReader = new JsonTextReader(projectFileReader);
+                var projectJsonReader = new JsonTextReader(reader);
 
                 var serializer = new JsonSerializer();
                 return serializer.Deserialize<JObject>(projectJsonReader);
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             foreach (var projectJsonPath in ProjectJsons.Select(item => item.ItemSpec))
             {
-                JObject projectRoot = ReadProject(projectJsonPath);
+                JObject projectRoot = ReadJsonFile(projectJsonPath);
 
                 bool changedAnyPackage = FindAllDependencyProperties(projectRoot)
                     .Select(package => VisitPackage(package, projectJsonPath))


### PR DESCRIPTION
Examines lockfiles to make sure all dependencies were found and restored correctly.

When a `project.json` specifies a version of a package that doesn't exist, NuGet tries to find a best match. In our case, we want an error when this happens because it can cause a bunch of problems:

1. The build isn't repeatable. If these fuzzy-matched dependencies are used, the build depends on which packages are available on the feed which may change at any time. (Similar to `*` dependencies.)
1. Restore is slowed. Now that NuGet depends on the feed state, it needs to fetch a list of versions from the feed every restore.
1. NuGet can encounter corrupted files that otherwise would be ignored, like in https://github.com/dotnet/corefx/issues/7902.
1. The wrong packages sometimes break builds.

This would activate the validation in CoreFX: https://github.com/dotnet/corefx/compare/master...dagood:ensure-exact-restore

This doesn't run in sync.cmd, but neither does project.json validation right now. That might be something to change when adding this to CoreFX, but either way it would be caught by CI `RestoreDuringBuild`.

/cc @ericstj @weshaggard 