### PR TITLE
Enable NugetPack to pass through nuspec properties

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="GetApplicableAssetsFromPackages.cs" />
     <Compile Include="GetMinimumNETStandard.cs" />
+    <Compile Include="NugetPropertyStringProvider.cs" />
     <Compile Include="GetRuntimeJsonValues.cs" />
     <Compile Include="GetRuntimeTargets.cs" />
     <Compile Include="SplitDependenciesBySupport.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NugetPropertyStringProvider.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NugetPropertyStringProvider.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class NuspecPropertyStringProvider
+    {
+        public static Dictionary<string, string> GetNuspecPropertyDictionary(string[] nuspecProperties)
+        {
+            if (nuspecProperties == null)
+            {
+                return null;
+            }
+
+            var propertyDictionary = new Dictionary<string, string>();
+            foreach (var propertyString in nuspecProperties)
+            {
+                var property = GetKeyValuePair(propertyString);
+                propertyDictionary[property.Item1] = property.Item2;
+            }
+
+            return propertyDictionary;
+        }
+
+        public static Func<string, string> GetNuspecPropertyProviderFunction(string[] nuspecPropertyStrings)
+        {
+            var propertyDictionary = GetNuspecPropertyDictionary(nuspecPropertyStrings);
+
+            if (propertyDictionary == null)
+            {
+                return null;
+            }
+
+            return k => propertyDictionary[k];
+        }
+
+        private static Tuple<string, string> GetKeyValuePair(string propertyString)
+        {
+            propertyString = propertyString.Trim();
+
+            var indexOfEquals = propertyString.IndexOf("=", StringComparison.Ordinal);
+
+            if (indexOfEquals == -1)
+            {
+                throw new InvalidDataException($"Nuspec property {propertyString} does not have an \'=\' character in it");
+            }
+
+            if (indexOfEquals == propertyString.Length - 1)
+            {
+                throw new InvalidDataException($"Nuspec property {propertyString} does not have a value");
+            }
+
+            if (indexOfEquals == 0)
+            {
+                throw new InvalidDataException($"Nuspec property {propertyString} does not have a key");
+            }
+
+            var key = propertyString.Substring(0, indexOfEquals);
+
+            var valueStartIndex = indexOfEquals + 1;
+            var valueLength = propertyString.Length - valueStartIndex;
+            var value = propertyString.Substring(valueStartIndex, valueLength);
+
+            return new Tuple<string, string>(key, value);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/Microsoft.DotNet.Build.Tasks.Packaging.Tests.Desktop.nuget.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/Microsoft.DotNet.Build.Tasks.Packaging.Tests.Desktop.nuget.props
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup>
+    <Import Project="$(NuGetPackageRoot)\xunit.core\2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('$(NuGetPackageRoot)\xunit.core\2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
+    <Import Project="$(NuGetPackageRoot)\xunit.runner.visualstudio\2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('$(NuGetPackageRoot)\xunit.runner.visualstudio\2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  </ImportGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
@@ -17,6 +17,7 @@
     <Compile Include="CreateTrimDependencyGroupsTests.cs" />
     <Compile Include="ApplyBaseLineTests.cs" />
     <Compile Include="EnsureOOBFrameworkTests.cs" />
+    <Compile Include="NugetPropertyStringProviderTests.cs" />
     <Compile Include="NuGetAssetResolverTests.cs" />
     <Compile Include="GenerationsTests.cs" />
     <Compile Include="Log.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.nuget.props
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.nuget.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup>
+    <Import Project="$(NuGetPackageRoot)\xunit.core\2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('$(NuGetPackageRoot)\xunit.core\2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
+  </ImportGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/NugetPropertyStringProviderTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/NugetPropertyStringProviderTests.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NuGet.Frameworks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
+{
+    public class NugetPropertyStringProviderTests
+    {
+
+        [Fact]
+        public void ShouldParseSingleValidKeyValue()
+        {
+            var expectedDictionary = new Dictionary<string, string>{ {"a", "b"} };
+            AssertPropertyStringsParseToDictionary(new[] { "a=b" }, expectedDictionary);
+            AssertPropertyStringsParseToDictionary(new[] { " a=b " }, expectedDictionary);
+        }
+
+        [Fact]
+        public void ShouldParseSingleValidKeyValueWithEqualsInValue()
+        {
+            var expectedDictionary = new Dictionary<string, string> { { "a", "=b=" } };
+            AssertPropertyStringsParseToDictionary(new[] { "a==b=" }, expectedDictionary);
+        }
+
+        [Fact]
+        public void ShouldParseSingleValidKeyValueWithMultineContents()
+        {
+            var multiLineString = @"b
+                                    c";
+            var expectedDictionary = new Dictionary<string, string> { { "a", multiLineString } };
+            AssertPropertyStringsParseToDictionary(new[] { $"a={multiLineString}" }, expectedDictionary);
+
+            expectedDictionary = new Dictionary<string, string> { { multiLineString, "b" } };
+            AssertPropertyStringsParseToDictionary(new[] { $"{multiLineString}=b" }, expectedDictionary);
+
+            expectedDictionary = new Dictionary<string, string> { { multiLineString, multiLineString } };
+            AssertPropertyStringsParseToDictionary(new[] { $"{multiLineString}={multiLineString}" }, expectedDictionary);
+        }
+
+        [Fact]
+        public void ShouldReturnNullOnNullInput()
+        {
+            Assert.Equal(null, NuspecPropertyStringProvider.GetNuspecPropertyDictionary(null));
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyDictionaryOnEmptyInput()
+        {
+            var expectedDictionary = new Dictionary<string, string>();
+            AssertPropertyStringsParseToDictionary(new string[0], expectedDictionary);
+        }
+
+        [Fact]
+        public void ShouldFailWithNoEquals()
+        {
+            Assert.Throws<InvalidDataException>(() => NuspecPropertyStringProvider.GetNuspecPropertyDictionary(new[] { "abc" }));
+        }
+
+        [Fact]
+        public void ShouldFailWithNoValue()
+        {
+            Assert.Throws<InvalidDataException>(() => NuspecPropertyStringProvider.GetNuspecPropertyDictionary(new[] { "a= " }));
+        }
+
+        [Fact]
+        public void ShouldFailWithNoKey()
+        {
+            Assert.Throws<InvalidDataException>(() => NuspecPropertyStringProvider.GetNuspecPropertyDictionary(new[] { " = b" }));
+        }
+
+        [Fact]
+        public void ShouldFailWithNoKeyAndValue()
+        {
+            Assert.Throws<InvalidDataException>(() => NuspecPropertyStringProvider.GetNuspecPropertyDictionary(new[] { " = " }));
+        }
+
+        private static void AssertPropertyStringsParseToDictionary(string[] propertyStrings, Dictionary<string, string> expectedDictionary)
+        {
+            Assert.Equal(expectedDictionary, NuspecPropertyStringProvider.GetNuspecPropertyDictionary(propertyStrings));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
@@ -15,7 +15,7 @@
   <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   
   <Target Name="BuildPackages"
-    DependsOnTargets="GetNuGetPackageVersions"
+    DependsOnTargets="AddNuGetPackageVersionMetadataToNuspecs"
     Condition="'$(SkipBuildPackages)' != 'true'">
     
     <!-- Create package output directory -->
@@ -28,7 +28,8 @@
       OutputDirectory="$(PackagesOutDir)"
       BaseDirectory="$(PackagesBasePath)"
       PackageVersion="%(PackagesNuSpecFiles.PackageVersion)"
-      ExcludeEmptyDirectories="true"/>
+      ExcludeEmptyDirectories="true"
+      NuspecProperties="@(NuspecProperties)"/>
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"
@@ -47,7 +48,7 @@
   </Target>
 
   <Target
-    Name="GetNuGetPackageVersions"
+    Name="AddNuGetPackageVersionMetadataToNuspecs"
     Condition="'@(PackagesNuSpecFiles)'!=''"
     Outputs="%(PackagesNuSpecFiles.Identity)"
     DependsOnTargets="$(GetNuGetPackageVersionsDependsOn)">
@@ -57,17 +58,32 @@
     </PropertyGroup>
 
     <GetPackageVersion
-      Condition="Exists('$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll')"
+      Condition="Exists('$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll') and $(DoNotGeneratePackageVersion) != 'true'"
       RevisionNumber="$(SelectedPackageVersion)"
       NuSpecFile="%(PackagesNuSpecFiles.Identity)">
       <Output PropertyName="_TempPackageVersion" TaskParameter="PackageVersion" />
     </GetPackageVersion>
     
-    <ItemGroup>
+    <!-- Assign the package version that was automatically generated from the nuspecs -->
+    <ItemGroup
+      Condition="$(DoNotGeneratePackageVersion) != 'true'">
       <PackagesNuSpecFiles Condition="'%(PackagesNuSpecFiles.Identity)' == '%(Identity)'">
         <PackageVersion>$(_TempPackageVersion)</PackageVersion>
       </PackagesNuSpecFiles>
     </ItemGroup>
+
+    <!-- Assign the package version that was provided by the user -->
+    <ItemGroup
+      Condition="$(DoNotGeneratePackageVersion) == 'true' and $(PackageVersion) != ''">
+      <PackagesNuSpecFiles Condition="'%(PackagesNuSpecFiles.Identity)' == '%(Identity)'">
+        <PackageVersion>$(PackageVersion)</PackageVersion>
+      </PackagesNuSpecFiles>
+    </ItemGroup>
+
+    <Error
+      Condition="$(DoNotGeneratePackageVersion) == 'true' and $(PackageVersion) == ''"
+      Text="When DoNotGeneratePackageVersion is set to 'true' the user has to provide a PackageVersion property that applies to all nuget packages"
+      />
 
     <PropertyGroup>
       <_TempPackageVersion />


### PR DESCRIPTION
With MSBuild nuget packages, we want to have versioned project to project dependencies. For this, nuspec properties seem like an ideal solution: we add a `$version$` variable in the nuspecs and then compute and inject the actual value at build time.

I also changed packages.targets to allow the user to override the package version and not have it automatically generated.

Usage example of the changes (WIP msbuild branch):
- https://github.com/cdmihai/msbuild/commit/18ea882c144a0a0bc9a8b9fab550eb127675f926#diff-aade4fae49f1d220b531687680bb6718
- https://github.com/cdmihai/msbuild/commit/18ea882c144a0a0bc9a8b9fab550eb127675f926#diff-fcc4a9bafd113347e0ca9e95377d8f73