### PR TITLE
Allow ReleaseNotes and ProjectUrl to be set

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -51,8 +51,6 @@
     <Authors>Microsoft</Authors>
     <Owners>microsoft,dotnetframework</Owners>
     <Description>TODO</Description>
-    <ReleaseNotes></ReleaseNotes>
-    <ProjectUrl></ProjectUrl>
     <LicenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</LicenseUrl>
     <IconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</IconUrl>
     <Copyright>&#169; Microsoft Corporation.  All rights reserved.</Copyright>


### PR DESCRIPTION
Permit repos to define their own ReleaseNotes and Project URLs.

/cc @weshaggard @joshfree