### PR TITLE
Include TargetGroup in the test archive name as required.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -218,18 +218,21 @@
 
   <!-- archive the test binaries along with some supporting files -->
   <Target Name="ArchiveTestBuild" AfterTargets="CreateAssemblyListTxt" Condition="'$(ArchiveTests)' == 'true'">
+    <PropertyGroup Condition="'$(TestProjectName)'==''">
+      <TestProjectName>$(MSBuildProjectName)</TestProjectName>
+    </PropertyGroup>
     <PropertyGroup>
       <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>
       <ProjectJson Condition="!Exists('$(ProjectJson)')">$(OriginalProjectJson)</ProjectJson>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(TestProjectName)'==''">
-      <TestProjectName>$(MSBuildProjectName)</TestProjectName>
+      <DestinationArchiveFile>$(TestArchiveDir)$(TestProjectName)</DestinationArchiveFile>
+      <DestinationArchiveFile Condition="'$(TargetGroup)' != ''">$(DestinationArchiveFile).$(TargetGroup)</DestinationArchiveFile>
+      <DestinationArchiveFile>$(DestinationArchiveFile).zip</DestinationArchiveFile>
     </PropertyGroup>
 
     <!-- the project json files need to be included in the archive -->
     <Copy SourceFiles="$(ProjectJson);$(ProjectLockJson)" DestinationFolder="$(OutDir)" />
     <MakeDir Directories="$(TestArchiveDir)" />
-    <ZipFileCreateFromDirectory SourceDirectory="$(OutDir)" DestinationArchive="$(TestArchiveDir)$(TestProjectName).zip" OverwriteDestination="true" />
+    <ZipFileCreateFromDirectory SourceDirectory="$(OutDir)" DestinationArchive="$(DestinationArchiveFile)" OverwriteDestination="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Some tests build for multiple target groups; in these cases include the
target group value in the archive name to ensure they're unique.

Fixes issue https://github.com/dotnet/buildtools/issues/687#event-649282773.