### PR TITLE
AddCloudTestContainerSuffix, new optionally property for container name

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ContainerName Condition="'$(ContainerName)' == ''">$(TestProduct)-$(Branch)-$(BuildMoniker)</ContainerName>
+    <ContainerName Condition="'$(ContainerName)' == ''">$(TestProduct)-$(Branch)-$(BuildMoniker)$(CloudTestContainerSuffix)</ContainerName>
     <ContainerName>$(ContainerName.ToLower())</ContainerName>
     <FuncTestListFilename>FuncTests.$(OSGroup).$(Platform)$(ConfigurationGroup).json</FuncTestListFilename>
     <PerfTestListFilename>PerfTests.$(OSGroup).$(Platform)$(ConfigurationGroup).json</PerfTestListFilename>


### PR DESCRIPTION
This allows differentiating between different target OS'es.  Previously TargetOS was used, but now that we need this value to be set properly and since when set properly it can be the same across different OS'es (I.e. all Windows SKUs get Windows_NT) we need a mechanism to keep the containers separate.