### PR TITLE
Update NuGetTargetMoniker in CCI.Ext fix warning

### DIFF
--- a/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -14,6 +14,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{2179F9B5-1DBA-4563-9402-A94DE75EA9FA}</ProjectGuid>
     <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />


### PR DESCRIPTION
I missed this when I made https://github.com/dotnet/buildtools/commit/911c044a01f4ae23d4092206326007a5edb61b54.

/cc @weshaggard @mellinoe 