### PR TITLE
Fix for OOM in UploadToAzure when a large number of items are specified

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -57,7 +57,9 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         /// </summary>
         public bool Overwrite { get; set; } = false;
 
-
+        /// <summary>
+        /// Specifies the maximum number of clients to concurrently upload blobs to azure
+        /// </summary>
         public int MaxClients { get; set; } = 8;
 
         public void Cancel()

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -72,9 +72,7 @@
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
-
     <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
-    
     <XunitArguments>$(XunitTestAssembly) $(XunitOptions)</XunitArguments>
 
     <TestProgram Condition="'$(TestHostExecutable)'!=''">$(TestHostExecutable)</TestProgram>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -72,7 +72,10 @@
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
-    <XunitArguments>$(TargetFileName) $(XunitOptions)</XunitArguments>
+
+    <XunitTestAssebly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssebly>
+    
+    <XunitArguments>$(XunitTestAssebly) $(XunitOptions)</XunitArguments>
 
     <TestProgram Condition="'$(TestHostExecutable)'!=''">$(TestHostExecutable)</TestProgram>
     <TestArguments Condition="'$(TestHostExecutable)'!=''">$(XunitExecutable) $(XunitArguments)</TestArguments>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -73,9 +73,9 @@
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
 
-    <XunitTestAssebly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssebly>
+    <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
     
-    <XunitArguments>$(XunitTestAssebly) $(XunitOptions)</XunitArguments>
+    <XunitArguments>$(XunitTestAssembly) $(XunitOptions)</XunitArguments>
 
     <TestProgram Condition="'$(TestHostExecutable)'!=''">$(TestHostExecutable)</TestProgram>
     <TestArguments Condition="'$(TestHostExecutable)'!=''">$(XunitExecutable) $(XunitArguments)</TestArguments>


### PR DESCRIPTION
  Introduced property MaxClients which is used to throttle the number of UploadClients which will be used concurrently to upload blobs