### PR TITLE
Hook .ilproj files into the build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -60,6 +60,9 @@
   <Import Project="depProj.targets"
           Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
 
+  <Import Project="IL.targets"
+           Condition="'$(MSBuildProjectExtension)' == '.ilproj'" />
+
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
@@ -21,15 +21,15 @@
           Returns=""
           DependsOnTargets="GetIlasmPath;$(CoreCompileDependsOn)">
     <PropertyGroup>
-      <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">/DLL</_OutputTypeArgument>
-      <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">/EXE</_OutputTypeArgument>
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">-DLL</_OutputTypeArgument>
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">-EXE</_OutputTypeArgument>
 
-      <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">/KEY=$(KeyOriginatorFile)</_KeyFileArgument>
+      <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">-KEY=$(KeyOriginatorFile)</_KeyFileArgument>
 
       <IlasmExePath Condition="'$(IlasmExePath)' == ''">$(IlasmPath)ilasm</IlasmExePath>
     </PropertyGroup>
 
-    <Exec Command="$(IlasmExePath) /QUIET $(_OutputTypeArgument) $(IlasmFlags) /OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile, ' ')">
+    <Exec Command="$(IlasmExePath) -QUIET $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile, ' ')">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
     <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />


### PR DESCRIPTION
This is a few small changes to enable building "ilproj" files as a regular participant in the build. This just imports the existing targets file if the file's extension is detected as ".ilproj". This will be used to build the `System.Unsafe` library in corefx (https://github.com/mellinoe/corefx/tree/system.unsafe).

There is also a minor modification to the calling syntax for ilasm so that it will work with the x-plat version of ilasm. "Forward-slash syntax" doesn't work in the x-plat version of ilasm. Currently it seems like the nuget packages for ilasm are broken, though, so I have not been able to incorporate it into the tool runtime yet. I have done manual testing of the scenario.

* Import IL.targets if the project extension is ".ilproj"
* Use hyphen syntax for ilasm flags, the forward-slash syntax does not
  work on non-Windows ilasm.

@weshaggard