### PR TITLE
Add support for external package dependencies with fixed versions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -203,13 +203,12 @@ namespace Microsoft.DotNet.Build.Tasks
                 // Don't add a new dependency if one already exists.
                 if (returnDependenciesList.FirstOrDefault(rd => ((JProperty)rd).Name.Equals(name)) == null)
                 {
-                    var externalPackageVersion = externalPackageVersions.FirstOrDefault(epv => epv.ItemSpec.Equals(name, StringComparison.OrdinalIgnoreCase))?.GetMetadata("Version");
-                    string version = externalPackageVersion;
+                    var version = externalPackageVersions.FirstOrDefault(epv => epv.ItemSpec.Equals(name, StringComparison.OrdinalIgnoreCase))?.GetMetadata("Version");
                     if (version == null)
                     {
                         NuGetVersion dependencyVersion = NuGetVersion.Parse(dependency.GetMetadata("Version"));
                         version = string.Join(".", dependencyVersion.Major, dependencyVersion.Minor, dependencyVersion.Patch);
-                        if (!string.IsNullOrWhiteSpace(PackageBuildNumberOverride) && externalPackageVersion == null)
+                        if (!string.IsNullOrWhiteSpace(PackageBuildNumberOverride) && version == null)
                         {
                             version += "-" + PackageBuildNumberOverride;
                         }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -5,7 +5,6 @@
   <UsingTask TaskName="GetPackageNumberFromPackageDrop" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="DumpItem" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   
-
   <ItemGroup>
     <_PackagesDrops Include="$(PackagesDrops)" />
   </ItemGroup>
@@ -186,7 +185,8 @@
                                   Frameworks="$(GeneratedTargetGroup)"
                                   OutputProjectJson="$(ProjectJson)" 
                                   PackageBuildNumberOverride="$(PackageBuildNumberOverride)"
-                                  BuildNumberOverrideStructureRegex="$(BuildNumberOverrideStructureRegex)" />
+                                  BuildNumberOverrideStructureRegex="$(BuildNumberOverrideStructureRegex)" 
+                                  ExternalPackages="@(ExternalPackage)" />
 
     <Message Condition="'$(ErrorNoVersion)' == ''" Text="Generated project.json file - '$(ProjectJson)'" />
   </Target>


### PR DESCRIPTION
This is an interim change while we sort out inter-dependency versioning.

This change allows us to specify package versions for packages not built in the current repo, and then use those package versions when generating a new project.json during the test library build when we are adding a new package dependency into a framework.  ie, Supersede package versions we find in a PackagesDrop with those specified in ExternalPackages ITaskItem.  

I don't expect this to be how we ultimately handle these external packages (though perhaps some form of this will be involved), but this will unblock the corefx repo for Helix failures where it is trying to use the latest build of System.IO.Compression from the CoreFx repo instead of the publically published version which has stable bits.

There is a small related corefx change (the package versions file) which I will send a PR for today.

/cc @weshaggard @dagood @jhendrixMSFT 