### PR TITLE
Handle case when ExternalPackages is null.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -203,7 +203,10 @@ namespace Microsoft.DotNet.Build.Tasks
                 // Don't add a new dependency if one already exists.
                 if (returnDependenciesList.FirstOrDefault(rd => ((JProperty)rd).Name.Equals(name)) == null)
                 {
-                    var version = externalPackageVersions.FirstOrDefault(epv => epv.ItemSpec.Equals(name, StringComparison.OrdinalIgnoreCase))?.GetMetadata("Version");
+                    string version = null;
+                    if (externalPackageVersions != null)
+                        version = externalPackageVersions.FirstOrDefault(epv => epv.ItemSpec.Equals(name, StringComparison.OrdinalIgnoreCase))?.GetMetadata("Version");
+
                     if (version == null)
                     {
                         NuGetVersion dependencyVersion = NuGetVersion.Parse(dependency.GetMetadata("Version"));


### PR DESCRIPTION
The ExternalPackages property is optional, so check for null first.