### PR TITLE
Change .NET Helix packaging to zip up only needed files

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -261,9 +261,11 @@
       <ExcludeFromArchive Include="nupkg$" />
       <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
       <ExcludeFromArchive Include="TestData" />
+      <TestDependencyListFile Include="$(BinDir)/TestDependencies/*.dependencylist.txt" />      
     </ItemGroup>
+    
     <ZipFileCreateFromDependencyLists
-      DependencyListsFolder="$(BinDir)/TestDependencies"
+      DependencyListFiles="@(TestDependencyListFile)"
       DestinationArchive="$(PackagesArchiveFile)"
       RelativePathBaseDirectory="$(PackagesDir)"
       OverwriteDestination="true" />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -10,6 +10,7 @@
   <UsingTask TaskName="WriteItemsToJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="WriteTestBuildStatsJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ZipFileCreateFromDependencyLists" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <!-- set Helix environment vars based on target platform -->
   <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
@@ -29,11 +30,11 @@
     <FuncTestListFilename>FuncTests.$(OSGroup).$(Platform)$(ConfigurationGroup).json</FuncTestListFilename>
     <PerfTestListFilename>PerfTests.$(OSGroup).$(Platform)$(ConfigurationGroup).json</PerfTestListFilename>
     <!-- Test builds consist of the tests that are platform specific in one root, plus others in AnyOS. -->
-    <AnyOSPlatformConfig>AnyOS.AnyCPU.$(ConfigurationGroup)</AnyOSPlatformConfig>    
+    <AnyOSPlatformConfig>AnyOS.AnyCPU.$(ConfigurationGroup)</AnyOSPlatformConfig>
     <AnyOsArchivesRoot>$(TestWorkingDir)$(AnyOSPlatformConfig)/archive/</AnyOsArchivesRoot>
     <AnyOSTestArchivesRoot>$(AnyOsArchivesRoot)tests/</AnyOSTestArchivesRoot>
-    <!-- Additionally, *NIX variations may need to include their own root folders -->    
-    <UnixPlatformConfig>Unix.$(Platform).$(ConfigurationGroup)</UnixPlatformConfig>    
+    <!-- Additionally, *NIX variations may need to include their own root folders -->
+    <UnixPlatformConfig>Unix.$(Platform).$(ConfigurationGroup)</UnixPlatformConfig>
     <UnixArchivesRoot>$(TestWorkingDir)$(UnixPlatformConfig)/archive/</UnixArchivesRoot>
     <UnixTestArchivesRoot>$(UnixArchivesRoot)tests/</UnixTestArchivesRoot>
     <!-- Finally, these archives represent the zips of tests that are OSPlatform specific -->
@@ -76,7 +77,7 @@
     <Error Condition="'$(BuildIsOfficial)' == 'true' and '$(BuildIsOfficialEventHubSharedAccessKey)' == ''" Text="Missing required property BuildIsOfficialEventHubSharedAccessKey." />
     <!-- TODO: Once we all users are no longer setting EventHubInfoMissing, we can remove this message, and the '$(EventHubInfoMissing)' == '' condition from the error following -->
     <PropertyGroup>
-     <EventHubInfoMissing Condition="'$(EventHubPath)' == '' or '$(EventHubSharedAccessKey)' == '' or '$(EventHubSharedAccessKeyName)' == ''">true</EventHubInfoMissing>
+      <EventHubInfoMissing Condition="'$(EventHubPath)' == '' or '$(EventHubSharedAccessKey)' == '' or '$(EventHubSharedAccessKeyName)' == ''">true</EventHubInfoMissing>
     </PropertyGroup>
     <Warning Condition="'$(SkipNotifyEvent)' != 'true' and '$(HelixApiAccessKey)' == '' and '$(EventHubInfoMissing)' == '' " Text="EventHubPath and EventHubAccessKeys are depricated, use HelixApiAccessKey" />
     <Error Condition="'$(SkipNotifyEvent)' != 'true' and '$(HelixApiAccessKey)' == '' and '$(EventHubInfoMissing)' == 'true' " Text="HelixApiAccessKey must be set to start Helix jobs" />
@@ -85,14 +86,14 @@
     <ItemGroup>
       <ForUpload Include="$(TestArchivesRoot)**/*.zip" />
       <ForUpload Include="$(AnyOSTestArchivesRoot)*.zip" />
-      <!-- Only include Unix folders if supported by the current target OS --> 
-      <ForUpload Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />      
-    </ItemGroup>   
-    
-    <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" /> 
+      <!-- Only include Unix folders if supported by the current target OS -->
+      <ForUpload Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />
+    </ItemGroup>
+
+    <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" />
     <Message Text="Using AnyOS test archives from: $(AnyOSTestArchivesRoot)" />
     <Message Condition="'$(TargetsUnix)' == 'true'"  Text="Using Unix test archives from: $(UnixTestArchivesRoot)" />
-    
+
     <!-- verify the test archives were created -->
     <Error Condition="'@(ForUpload->Count())' == '0'" Text="Didn't find any test archives in supplied folders." />
     <!-- add relative blob path metadata -->
@@ -166,12 +167,12 @@
     <ItemGroup>
       <FunctionalTest Include="$(TestArchivesRoot)**/*.zip" />
       <FunctionalTest Include="$(AnyOSTestArchivesRoot)*.zip" />
-      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />  
+      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />
     </ItemGroup>
 
     <PropertyGroup>
-        <OtherRunnerScriptArgs Condition="'$(FilterToTargetGroup)' == 'net46'">$(OtherRunnerScriptArgs) --xunit-test-type=desktop </OtherRunnerScriptArgs>
-        <XunitArgs Condition="'$(FilterToTargetGroup)' == 'net46'"> -noshadow $(XunitArgs)</XunitArgs>
+      <OtherRunnerScriptArgs Condition="'$(FilterToTargetGroup)' == 'net46'">$(OtherRunnerScriptArgs) --xunit-test-type=desktop </OtherRunnerScriptArgs>
+      <XunitArgs Condition="'$(FilterToTargetGroup)' == 'net46'"> -noshadow $(XunitArgs)</XunitArgs>
     </PropertyGroup>
 
     <ItemGroup>
@@ -254,19 +255,18 @@
     </ItemGroup>
   </Target>
 
-  <!-- compress the packages dir in preparation for uploading -->
+  <!-- compress the required files from the packages dir in preparation for uploading -->
   <Target Name="CompressPackagesDir" Condition="'$(SkipArchive)' != 'true'">
     <ItemGroup>
       <ExcludeFromArchive Include="nupkg$" />
       <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
       <ExcludeFromArchive Include="TestData" />
     </ItemGroup>
-    <ZipFileCreateFromDirectory
-        SourceDirectory="$(PackagesDir)"
-        DestinationArchive="$(PackagesArchiveFile)"
-        ExcludePatterns="@(ExcludeFromArchive)"
-        OverwriteDestination="true" />
-    <!-- add to the list of uploads -->
+    <ZipFileCreateFromDependencyLists
+      DependencyListsFolder="$(BinDir)/TestDependencies"
+      DestinationArchive="$(PackagesArchiveFile)"
+      RelativePathBaseDirectory="$(PackagesDir)"
+      OverwriteDestination="true" />
     <ItemGroup>
       <ForUpload Include="$(PackagesArchiveFile)">
         <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/$(PackagesArchiveFilename)</RelativeBlobPath>
@@ -318,8 +318,8 @@
     <!-- write out build statistics (only contains number of built projects at present) -->
     <ItemGroup>
       <BuiltSuccessfully Include="$(TestArchivesRoot)*.zip" />
-      <BuiltSuccessfully Include="$(AnyOSTestArchivesRoot)*.zip" />      
-      <BuiltSuccessfully Condition="'$(TargetsUnix)' == 'true'"  Include="$(UnixTestArchivesRoot)*.zip" />      
+      <BuiltSuccessfully Include="$(AnyOSTestArchivesRoot)*.zip" />
+      <BuiltSuccessfully Condition="'$(TargetsUnix)' == 'true'"  Include="$(UnixTestArchivesRoot)*.zip" />
     </ItemGroup>
   </Target>
 
@@ -341,7 +341,7 @@
       <Output TaskParameter="JobId" PropertyName="GeneratedCorrelationId" />
     </SendToHelix>
     <PropertyGroup Condition="'$(HelixApiAccessKey)' == ''">
-     <GeneratedCorrelationId>%(TestListFile.CorrelationId)</GeneratedCorrelationId>
+      <GeneratedCorrelationId>%(TestListFile.CorrelationId)</GeneratedCorrelationId>
     </PropertyGroup>
     <WriteLinesToFile File="%(TestListFile.HelixJobUploadCompletePath)" Overwrite="true" Lines="Correlation Id : $(GeneratedCorrelationId)"/>
     <Message Condition="'$(HelixApiAccessKey)' == ''" Importance="high" Text="Started Helix job: CorrelationId = $(GeneratedCorrelationId)"/>

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class GenerateAssemblyList : Task
+    {
+        [Required]
+        public string InputListLocation { get; set; }
+
+        [Required]
+        public string OutputListLocation { get; set; }
+
+        public override bool Execute()
+        {
+            HashSet<string> processedFileNames = new HashSet<string>();
+            AssemblyList corerun = new AssemblyList("Microsoft.NETCore.Runtime", "Microsoft.NETCore.TestHost", "Microsoft.NETCore.Windows.ApiSets");
+            AssemblyList xunit = new AssemblyList("xunit");
+            List<string> unmatched = new List<string>();
+            bool foundDuplicates = false;
+            Stream inputListLocationStream = File.OpenRead(InputListLocation);
+            Stream outputListLocationStream = new FileStream(OutputListLocation, FileMode.Create, FileAccess.Write, FileShare.None);
+
+            using (StreamReader listReader = new StreamReader(inputListLocationStream))
+            {
+                string line;
+                while ((line = listReader.ReadLine()) != null)
+                {
+                    var fileName = Path.GetFileName(line);
+                    if (!processedFileNames.Add(fileName))
+                    {
+                        Log.LogError("Duplicate assembly found: {0}", fileName);
+                        foundDuplicates = true;
+                        continue;
+                    }
+
+                    if (corerun.TryAdd(line))
+                    {
+                        continue;
+                    }
+
+                    if (xunit.TryAdd(line))
+                    {
+                        continue;
+                    }
+
+                    unmatched.Add(line);
+                }
+            }
+
+            if (foundDuplicates)
+            {
+                return false;
+            }
+
+            Dictionary<string, List<string>> headers = new Dictionary<string, List<string>>
+            {
+                {"corerun", corerun.Dependencies},
+                {"xunit", xunit.Dependencies},
+                {"testdependency", unmatched},
+            };
+
+            using (StreamWriter listRewriter = new StreamWriter(outputListLocationStream))
+            using (JsonWriter jsonWriter = new JsonTextWriter(listRewriter))
+            {
+                jsonWriter.Formatting = Formatting.Indented;
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Serialize(jsonWriter, headers);
+            }
+
+            return true;
+        }
+
+        private class AssemblyList
+        {
+            public List<string> Dependencies { get; private set; }
+            private readonly List<string> _patternToContain;
+
+            public AssemblyList(params string[] patterns)
+            {
+                _patternToContain = new List<string>(patterns);
+                Dependencies = new List<string>();
+            }
+
+            public bool TryAdd(string packageId)
+            {
+                if (_patternToContain.Any(packageId.Contains))
+                {
+                    Dependencies.Add(packageId);
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -21,6 +21,7 @@
     <Compile Include="ExceptionFromResource.cs" />
     <Compile Include="ExecWithMutex.cs" />
     <Compile Include="GatherFoldersToRestore.cs" />
+    <Compile Include="GenerateAssemblyList.cs" />
     <Compile Include="AddDependenciesToProjectJson.cs" />
     <Compile Include="GenerateTestExecutionScripts.cs" />
     <Compile Include="ParsePackageNames.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -48,6 +48,7 @@
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="WriteSigningRequired.cs" />
+    <Compile Include="ZipFileCreateFromDependencyLists.cs" />
     <Compile Include="ZipFileExtractToDirectory.cs" />
     <Compile Include="ZipFileCreateFromDirectory.cs" />
     <Compile Include="Strings.Designer.cs">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -173,6 +173,12 @@
       Lines="@(IncludedFileForRunnerScript -> '%(PackageRelativePath)')"
       Overwrite="true"
       Encoding="Ascii" />
+    
+    <Message Text="Generating JSON-Processed $(OutDir)assemblylist.txt for legacy execution" />
+    <GenerateAssemblyList
+      InputListLocation="$(OutputFolderForTestDependencies)/$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup).dependencylist.txt"
+      OutputListLocation="$(OutDir)assemblylist.txt"
+     />
 
     <!-- Add commands for before / after test execution here.  -->
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -152,7 +152,6 @@
       <OutputFolderForScriptGenerator>$(TestPath)%(TestTargetFramework.Folder)</OutputFolderForScriptGenerator>
       <OutputPathForScriptGenerator>$(OutputFolderForScriptGenerator)/$(RunnerScriptName)</OutputPathForScriptGenerator>
       <OutputFolderForTestDependencies>$(BinDir)/TestDependencies</OutputFolderForTestDependencies>
-
     </PropertyGroup>
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
@@ -168,9 +167,9 @@
     </ItemGroup>
     
     <MakeDir Directories="$(OutputFolderForTestDependencies)" />
-    <Message Text="Generating $(OutputFolderForTestDependencies)/$(AssemblyName).dependencylist.txt" />
+    <Message Text="Generating $(OutputFolderForTestDependencies)/$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup).dependencylist.txt" />
     <WriteLinesToFile
-      File="$(OutputFolderForTestDependencies)/$(AssemblyName).dependencylist.txt"
+      File="$(OutputFolderForTestDependencies)/$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup).dependencylist.txt"
       Lines="@(IncludedFileForRunnerScript -> '%(PackageRelativePath)')"
       Overwrite="true"
       Encoding="Ascii" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -151,6 +151,8 @@
       <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
       <OutputFolderForScriptGenerator>$(TestPath)%(TestTargetFramework.Folder)</OutputFolderForScriptGenerator>
       <OutputPathForScriptGenerator>$(OutputFolderForScriptGenerator)/$(RunnerScriptName)</OutputPathForScriptGenerator>
+      <OutputFolderForTestDependencies>$(BinDir)/TestDependencies</OutputFolderForTestDependencies>
+
     </PropertyGroup>
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
@@ -164,6 +166,14 @@
         <UseAbsolutePath Condition="'$(TestWithLocalLibraries)'=='true'">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').StartsWith('$(BinDir)'))</UseAbsolutePath>
       </IncludedFileForRunnerScript>
     </ItemGroup>
+    
+    <MakeDir Directories="$(OutputFolderForTestDependencies)" />
+    <Message Text="Generating $(OutputFolderForTestDependencies)/$(AssemblyName).dependencylist.txt" />
+    <WriteLinesToFile
+      File="$(OutputFolderForTestDependencies)/$(AssemblyName).dependencylist.txt"
+      Lines="@(IncludedFileForRunnerScript -> '%(PackageRelativePath)')"
+      Overwrite="true"
+      Encoding="Ascii" />
 
     <!-- Add commands for before / after test execution here.  -->
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileCreateFromDependencyLists.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileCreateFromDependencyLists.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class ZipFileCreateFromDependencyLists : Task
+    {
+        /// <summary>
+        /// List of dependency text files to be unified.
+        /// </summary>
+        [Required]
+        public string DependencyListsFolder { get; set; }
+
+        /// <summary>
+        /// The path of the archive to be created.
+        /// </summary>
+        [Required]
+        public string DestinationArchive { get; set; }
+
+        [Required]
+        /// <summary>
+        /// Base path for paths specified in txt files in DependencyListsFolder
+        /// </summary>
+        public string RelativePathBaseDirectory { get; set; }
+
+        /// <summary>
+        /// Indicates if the destination archive should be overwritten if it already exists.
+        /// </summary>
+        public bool OverwriteDestination { get; set; } = false;
+
+        public override bool Execute()
+        {
+            Log.LogMessage($"DependencyListsFolder = {DependencyListsFolder}");
+            Log.LogMessage($"DestinationArchive = {DestinationArchive}");
+            Log.LogMessage($"RelativePathBaseDirectory = {RelativePathBaseDirectory}");
+            Log.LogMessage($"OverwriteDestination = {OverwriteDestination}");
+
+            try
+            {
+                if (File.Exists(DestinationArchive))
+                {
+                    if (OverwriteDestination == true)
+                    {
+                        Log.LogMessage(MessageImportance.Low, $"{DestinationArchive} already existed, deleting before zipping...");
+                        File.Delete(DestinationArchive);
+                    }
+                    else
+                    {
+                        Log.LogWarning($"'{DestinationArchive}' already exists, no change will occur. Did you forget to set '{nameof(OverwriteDestination)}' to true?");
+                    }
+                }
+
+                Log.LogMessage(MessageImportance.High, $"Compressing files listed in {DependencyListsFolder} into {DestinationArchive}...");
+                if (!Directory.Exists(Path.GetDirectoryName(DestinationArchive)))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(DestinationArchive));
+                }
+                List<string> filesForArchiving = GetUniquePaths(DependencyListsFolder, "*");
+                Log.LogMessage($"{DependencyListsFolder} contained files referencing {filesForArchiving.Count} unique file paths.");
+                ZipDependencies(filesForArchiving, RelativePathBaseDirectory, DestinationArchive);
+            }
+            catch (Exception e)
+            {
+                // We have 2 log calls because we want a nice error message but we also want to capture the callstack in the log.
+                Log.LogError($"An exception has occured while trying to compress files listed in '{DependencyListsFolder}' into '{DestinationArchive}'.");
+                Log.LogMessage(MessageImportance.Low, e.ToString());
+                return false;
+            }
+
+            return true;
+        }
+
+
+        private List<string> GetUniquePaths(string folder, string filePattern)
+        {
+            HashSet<string> everyDependency = new HashSet<string>();
+            foreach (string path in Directory.GetFiles(folder, filePattern))
+            {
+                IEnumerable<string> specificDependencies = File.ReadAllLines(path);
+                everyDependency.UnionWith(specificDependencies);
+            }
+            return everyDependency.Distinct().ToList<string>();
+        }
+
+        private void ZipDependencies(List<string> dependencies, string basePath, string outputFileName)
+        {
+            using (FileStream zipToOpen = new FileStream(outputFileName, FileMode.Create))
+            {
+                using (ZipArchive archive = new ZipArchive(zipToOpen, ZipArchiveMode.Create))
+                {
+                    foreach (string dependency in dependencies)
+                    {
+                        string absolutePath = Path.Combine(basePath, dependency);
+                        archive.CreateEntryFromFile(absolutePath, dependency.Replace('\\', '/'));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
First draft of writing dependency lists to disk during build, and only including these files in the resulting zip archive.  This results in a drop in packed size from ~300 MB to ~18 MB, and a drop in unpacked sized from ~1.5 GB to ~46 MB.

(Note whitespace changes in CloudTest.targets are just VS automated formatting)
@weshaggard @Petermarcu 