### PR TITLE
Switch test framework to netcoreapp1.0

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/CreateTrimDependencyGroupsTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/CreateTrimDependencyGroupsTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         {
             ITaskItem[] files = new[]
             {
-                CreateFileItem(@"E:\ProjectK\binaries\x86ret\NETCore\Libraries\dnxcore\System.Threading.AccessControl.dll", "lib/DNXCore50", "dnxcore50"),
+                CreateFileItem(@"E:\ProjectK\binaries\x86ret\NETCore\Libraries\System.Threading.AccessControl.dll", "lib/netcoreapp1.0", "netcoreapp1.0"),
                 CreateFileItem(@"E:\ProjectK\binaries\x86ret\NETCore\Libraries\net\System.Threading.AccessControl.dll", "lib/net46", "net46"),
                 CreateFileItem(@"E:\ProjectK\binaries\x86ret\Contracts\System.Threading.AccessControl\4.0.0.0\System.Threading.AccessControl.dll", "ref/netstandard1.3", "netstandard1.3"),
                 CreateFileItem(@"E:\ProjectK\src\Redist\x86\retail\bin\i386\HelpDocs\intellisense\NETCore5\1033\System.Threading.AccessControl.xml", "ref/netstandard1.3", "netstandard1.3"),
@@ -238,12 +238,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             };
             ITaskItem[] dependencies = new[]
             {
-                CreateDependencyItem(@"System.Runtime", "4.0.20", "dnxcore50"),
-                CreateDependencyItem(@"System.Resources.ResourceManager", "4.0.0", "dnxcore50"),
-                CreateDependencyItem(@"System.Security.AccessControl", "4.0.0-rc2-23516", "dnxcore50"),
-                CreateDependencyItem(@"System.Security.Principal.Windows", "4.0.0-rc2-23516", "dnxcore50"),
-                CreateDependencyItem(@"System.Runtime.Handles", "4.0.0", "dnxcore50"),
-                CreateDependencyItem(@"System.Threading", "4.0.10", "dnxcore50")
+                CreateDependencyItem(@"System.Runtime", "4.0.20", "netcoreapp1.0"),
+                CreateDependencyItem(@"System.Resources.ResourceManager", "4.0.0", "netcoreapp1.0"),
+                CreateDependencyItem(@"System.Security.AccessControl", "4.0.0-rc2-23516", "netcoreapp1.0"),
+                CreateDependencyItem(@"System.Security.Principal.Windows", "4.0.0-rc2-23516", "netcoreapp1.0"),
+                CreateDependencyItem(@"System.Runtime.Handles", "4.0.0", "netcoreapp1.0"),
+                CreateDependencyItem(@"System.Threading", "4.0.10", "netcoreapp1.0")
             };
             string frameworkListsPath = "FrameworkLists";
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/EnsureOOBFrameworkTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/EnsureOOBFrameworkTests.cs
@@ -152,8 +152,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         {
             ITaskItem[] files = new[]
             {
-                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\dnxcore\System.Xml.XmlSerializer.dll", "lib/DNXCore50", "dnxcore50"),
-                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\dnxcore\System.Xml.XmlSerializer.dll", "lib/netcore50", "netcore50"),
+                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\System.Xml.XmlSerializer.dll", "lib/netcoreapp1.0", "netcoreapp1.0"),
+                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\System.Xml.XmlSerializer.dll", "lib/netcore50", "netcore50"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/MonoAndroid10", "MonoAndroid10"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/MonoTouch10", "MonoTouch10"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/net45", "net45"),
@@ -241,7 +241,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\Redist\x86\retail\bin\i386\HelpDocs\intellisense\NETCore5\1049\System.Reflection.Emit.xml", "ref/netstandard1.1/ru", ""),
                 CreateItem(@"D:\K2\src\Redist\x86\retail\bin\i386\HelpDocs\intellisense\NETCore5\2052\System.Reflection.Emit.xml", "ref/netstandard1.1/zh-hans", ""),
                 CreateItem(@"D:\K2\src\Redist\x86\retail\bin\i386\HelpDocs\intellisense\NETCore5\3082\System.Reflection.Emit.xml", "ref/netstandard1.1/es", ""),
-                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\dnxcore\System.Reflection.Emit.dll", "lib/DNXCore50", "DNXCore50"),
+                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\System.Reflection.Emit.dll", "lib/netcoreapp1.0", "netcoreapp1.0"),
                 CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\netcoreforcoreclr\System.Reflection.Emit.dll", "lib/netcore50", "netcore50"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/MonoAndroid10", ""),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/MonoAndroid10", ""),
@@ -277,7 +277,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "runtimes/win7/lib/win8", "win8"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "runtimes/win7/lib/wp8", "wp8"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "runtimes/win7/lib/wpa81", "wpa81"),
-                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\dnxcore\System.Diagnostics.FileVersionInfo.dll", "runtimes/win7/lib/netstandard1.3", "netstandard1.3"),
+                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\System.Diagnostics.FileVersionInfo.dll", "runtimes/win7/lib/netstandard1.3", "netstandard1.3"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/netstandard", "netstandard")
             };
 
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "runtimes/win7/lib/wp8", "wp8"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "runtimes/win7/lib/wpa81", "wpa81"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "runtimes/win7/lib/netcore50", "netcore50"),
-                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\dnxcore\System.Diagnostics.FileVersionInfo.dll", "runtimes/win7/lib/netstandard1.3", "netstandard1.3"),
+                CreateItem(@"D:\K2\binaries\x86ret\NETCore\Libraries\System.Diagnostics.FileVersionInfo.dll", "runtimes/win7/lib/netstandard1.3", "netstandard1.3"),
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/netstandard", "netstandard")
             };
 

--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.Build.Tasks
         /* JProperties are encapsulated with "['" and "']" to assist with matching Paths which
            contain properties with a '.'.  ie. frameworks.netcoreapp1.0 becomes frameworks.['netcoreapp1.0'].
            A match for a property without a '.' and unencapsulated still works.  ie, we can still select
-           frameworks.['dnxcore50'] even if internally its path is frameworks.dnxcore50. */
+           frameworks.['netcoreapp1.0'] even if internally its path is frameworks.netcoreapp1.0. */
         private static string NewtonsoftEscapeJProperty(string property)
         {
             if (string.IsNullOrWhiteSpace(property))

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -38,7 +38,7 @@
     <ImplicitlyExpandTargetFramework>false</ImplicitlyExpandTargetFramework>
     <!-- Disable RAR complaining about us referencing higher .NET Portable libraries as we aren't a traditional portable library -->
     <ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>true</ResolveAssemblyReferenceIgnoreTargetFrameworkAttributeVersionMismatch>
-    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">DNXCore,Version=v5.0</NuGetTargetMoniker>
+    <NuGetTargetMoniker Condition="'$(NuGetTargetMoniker)' == ''">.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>
 
   <!-- Need to add references to the mscorlib design-time facade for some old-style portable dependencies like xunit -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -56,7 +56,7 @@
     <ItemGroup>
       <_OptimizationDataJsonLine Include="{&quot;dependencies&quot;: {" />
       <_OptimizationDataJsonLine Include="&quot;$(OptimizationDataPackageName)&quot; : &quot;$(OptimizationDataVersion)&quot; " />
-      <_OptimizationDataJsonLine Include="},&quot;frameworks&quot;: {&quot;dnxcore50&quot;: {},&quot;net46&quot;: {}}}"/>
+      <_OptimizationDataJsonLine Include="},&quot;frameworks&quot;: {&quot;netcoreapp1.0&quot;: {},&quot;net46&quot;: {}}}"/>
     </ItemGroup>
     
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -14,7 +14,7 @@ set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
 set PORTABLETARGETS_VERSION=0.1.1-dev
 set ROSLYNCOMPILERS_VERSION=1.3.0-beta1-20160429-01
-set MSBUILD_CONTENT_JSON={"dependencies": { "MicroBuild.Core": "%MICROBUILD_VERSION%", "Microsoft.Portable.Targets": "%PORTABLETARGETS_VERSION%", "Microsoft.Net.Compilers": "%ROSLYNCOMPILERS_VERSION%"},"frameworks": {"dnxcore50": {},"net46": {}}}
+set MSBUILD_CONTENT_JSON={"dependencies": { "MicroBuild.Core": "%MICROBUILD_VERSION%", "Microsoft.Portable.Targets": "%PORTABLETARGETS_VERSION%", "Microsoft.Net.Compilers": "%ROSLYNCOMPILERS_VERSION%"},"frameworks": {"netcoreapp1.0": {},"net46": {}}}
 
 if not exist "%PROJECT_DIR%" (
   echo ERROR: Cannot find project root path at [%PROJECT_DIR%]. Please pass in the source directory as the 1st parameter.
@@ -39,11 +39,11 @@ if not [%RESTORE_ERROR_LEVEL%]==[0] (
 )
 @echo on
 call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECTJSON%" -f netcoreapp1.0 -r %BUILDTOOLS_TARGET_RUNTIME% -o "%TOOLRUNTIME_DIR%"
-set DNXCORE_PUBLISH_ERROR_LEVEL=%ERRORLEVEL%
+set TOOLRUNTIME_PUBLISH_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
-if not [%DNXCORE_PUBLISH_ERROR_LEVEL%]==[0] (
+if not [%TOOLRUNTIME_PUBLISH_ERROR_LEVEL%]==[0] (
 	echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECTJSON%" -f netcoreapp1.0'. Please check above for more details.
-	exit /b %DNXCORE_PUBLISH_ERROR_LEVEL%
+	exit /b %TOOLRUNTIME_PUBLISH_ERROR_LEVEL%
 )
 @echo on
 call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECTJSON%" -f net45 -r %BUILDTOOLS_NET45_TARGET_RUNTIME% -o "%TOOLRUNTIME_DIR%\net45"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -8,7 +8,7 @@ if [ "$__PACKAGES_DIR" == "" ]; then __PACKAGES_DIR=${__TOOLRUNTIME_DIR}; fi
 __TOOLS_DIR=$(cd "$(dirname "$0")"; pwd -P)
 __MICROBUILD_VERSION=0.2.0
 __PORTABLETARGETS_VERSION=0.1.1-dev
-__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"MicroBuild.Core\": \"${__MICROBUILD_VERSION}\", \"Microsoft.Portable.Targets\": \"${__PORTABLETARGETS_VERSION}\"},\"frameworks\": {\"dnxcore50\": {},\"net46\": {}}}"
+__MSBUILD_CONTENT_JSON="{\"dependencies\": {\"MicroBuild.Core\": \"${__MICROBUILD_VERSION}\", \"Microsoft.Portable.Targets\": \"${__PORTABLETARGETS_VERSION}\"},\"frameworks\": {\"netcoreapp1.0\": {},\"net46\": {}}}"
 
 if [ ! -d "$__PROJECT_DIR" ]; then
     echo "ERROR: Cannot find project root path at '$__PROJECT_DIR'. Please pass in the source directory as the 1st parameter."

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/test-runtime/project.json
@@ -9,7 +9,7 @@
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {
+    "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.DotNet.xunit.performance.analysis.cli": "1.0.0-alpha-build0033",
         "Microsoft.DotNet.xunit.performance.runner.cli": "1.0.0-alpha-build0033",
@@ -18,7 +18,7 @@
         "Microsoft.NETCore.Console": "1.0.0-rc2-24027",
         "xunit.console.netcore": "1.0.2-prerelease-00101"
       },
-      "imports": "portable-net45+win8"
+      "imports": [ "dnxcore50", "portable-net45+win8" ]
     },
     "net462": {
       "dependencies": {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -30,20 +30,20 @@
 
   <PropertyGroup Condition="'$(TestWithCore)' == 'true'">
     <TestHostExecutable>CoreRun.exe</TestHostExecutable>
-    <TestHostDirectory>$(TestPath)dnxcore50/</TestHostDirectory>
+    <TestHostDirectory>$(TestPath)netcoreapp1.0/</TestHostDirectory>
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.netcore.exe</XunitExecutable>
-    <DebugTestFrameworkFolder>dnxcore50</DebugTestFrameworkFolder>
+    <DebugTestFrameworkFolder>netcoreapp1.0</DebugTestFrameworkFolder>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestWithCore)' != 'true'">
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.exe</XunitExecutable>
-    <DebugTestFrameworkFolder>dnx45</DebugTestFrameworkFolder>
+    <DebugTestFrameworkFolder>net45</DebugTestFrameworkFolder>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TestWithCore)' == 'true'">
-    <TestTargetFramework Include="DNXCore,Version=v5.0">
-      <Folder>dnxcore50</Folder>
+    <TestTargetFramework Include=".NETCoreApp,Version=v1.0">
+      <Folder>netcoreapp1.0</Folder>
     </TestTargetFramework>
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
+++ b/src/Microsoft.DotNet.CodeAnalysis/Microsoft.DotNet.CodeAnalysis.csproj
@@ -10,6 +10,7 @@
     <AssemblyName>Microsoft.DotNet.CodeAnalysis</AssemblyName>
     <CLSCompliant>false</CLSCompliant>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/Microsoft.DotNet.CodeAnalysis/project.json
+++ b/src/Microsoft.DotNet.CodeAnalysis/project.json
@@ -8,8 +8,8 @@
     "System.Runtime.Extensions": "4.1.0-rc2-24027"
   },
   "frameworks": {
-    "dnxcore50": {
-      "imports": "portable-net45+win8"
+    "netcoreapp1.0": {
+      "imports": [ "dnxcore50", "portable-net45+win8" ]
     }
   }
 }

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -18,25 +18,6 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group>
-        <!-- kept around temporarily for compatibility with old nuget clients that don't understand NETStandard. -->
-        <dependency id="System.Collections" version="4.0.10" />
-        <dependency id="System.Collections.Concurrent" version="4.0.10" />
-        <dependency id="System.Console" version="4.0.0-beta-23213" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
-        <dependency id="System.Globalization" version="4.0.10" />
-        <dependency id="System.IO" version="4.0.10" />
-        <dependency id="System.IO.FileSystem" version="4.0.0" />
-        <dependency id="System.IO.FileSystem.Primitives" version="4.0.0" />
-        <dependency id="System.Linq" version="4.0.0" />
-        <dependency id="System.Runtime" version="4.0.20" />
-        <dependency id="System.Runtime.Extensions" version="4.0.10" />
-        <dependency id="System.Text.RegularExpressions" version="4.0.10" />
-        <dependency id="System.Threading" version="4.0.10" />
-        <dependency id="System.Threading.Tasks" version="4.0.10" />
-        <dependency id="System.Xml.XDocument" version="4.0.10" />
-        <dependency id="xunit.runner.utility" version="2.1.0" />
-      </group>
       <group targetFramework="netstandard1.3">
         <dependency id="System.Collections" version="4.0.11-rc2-23923" />
         <dependency id="System.Collections.Concurrent" version="4.0.12-rc2-23923" />
@@ -62,10 +43,8 @@
   </metadata>
   <files>
     <!-- xunit runner for .NET Core -->
-    <file src="xunit.console.netcore\xunit.console.netcore.exe" target="lib\aspnetcore50" />
-    <file src="xunit.console.netcore\_._" target="lib\dnxcore50" />
-    <file src="xunit.console.netcore\_._" target="lib\dotnet" />
-  
+    <!-- don't reference anything, only provide runner as runtime asset -->
+    <file src="xunit.console.netcore\_._" target="lib\netstandard1.0" />  
     <file src="xunit.console.netcore\xunit.console.netcore.exe" target="runtimes\any\native" />
   </files>
   

--- a/src/nuget/xunit.netcore.extensions.nuspec
+++ b/src/nuget/xunit.netcore.extensions.nuspec
@@ -14,23 +14,6 @@
     <description>This package provides things like various traits and discovers like OuterLoop/ActiveIssue that are used by .NET Core framework test projects.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
-      <group>
-        <!-- kept around temporarily for compatibility with old nuget clients that don't understand NETStandard. -->
-        <dependency id="System.Diagnostics.Debug" version="4.0.10" />
-        <dependency id="System.IO" version="4.0.10" />
-        <dependency id="System.Linq" version="4.0.0" />
-        <dependency id="System.Reflection" version="4.0.10" />
-        <dependency id="System.Reflection.Primitives" version="4.0.0" />
-        <dependency id="System.Runtime" version="4.0.20" />
-        <dependency id="System.Runtime.Extensions" version="4.0.10" />
-        <dependency id="System.Runtime.Handles" version="4.0.0" />
-        <dependency id="System.Runtime.InteropServices" version="4.0.20" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0-beta-23213" />
-        <dependency id="System.Text.Encoding" version="4.0.10" />
-        <dependency id="System.Threading" version="4.0.10" />
-        <dependency id="System.Threading.Tasks" version="4.0.10" />
-        <dependency id="xunit" version="2.1.0" />
-      </group>
       <group targetFramework="netstandard1.3">
         <dependency id="System.Diagnostics.Debug" version="4.0.11-rc2-23923" />
         <dependency id="System.IO" version="4.1.0-rc2-23923" />
@@ -55,6 +38,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="xunit.netcore.extensions\xunit.netcore.extensions.dll" target="lib/dotnet" />
+    <file src="xunit.netcore.extensions\xunit.netcore.extensions.dll" target="lib/netstandard1.3" />
   </files>
 </package>


### PR DESCRIPTION
This switches the default framework and the test framework from
DNXCore50 to netcoreapp1.0.  I've also taken the opportunity to clean
up all non-essential refs to DNXCore50, DNXCore, and DNX.

The only remaining references to these deprecated monikers are:
1. Import statements: needed until all packages are updated.
2. Microsoft.DotNet.Build.Tasks.Packaging.Tests: needed until we can
update the version of BuildTools used by BuildTools to get this change.

/cc @weshaggard @karajas @MattGal @joshfree 