### PR TITLE
Change default to not use slash for qualifiers

### DIFF
--- a/src/common/CommandLine.cs
+++ b/src/common/CommandLine.cs
@@ -15,36 +15,36 @@ namespace Microsoft.Fx.CommandLine
     // See code:#Overview to get started.
     /// <summary>
     /// #Overview
-    /// 
+    ///
     /// The code:CommandLineParser is a utility for parsing command lines. Command lines consist of three basic
     /// entities. A command can have any (or none) of the following (separated by whitespace of any size).
-    /// 
+    ///
     ///    * PARAMETERS - this are non-space strings. They are positional (logicaly they are numbered). Strings
     ///        with space can be specified by enclosing in double quotes.
-    ///        
+    ///
     ///    * QUALIFIERS - Qualifiers are name-value pairs. The following syntax is supported.
     ///        * -QUALIFIER
     ///        * -QUALIFIER:VALUE
     ///        * -QUALIFIER=VALUE
     ///        * -QUALIFIER VALUE
-    ///        
+    ///
     ///      The end of a value is delimited by space. Again values with spaces can be encoded by enclosing them
     ///      the value (or the whole qualifer-value string), in double quotes. The first form (where a value is
     ///      not specified is only available for boolean qualifiers, and boolean values can not use the form where
     ///      the qualifer and value are separated by space. The '/' character can also be used instead of the '-'
     ///      to begin a qualifier.
-    ///      
+    ///
     ///      Unlike parameters, qualifiers are NOT ordered. They may occur in any order with respect to the
     ///      parameters or other qualifiers and THAT ORDER IS NOT COMMUNICATED THROUGH THE PARSER. Thus it is not
     ///      possible to have qualifiers that only apply to specific parameters.
-    ///      
+    ///
     ///    * PARAMETER SET SPECIFIER - A parameter set is optional argument that looks like a boolean qualifier
     ///        (however if NoDashOnParameterSets is set the dash is not need, so it is looks like a parameter),
     ///        that is special in that it decides what qualifiers and positional parameters are allowed. See
     ///        code:#ParameterSets for more
-    ///        
+    ///
     /// #ParameterSets
-    /// 
+    ///
     /// Parameter sets are an OPTIONAL facility of code:CommandLineParser that allow more complex command lines
     /// to be specified accurately. It not uncommon for a EXE to have several 'commands' that are logically
     /// independent of one another. For example a for example For example a program might have 'checkin'
@@ -52,47 +52,47 @@ namespace Microsoft.Fx.CommandLine
     /// and qualifiers that are allowed. (for example checkout will take a list of file names, list needs nothing,
     /// and checkin needs a comment). Additionally some qualifiers (like say -dataBaseName can apply to any of hte
     /// commands). Thus You would like to say that the following command lines are legal
-    /// 
+    ///
     ///     * EXE -checkout MyFile1 MyFile -dataBaseName:MyDatabase
     ///     * EXE -dataBaseName:MyDatabase -list
     ///     * EXE -comment "Specifying the comment first" -checkin
     ///     * EXE -checkin -comment "Specifying the comment afterward"
-    /// 
+    ///
     /// But the following are not
-    /// 
+    ///
     ///     * EXE -checkout
     ///     * EXE -checkout -comment "hello"
     ///     * EXE -list MyFile
-    /// 
+    ///
     /// You do this by specifying 'checkout', 'list' and 'checkin' as parameters sets. On the command line they
     /// look like boolean qualifiers, however they have additional sematantics. They must come before any
     /// positional parameters (because they affect whether the parameters are allowed and what they are named),
     /// and they are mutually exclusive. Each parameter set gets its own set of parameter definitions, and
     /// qualifiers can either be associated with a particular parameter set (like -comment) or global to all
     /// parameter sets (like -dataBaseName) .
-    /// 
+    ///
     /// By default parameter set specifiers look like a boolean specifier (begin with a '-' or '/'), however
     /// because it is common practice to NOT have a dash for commands, there there is a Property
     /// code:CommandLineParser.NoDashOnParameterSets that indicates that the dash is not used. If this was
     /// specified then the following command would be legal.
-    /// 
+    ///
     ///     * EXE checkout MyFile1 MyFile -dataBaseName:MyDatabase
-    /// 
+    ///
     /// #DefaultParameterSet
-    /// 
+    ///
     /// One parameters set (which has the empty string name), is special in that it is used when no other
     /// parameter set is matched. This is the default parameter set. For example, if -checkout was defined to be
     /// the default parameter set, then the following would be legal.
-    /// 
+    ///
     ///     * EXE Myfile1 Myfile
-    /// 
+    ///
     /// And would implicitly mean 'checkout' Myfile1, Myfile2
-    /// 
+    ///
     /// If no parameter sets are defined, then all qualifiers and parameters are in the default parameter set.
-    /// 
+    ///
     /// -------------------------------------------------------------------------
     /// #Syntatic ambiguities
-    /// 
+    ///
     /// Because whitespace can separate a qualifier from its value AND Qualifier from each other, and because
     /// parameter values might start with a dash (and thus look like qualifiers), the syntax is ambiguous. It is
     /// disambigutated with the following rules.
@@ -109,10 +109,10 @@ namespace Microsoft.Fx.CommandLine
     ///         that begin with '-' to use space as a separator. They must instead use the ':' or '=' form. This
     ///         is because it is too confusing for humans to parse (values look like qualifiers).
     ///      * Parameters are parsed. Whatever arguments that were not used by qualifiers are parameters.
-    /// 
+    ///
     /// --------------------------------------------------------------------------------------------
     /// #DefiningParametersAndQualifiers
-    /// 
+    ///
     /// The following example shows the steps for defining the parameters and qualifiers for the example. Note
     /// that the order is important. Qualifiers that apply to all commands must be specified first, then each
     /// parameter set then finally the default parameter set. Most steps are optional.
@@ -127,10 +127,10 @@ namespace Microsoft.Fx.CommandLine
                 Command command = checkout;
                 string[] fileNames = null;
 
-                // Step 1 define the parser. 
+                // Step 1 define the parser.
                 CommandLineParser commandLineParser = new CommandLineParser();      // by default uses Environment.CommandLine
 
-                // Step 2 (optional) define qualifiers that apply to all parameter sets. 
+                // Step 2 (optional) define qualifiers that apply to all parameter sets.
                 commandLineParser.DefineOptionalParameter("dataBaseName", ref dataBaseName, "Help for database.");
 
                 // Step 3A define the checkin command this includes all parameters and qualifiers specific to this command
@@ -140,7 +140,7 @@ namespace Microsoft.Fx.CommandLine
                 // Step 3B define the list command this includes all parameters and qualifiers specific to this command
                 commandLineParser.DefineParameterSet("list", ref command, Command.list, "Help for list.");
 
-                // Step 4 (optional) define the default parameter set (in this case checkout). 
+                // Step 4 (optional) define the default parameter set (in this case checkout).
                 commandLineParser.DefineDefaultParameterSet("checkout", ref command, Command.checkout, "Help for checkout.");
                 commandLineParser.DefineParamter("fileNames", ref fileNames, "Help for fileNames.");
 
@@ -153,81 +153,81 @@ namespace Microsoft.Fx.CommandLine
         }
 #endif
     /// #RequiredAndOptional
-    /// 
+    ///
     /// Parameters and qualifiers can be specified as required (the default), or optional. Makeing the default
     /// required was choses to make any mistakes 'obvious' since the parser will fail if a required parameter is
     /// not present (if the default was optional, it would be easy to make what should have been a required
     /// qualifier optional, leading to business logic failiure).
-    /// 
+    ///
     /// #ParsedValues
-    /// 
+    ///
     /// The class was designed maximize programmer convinience. For each parameter, only one call is needed to
     /// both define the parameter, its help message, and retrive its (strong typed) value. For example
-    /// 
+    ///
     ///      * int count = 5;
     ///      * parser.DefineOptionalQualifier("count", ref count, "help for optional debugs qualifier");
-    /// 
+    ///
     /// Defines a qualifier 'count' and will place its value in the local variable 'count' as a integer. Default
     /// values are supported by doing nothing, so in the example above the default value will be 5.
-    /// 
+    ///
     /// Types supported: The parser will support any type that has a static method called 'Parse' taking one
     /// string argument and returning that type. This is true for all primtive types, DateTime, Enumerations, and
     /// any user defined type that follows this convention.
-    /// 
+    ///
     /// Array types: The parser has special knowedge of arrays. If the type of a qualifier is an array, then the
     /// string value is assumed to be a ',' separated list of strings which will be parsed as the element type of
     /// the array. In addition to the ',' syntax, it is also legal to specify the qualifier more than once. For
     /// example given the defintion
-    /// 
+    ///
     ///      * int[] counts;
     ///      * parser.DefineOptionalQualifier("counts", ref counts, "help for optional counts qualifier");
-    ///      
+    ///
     /// The command line
-    /// 
+    ///
     ///     * EXE -counts 5 SomeArg -counts 6 -counts:7
-    /// 
+    ///
     /// Is the same as
-    /// 
+    ///
     ///     * EXE -counts:5,6,7 SomeArg
-    ///      
+    ///
     /// If a qualifier or parameter is an array type and is required, then the array must have at least one
     /// element. If it is optional, then the array can be empty (but in all cases, the array is created, thus
     /// null is never returned by the command line parser).
-    /// 
+    ///
     /// By default is it is illegal for a non-array qualifier to be specified more than once. It is however
     /// possible to override this behavior by setting the LastQualifierWins property before defining the qualifier.
-    /// 
+    ///
     /// -------------------------------------------------------------------------
     /// #Misc
-    /// 
+    ///
     /// Qualifier can have more than one string form (typically a long and a short form). These are specified
     /// with the code:CommandLineParser.DefineAliases method.
-    /// 
+    ///
     /// After defining all the qualifiers and parameters, it is necessary to call the parser to check for the user
     /// specifying a qualifier (or parameter) that does not exist. This is the purpose of the
     /// code:CommandLineParser.CompleteValidation method.
-    /// 
+    ///
     /// When an error is detected at runtime an instance of code:CommandLineParserException is thrown. The error
     /// message in this exception was designed to be suitable to print to the user directly.
-    /// 
+    ///
     /// #CommandLineHelp
-    /// 
+    ///
     /// The parser also can generate help that is correct for the qualifier and parameter definitions. This can be
     /// accessed from the code:CommandLineParser.GetHelp method. It is also possible to get the help for just a
     /// particular Parameter set with code:CommandLineParser.GetHelpForParameterSet. This help includes command
     /// line syntax, whether the qualifier or parameter is optional or a list, the types of the qualifiers and
     /// parameters, the help text, and default values.   The help text comes from the 'Define' Methods, and is
-    /// properly word-wrapped.  Newlines in the help text indicate new paragraphs.   
-    /// 
+    /// properly word-wrapped.  Newlines in the help text indicate new paragraphs.
+    ///
     /// #AutomaticExceptionProcessingAndHelp
-    /// 
+    ///
     /// In the CommandLineParserExample1, while the command line parser did alot of the work there is still work
     /// needed to make the application user friendly that pretty much all applications need. These include
-    ///  
+    ///
     ///     * Call the code:CommandLineParser constructor and code:CommandLineParser.CompleteValidation
     ///     * Catch any code:CommandLineParserException and print a friendly message
     ///     * Define a -? qualifier and wire it up to print the help.
-    /// 
+    ///
     /// Since this is stuff that all applications will likely need the
     /// code:CommandLineParser.ParseForConsoleApplication was created to do all of this for you, thus making it
     /// super-easy to make a production quality parser (and concentrate on getting your application logic instead
@@ -240,11 +240,11 @@ namespace Microsoft.Fx.CommandLine
             static void Main()
             {
 	            // Step 1: Initialize to the defaults
-	            string Host = null;       
+	            string Host = null;
 	            int Timeout = 1000;
 	            bool Forever = false;
 
-	            // Step 2: Define the parameters, in this case there is only the default parameter set. 
+	            // Step 2: Define the parameters, in this case there is only the default parameter set.
 	            CommandLineParser.ParseForConsoleApplication(args, delegate(CommandLineParser parser)
 	            {
 	                parser.DefineOptionalQualifier("Timeout", ref Timeout, "Timeout in milliseconds to wait for each reply.");
@@ -263,7 +263,7 @@ namespace Microsoft.Fx.CommandLine
     /// create a class whose sole purpose is to act as a repository for the parsed arguments.   This also nicely
     /// separates all command line processing into a single class.   This is how the ping example would look  in
     /// that style. Notice that the main program no longer holds any command line processing logic.  and that
-    /// 'commandLine' can be passed to other routines in bulk easily.  
+    /// 'commandLine' can be passed to other routines in bulk easily.
 #if EXAMPLE3
 class CommandLineParserExample3
 {
@@ -291,14 +291,14 @@ class CommandLine
 };
 #endif
     /// <summary>
-    /// see code:#Overview for more 
+    /// see code:#Overview for more
     /// </summary>
     public class CommandLineParser
     {
         /// <summary>
         /// If you are building a console Application, there is a common structure to parsing arguments. You want
         /// the text formated and output for console windows, and you want /? to be wired up to do this. All
-        /// errors should be caught and displayed in a nice way.  This routine does this 'boiler plate'.  
+        /// errors should be caught and displayed in a nice way.  This routine does this 'boiler plate'.
         /// </summary>
         /// <param name="parseBody">parseBody is the body of the parsing that this outer shell does not provide.
         /// in this delegate, you should be defining all the command line parameters using calls to Define* methods.
@@ -331,7 +331,7 @@ class CommandLine
 
             try
             {
-                // RawPrint the help. 
+                // RawPrint the help.
                 if (parser.HelpRequested != null)
                 {
                     parser._skipParameterSets = true;
@@ -359,16 +359,16 @@ class CommandLine
         /// boolan parameters, the VALUE can be dropped (which means true), and a empty string VALUE means false.
         /// Thus -NAME means the same as -NAME:true and -NAME: means the same as -NAME:false (and boolean
         /// qualifiers DONT allow -NAME true or -NAME false).
-        /// 
+        ///
         /// The types that are supported are any type that has a static 'Parse' function that takes a string
         /// (this includes all primitive types as well as DateTime, and Enumerations, as well as arrays of
         /// parsable types (values are comma separated without space).
-        /// 
+        ///
         /// Qualifiers that are defined BEFORE any parameter sets apply to ALL parameter sets.  qualifiers that
-        /// are defined AFTER a parameter set will apply only the the parameter set that preceeds them.  
-        /// 
+        /// are defined AFTER a parameter set will apply only the the parameter set that preceeds them.
+        ///
         /// See code:#DefiningParametersAndQualifiers
-        /// See code:#Overview 
+        /// See code:#Overview
         /// <param name="name">The name of the qualifier.</param>
         /// <param name="retVal">The place to put the parsed value</param>
         /// <param name="helpText">Text to print for this qualifier.  It will be word-wrapped.  Newlines indicate
@@ -381,11 +381,11 @@ class CommandLine
                 retVal = (T)obj;
         }
         /// <summary>
-        /// Like code:DeclareOptionalQualifier except it is an error if this parameter is not on the command line. 
+        /// Like code:DeclareOptionalQualifier except it is an error if this parameter is not on the command line.
         /// <param name="name">The name of the qualifer.</param>
         /// <param name="retVal">The place to put the parsed value</param>
         /// <param name="helpText">Text to print for this qualifer.  It will be word-wrapped.  Newlines indicate
-        /// new paragraphs.</param> 
+        /// new paragraphs.</param>
         /// </summary>
         public void DefineQualifier<T>(string name, ref T retVal, string helpText)
         {
@@ -395,12 +395,12 @@ class CommandLine
         }
         /// <summary>
         /// Specify additional aliases for an qualifier.  This call must come BEFORE the call to
-        /// Define*Qualifier, since the definition needs to know about its aliases to do its job.  
+        /// Define*Qualifier, since the definition needs to know about its aliases to do its job.
         /// </summary>
         public void DefineAliases(string officalName, params string[] alaises)
         {
-            // TODO assert that aliases are defined before the Definition.  
-            // TODO confirm no ambiguities (same alias used again).  
+            // TODO assert that aliases are defined before the Definition.
+            // TODO confirm no ambiguities (same alias used again).
             if (_aliasDefinitions != null && _aliasDefinitions.ContainsKey(officalName))
                 throw new CommandLineParserDesignerException("Named parameter " + officalName + " already has been given aliases.");
 
@@ -413,14 +413,14 @@ class CommandLine
         /// DefineParameter declares an unnamed mandatory parameter (basically any parameter that is not a
         /// qualifier). These are given ordinal numbers (starting at 0). You should declare the parameter in the
         /// desired order.
-        /// 
-        /// 
+        ///
+        ///
         /// See code:#DefiningParametersAndQualifiers
-        /// See code:#Overview 
+        /// See code:#Overview
         /// <param name="name">The name of the parameter.</param>
         /// <param name="retVal">The place to put the parsed value</param>
         /// <param name="helpText">Text to print for this qualifer.  It will be word-wrapped.  Newlines indicate
-        /// new paragraphs.</param> 
+        /// new paragraphs.</param>
         /// </summary>
         public void DefineParameter<T>(string name, ref T retVal, string helpText)
         {
@@ -429,13 +429,13 @@ class CommandLine
                 retVal = (T)obj;
         }
         /// <summary>
-        /// Like code:DeclareParameter except the parameter is optional. 
-        /// These must come after non-optional (required) parameters. 
+        /// Like code:DeclareParameter except the parameter is optional.
+        /// These must come after non-optional (required) parameters.
         /// </summary>
         /// <param name="name">The name of the parameter</param>
         /// <param name="retVal">The location to place the parsed value.</param>
         /// <param name="helpText">Text to print for this qualifer.  It will be word-wrapped.  Newlines indicate
-        /// new paragraphs.</param> 
+        /// new paragraphs.</param>
         public void DefineOptionalParameter<T>(string name, ref T retVal, string helpText)
         {
             object obj = DefineParameter(name, typeof(T), retVal, helpText, false);
@@ -445,18 +445,18 @@ class CommandLine
 
         /// <summary>
         /// A parameter set defines on of a set of 'commands' that decides how to parse the rest of the command
-        /// line.   If this 'command' is present on the command line then 'val' is assigned to 'retVal'. 
+        /// line.   If this 'command' is present on the command line then 'val' is assigned to 'retVal'.
         /// Typically 'retVal' is a variable of a enumerated type (one for each command), and 'val' is one
-        /// specific value of that enumeration.  
-        /// 
+        /// specific value of that enumeration.
+        ///
         /// * See code:#ParameterSets
         /// * See code:#DefiningParametersAndQualifiers
-        /// * See code:#Overview 
+        /// * See code:#Overview
         /// <param name="name">The name of the parameter set.</param>
-        /// <param name="retVal">The place to put the parsed value</param> 
+        /// <param name="retVal">The place to put the parsed value</param>
         /// <param name="val">The value to place into 'retVal' if this parameter set is indicated</param>
         /// <param name="helpText">Text to print for this qualifer.  It will be word-wrapped.  Newlines indicate
-        /// new paragraphs.</param> 
+        /// new paragraphs.</param>
         /// </summary>
         public void DefineParameterSet<T>(string name, ref T retVal, T val, string helpText)
         {
@@ -468,13 +468,13 @@ class CommandLine
         /// used when a command line does not have one of defined parameter sets. It is always present, even if
         /// this method is not called, so calling this method is optional, however, by calling this method you can
         /// add help text for this case.  If present this call must be AFTER all other parameter set
-        /// definitions. 
-        /// 
-        /// * See code:#DefaultParameterSet 
+        /// definitions.
+        ///
+        /// * See code:#DefaultParameterSet
         /// * See code:#DefiningParametersAndQualifiers
         /// * See code:#Overview
         /// <param name="helpText">Text to print for this qualifer.  It will be word-wrapped.  Newlines indicate
-        /// new paragraphs.</param> 
+        /// new paragraphs.</param>
         /// </summary>
         public void DefineDefaultParameterSet(string helpText)
         {
@@ -482,14 +482,14 @@ class CommandLine
         }
         /// <summary>
         /// This variation of DefineDefaultParameterSet has a 'retVal' and 'val' parameters.  If the command
-        /// line does not match any of the other parameter set defintions, then 'val' is asigned to 'retVal'. 
-        /// Typically 'retVal' is a variable of a enumerated type and 'val' is a value of that type.    
-        /// 
+        /// line does not match any of the other parameter set defintions, then 'val' is asigned to 'retVal'.
+        /// Typically 'retVal' is a variable of a enumerated type and 'val' is a value of that type.
+        ///
         /// * See code:DefineDefaultParameterSet for more.
-        /// <param name="retVal">The place to put the parsed value</param> 
+        /// <param name="retVal">The place to put the parsed value</param>
         /// <param name="val">The value to place into 'retVal' if this parameter set is indicated</param>
         /// <param name="helpText">Text to print for this qualifer.  It will be word-wrapped.  Newlines indicate
-        /// new paragraphs.</param> 
+        /// new paragraphs.</param>
         /// </summary>
         public void DefineDefaultParameterSet<T>(ref T retVal, T val, string helpText)
         {
@@ -497,13 +497,13 @@ class CommandLine
                 retVal = val;
         }
 
-        // You can influence details of command line parsing by setting the following properties.  
-        // These should be set before the first call to Define* routines and should not change 
-        // thereafter.  
+        // You can influence details of command line parsing by setting the following properties.
+        // These should be set before the first call to Define* routines and should not change
+        // thereafter.
         /// <summary>
         /// By default parameter set specifiers must look like a qualifier (begin with a -), however setting
         /// code:NoDashOnParameterSets will define a parameter set marker not to have any special prefix (just
-        /// the name itself.  
+        /// the name itself.
         /// </summary>
         public bool NoDashOnParameterSets
         {
@@ -519,7 +519,7 @@ class CommandLine
         /// By default, the syntax (-Qualifier:Value) and (-Qualifer Value) are both allowed.   However
         /// this makes it impossible to use -Qualifier to specify that a qualifier is present but uses
         /// a default value (you have to use (-Qualifier: )) Specifying code:NoSpaceOnQualifierValues
-        /// indicates that the syntax (-Qualifer ObjectEnumerator) is not allowed, which allows this.  
+        /// indicates that the syntax (-Qualifer ObjectEnumerator) is not allowed, which allows this.
         /// </summary>
         /// TODO decide if we should keep this...
         public bool NoSpaceOnQualifierValues
@@ -535,16 +535,16 @@ class CommandLine
         /// <summary>
         /// If the positional parameters might look like named parameters (typically happens when the tail of the
         /// command line is literal text), it is useful to stop the search for named parameters at the first
-        /// positional parameter. 
-        /// 
+        /// positional parameter.
+        ///
         /// Because some parameters sets might want this behavior and some might not, you specify the list of
         /// parameter sets that you want to opt in.
-        /// 
+        ///
         /// The expectation is you do something like
         ///     * commandLine.ParameterSetsWhereQualifiersMustBeFirst = new string[] { "parameterSet1" };
-        ///     
-        /// The empty string is a wildcard that indicats all parameter sets have the qualifiersMustBeFirst 
-        /// attribute.   This is the only way to get this attribute on the default parameter set.  
+        ///
+        /// The empty string is a wildcard that indicats all parameter sets have the qualifiersMustBeFirst
+        /// attribute.   This is the only way to get this attribute on the default parameter set.
         /// </summary>
         public string[] ParameterSetsWhereQualifiersMustBeFirst
         {
@@ -572,11 +572,11 @@ class CommandLine
         }
 
 
-        // TODO remove?   Not clear it is useful.  Can be useful for CMD.EXE alias (which provide a default) but later user may override.  
+        // TODO remove?   Not clear it is useful.  Can be useful for CMD.EXE alias (which provide a default) but later user may override.
         /// <summary>
         /// By default, a non-list qualifier can not be specified more than once (since one or the other will
         /// have to be ignored).  Normally an error is thrown.  Setting code:LastQualifierWins makes it legal, and
-        /// the last qualifier is the one that is used.  
+        /// the last qualifier is the one that is used.
         /// </summary>
         public bool LastQualifierWins
         {
@@ -584,7 +584,7 @@ class CommandLine
             set { _lastQualifierWins = value; }
         }
 
-        // These routines are typically are not needed because ParseArgsForConsoleApp does the work.  
+        // These routines are typically are not needed because ParseArgsForConsoleApp does the work.
 #if !COREFX
         public CommandLineParser() : this(Environment.CommandLine) { }
 #endif
@@ -599,14 +599,14 @@ class CommandLine
 
         /// <summary>
         /// Check for any parameters that the user specified but that were not defined by a Define*Parameter call
-        /// and throw an exception if any are found. 
-        /// 
+        /// and throw an exception if any are found.
+        ///
         /// Returns true if validation was completed.  It can return false (rather than throwing), If the user
         /// requested help (/?).   Thus if this routine returns false, the 'GetHelp' should be called.
         /// </summary>
         public bool CompleteValidation()
         {
-            // Check if there are any undefined parameters or ones specified twice.  
+            // Check if there are any undefined parameters or ones specified twice.
             foreach (int encodedPos in _dashedParameterEncodedPositions.Values)
             {
                 throw new CommandLineParserException("Unexpected qualifier: " + _args[GetPosition(encodedPos)] + ".");
@@ -619,7 +619,7 @@ class CommandLine
             if (_curPosition < _args.Count)
                 throw new CommandLineParserException("Extra positional parameter: " + _args[_curPosition] + ".");
 
-            // TODO we should null out data structures we no longer need, to save space. 
+            // TODO we should null out data structures we no longer need, to save space.
             // Not critical because in the common case, the parser as a whole becomes dead.
 
             if (_helpRequestedFor != null)
@@ -641,28 +641,28 @@ class CommandLine
         /// <summary>
         /// Return the string representing the help for a single paramter set.  If displayGlobalQualifiers is
         /// true than qualifiers that apply to all parameter sets is also included, otherwise it is just the
-        /// parameters and qualifiers that are specific to that parameters set. 
-        /// 
+        /// parameters and qualifiers that are specific to that parameters set.
+        ///
         /// If the parameterSetName null, then the help for the entire program (all parameter
         /// sets) is returned.  If parameterSetName is not null (empty string is default parameter set),
         /// then it generates help for the parameter set specified on the command line.
-        /// 
+        ///
         /// Since most of the time you don't need help, helpInformatin is NOT collected during the Define* calls
         /// unless HelpRequested is true.   If /? is seen on the command line first, then this works.  You can
-        /// also force this by setting HelpRequested to True before calling all the Define* APIs. 
-        /// 
+        /// also force this by setting HelpRequested to True before calling all the Define* APIs.
+        ///
         /// </summary>
         public string GetHelp(int maxLineWidth, string parameterSetName = null, bool displayGlobalQualifiers = true)
         {
             Debug.Assert(_mustParseHelpStrings);
-            if (!_mustParseHelpStrings)          // Backup for retail code.  
+            if (!_mustParseHelpStrings)          // Backup for retail code.
                 return null;
 
             if (parameterSetName == null)
                 return GetFullHelp(maxLineWidth);
 
             // Find the beginning of the parameter set parameters, as well as the end of the global parameters
-            // (Which come before any parameters set). 
+            // (Which come before any parameters set).
             int parameterSetBody = 0;         // Points at body of the parameter set (parameters after the parameter set)
             CommandLineParameter parameterSetParameter = null;
             for (int i = 0; i < _parameterDescriptions.Count; i++)
@@ -713,7 +713,7 @@ class CommandLine
             }
             sb.AppendLine();
 
-            // Print the help for the command itself.  
+            // Print the help for the command itself.
             if (parameterSetParameter != null && !string.IsNullOrEmpty(parameterSetParameter.HelpText))
             {
                 sb.AppendLine();
@@ -902,9 +902,9 @@ class CommandLine
 
         /// <summary>
         /// Parses 'commandLine' into words (space separated items).  Handles quoting (using double quotes)
-        /// and handles escapes of double quotes and backslashes with the \" and \\ syntax.  
+        /// and handles escapes of double quotes and backslashes with the \" and \\ syntax.
         /// In theory this mimics the behavior of the parsing done before Main to parse the command line into
-        /// the string[].  
+        /// the string[].
         /// </summary>
         /// <param name="commandLine"></param>
         private void ParseWords(string commandLine)
@@ -974,7 +974,7 @@ class CommandLine
             string word;
             if (numQuotes > 0)
             {
-                // Common case, the whole word is quoted, and no escaping happened.   
+                // Common case, the whole word is quoted, and no escaping happened.
                 if (!hasExcapedQuotes && numQuotes == 1 && commandLine[wordStartIndex] == '"' && commandLine[wordEndIndex - 1] == '"')
                     word = commandLine.Substring(wordStartIndex + 1, wordEndIndex - wordStartIndex - 2);
                 else
@@ -1087,7 +1087,7 @@ class CommandLine
 
         // Phase 2 parsing works into things that look like qualifiers (but without  knowledge of which qualifiers the command supports)
         /// <summary>
-        /// Find the locations of all arguments that look like named parameters. 
+        /// Find the locations of all arguments that look like named parameters.
         /// </summary>
         private void ParseWordsIntoQualifiers()
         {
@@ -1139,7 +1139,7 @@ class CommandLine
                             break;
                         else if (IsParameterSetWithqualifiersMustBeFirst(String.Empty))        // Then we are the default parameter set
                             break;
-                        paramSetEncountered = true;     // If we have hit a parameter, we must have hit a parameter set.  
+                        paramSetEncountered = true;     // If we have hit a parameter, we must have hit a parameter set.
                     }
                 }
             }
@@ -1157,10 +1157,10 @@ class CommandLine
             return false;
         }
 
-        // Phase 3, processing user defintions of qualifiers parameter sets etc.  
+        // Phase 3, processing user defintions of qualifiers parameter sets etc.
         /// <summary>
-        /// returns the index in the 'args' array of the next instance of the 'name' qualifier.   returns -1 if there is 
-        /// no next instance of the qualifer.  
+        /// returns the index in the 'args' array of the next instance of the 'name' qualifier.   returns -1 if there is
+        /// no next instance of the qualifer.
         /// </summary>
         private object DefineQualifier(string name, Type type, object defaultValue, string helpText, bool isRequired)
         {
@@ -1220,7 +1220,7 @@ class CommandLine
                     // complicate the code, and also leads to confusing error messages when we parse the command
                     // in a very different way then the user is expecting. Since you can provide values that
                     // begin with a '-' by doing -qualifier:-value instead of -qualifier -value I force the issue
-                    // by excluding it here.  TODO: this makes negative numbers harder... 
+                    // by excluding it here.  TODO: this makes negative numbers harder...
                     if (value.Length > 0 && IsQualifier(value))
                         throw new CommandLineParserException("Use " + name + ":" + value + " if " + value +
                             " is meant to be value rather than a named parameter");
@@ -1315,7 +1315,7 @@ class CommandLine
                 throw new CommandLineParserDesignerException("Positional parameters must not preceed parameter set definitions.");
 
             _paramSetEncountered = true;
-            _positionalArgEncountered = false;               // each parameter set gets a new arg set   
+            _positionalArgEncountered = false;               // each parameter set gets a new arg set
             _optionalPositionalArgEncountered = false;
             if (_defaultParamSetEncountered)
                 throw new CommandLineParserDesignerException("The default parameter set must be defined last.");
@@ -1333,7 +1333,7 @@ class CommandLine
             if (_parameterSetName != null)
             {
                 _skipDefinitions = true;
-                _skipParameterSets = true;       // if yes, we are done, ignore all parameter set definitions. 
+                _skipParameterSets = true;       // if yes, we are done, ignore all parameter set definitions.
                 return false;
             }
 
@@ -1372,7 +1372,7 @@ class CommandLine
 
             _skipDefinitions = !((_parameterSetName != null) || isDefaultParameterSet);
 
-            // To avoid errors when users ask for help, skip any parsing once we have found a parameter set.  
+            // To avoid errors when users ask for help, skip any parsing once we have found a parameter set.
             if (_helpRequestedFor != null && ret)
             {
                 _skipDefinitions = true;
@@ -1421,7 +1421,7 @@ class CommandLine
                     return valueString.Split(',');
                 else if (type.IsArray)
                 {
-                    // TODO I need some way of handling string with , in them.  
+                    // TODO I need some way of handling string with , in them.
                     Type elementType = type.GetElementType();
                     string[] elementStrings = valueString.Split(',');
                     Array array = Array.CreateInstance(elementType, elementStrings.Length);
@@ -1464,7 +1464,7 @@ class CommandLine
         }
         /// <summary>
         /// Enums that are bitfields can have multiple values.  Support + and - (for oring and diffing bits).  Returns
-        /// the final enum value.  for the 'valueString' which is a string form of 'type' for the parameter 'parameter'.  
+        /// the final enum value.  for the 'valueString' which is a string form of 'type' for the parameter 'parameter'.
         /// </summary>
         private object ParseCompositeEnumValue(string valueString, Type type, string parameterName)
         {
@@ -1542,7 +1542,7 @@ class CommandLine
 
 
         /// <summary>
-        /// Return a string giving the help for the command, word wrapped at 'maxLineWidth' 
+        /// Return a string giving the help for the command, word wrapped at 'maxLineWidth'
         /// </summary>
         private string GetFullHelp(int maxLineWidth)
         {
@@ -1563,7 +1563,7 @@ class CommandLine
                 "Options that are common to all commands are listed at the end.";
             Wrap(sb, intro, 0, String.Empty, maxLineWidth);
 
-            // Always print the default parameter set first.  
+            // Always print the default parameter set first.
             if (_defaultParamSetEncountered)
             {
                 sb.AppendLine().Append('-', maxLineWidth - 1).AppendLine();
@@ -1591,13 +1591,13 @@ class CommandLine
             return sb.ToString();
         }
         /// <summary>
-        /// prints a string to the console in a nice way.  In particular it 
-        /// displays a sceeen full of data and then as user to type a space to continue. 
+        /// prints a string to the console in a nice way.  In particular it
+        /// displays a sceeen full of data and then as user to type a space to continue.
         /// </summary>
         /// <param name="helpString"></param>
         private static void DisplayStringToConsole(string helpString)
         {
-            // TODO we do paging, but this is not what we want when it is redirected.  
+            // TODO we do paging, but this is not what we want when it is redirected.
             bool first = true;
             for (int pos = 0; ;)
             {
@@ -1630,7 +1630,7 @@ class CommandLine
         }
         private static void ParameterHelp(CommandLineParameter parameter, StringBuilder sb, int firstColumnWidth, int maxLineWidth)
         {
-            // TODO alias information. 
+            // TODO alias information.
             sb.Append("    ").Append(parameter.Syntax(true, true).PadRight(firstColumnWidth)).Append(' ');
             string helpText = parameter.HelpText;
             if (typeof(Enum).IsAssignableFrom(parameter.Type))
@@ -1667,7 +1667,7 @@ class CommandLine
                         }
                         else if (!first)
                         {
-                            // add an extra space at the end of sentences. 
+                            // add an extra space at the end of sentences.
                             if (previousWord.Length > 0 && previousWord[previousWord.Length - 1] == '.')
                             {
                                 sb.Append(' ');
@@ -1746,18 +1746,18 @@ class CommandLine
         private bool _noDashOnParameterSets;
         private bool _noSpaceOnQualifierValues;
         private string[] _parameterSetsWhereQualifiersMustBeFirst;
-        private bool _qualifiersUseOnlyDash;
+        private bool _qualifiersUseOnlyDash = true;
         private bool _lastQualifierWins;
 
         // In order to produce help, we need to remember everything useful about all the parameters.  This list
-        // does this.  It is only done when help is needed, so it is not here in the common scenario.  
+        // does this.  It is only done when help is needed, so it is not here in the common scenario.
         private List<CommandLineParameter> _parameterDescriptions;
-        private int _qualifierSyntaxWidth;       // When printing help, how much indent any line wraps.  
+        private int _qualifierSyntaxWidth;       // When printing help, how much indent any line wraps.
         public int QualifierSyntaxWidth
         {
             get
             {
-                // Find the optimal size for the 'first column' of the help text. 
+                // Find the optimal size for the 'first column' of the help text.
                 if (_qualifierSyntaxWidth == 0)
                 {
                     _qualifierSyntaxWidth = 35;
@@ -1775,30 +1775,30 @@ class CommandLine
 
 
         /// <summary>
-        /// Qualifiers can have aliases (e.g. for short names).  This holds these aliases.  
+        /// Qualifiers can have aliases (e.g. for short names).  This holds these aliases.
         /// </summary>
-        private Dictionary<string, string[]> _aliasDefinitions;       // Often null if no aliases are defined.  
+        private Dictionary<string, string[]> _aliasDefinitions;       // Often null if no aliases are defined.
 
         // Because we do all the parsing for a single parameter at once, it is useful to know quickly if the
         // parameter even exists, exists once, or exist more than once.  This dictionary holds this.  It is
         // initialized in code:PreParseQualifiers.  The value in this dictionary is an ecncoded position
         // which encodes both the position and whether this qualifer occurs multiple times (see GetMultiple,
-        // GetPosition, IsMultiple methods).  
+        // GetPosition, IsMultiple methods).
         private Dictionary<string, int> _dashedParameterEncodedPositions;
-        // We steal the top bit to prepresent whether the parameter occurs more than once. 
+        // We steal the top bit to prepresent whether the parameter occurs more than once.
         private const int MultiplePositions = unchecked((int)0x80000000);
         private static int SetMulitple(int encodedPos) { return encodedPos | MultiplePositions; }
         private static int GetPosition(int encodedPos) { return encodedPos & ~MultiplePositions; }
         private static bool IsMulitple(int encodedPos) { return (encodedPos & MultiplePositions) != 0; }
 
         // As we parse qualifiers we remove them from the command line by nulling them out, and thus
-        // ultimately ends up only having positional parameters being non-null.    
+        // ultimately ends up only having positional parameters being non-null.
         private List<string> _args;
 
-        private int _curPosition;                    // All arguments before this position have been processed. 
-        private bool _skipParameterSets;             // Have we found the parameter set qualifer, so we don't look at any others.   
+        private int _curPosition;                    // All arguments before this position have been processed.
+        private bool _skipParameterSets;             // Have we found the parameter set qualifer, so we don't look at any others.
         private bool _skipDefinitions;               // Should we skip all subsequent definitions (typically until the next parameter set def)
-        private string _parameterSetName;            // if we matched a parameter set, this is it.   
+        private string _parameterSetName;            // if we matched a parameter set, this is it.
         private bool _mustParseHelpStrings;          // we have to go to the overhead of parsing the help strings (because user wants help)
         private string _helpRequestedFor;            // The user specified /? on the command line.  This is the word after the /? may be empty
         private bool _seenExeArg;                    // Used in AddWord, indicates we have seen the exe itself (before the args) on the command line
@@ -1813,7 +1813,7 @@ class CommandLine
 
     /// <summary>
     /// Run time parsing error throw this exception.   These are expected to be caught and the error message
-    /// printed out to the user.   Thus the messages should be 'user friendly'.  
+    /// printed out to the user.   Thus the messages should be 'user friendly'.
     /// </summary>
     public class CommandLineParserException : Exception
     {


### PR DESCRIPTION
When tools need to parse arguments for other platforms (i.e. Linux/OSX)
they have files that begin with "/" and that messes up the parser and
causes an "undefined qualifer" error. The best way to handle this is
to disable the uses of slash for qualifiers by default. People can still
manually enable it if they chose to want to support it but for most
of our tools that are now running x-plat we need to disable this and
only support dash for qualifiers.

cc @stephentoub @ellismg