### PR TITLE
Packaging cleanup

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Generations.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Generations.json
@@ -136,7 +136,6 @@
         "System.Net.Requests": "4.0.10.0",
         "System.Net.Sockets": "4.1.0.0",
         "System.Net.WebHeaderCollection": "4.0.0.0",
-        "System.Numerics.Vectors": "4.0.0.0",
         "System.ObjectModel": "4.0.10.0",
         "System.Reflection": "4.0.10.0",
         "System.Runtime": "4.0.20.0",

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -89,12 +89,6 @@
     <Error Condition="'$(IsReferenceAsset)' == 'true' AND '$(PackageAsRefAndLib)' != 'true' AND '$(PackageTargetRuntime)' != ''"
            Text="Reference assemblies should not specify the PackageTargetRuntime property since runtimes cannot effect compile time assets."/>
 
-    <!-- PackageTargetRuntime Defaults -->
-    <PropertyGroup Condition="'$(UsePackageTargetRuntimeDefaults)' == 'true' AND '$(PackageTargetRuntime)' == ''">
-      <PackageTargetRuntime Condition=" '$(TargetsWindows)' == 'true'">win7</PackageTargetRuntime>
-      <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
-    </PropertyGroup>
-
     <!-- *** determine destination path for assets *** -->
     <PropertyGroup>
       <_packageTargetRefLib>lib</_packageTargetRefLib>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/GenerationsTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/GenerationsTests.cs
@@ -67,6 +67,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         {
             FrameworkSet fxs = FrameworkSet.Load("FrameworkLists");
             Version maxVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+            HashSet<string> ignoredAssemblies = new HashSet<string>()
+            {
+                // We can OOB vectors to older frameworks
+                "System.Numerics.Vectors"
+            };
 
             foreach (var fxGroup in fxs.Frameworks)
             {
@@ -77,6 +82,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
 
                     foreach (var assembly in fx.Assemblies.Where(a => !s_classicAssemblies.Contains(a.Key) && a.Value != maxVersion))
                     {
+                        if (ignoredAssemblies.Contains(assembly.Key))
+                        {
+                            continue;
+                        }
+
                         _log.Reset();
                         Version assmGeneration = _generations.DetermineGenerationFromSeeds(assembly.Key, assembly.Value, _log);
 


### PR DESCRIPTION
Remove UsePackageTargetRuntimeDefaults since it is no longer used and replaced with OSGroup > PackageTargetRuntime mapping.

Remove System.Numerics.Vectors from generations as part of https://github.com/dotnet/corefx/issues/5900

/cc @chcosta @weshaggard 