### PR TITLE
Conditional include for perf targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -88,7 +88,7 @@
   <Import Project="$(MSBuildThisFileDirectory)CodeCoverage.targets" />
 
   <!-- import settings for perf testing -->
-  <Import Project="$(MSBuildThisFileDirectory)PerfTesting.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)PerfTesting.targets" Condition="'$(Performance)'=='true'"/>
 
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">


### PR DESCRIPTION
Conditionally include perf targets since otherwise we would end up running perf tests by default.
Some perf tests take a long time to finish and this affects the CI for build tools dependent repos
@MattGal 