### PR TITLE
Add a delay when retrying in SendToHelix task.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/SendToHelix.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/SendToHelix.cs
@@ -55,7 +55,11 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
             using (HttpClient client = new HttpClient())
             {
-                int retryCount = 15;
+                const int MaxAttempts = 15;
+                // add a bit of randomness to the retry delay
+                var rng = new Random();
+                int retryCount = MaxAttempts;
+
                 while (true)
                 {
                     HttpResponseMessage response;
@@ -99,6 +103,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     }
 
                     Log.LogWarning("Failed to publish to '{0}', {1} retries remaining", ApiEndpoint, retryCount);
+                    int delay = (MaxAttempts - retryCount) * rng.Next(1, 5);
+                    await System.Threading.Tasks.Task.Delay(delay * 1000);
                 }
             }
         }


### PR DESCRIPTION
The SendToHelix task has retry logic but it doesn't sleep between
iterations; as a result the retries fail.  I've added a delay between
iterations that scales based on the iteration number.