### PR TITLE
Ensure Desktop assets work with packages.config

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -73,10 +73,12 @@
       <XmlDocFile Remove="@(XmlDocFile)" Condition="!Exists('%(XmlDocFile.Identity)')"/>
     </ItemGroup>
 
-    <!-- Desktop libraries that contain types in classic assemblies need to be included in ref
-         so that the types unify with the classic assemblies from the targeting pack. -->
     <PropertyGroup>
-      <PackageAsRefAndLib Condition="'$(PackageAsRefAndLib)' == '' AND '$(IsPartialFacadeAssembly)' == 'true' AND $(PackageTargetFramework.StartsWith('net4', StringComparison.OrdinalIgnoreCase))">true</PackageAsRefAndLib>
+      <IsNetFxLibrary Condition="'$(IsNetFxLibrary)' == '' AND $(PackageTargetFramework.StartsWith('net4', StringComparison.OrdinalIgnoreCase))">true</IsNetFxLibrary>
+      
+      <!-- Desktop libraries that contain types in classic assemblies need to be included in ref
+         so that the types unify with the classic assemblies from the targeting pack. -->
+      <PackageAsRefAndLib Condition="'$(PackageAsRefAndLib)' == '' AND '$(IsPartialFacadeAssembly)' == 'true' AND '$(IsNetFxLibrary)' == 'true'">true</PackageAsRefAndLib>
 
       <!-- A reference asset is any file contributed from a project that is contributing a reference,
            not just the file in the ref folder. -->
@@ -84,7 +86,7 @@
       <IsReferenceAsset Condition="'$(IsReferenceAssembly)' == 'true' OR '$(PackageAsRefAndLib)' == 'true'">true</IsReferenceAsset>
     </PropertyGroup>
 
-    <Error Condition="'$(IsReferenceAsset)' == 'true' AND '$(PackageTargetRuntime)' != ''"
+    <Error Condition="'$(IsReferenceAsset)' == 'true' AND '$(PackageAsRefAndLib)' != 'true' AND '$(PackageTargetRuntime)' != ''"
            Text="Reference assemblies should not specify the PackageTargetRuntime property since runtimes cannot effect compile time assets."/>
 
     <!-- PackageTargetRuntime Defaults -->
@@ -114,6 +116,12 @@
       <PackageDestination Include="$(PackageTargetPath)">
         <TargetFramework Condition="'$(PackageTargetFramework)' != ''">$(PackageTargetFramework)</TargetFramework>
       </PackageDestination>
+      
+      <!-- RID-specific desktop libraries should also be packaged without a RID to work in packages.config projects -->
+      <PackageDestination Condition="'$(IsNetFxLibrary)' == 'true' AND '$(PackageTargetRuntime)' != '' AND '$(ExludeNetFxLibraryFromLib)' != 'true'" Include="lib/$(PackageTargetFramework)">
+        <TargetFramework>$(PackageTargetFramework)</TargetFramework>
+      </PackageDestination>
+      
       <PackageDestination Condition="'$(PackageAsRefAndLib)' == 'true'" Include="ref/$(PackageTargetFramework)">
         <TargetFramework>$(PackageTargetFramework)</TargetFramework>
       </PackageDestination>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -825,29 +825,31 @@
       <RuntimeIDs>win10-x86;win10-x86-aot;win10-x64;win10-x64-aot;win10-arm;win10-arm-aot</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="netcore45">
-      <RuntimeIDs>win8-x86;win8-x64;win8-arm</RuntimeIDs>
+      <!-- Intentionally empty, no RIDs defined for Win8 as it must work with packages.config-->
+      <RuntimeIDs></RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="netcore451">
-      <RuntimeIDs>win81-x86;win81-x64;win81-arm</RuntimeIDs>
+      <!-- Intentionally empty, no RIDs defined for Win81 as it must work with packages.config-->
+      <RuntimeIDs></RuntimeIDs>
     </DefaultValidateFramework>
 
     <DefaultValidateFramework Include="net45" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
-      <RuntimeIDs>win-x86;win-x64</RuntimeIDs>
+      <RuntimeIDs>;win-x86;win-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="net451" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
-      <RuntimeIDs>win-x86;win-x64</RuntimeIDs>
+      <RuntimeIDs>;win-x86;win-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="net46" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
-      <!-- add additional win7 RIDs to validate up-level authoring -->
-      <RuntimeIDs>win-x86;win-x64;win7-x86;win7-x64</RuntimeIDs>
+      <!-- additional win7 RIDs to validate up-level authoring -->
+      <RuntimeIDs>;win-x86;win-x64;win7-x86;win7-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="net461" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
       <!-- add additional win7 RIDs to validate up-level authoring -->
-      <RuntimeIDs>win-x86;win-x64;win7-x86;win7-x64</RuntimeIDs>
+      <RuntimeIDs>;win-x86;win-x64;win7-x86;win7-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="net462" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
       <!-- add additional win7 RIDs to validate up-level authoring -->
-      <RuntimeIDs>win-x86;win-x64;win7-x86;win7-x64</RuntimeIDs>
+      <RuntimeIDs>;win-x86;win-x64;win7-x86;win7-x64</RuntimeIDs>
     </DefaultValidateFramework>
 
     <DefaultValidateFramework Include="wpa81">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -3,4 +3,13 @@
      This file will contain all of the common properties from most repos. The intention is to only have 
      repo specific properties inside the repos, and move to this file everything that is common.
   -->
+
+  <!--
+    Import the reference assembly props
+    
+      Sets Properties:
+        IsReferenceAssembly - Set if the project is in the ref assm path
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)ReferenceAssemblies.props" Condition="'$(ExcludeReferenceAssembliesImport)'!='true'" />
+
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -45,9 +45,9 @@
     
       Depends on Properties:
         AssemblyVersion - Needed to determine API version used in
+        IsReferenceAssembly - Set if the project is in the ref assm path
     
       Sets Properties:
-        IsReferenceAssembly - Set if the project is in the ref assm path
         APIVersion - Major.Minor assembly version for the project
   -->
   <Import Project="$(MSBuildThisFileDirectory)ReferenceAssemblies.targets" Condition="'$(ExcludeReferenceAssembliesImport)'!='true'" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IsReferenceAssembly Condition="'$(IsReferenceAssembly)'=='' AND ($(MSBuildProjectFullPath.Contains('\ref\')) OR $(MSBuildProjectFullPath.Contains('/ref/')))">true</IsReferenceAssembly>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
@@ -2,8 +2,6 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <IsReferenceAssembly Condition="'$(IsReferenceAssembly)'=='' AND ($(MSBuildProjectFullPath.Contains('\ref\')) OR $(MSBuildProjectFullPath.Contains('/ref/')))">true</IsReferenceAssembly>
-
     <!-- The first two parts of the assembly version represent API version, 
          the third part is for bugfixes, the fourth is for hotfixes/securtity-updates -->
     <APIVersion>$([System.Version]::Parse('$(AssemblyVersion)').ToString(2))</APIVersion>


### PR DESCRIPTION
Desktop projects by default use packages.config, we shouldn't require
folks to use project.json + RID if we don't actually depend on RID
selection as is the case for most desktop packages.

We should make sure that project types that can use packages.config
are supported by our packages.  I've added empty RID entires to the
DefaultValidateFramework list for all of these frameworks.

I'm also addressing a problem where we might get a different asset when
someone uses a RID over not having a RID: eg the package has lib/net45
asset that is different from its runtimes/win/lib/netstandard1.1 asset.
To catch this case I added a check that tries to see if there is a
better matching asset by framework for any runtime asset.

This caught a number of cases where we were making this mistake for
desktop, so I've made a general rule that any desktop project with a
RID will also put the asset in the RID-less folder.

/cc @weshaggard 

CoreFx change consuming this buildtools update: https://github.com/ericstj/corefx/commit/0c3d7e74d0161d3cf42a074fdf5806029d1f7666