### PR TITLE
Add wrapper script so we can call the CloudTest targets directly

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTestWrapper.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTestWrapper.targets
@@ -1,0 +1,4 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$(MSBuildThisFileDirectory)CloudTest.targets" />
+</Project>


### PR DESCRIPTION
Adds a wrapper script which imports dir.props and CloudTest.targets so that we can make a direct call to the CloudTest targets.  This enables us to push to Helix by running "msbuild Tools\CloudTestWrapper.targets /t:CloudBuild /p:blah".  The test build does not utilize build,proj, it's simply a build of tests.builds, which doesn't import the cloud test targets.  In addition, it is useful to have this a discrete step in the build pipeline so that our test build does not claim failure if there is an issue pushing to Helix, and it allows us to more easily rerun that single failed step.

/cc @weshaggard @jhendrixMSFT , @MattGal 