### PR TITLE
Remove --infer-runtimes restore argument

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -120,7 +120,6 @@
     <DnuRestoreCommand Condition="'$(ParallelRestore)'=='true'">$(DnuRestoreCommand) --parallel</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
-    <DnuRestoreCommand Condition="'$(InferRuntimes)'!='false'">$(DnuRestoreCommand) --infer-runtimes</DnuRestoreCommand>
   </PropertyGroup>
 
   <!-- Create a collection of all project.json files for dependency updates. -->


### PR DESCRIPTION
project.json files in this repository already have runtimes, so we should be able to remove `--infer-runtimes`. I haven't validated using all the packages in builds, but diffing the contents of `Microsoft.DotNet.BuildTools` before/after looks as similar I could expect from two builds.

Related CoreFX removal: https://github.com/dotnet/corefx/pull/8107

/cc @ericstj @weshaggard 