### PR TITLE
Fix BUILDTOOLS_OVERRIDE_RUNTIME for tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -108,7 +108,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(BUILDTOOLS_OVERRIDE_RUNTIME)' != ''">
-      <TestCopyLocal Include="$(BUILDTOOLS_OVERRIDE_RUNTIME)/*.*" />
+      <OverridenRuntimeContent Include="$(BUILDTOOLS_OVERRIDE_RUNTIME)/*.*" />
+      <TestCopyLocal Include="@(OverridenRuntimeContent)" />
     </ItemGroup>
 
     <!-- Remove duplicates. Note that we mustn't just copy in sequence and let
@@ -143,6 +144,9 @@
 
       <SourcesToCopyToTestDir Include="@(ContentWithTargetPath)" />
       <DestinationsForTestDir Include="@(ContentWithTargetPath->'$(TestPath)$(TestTargetFrameworkFolder)\%(TargetPath)')" />
+
+      <SourcesToCopyToTestDir Include="@(OverridenRuntimeContent)" />
+      <DestinationsForTestDir Include="@(OverridenRuntimeContent->'$(TestPath)$(TestTargetFrameworkFolder)\%(Filename)%(Extension)')" />
     </ItemGroup>
 
     <Copy


### PR DESCRIPTION
As part of the universal runner work, BUILDTOOLS_OVERRIDE_RUNTIME no
longer would copy content from the folder into the test folder (however
the generated RunTests.cmd/sh file would correctly not try to deploy the
items from pacakges)