### PR TITLE
Add docker cleanup script

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/cleanup-docker.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/cleanup-docker.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+
+#
+# ./cleanup-docker.sh 
+#
+
+# cleanup containers
+my $psList = `docker ps -a`;
+my @psItems = split /\n/, $psList;
+foreach(@psItems) {
+  if($_ =~ /.*\s+([^\s]+)$/ig) {
+    my $containerName = $1;
+    if($containerName !~ /NAME/ig) {
+      printf "delete container $containerName\n";
+      my $deleteOutput = `docker rm -f $1`;
+      print "$deleteOutput\n";
+    }
+  }
+}
+
+#cleanup images
+my $imageList = `docker images`;
+@imageItems = split /\n/, $imageList;
+foreach(@imageItems) {
+  if($_ =~ /([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+.*/ig) {
+    my $imageId = $3;
+    if($imageId !~ /IMAGE/ig) {
+      printf "delete image ID $imageId\n";
+      my $deleteImageOutput = `docker rmi $imageId`;
+      printf "$deleteImageOutput\n";
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/cleanup-docker.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/cleanup-docker.sh
@@ -8,6 +8,7 @@
 my $psList = `docker ps -a`;
 my @psItems = split /\n/, $psList;
 foreach(@psItems) {
+  # match 'docker ps' output to capture the container name
   if($_ =~ /.*\s+([^\s]+)$/ig) {
     my $containerName = $1;
     if($containerName !~ /NAME/ig) {
@@ -22,6 +23,7 @@ foreach(@psItems) {
 my $imageList = `docker images`;
 @imageItems = split /\n/, $imageList;
 foreach(@imageItems) {
+  # match 'docker images' output to capture the image id
   if($_ =~ /([^\s]+)\s+([^\s]+)\s+([^\s]+)\s+.*/ig) {
     my $imageId = $3;
     if($imageId !~ /IMAGE/ig) {


### PR DESCRIPTION
Cleanup script removes all containers and images from a VM using docker.

It would be nice to have more fine grained control over what is removed, but having a cleanup script available from BuildTools puts us in a much better place for having clean build machines in our build lab which aren't running out of disk space issues due to docker images / containers lingering.

It would also be nice if this functionality was a part of clean.sh, but I'm not really certain how it would fit into the flow seamlessly (perhaps checking for 'docker' and then running the script if docker is installed).  We wouldn't want this to be a default as it could be extremely disruptive to have all of a devs images / containers disappear.

/cc @weshaggard , @jhendrixMSFT 