### PR TITLE
Fix UpdatePackageDependencyVersion: shouldn't require a version on all dependencies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/UpdatePackageDependencyVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdatePackageDependencyVersion.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Build.Tasks
             string dependencyVersion;
             if (package.Value is JObject)
             {
-                dependencyVersion = package.Value["version"].Value<string>();
+                dependencyVersion = package.Value["version"]?.Value<string>();
             }
             else if (package.Value is JValue)
             {
@@ -34,6 +34,11 @@ namespace Microsoft.DotNet.Build.Tasks
                     "Unrecognized dependency element for {0} in {1}",
                     package.Name,
                     projectJsonPath));
+            }
+
+            if (dependencyVersion == null)
+            {
+                return false;
             }
 
             if (dependencyIdentifier == PackageId && dependencyVersion == OldVersion)


### PR DESCRIPTION
In corefx this fixes references to 'test-runtime' and 'net46-test-runtime', which don't have `version` values.

I only noticed this now because `UpdatePackageDependencyVersion` is the easiest way to fix incorrect package versions when a prerelease upgrade doesn't account for the major, minor, or patch version changing, and I tried out this flow when preparing the corefx lockfile validation PR.

/cc @ericstj @weshaggard 