### PR TITLE
Capture exit codes, and set the exit code correctly

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -34,7 +34,7 @@ call "%DOTNET_CMD%" restore "%TOOLRUNTIME_PROJECTJSON%" --source https://dotnet.
 set RESTORE_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%RESTORE_ERROR_LEVEL%]==[0] (
-	echo ERROR: An error occured on the restore.
+	echo ERROR: An error occured when running: '"%DOTNET_CMD%" restore "%TOOLRUNTIME_PROJECTJSON%"'. Please check above for more details.
 	exit /b %RESTORE_ERROR_LEVEL%
 )
 @echo on
@@ -42,7 +42,7 @@ call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECTJSON%" -f dnxcore50 -r %BUILDTO
 set DNXCORE_PUBLISH_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%DNXCORE_PUBLISH_ERROR_LEVEL%]==[0] (
-	echo ERROR: An error ocurred when publishing to dnxcore50.
+	echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECTJSON%" -f dnxcore50'. Please check above for more details.
 	exit /b %DNXCORE_PUBLISH_ERROR_LEVEL%
 )
 @echo on
@@ -50,7 +50,7 @@ call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECTJSON%" -f net45 -r %BUILDTOOLS_
 set NET45_PUBLISH_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%NET45_PUBLISH_ERROR_LEVEL%]==[0] (
-	echo ERROR: An error ocurred when publishing to net45.
+	echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECTJSON%" -f net45'. Please check above for more details.
 	exit /b %NET45_PUBLISH_ERROR_LEVEL%
 )
 
@@ -63,7 +63,7 @@ call "%DOTNET_CMD%" restore "%PORTABLETARGETS_PROJECTJSON%" --source https://dot
 set RESTORE_PORTABLETARGETS_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%RESTORE_PORTABLETARGETS_ERROR_LEVEL%]==[0] (
-	echo ERROR: An error ocurred on the restore of the portable targets.
+	echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" restore "%PORTABLETARGETS_PROJECTJSON%"'. Please check above for more details.
 	exit /b %RESTORE_PORTABLETARGETS_ERROR_LEVEL%
 )
 Robocopy "%PACKAGES_DIR%\Microsoft.Portable.Targets\%PORTABLETARGETS_VERSION%\contentFiles\any\any\." "%TOOLRUNTIME_DIR%\." /E

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -63,13 +63,13 @@ __TOOLRUNTIME_PROJECTJSON=$__TOOLS_DIR/tool-runtime/project.json
 echo "Running: $__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECTJSON}\" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json"
 $__DOTNET_CMD restore "${__TOOLRUNTIME_PROJECTJSON}" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json
 if [ "$?" != "0" ]; then
-    echo "ERROR: An error occured on the restore."
+    echo "ERROR: An error occured when running: '$__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECTJSON}\"'. Please check above for more details."
     exit 1
 fi
 echo "Running: $__DOTNET_CMD publish \"${__TOOLRUNTIME_PROJECTJSON}\" -f dnxcore50 -r ${__PUBLISH_RID} -o $__TOOLRUNTIME_DIR"
 $__DOTNET_CMD publish "${__TOOLRUNTIME_PROJECTJSON}" -f dnxcore50 -r ${__PUBLISH_RID} -o $__TOOLRUNTIME_DIR
 if [ "$?" != "0" ]; then
-    echo "ERROR: An error occured on publish."
+    echo "ERROR: An error ocurred when running: '$__DOTNET_CMD publish \"${__TOOLRUNTIME_PROJECTJSON}\"'. Please check above for more details."
     exit 1
 fi
 chmod a+x $__TOOLRUNTIME_DIR/corerun
@@ -86,7 +86,7 @@ echo $__MSBUILD_CONTENT_JSON > "${__PORTABLETARGETS_PROJECTJSON}"
 echo "Running: \"$__DOTNET_CMD\" restore \"${__PORTABLETARGETS_PROJECTJSON}\" --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --packages \"${__PACKAGES_DIR}/.\""
 $__DOTNET_CMD restore "${__PORTABLETARGETS_PROJECTJSON}" --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --packages "${__PACKAGES_DIR}/."
 if [ "$?" != "0" ]; then
-    echo "ERROR: An error occured on the restore of the portable targets."
+    echo "ERROR: An error ocurred when running: '$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECTJSON}\"'. Please check above for more details."
     exit 1
 fi
 cp -R "${__PACKAGES_DIR}/Microsoft.Portable.Targets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."


### PR DESCRIPTION
turns out we were not caching the exit codes when calling dotnet cli for restore or publish commands, so if they failed we were not returning the failure, which in some cases makes the user think that init tools succeeded even though it didin't.

This, plus a change in the consumer's init-tools script to read the exit code of this scripts, will hopefully make errors more clear.

cc: @weshaggard 

fixes: #473 