### PR TITLE
Support OfficialBuildId with '-' 

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
@@ -25,9 +25,7 @@
     <CreateAzureContainer
       AccountKey="$(CloudDropAccessToken)"
       AccountName="$(CloudDropAccountName)"
-      ContainerName="$(ContainerName)"
-      WriteOnlyTokenDaysValid="1"
-      ReadOnlyTokenDaysValid="1" />
+      ContainerName="$(ContainerName)" />
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
@@ -25,7 +25,9 @@
     <CreateAzureContainer
       AccountKey="$(CloudDropAccessToken)"
       AccountName="$(CloudDropAccountName)"
-      ContainerName="$(ContainerName)" />
+      ContainerName="$(ContainerName)"
+      WriteOnlyTokenDaysValid="1"
+      ReadOnlyTokenDaysValid="1" />
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateCurrentVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateCurrentVersion.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public bool SetVersionAndRevisionFromBuildId(string buildId)
         {
-            Regex regex = new Regex(@"(\d{8})\.(\d+)$");
+            Regex regex = new Regex(@"(\d{8})[\-\.](\d+)$");
             string dateFormat = "yyyyMMdd";
             Match match = regex.Match(buildId);
             if (match.Success && match.Groups.Count > 2)


### PR DESCRIPTION
Allows buildId in the form "[build number major]-[revision]".  Azure container names only permit letters (lower-case), numbers, and hyphens (non-consecutive).  This change allows us to specify an OfficialBuildId in an Azure container name conformant format.

<s>Also, minor fix to PublishContent.targets to set the token expiration to 1 day.  We aren't currently using these tokens anywhere (or even retrieving them), but a token expiration of 0 causes a warning in the build.</s>

/cc @weshaggard , @joperezr , @jhendrixMSFT , @maririos 