### PR TITLE
Fix to UploadToAzure to return false when something fail

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -120,10 +120,17 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     Log.LogMessage(MessageImportance.Normal, "Received response to check whether Container blobs exist");
                 }
             }
-            await ThreadingTask.WhenAll(Items.Select(item => UploadAsync(ct, item, blobsPresent)));
+            try
+            {
+                await ThreadingTask.WhenAll(Items.Select(item => UploadAsync(ct, item, blobsPresent)));
+            }
+            catch (Exception)
+            {
+                Log.LogError("Failed to upload to Azure");
+                return false;
+            }
 
-           Log.LogMessage(MessageImportance.High, "Upload to Azure is complete, a total of {0} items were uploaded.", Items.Length);
-
+            Log.LogMessage(MessageImportance.High, "Upload to Azure is complete, a total of {0} items were uploaded.", Items.Length);
             return true;
         }
 
@@ -155,7 +162,11 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 result = false;
             }
 
-            if (result)
+            if (!result)
+            {
+                throw new Exception ("Task UploadToAzure failed.");
+            }
+            else
             {
                 Log.LogMessage("Uploading {0} to {1}.", item.ItemSpec, ContainerName);
                 UploadClient uploadClient = new UploadClient(Log);

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 ContainerName);
 
             DateTime dt = DateTime.UtcNow;
-            HashSet<string> blobsPresent = new HashSet<string>();
+            HashSet<string> blobsPresent = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             using (HttpClient client = new HttpClient())
             {
@@ -124,9 +124,9 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             {
                 await ThreadingTask.WhenAll(Items.Select(item => UploadAsync(ct, item, blobsPresent)));
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                Log.LogError("Failed to upload to Azure");
+                Log.LogErrorFromException(e,true);
                 return false;
             }
 


### PR DESCRIPTION
The task UploadToAzure was always returning true even if there were failures in the execution.
With this change we validate that if an exception happened we are returning false. 

cc: @karajas @chcosta @jhendrixMSFT 