### PR TITLE
Fix block upload encode

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -219,6 +219,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         private static Dictionary<string, HashSet<string>> ExtractQueryKeyValues(Uri address)
         {
             Dictionary<string, HashSet<string>> values = new Dictionary<string, HashSet<string>>();
+            address = new Uri(WebUtility.UrlDecode(address.ToString()));
             Regex newreg = new Regex(@"\?(\w+)\=([\w|\=]+)|\&(\w+)\=([\w|\=]+)");
             MatchCollection matches = newreg.Matches(address.Query);
             foreach (Match match in matches)


### PR DESCRIPTION
This is a fix for PR #714 . There was a mismatch during upload to use the encoded url paramters instead of the decoded ones to construct the string to sign for authorization.