### PR TITLE
Always use 'rhel.7-x64' as the RHEL 7 publish RID

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -43,6 +43,13 @@ case $OSName in
             source /etc/os-release
             __PUBLISH_RID=$ID.$VERSION_ID-x64
         fi
+
+        # RHEL bumps their OS Version with minor releases, but we only put the "rhel.7-x64" RID in our
+        # tool runtime, since there's binary compatibility between minor versions.
+
+        if [[ $__PUBLISH_RID == rhel.7*-x64 ]]; then
+            __PUBLISH_RID=rhel.7-x64
+        fi
         ;;
 
     *)


### PR DESCRIPTION
I broke building on RHEL with my previous change to simplify the publishing RID, since we don't explicitly list rhel.7.2-x64 in our `tool-runtime.json`.

This change forces us to `rhel.7-x64` as the rid to restore on RHEL. The other supported distros don't bump `$VERSION_ID` for minor releases.