### PR TITLE
Add missing dependency of System.Runtime.Serialization.Primitives required for xplat builds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -17,6 +17,7 @@
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-24027",
         "NETStandard.Library": "1.5.0-rc2-24027",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-24027",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
         "Newtonsoft.Json": "7.0.1",
         "NuGet.Client": "3.5.0-rc-1220",
         "NuGet.Versioning": "3.5.0-rc-1220"


### PR DESCRIPTION
cc: @weshaggard 

I missed this runtime dependency with my last merge, and due to it the xplat build won't work when upgrading buildtools. With this change that adds it, building xplat should work now.