### PR TITLE
PkgProj test reference

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class GetApplicableAssetsFromPackages : PackagingTask
+    {
+        private Dictionary<string, List<PackageItem>> _packageToPackageItems;
+        private Dictionary<string, PackageItem> _targetPathToPackageItem;
+        private AggregateNuGetAssetResolver _resolver;
+
+        /// <summary>
+        /// All items that make up packages to resolve from.  
+        /// Must have the following metadata
+        ///     Identity - path to the file in the binary directory
+        ///         TargetPath - path to the file in the package
+        ///         PackageId - ID of the package containing the file
+        /// </summary>
+        [Required]
+        public ITaskItem[] PackageAssets { get; set; }
+
+        /// <summary>
+        /// TargetMoniker to use when resolving assets.  EG: netcoreapp1.0, netstandard1.4
+        /// </summary>
+        [Required]
+        public string TargetMoniker { get; set; }
+
+        /// <summary>
+        /// runtime.json that defines the RID graph
+        /// </summary>
+        [Required]
+        public string RuntimeFile { get; set; }
+        
+        /// <summary>
+        /// If specified will be used when resolving runtime assets, otherwise TargetMoniker will be used.
+        /// </summary>
+        public string RuntimeTargetMoniker { get; set; }
+
+        /// <summary>
+        /// If specified will be used when resolving runtime assets, otherwise no RID will be used.
+        /// </summary>
+        public string TargetRuntime { get; set; }
+
+        [Output]
+        public ITaskItem[] CompileAssets { get; set; }
+
+        [Output]
+        public ITaskItem[] RuntimeAssets { get; set; }
+
+        /// <summary>
+        /// Generates a table in markdown that lists the API version supported by 
+        /// various packages at all levels of NETStandard.
+        /// </summary>
+        /// <returns></returns>
+        public override bool Execute()
+        {
+            if (PackageAssets == null || PackageAssets.Length == 0)
+            {
+                Log.LogError("PackageAssets argument must be specified");
+                return false;
+            }
+
+            if (String.IsNullOrEmpty(TargetMoniker))
+            {
+                Log.LogError("TargetMoniker argument must be specified");
+                return false;
+            }
+
+            NuGetFramework fx = NuGetFramework.Parse(TargetMoniker);
+            NuGetFramework runtimeFx = fx;
+
+            if (!String.IsNullOrEmpty(RuntimeTargetMoniker))
+            {
+                runtimeFx = NuGetFramework.Parse(RuntimeTargetMoniker);
+            }
+
+            string targetString = String.IsNullOrEmpty(TargetRuntime) ? fx.ToString() : $"{fx}/{TargetRuntime}";
+
+            LoadFiles();
+
+            CompileAssets = _resolver.ResolveCompileAssets(fx)
+                                .Where(ca => !NuGetAssetResolver.IsPlaceholder(ca))
+                                .Select(ca => PackageItemAsResolvedAsset(_targetPathToPackageItem[ca]))
+                                .ToArray();
+            RuntimeAssets = _resolver.ResolveRuntimeAssets(runtimeFx, TargetRuntime)
+                                .Where(ra => !NuGetAssetResolver.IsPlaceholder(ra))
+                                .Select(ra => PackageItemAsResolvedAsset(_targetPathToPackageItem[ra]))
+                                .ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void LoadFiles()
+        {
+            _packageToPackageItems = new Dictionary<string, List<PackageItem>>();
+            foreach (var file in PackageAssets)
+            {
+                try
+                {
+                    var packageItem = new PackageItem(file);
+
+                    if (String.IsNullOrWhiteSpace(packageItem.TargetPath))
+                    {
+                        Log.LogError($"{packageItem.TargetPath} is missing TargetPath metadata");
+                    }
+
+                    if (!_packageToPackageItems.ContainsKey(packageItem.Package))
+                    {
+                        _packageToPackageItems[packageItem.Package] = new List<PackageItem>();
+                    }
+                    _packageToPackageItems[packageItem.Package].Add(packageItem);
+                }
+                catch (Exception ex)
+                {
+                    Log.LogError($"Could not parse File {file.ItemSpec}. {ex}");
+                    // skip it.
+                }
+            }
+
+            // build a map to translate back to source file from resolved asset
+            // we use package-specific paths since we're resolving a set of packages.
+            _targetPathToPackageItem = new Dictionary<string, PackageItem>();
+            foreach (var packageFiles in _packageToPackageItems)
+            {
+                foreach (PackageItem packageFile in packageFiles.Value)
+                {
+                    string packageSpecificTargetPath = AggregateNuGetAssetResolver.AsPackageSpecificTargetPath(packageFiles.Key, packageFile.TargetPath);
+
+                    if (_targetPathToPackageItem.ContainsKey(packageSpecificTargetPath))
+                    {
+                        Log.LogError($"Files {_targetPathToPackageItem[packageSpecificTargetPath].SourcePath} and {packageFile.SourcePath} have the same TargetPath {packageSpecificTargetPath}.");
+                    }
+                    _targetPathToPackageItem[packageSpecificTargetPath] = packageFile;
+                }
+            }
+
+            _resolver = new AggregateNuGetAssetResolver(RuntimeFile);
+            foreach (string packageId in _packageToPackageItems.Keys)
+            {
+                _resolver.AddPackageItems(packageId, _packageToPackageItems[packageId].Select(f => f.TargetPath));
+            }
+        }
+
+        private ITaskItem PackageItemAsResolvedAsset(PackageItem packageItem)
+        {
+            var item = new TaskItem(packageItem.OriginalItem);
+            item.SetMetadata("Private", "false");
+            item.SetMetadata("FromPkgProj", "true");
+            item.SetMetadata("NuGetPackageId", packageItem.Package);
+            item.SetMetadata("NuGetPackageVersion", packageItem.PackageVersion);
+            return item;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GetApplicableAssetsFromPackages.cs" />
     <Compile Include="GetMinimumNETStandard.cs" />
     <Compile Include="SplitDependenciesBySupport.cs" />
     <Compile Include="GenerateNetStandardSupportTable.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetAssetResolver.cs
@@ -185,6 +185,24 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 Enumerable.Empty<string>();
         }
 
+        public IEnumerable<string> ResolveCompileAssets(NuGetFramework framework)
+        {
+            var allCompileItems = GetCompileItems(framework);
+            foreach (var packageId in allCompileItems.Keys)
+            {
+                var packageAssets = allCompileItems[packageId];
+                if (packageAssets == null)
+                {
+                    continue;
+                }
+
+                foreach (var packageAsset in packageAssets.Items)
+                {
+                    yield return AsPackageSpecificTargetPath(packageId, packageAsset.Path);
+                }
+            }
+        }
+
         public IReadOnlyDictionary<string, ContentItemGroup> GetRuntimeItems(NuGetFramework framework, string runtimeIdentifier)
         {
             var managedCriteria = _conventions.Criteria.ForFrameworkAndRuntime(framework, runtimeIdentifier);

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -3,10 +3,44 @@
   <PropertyGroup>
     <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
     <GenerationDefinitionFile Condition="'$(GenerationDefinitionFile)' == ''">$(MSBuildThisFileDirectory)Generations.json</GenerationDefinitionFile>
+    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == '' AND Exists('$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json')">$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
+    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
   </PropertyGroup>
 
   <UsingTask TaskName="ValidatePackageTargetFramework" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetApplicableAssetsFromPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
+  <Target Name="UpdatePkgProjProjectReferences" BeforeTargets="BeforeResolveReferences">
+    <!-- Update PkgProj references to call the GetPackageAssets target -->
+    <ItemGroup>
+      <ProjectReference Condition="'%(Extension)'=='.pkgproj'">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <Targets>Build;GetPackageAssets</Targets>
+        <OutputItemType>PkgProjAsset</OutputItemType>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
+  
+  <PropertyGroup>
+    <!-- Resolve from pkgProjs before nuget packages -->
+    <ResolveNugetPackagesDependsOn>$(ResolveNugetPackagesDependsOn);ResolvePkgProjReferences</ResolveNugetPackagesDependsOn>
+    <ResolvePkgProjReferencesDependsOn>ResolveProjectReferences</ResolvePkgProjReferencesDependsOn>
+  </PropertyGroup>
+
+  <!-- Resolves applicable files from all files in PkgProjs. Similar to ResolveNuGetPackageAssets, except operates on a file list
+       without requiring actual nupkgs, project.json, or restore -->
+  <Target Name="ResolvePkgProjReferences" Condition="'@(PkgProjAsset)' != ''" DependsOnTargets="$(ResolvePkgProjReferencesDependsOn)">
+    <!-- If TestNuGetTargetMoniker is set, use that for resolving runtime assets. -->
+    <GetApplicableAssetsFromPackages PackageAssets="@(PkgProjAsset)" 
+                                     TargetMoniker="$(NuGetTargetMoniker)"
+                                     RuntimeTargetMoniker="$(TestNuGetTargetMoniker)"
+                                     TargetRuntime="$(TestNugetRuntimeId)"
+                                     RuntimeFile="$(RuntimeIdGraphDefinitionFile)">
+      <Output TaskParameter="CompileAssets" ItemName="Reference" />
+      <Output TaskParameter="RuntimeAssets" ItemName="ReferenceCopyLocalPaths" />
+    </GetApplicableAssetsFromPackages>
+  </Target>
+  
   <!-- Returns the set of files to be included in the nuget package
        with appropriate metadata.-->
   <Target Name="GetFilesToPackage"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -890,10 +890,10 @@
     <SkipValidatePackage Condition="'$(SkipValidateTargetFrameworks)' == '' AND '$(PackageTargetRuntime)' != ''">true</SkipValidatePackage>
     <SkipSupportCheck Condition="'$(SkipSupportCheck)' == '' AND ($(Id.StartsWith('System.Private.')) OR $(Id.StartsWith('Microsoft.NETCore.')))">true</SkipSupportCheck>
   </PropertyGroup>
-
-  <Target Name="ValidatePackage"
+  
+  <Target Name="GetPackageAssets"
           DependsOnTargets="GetPackageFiles;DetermineRuntimeDependencies"
-          Condition="'$(SkipValidatePackage)' != 'true'">
+          Returns="@(PackageAsset)">
     <ItemGroup>
       <RuntimeDependencyProject Include="%(RuntimeDependency.OriginalItemSpec)" KeepDuplicates="false" />
       <!-- map back to the project references -->
@@ -901,6 +901,27 @@
       <ProjectReferenceFullPath Include="@(ProjectReference->'%(FullPath)')"/>
       <RuntimeProjectReference Include="@(ProjectReferenceFullPath)" Condition="'@(ProjectReferenceFullPath)' == '@(RuntimeDependencyProjectFullPath)' AND '%(Identity)' != ''"/>
     </ItemGroup>
+      
+
+    <!-- Get all the files from runtime implementation packages to include in reference path-->
+    <MSBuild Projects="@(RuntimeProjectReference)" 
+             Targets="GetPackageFiles" 
+             BuildInParallel="$(BuildInParallel)"
+             Properties="$(ProjectProperties)">
+      <Output TaskParameter="TargetOutputs" ItemName="RuntimeFile" />
+    </MSBuild>
+
+    <ItemGroup>
+      <PackageAsset Include="@(RuntimeFile)"
+                    Condition="'%(RuntimeFile.IsSourceCodeFile)'!='true'" />
+      <PackageAsset Include="@(PackageFile)"
+                    Condition="'%(PackageFile.IsSourceCodeFile)'!='true'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="ValidatePackage"
+          DependsOnTargets="GetPackageAssets"
+          Condition="'$(SkipValidatePackage)' != 'true'">
 
     <ItemGroup>
       <!-- Validation framework metadata can be sepecified in multiple ways.
@@ -926,33 +947,10 @@
       </SupportedFramework>
     </ItemGroup>
 
-    <!-- Get all the files from runtime implementation packages to include in reference path-->
-    <MSBuild Projects="@(RuntimeProjectReference)" 
-             Targets="GetPackageFiles" 
-             BuildInParallel="$(BuildInParallel)"
-             Properties="$(ProjectProperties)">
-      <Output TaskParameter="TargetOutputs" ItemName="RuntimeFile" />
-    </MSBuild>
-
-    <ItemGroup>
-      <EveryUnfilteredFile Include="@(RuntimeFile);@(PackageFile)" />
-
-      <!-- Include all files except source files. Sources need to be deduplicated. -->
-      <EveryFile Include="@(EveryUnfilteredFile)"
-                 Condition="'%(EveryUnfilteredFile.IsSourceCodeFile)'!='true'" />
-
-      <!-- Include Sources. Deduplicate so they pass package validation. -->
-      <SourceFile Include="@(EveryUnfilteredFile)"
-                  KeepMetadata="TargetPath;IsSourceCodeFile"
-                  KeepDuplicates="false"
-                  Condition="'%(EveryUnfilteredFile.IsSourceCodeFile)'=='true'" />
-      <EveryFile Include="@(SourceFile)" />
-    </ItemGroup>
-
     <ValidatePackage ContractName="$(BaseId)"
                      PackageId="$(Id)"
                      PackageVersion="$(Version)"
-                     Files="@(EveryFile)"
+                     Files="@(PackageAsset)"
                      SupportedFrameworks="@(SupportedFramework)"
                      Frameworks="@(ValidateFramework)"
                      RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
@@ -976,6 +974,20 @@
     <Error Condition="'$(SkipBaseLineCheck)' != 'true' AND '@(_thisPackageBaseLine)' != '' AND '@(_thisPackageBaseLine->WithMetadataValue('Version', '$(_VersionWithoutPreRelease)'))' == ''"
            Text="This package's version '$(_VersionWithoutPreRelease)' is not part of any BaseLine '@(_thisPackageBaseLine->'%(Version)')'.$(BaseLinePropsUpdateMessage)" />
   </Target>
+
+  <Target Name="GetValidationReport" DependsOnTargets="ValidatePackage" Returns="$(PackageReportPath)" />
+
+  <!-- Required by Common.Targets when evaluating projectReferences -->
+  <Target Name="GetNativeManifest" />
+  <Target Name="GetCopyToOutputDirectoryItems" />
+  <!-- App packaging support -->
+  <!-- 
+    Following two targets are needed to be present in every project being built
+    because the app packaging targets recursively scan all projects referenced
+    from projects that generate app packages for them.
+  -->
+  <Target Name="CleanAppxPackage" />
+  <Target Name="GetPackagingOutputs" />
 
   <Target Name="GenerateNuSpec"
           DependsOnTargets="GetPackageDependencies;GetPackageFiles;GetPackageMetadata;GenerateRuntimeDependencies;EnsureEmptyPackage;ValidatePackage">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageItem.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageItem.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
             TargetPath = item.GetMetadata("TargetPath");
             Package = item.GetMetadata("PackageId");
+            PackageVersion = item.GetMetadata("PackageVersion");
 
             // determine if we need to append filename to TargetPath
             // see https://docs.nuget.org/create/nuspec-reference#specifying-files-to-include-in-the-package
@@ -88,5 +89,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         public string TargetDirectory { get; }
         public string TargetPath { get; }
         public string Package { get; }
+        public string PackageVersion { get; }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -38,6 +38,7 @@
     <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
     <!-- Disable RAR complaining about us referencing higher .NET Portable libraries as we aren't a traditional portable library -->
     <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">DNXCore,Version=v5.0</NuGetTargetMoniker>
   </PropertyGroup>
 
   <!-- Need to add references to the mscorlib design-time facade for some old-style portable dependencies like xunit -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -70,11 +70,6 @@
   <Target Name="ResolveNuGetPackages"
           Condition="'$(PrereleaseResolveNuGetPackages)'=='true'"
           DependsOnTargets="$(ResolveNugetPackagesDependsOn)">
-    <PropertyGroup>
-      <!-- Temporary workaround -->
-      <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == '.NETPortable,Version=v4.5,Profile=Profile7'">DNXCore,Version=v5.0</NuGetTargetMoniker>
-    </PropertyGroup>
-
     <PrereleaseResolveNuGetPackageAssets Condition="Exists('$(ProjectLockJson)')"
                                AllowFallbackOnTargetSelection="true"
                                IncludeFrameworkReferences="false"


### PR DESCRIPTION
Support P2P reference from test to PkgProj.

This adds support for CSProj referencing PkgProj.  I chose a basic way to plug in the resolve task.  Depending on how we decide to deal with publishing for different TestFrameworks/Runtimes we might want to change how this plugs in.

/cc @weshaggard @karajas @tarekgh @MattGal @mellinoe 

PS: will rebase/squash before comitting.