### PR TITLE
Avoid having xunit runner do shadow copy

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -172,6 +172,7 @@
 
     <PropertyGroup>
         <OtherRunnerScriptArgs Condition="'$(FilterToTargetGroup)' == 'net46'">$(OtherRunnerScriptArgs) --xunit-test-type=desktop </OtherRunnerScriptArgs>
+        <XunitArgs Condition="'$(FilterToTargetGroup)' == 'net46'"> -noshadow $(XunitArgs)</XunitArgs>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -69,6 +69,8 @@
   <!-- General xunit options -->
   <PropertyGroup>
     <XunitResultsFileName>testResults.xml</XunitResultsFileName>
+    
+    <XunitOptions Condition="'$(TestWithCore)' != 'true'">$(XunitOptions) -noshadow </XunitOptions>
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
 
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>


### PR DESCRIPTION
When xunit runner does shadow copy for used assemblies it causes a problem when running agaist the desktop. the framework will disallow loading our assemblies which is open source signed.
we pass -noshadow to xunit runner to avoid such issues