### PR TITLE
Relax version structure Regex

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -11,7 +11,7 @@
   </ItemGroup>
   <PropertyGroup>
     <PackageNameRegex Condition="'$(PackageNameRegex)' == ''">(.*)\.(\d+\.\d+\.\d+)-([^-]+-\d+-\d+)</PackageNameRegex>
-    <VersionStructureRegex Condition="'$(VersionStructureRegex)' == ''">(\d+\.\d+\.\d+)-((beta|rc2|rc3)-?(\d+(-\d+)?)?)</VersionStructureRegex>
+    <VersionStructureRegex Condition="'$(VersionStructureRegex)' == ''">(\d+\.\d+\.\d+)-(([^-]+)-?(\d+(-\d+)?)?)</VersionStructureRegex>
     <BuildNumberOverrideStructureRegex Condition="'$(BuildNumberOverrideStructureRegex)' == ''">([^-]+)?-?(\d+(-\d+)?)?</BuildNumberOverrideStructureRegex>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Permit additional release values in version structure Regex.

BuildNumberOverrideStructureRegex and VersionStructureRegEx are now nearly identical and these should be collapsed into one regex in an additional cleanup PR (not part of this PR).

/cc @jhendrixMSFT @weshaggard 