### PR TITLE
MS.CCI.Extensions needs to support desktop

### DIFF
--- a/src/Microsoft.Cci.Extensions/project.json
+++ b/src/Microsoft.Cci.Extensions/project.json
@@ -17,8 +17,8 @@
     "System.Xml.XDocument": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8"
+    "netstandard1.3": {
+      "imports": [ "dotnet5.4", "portable-net45+win8" ]
     }
   }
 }


### PR DESCRIPTION
We use this library in tools that run on desktop.  As such it needs to
be built as a PCL.

/cc @mellinoe @weshaggard 