### PR TITLE
Enabling local execution of Perf tests on linux

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -110,6 +110,7 @@
     <ItemGroup>
       <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.py" />
       <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.sh" />
+      <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.txt" />
     </ItemGroup>
     <Copy SourceFiles="@(RunnerScripts)"
           DestinationFiles="@(RunnerScripts->'$(SupplementalPayloadDir)RunnerScripts/%(RecursiveDir)%(Filename)%(Extension)')"
@@ -268,9 +269,9 @@
       <ExcludeFromArchive Include="nupkg$" />
       <ExcludeFromArchive Include="Microsoft.DotNet.BuildTools" />
       <ExcludeFromArchive Include="TestData" />
-      <TestDependencyListFile Include="$(BinDir)/TestDependencies/*.dependencylist.txt" />      
+      <TestDependencyListFile Include="$(BinDir)/TestDependencies/*.dependencylist.txt" />
     </ItemGroup>
-    
+
     <ZipFileCreateFromDependencyLists
       DependencyListFiles="@(TestDependencyListFile)"
       DestinationArchive="$(PackagesArchiveFile)"

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Argument = -d destdir
+# Argument = -d destdir -v versionfile
 usage()
 {
 cat << EOF
@@ -10,13 +10,14 @@ This script installs dotnet cli on the linux machine
 OPTIONS:
    -h      Show this message
    -d      Directory where dotnet cli will be installed
-   -v      Location of DotNetCliVersion.txt file
+   -v      Location of DotNetCliVersion.txt 
 
 EOF
 }
 
 DESTDIR=
-while getopts “hd:” OPTION
+VERFILE=
+while getopts “hd:v:” OPTION
 do
      case $OPTION in
          h)
@@ -37,7 +38,8 @@ do
 done
 
 echo $DESTDIR
-if [[ -z $DESTDIR ]]
+echo $VERFILE
+if [ -z $DESTDIR ] || [ -z $VERFILE ];
 then
      usage
      exit 1
@@ -46,6 +48,6 @@ fi
 echo "Initiating local dotnet install"
 wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
 chmod 777 dotnet-install.sh
-versionnum=$(cat VERFILE)
+versionnum=$(cat $VERFILE)
 mkdir $DESTDIR
 source dotnet-install.sh -i $DESTDIR -v $versionnum

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
@@ -10,7 +10,7 @@ This script installs dotnet cli on the linux machine
 OPTIONS:
    -h      Show this message
    -d      Directory where dotnet cli will be installed
-   -v      Location of DotNetCliVersion.txt 
+   -v      Location of DotNetCliVersion.txt
 
 EOF
 }
@@ -46,7 +46,7 @@ then
 fi
 
 echo "Initiating local dotnet install"
-wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
+wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh
 chmod 777 dotnet-install.sh
 versionnum=$(cat $VERFILE)
 mkdir $DESTDIR

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
@@ -9,7 +9,8 @@ This script installs dotnet cli on the linux machine
 
 OPTIONS:
    -h      Show this message
-   -d      directory where dotnet cli will be installed
+   -d      Directory where dotnet cli will be installed
+   -v      Location of DotNetCliVersion.txt file
 
 EOF
 }
@@ -24,6 +25,9 @@ do
              ;;
          d)
              DESTDIR=$OPTARG
+             ;;
+         v)
+             VERFILE=$OPTARG
              ;;
          ?)
              usage
@@ -42,7 +46,6 @@ fi
 echo "Initiating local dotnet install"
 wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh
 chmod 777 dotnet-install.sh
-wget https://raw.githubusercontent.com/Microsoft/xunit-performance/master/DotNetCliVersion.txt
-versionnum=$(cat DotNetCliVersion.txt)
+versionnum=$(cat VERFILE)
 mkdir $DESTDIR
 source dotnet-install.sh -i $DESTDIR -v $versionnum

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
@@ -102,7 +102,7 @@ def _prepare_linux_env_for_perf(correlation_dir, xunit_perf_drop, test_location,
         log.info('Setting dotnet cli installation script at '+dotnet_installer+' as executable')
         helix.proc.run_and_log_output(("chmod 777 "+dotnet_installer).split(" "))
         log.info('Running script '+dotnet_installer)
-        helix.proc.run_and_log_output((dotnet_installer+" -d "+dotnet_cli_dir).split(" "))
+        helix.proc.run_and_log_output((dotnet_installer+" -d "+dotnet_cli_dir+" -v "+os.path.join(xunit_perf_drop,"DotNetCliVersion.txt")).split(" "))
     else:
         log.info('Local dotnet cli install found')
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
@@ -102,7 +102,7 @@ def _prepare_linux_env_for_perf(correlation_dir, xunit_perf_drop, test_location,
         log.info('Setting dotnet cli installation script at '+dotnet_installer+' as executable')
         helix.proc.run_and_log_output(("chmod 777 "+dotnet_installer).split(" "))
         log.info('Running script '+dotnet_installer)
-        helix.proc.run_and_log_output((dotnet_installer+" -d "+dotnet_cli_dir+" -v "+os.path.join(xunit_perf_drop,"DotNetCliVersion.txt")).split(" "))
+        helix.proc.run_and_log_output((dotnet_installer+" -d "+dotnet_cli_dir+" -v "+os.path.join(correlation_dir, "RunnerScripts", "xunitrunner-perf", "DotNetCliVersion.txt")).split(" "))
     else:
         log.info('Local dotnet cli install found')
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -6,14 +6,14 @@
     <PerfDotNetCliDir>$(TestPath)../perf.dotnetcli</PerfDotNetCliDir>
     <PerfDotNetCliInstaller>$(ToolsDir)/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh</PerfDotNetCliInstaller>
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.cli</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfRunnerPackageVersion>
     <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
     <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.runner.cli.dll</XunitPerfRunnerPath>
   </PropertyGroup>
   <!-- Perf Runner NuGet package paths -->
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfRunnerPackageVersion>
     <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
     <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/xunit.performance.run.exe</XunitPerfRunnerPath>
   </PropertyGroup>
@@ -21,12 +21,12 @@
   <!-- Perf Analysis NuGet package paths -->
   <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis.cli</XunitPerfAnalysisPackageId>
-    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfAnalysisPackageVersion>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.analysis.cli.dll</XunitPerfAnalysisPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
-    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfAnalysisPackageVersion>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+    <!-- Perf Runner NuGet package paths -->
+  <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
+    <PerfDotNetCliDir>$(TestPath)../perf.dotnetcli</PerfDotNetCliDir>
+    <PerfDotNetCliInstaller>$(ToolsDir)/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh</PerfDotNetCliInstaller>
+    <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.cli</XunitPerfRunnerPackageId>
+    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
+    <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.runner.cli.dll</XunitPerfRunnerPath>
+  </PropertyGroup>
   <!-- Perf Runner NuGet package paths -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
     <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfRunnerPackageVersion>
     <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
@@ -10,16 +19,26 @@
   </PropertyGroup>
 
   <!-- Perf Analysis NuGet package paths -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
+    <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis.cli</XunitPerfAnalysisPackageId>
+    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.analysis.cli.dll</XunitPerfAnalysisPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
     <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0033</XunitPerfAnalysisPackageVersion>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
   </PropertyGroup>
 
 
+  <Target Name="InstallDotnetCliForPerfExection" Condition="'$(TargetOS)'=='Linux' AND '$(Performance)'=='true' AND !Exists('$(PerfDotNetCliDir)/dotnet')" AfterTargets="CopyXunitExecutionFiles" >
+    <Exec Command="chmod +x $(PerfDotNetCliInstaller)" />
+    <Exec Command="$(PerfDotNetCliInstaller) -d $(PerfDotNetCliDir)" ContinueOnError="true"/>
+  </Target>
   <!-- Copy over the performance runners to the test directory-->
-  <Target Name="CopyXunitExecutionDesktop" AfterTargets="CopyTestToTestDirectory" Condition="'$(Performance)' == 'true'">
-    <ItemGroup>
+  <Target Name="CopyXunitExecutionFiles" AfterTargets="CopyTestToTestDirectory" Condition="'$(Performance)' == 'true'">
+
+    <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.run.exe" />
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.metrics.dll" />
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.logger.exe" />
@@ -30,6 +49,10 @@
       <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/*/*.*" />
       <XunitPerfRunnerFiles Include ="$(PackagesDir)$(XunitPerfRunnerPackageId)/**/*.*" />
       <XunitPerfAnalysisFiles Include ="$(PackagesDir)$(XunitPerfAnalysisPackageId)/**/*.*" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetOS)'=='Linux'">
+      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll" />
+      <PerfRunners Include="$(XunitPerfAnalysisPath)" />
     </ItemGroup>
     <Copy SourceFiles="@(PerfRunners)"
           DestinationFiles="@(PerfRunners->'$(TestPath)$(DebugTestFrameworkFolder)/%(RecursiveDir)%(Filename)%(Extension)')"
@@ -47,14 +70,24 @@
 
   <!-- Executable properties -->
   <PropertyGroup>
-    <PerfRunId Condition="'$(PerfRunId)' == ''">$(TargetFileName)-WindowsCore</PerfRunId>
+    <PerfRunId Condition="'$(PerfRunId)' == '' AND '$(TargetOS)'=='Windows_NT'">$(TargetFileName)-WindowsCore</PerfRunId>
+    <PerfRunId Condition="'$(PerfRunId)' == '' AND '$(TargetOS)'=='Linux'">$(TargetFileName)-LinuxCore</PerfRunId>
     <AnalysisReportFileName>$(PerfRunId)-analysis.html</AnalysisReportFileName>
     <XunitRunnerArgs>$(TargetFileName) -trait Benchmark=true -runnerhost $(TestHostExecutable) -runner $(XunitExecutable) -runid $(PerfRunId) -verbose</XunitRunnerArgs>
-    <PerfTestCommandLine>$(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
-
     <PerfRunOutputFile>$(TestPath)$(DebugTestFrameworkFolder)/$(PerfRunId).xml</PerfRunOutputFile>
-    <XunitAnalysisArgs>$(PerfRunOutputFile) -html $(AnalysisReportFileName) $(AdditionalXunitAnalysisArgs)</XunitAnalysisArgs>
-    <PerfAnalysisCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisArgs)</PerfAnalysisCommandLine>
+    <XunitAnalysisReportArgs>$(PerfRunOutputFile) -html $(AnalysisReportFileName) $(AdditionalXunitAnalysisArgs)</XunitAnalysisReportArgs>
+    <XunitAnalysisCsvArgs>$(PerfRunOutputFile) -csv test_results.csv</XunitAnalysisCsvArgs>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
+    <PerfTestCommandLine>$(PerfDotNetCliDir)/dotnet $(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
+    <PerfAnalysisReportCommandLine>$(PerfDotNetCliDir)/dotnet $(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisReportArgs)</PerfAnalysisReportCommandLine>
+    <PerfAnalysisCsvCommandLine>$(PerfDotNetCliDir)/dotnet $(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommandLine>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
+    <PerfTestCommandLine>$(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
+    <PerfAnalysisReportCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisReportArgs)</PerfAnalysisReportCommandLine>
+    <PerfAnalysisCsvCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommandLine>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Performance)' == 'true'">
@@ -71,12 +104,15 @@
   <Target Name="AnalyzePerfResults"
           AfterTargets="RunTestsForProject"
           Condition="'$(AnalyzePerfResults)' == 'true' and Exists('$(PerfRunOutputFile)')">
-    <Exec Command="$(PerfAnalysisCommandLine)"
+    <Exec Command="$(PerfAnalysisReportCommandLine)"
           WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
           ContinueOnError="false">
       <Output PropertyName="PerfTestRunExitCode" TaskParameter="ExitCode" />
     </Exec>
     <Message Text="Performance test analysis report is available at $(TestPath)$(DebugTestFrameworkFolder)/$(AnalysisReportFileName)" />
+    <Exec Command="$(PerfAnalysisCsvCommandLine)"
+          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          ContinueOnError="false" />
   </Target>
 
   <Target Name="WarnForDebugPerfConfiguration"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -31,9 +31,10 @@
   </PropertyGroup>
 
 
+  <!-- Installing dotnet cli version that can execute the xunit perf test runner -->
   <Target Name="InstallDotnetCliForPerfExection" Condition="'$(TargetOS)'=='Linux' AND '$(Performance)'=='true' AND !Exists('$(PerfDotNetCliDir)/dotnet')" AfterTargets="CopyXunitExecutionFiles" >
     <Exec Command="chmod +x $(PerfDotNetCliInstaller)" />
-    <Exec Command="$(PerfDotNetCliInstaller) -d $(PerfDotNetCliDir)" ContinueOnError="true"/>
+    <Exec Command="$(PerfDotNetCliInstaller) -d $(PerfDotNetCliDir) -v $(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/DotNetCliVersion.txt" ContinueOnError="true"/>
   </Target>
   <!-- Copy over the performance runners to the test directory-->
   <Target Name="CopyXunitExecutionFiles" AfterTargets="CopyTestToTestDirectory" Condition="'$(Performance)' == 'true'">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -63,6 +63,9 @@
     <Copy SourceFiles="@(XunitPerfRunnerFiles)"
           DestinationFiles="@(XunitPerfRunnerFiles->'$(TestWorkingDir)SupplementalPayload/$(XunitPerfRunnerPackageId)/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/DotNetCliVersion.txt"
+          DestinationFolder="$(TestWorkingDir)SupplementalPayload/RunnerScripts/xunitrunner-perf"
+          SkipUnchangedFiles="true" Condition="'$(TargetOS)'=='Linux'"/>
     <Copy SourceFiles="@(XunitPerfAnalysisFiles)"
           DestinationFiles="@(XunitPerfAnalysisFiles->'$(TestWorkingDir)SupplementalPayload/$(XunitPerfAnalysisPackageId)/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"/>
@@ -81,17 +84,18 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
-    <PerfTestCommandLine>$(PerfDotNetCliDir)/dotnet $(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
+    <PerfTestCommandDotnetExecutable>$(PerfDotNetCliDir)/dotnet</PerfTestCommandDotnetExecutable>
     <PerfAnalysisReportCommandLine>$(PerfDotNetCliDir)/dotnet $(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisReportArgs)</PerfAnalysisReportCommandLine>
     <PerfAnalysisCsvCommandLine>$(PerfDotNetCliDir)/dotnet $(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommandLine>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
-    <PerfTestCommandLine>$(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
+    <PerfTestCommandDotnetExecutable></PerfTestCommandDotnetExecutable>
     <PerfAnalysisReportCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisReportArgs)</PerfAnalysisReportCommandLine>
     <PerfAnalysisCsvCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommandLine>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Performance)' == 'true'">
+  <PropertyGroup>
+    <PerfTestCommandLine>$(PerfTestCommandDotnetExecutable) $(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
     <AnalyzePerfResults Condition="'$(AnalyzePerfResults)' != 'false'">true</AnalyzePerfResults>
     <TestCommandLine>$(PerfTestCommandLine)</TestCommandLine>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -3,7 +3,7 @@
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0033",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0035",
     "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0033",
     "xunit": "2.1.0",
     "xunit.runner.utility": "2.1.0"
@@ -11,8 +11,8 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0033",
-        "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0033",
+        "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0035",
+        "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0035",
         "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-24027",
         "Microsoft.NETCore.Console": "1.0.0-rc2-24027",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -4,7 +4,7 @@
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.3",
     "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0035",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0033",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0035",
     "xunit": "2.1.0",
     "xunit.runner.utility": "2.1.0"
   },


### PR DESCRIPTION
- Installing a local copy of dotnet cli compatible with the xunit cli tools and running perf tests on linux machine after build targets
- Generating a csv along with html report since this allows us to view results on internal apps

@lt72 @MattGal 