### PR TITLE
Azure retry logic incorrectly using stale DateTime in HTTP header.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CreateAzureContainer.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CreateAzureContainer.cs
@@ -82,7 +82,6 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 "Creating container named '{0}' in storage account {1}.", 
                 ContainerName, 
                 AccountName);
-            DateTime dt = DateTime.UtcNow;
             string url = string.Format(
                 "https://{0}.blob.core.windows.net/{1}?restype=container", 
                 AccountName, 
@@ -97,6 +96,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             {
                 Func<HttpRequestMessage> createRequest = () =>
                 {
+                    DateTime dt = DateTime.UtcNow;
                     var req = new HttpRequestMessage(HttpMethod.Put, url);
                     req.Headers.Add(AzureHelper.DateHeaderString, dt.ToString("R", CultureInfo.InvariantCulture));
                     req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -53,7 +53,6 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Log.LogMessage(MessageImportance.Normal, "Downloading contents of container {0} from storage account '{1}' to directory {2}.",
                 ContainerName, AccountName, DownloadDirectory);
 
-            DateTime dateTime = DateTime.UtcNow;
             List<string> blobsNames = null;
             string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list", AccountName, ContainerName);
 
@@ -65,6 +64,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {
                     Func<HttpRequestMessage> createRequest = () =>
                     {
+                        DateTime dateTime = DateTime.UtcNow;
                         var request = new HttpRequestMessage(HttpMethod.Get, urlListBlobs);
                         request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
                         request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
@@ -110,6 +110,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
                         createRequest = () =>
                         {
+                            DateTime dateTime = DateTime.UtcNow;
                             var request = new HttpRequestMessage(HttpMethod.Get, urlGetBlob);
                             request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
                             request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureContainers.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureContainers.cs
@@ -49,8 +49,6 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         public async Task<bool> ExecuteAsync()
         {
             Log.LogMessage(MessageImportance.Normal, "List of Azure containers in storage account '{0}'.", AccountName);
-
-            DateTime dateTime = DateTime.UtcNow;
             string url = string.Format("https://{0}.blob.core.windows.net/?comp=list", AccountName);
             
             Log.LogMessage(MessageImportance.Low, "Sending request to list containers in account '{0}'.", AccountName);
@@ -61,6 +59,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {
                     Func<HttpRequestMessage> createRequest = () =>
                     {
+                        DateTime dateTime = DateTime.UtcNow;
                         var request = new HttpRequestMessage(HttpMethod.Get, url);
                         request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
                         request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
@@ -83,12 +83,12 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     blockIds.Add(blockId);
                     string blockUploadUrl = blobUploadUrl + "?comp=block&blockid=" + WebUtility.UrlEncode(blockId);
 
-                    DateTime dt = DateTime.UtcNow;
                     using (HttpClient client = new HttpClient())
                     {
                         client.DefaultRequestHeaders.Clear();
                         Func<HttpRequestMessage> createRequest = () =>
                         {
+                            DateTime dt = DateTime.UtcNow;
                             var req = new HttpRequestMessage(HttpMethod.Put, blockUploadUrl);
                             req.Headers.Add(
                                 AzureHelper.DateHeaderString,
@@ -135,11 +135,12 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
 
             string blockListUploadUrl = blobUploadUrl + "?comp=blocklist";
-            DateTime dt1 = DateTime.UtcNow;
+
             using (HttpClient client = new HttpClient())
             {
                 Func<HttpRequestMessage> createRequest = () =>
                 {
+                    DateTime dt1 = DateTime.UtcNow;
                     var req = new HttpRequestMessage(HttpMethod.Put, blockListUploadUrl);
                     req.Headers.Add(AzureHelper.DateHeaderString, dt1.ToString("R", CultureInfo.InvariantCulture));
                     req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -87,7 +87,6 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 AccountName, 
                 ContainerName);
 
-            DateTime dt = DateTime.UtcNow;
             HashSet<string> blobsPresent = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             try
@@ -96,6 +95,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {
                     Func<HttpRequestMessage> createRequest = () =>
                     {
+                        DateTime dt = DateTime.UtcNow;
                         var req = new HttpRequestMessage(HttpMethod.Get, checkListUrl);
                         req.Headers.Add(AzureHelper.DateHeaderString, dt.ToString("R", CultureInfo.InvariantCulture));
                         req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);


### PR DESCRIPTION
The lambda to create HttpRequestMessage was incorrectly capturing a local
variable for DataTime instead of reading the current DateTime when
creating a new request; this lead to reusing the old DateTime causing the
value to be stale thus failing retries.