### PR TITLE
Fix for incorrect auth signing using encoded url parameters

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -219,6 +219,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         private static Dictionary<string, HashSet<string>> ExtractQueryKeyValues(Uri address)
         {
             Dictionary<string, HashSet<string>> values = new Dictionary<string, HashSet<string>>();
+            //Decode this to allow the regex to pull out the correct groups for signing
+            address = new Uri(WebUtility.UrlDecode(address.ToString()));
             Regex newreg = new Regex(@"\?(\w+)\=([\w|\=]+)|\&(\w+)\=([\w|\=]+)");
             MatchCollection matches = newreg.Matches(address.Query);
             foreach (Match match in matches)


### PR DESCRIPTION
Fix for errors introduced in #714 . There was a failure during upload due to the use of encoded url parameters instead of decoded ones during the construction of the string to sign for authorization.

/cc @schaabs @jhendrixMSFT 