### PR TITLE
Create symbol packages that have a "symbols." id prefix

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -999,15 +999,11 @@
                PrefixedSymbolPackageOutputDirectory="$(PrefixedSymbolPackageOutputPath)"
                AdditionalLibPackageExcludes="@(AdditionalLibPackageExcludes)"
                AdditionalSymbolPackageExcludes="@(AdditionalSymbolPackageExcludes)"
-               Condition="'$(_SkipCreatePackage)' != 'true'"/>
+               Condition="'$(_SkipCreatePackage)' != 'true'">
+      <Output TaskParameter="PackagesCreated" ItemName="OutputPackagePath" />
+    </NugetPack>
 
     <!-- Create markers that record the paths to the generated packages -->
-    <ItemGroup>
-      <OutputPackagePath Include="$(PackageOutputPath)$(Id).$(Version).nupkg" />
-      <OutputPackagePath Include="$(SymbolPackageOutputPath)$(Id).$(Version).symbols.nupkg" />
-      <OutputPackagePath Include="$(PrefixedSymbolPackageOutputPath)symbols.$(Id).$(Version).symbols.nupkg" />
-    </ItemGroup>
-
     <WriteLinesToFile Lines="@(OutputPackagePath)"
                       File="$(NuSpecPath).pkgpath"
                       Overwrite="true"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -66,6 +66,7 @@
   <PropertyGroup>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(BaseOutputPath)symbolpkg/</SymbolPackageOutputPath>
+    <PrefixedSymbolPackageOutputPath Condition="'$(PrefixedSymbolPackageOutputPath)' == ''">$(BaseOutputPath)prefixedsymbolpkg/</PrefixedSymbolPackageOutputPath>
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
@@ -994,11 +995,20 @@
                ExcludeEmptyDirectories="true"
                PackSymbolPackage="true"
                SymbolPackageOutputDirectory="$(SymbolPackageOutputPath)"
+               PackPrefixedSymbolPackage="$(PackPrefixedSymbolPackage)"
+               PrefixedSymbolPackageOutputDirectory="$(PrefixedSymbolPackageOutputPath)"
                AdditionalLibPackageExcludes="@(AdditionalLibPackageExcludes)"
                AdditionalSymbolPackageExcludes="@(AdditionalSymbolPackageExcludes)"
                Condition="'$(_SkipCreatePackage)' != 'true'"/>
-    <!-- Create a marker that records the path to the generated package -->
-    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(Version).nupkg;$(SymbolPackageOutputPath)$(Id).$(Version).symbols.nupkg"
+
+    <!-- Create markers that record the paths to the generated packages -->
+    <ItemGroup>
+      <OutputPackagePath Include="$(PackageOutputPath)$(Id).$(Version).nupkg" />
+      <OutputPackagePath Include="$(SymbolPackageOutputPath)$(Id).$(Version).symbols.nupkg" />
+      <OutputPackagePath Include="$(PrefixedSymbolPackageOutputPath)symbols.$(Id).$(Version).symbols.nupkg" />
+    </ItemGroup>
+
+    <WriteLinesToFile Lines="@(OutputPackagePath)"
                       File="$(NuSpecPath).pkgpath"
                       Overwrite="true"
                       Condition="'$(_SkipCreatePackage)' != 'true'"/>


### PR DESCRIPTION
Creates symbol packages that use a `symbols.` id prefix. This is in addition to the MyGet-convention symbol packages that we already make. The prefixing happens at the `NuGetPack` step, so there is still only a single `nuspec` used to create the library package and these two symbol packages.

To use this, set `PrefixedSymbolPackageOutputPath` to something (varies per repo) and set `PackPrefixedSymbolPackage` to `true`.

We'll want to turn off the MyGet-convention symbol packages at some point. I think this should happen after MyGet supports (to some degree) the prefixed-id symbol packages, so that until then, non-corpnet debuggers can use a working MyGet symbol server.

For example, the kind of structure this can have in CoreFX (all in `bin\packages\Debug`):

* `Microsoft.CSharp.4.0.1-rc3-24025-0.nupkg`
* `symbols\Microsoft.CSharp.4.0.1-rc3-24025-0.symbols.nupkg`
* `prefixedsymbols\symbols.Microsoft.CSharp.4.0.1-rc3-24025-0.symbols.nupkg`

/cc @noahfalk @weshaggard @ericstj 