### PR TITLE
Add the ability to filter out RIDs when building tests against packages.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -185,7 +185,8 @@
                                   Frameworks="$(GeneratedTargetGroup)"
                                   OutputProjectJson="$(ProjectJson)" 
                                   PackageBuildNumberOverride="$(PackageBuildNumberOverride)"
-                                  BuildNumberOverrideStructureRegex="$(BuildNumberOverrideStructureRegex)" 
+                                  BuildNumberOverrideStructureRegex="$(BuildNumberOverrideStructureRegex)"
+                                  ExcludedRuntimes="@(ExcludedRuntimes)"
                                   ExternalPackages="@(ExternalPackage)" />
 
     <Message Condition="'$(ErrorNoVersion)' == ''" Text="Generated project.json file - '$(ProjectJson)'" />


### PR DESCRIPTION
We have a situation where new RIDs have been added to the product but we
don't yet have the actual packages; as a result the test build fails when
buliding against packages as it can't resolve these runtime packages.  To
work around this I have added an optional property to filter out RIDs when
generating the test project.json files.