### PR TITLE
Allow FrameworkReference metadata on InboxOnTargetFramework 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -349,6 +349,9 @@
       <FrameworkReference Condition="'%(InboxOnTargetFramework.AsFrameworkReference)' == 'true'" Include="$(Id)">
         <TargetFramework>$(_target)</TargetFramework>
       </FrameworkReference>
+      <FrameworkReference Condition="'%(InboxOnTargetFramework.FrameworkReference)' != ''" Include="%(InboxOnTargetFramework.FrameworkReference)">
+        <TargetFramework>$(_target)</TargetFramework>
+      </FrameworkReference>
       <Dependency Include="_._">
         <TargetFramework>$(_target)</TargetFramework>
       </Dependency>


### PR DESCRIPTION
* In Packaging.targets, allow the AsFrameworkReference metadata on InboxOntargetFramework item to contain a list of assemblies which should be automatically referenced on the given framework.

This augments the already existing use of AsFrameworkReference. Currently, if you set that to "true", a FrameworkReference item will be added with the same name as the package. Now, you can specify a list of assembly names to include in the FrameworkReference ItemGroup. This will let us solve https://github.com/dotnet/corefx/issues/5952 without a lot of pkgproj churn.

@ericstj 