### PR TITLE
 Adding linux support for perf tests  

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Perf.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Perf.targets
@@ -11,9 +11,13 @@
     <PerfRunnerJsonFileName>xunitrunner-perf.json</PerfRunnerJsonFileName>
     <!-- place the JSON file in the same directory as the runner script -->
     <PerfRunnerJsonFile>$(SupplementalPayloadDir)RunnerScripts/xunitrunner-perf/$(PerfRunnerJsonFileName)</PerfRunnerJsonFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
     <RunnerScript>%HELIX_CORRELATION_PAYLOAD%\RunnerScripts\xunitrunner-perf\xunitrunner-perf.py</RunnerScript>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
+    <RunnerScript>$HELIX_CORRELATION_PAYLOAD/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py</RunnerScript>
+  </PropertyGroup>
   <!-- creates a JSON file to be uploaded as supplemental payload -->
   <Target Name="CreatePerfJson">
     <CreateAzureContainer

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -109,6 +109,7 @@
     <!-- copy runner scripts so they can be uploaded as supplemental payload -->
     <ItemGroup>
       <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.py" />
+      <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.sh" />
     </ItemGroup>
     <Copy SourceFiles="@(RunnerScripts)"
           DestinationFiles="@(RunnerScripts->'$(SupplementalPayloadDir)RunnerScripts/%(RecursiveDir)%(Filename)%(Extension)')"
@@ -203,8 +204,14 @@
   </Target>
 
   <Target Name="CreatePerfTestListJson" DependsOnTargets="CreateAzureStorage" Condition="'$(Performance)' == 'true'">
+    <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
+      <PerfRunner>Microsoft.DotNet.xunit.performance.runner.Windows</PerfRunner>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
+      <PerfRunner>Microsoft.DotNet.xunit.performance.runner.cli</PerfRunner>
+    </PropertyGroup>
     <PropertyGroup>
-      <OtherRunnerScriptArgs>--perf-runner Microsoft.DotNet.xunit.performance.runner.Windows $(OtherRunnerScriptArgs)</OtherRunnerScriptArgs>
+      <OtherRunnerScriptArgs>--perf-runner $(PerfRunner) --osgroup $(OSGroup) $(OtherRunnerScriptArgs)</OtherRunnerScriptArgs>
     </PropertyGroup>
     <!-- now gather the perf tests -->
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Argument = -d destdir
+usage()
+{
+cat << EOF
+usage: $0 options
+
+This script installs dotnet cli on the linux machine
+
+OPTIONS:
+   -h      Show this message
+   -d      directory where dotnet cli will be installed
+
+EOF
+}
+
+DESTDIR=
+while getopts “hd:” OPTION
+do
+     case $OPTION in
+         h)
+             usage
+             exit 1
+             ;;
+         d)
+             DESTDIR=$OPTARG
+             ;;
+         ?)
+             usage
+             exit
+             ;;
+     esac
+done
+
+echo $DESTDIR
+if [[ -z $DESTDIR ]]
+then
+     usage
+     exit 1
+fi
+
+echo "Initiating local dotnet install"
+wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
+chmod 777 dotnet-install.sh
+wget https://raw.githubusercontent.com/Microsoft/xunit-performance/master/DotNetCliVersion.txt
+versionnum=$(cat DotNetCliVersion.txt)
+mkdir $DESTDIR
+source dotnet-install.sh -i $DESTDIR -v $versionnum

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -4,7 +4,7 @@
   <!-- Perf Runner NuGet package paths -->
   <PropertyGroup>
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0030</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfRunnerPackageVersion>
     <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
     <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/xunit.performance.run.exe</XunitPerfRunnerPath>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   <!-- Perf Analysis NuGet package paths -->
   <PropertyGroup>
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
-    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0030</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfAnalysisPackageVersion>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -3,14 +3,16 @@
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0030",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0030",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0033",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0033",
     "xunit": "2.1.0",
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
+        "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0033",
+        "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0033",
         "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-24027",
         "Microsoft.NETCore.Console": "1.0.0-rc2-24027",


### PR DESCRIPTION
•Modifying python commands to run for Linux runs
•Modifying xunit perf runner to set up execution environment for running perf tests
•Modifying test runtime dependencies to restore the cli version of xunit perf runner for Linux
•Installing dotnet cli per correlation id (by referring to version number specified under xunit performance repo) 

P.S.: xunit perffornance package version 0032 is yet to be published
@lt72 @MattGal 
 