### PR TITLE
Don't overwrite TargetOS if it is already set

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -212,7 +212,7 @@
   <Target Name="CheckTestPlatforms"
           AfterTargets="Test">
     <GetTargetMachineInfo>
-      <Output TaskParameter="TargetOS" PropertyName="TargetOS" />
+      <Output TaskParameter="TargetOS" PropertyName="TargetOS" Condition="'$(TargetOS)' == ''" />
     </GetTargetMachineInfo>
     <PropertyGroup>
       <TestDisabled Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'">true</TestDisabled>


### PR DESCRIPTION
In cross building cases (where we compile on Windows but want to run
tests on Linux), the GetTargetMachineInfo task will get the host machine
information, and stomp over whatever TargetOS was set on the command
line.

Add a condition so this does not happen.