### PR TITLE
Add RequiresElevation constant

### DIFF
--- a/src/xunit.netcore.extensions/XunitConstants.cs
+++ b/src/xunit.netcore.extensions/XunitConstants.cs
@@ -19,5 +19,6 @@ namespace Xunit.NetCore.Extensions
         internal const string OuterLoop = "outerloop";
         public const string Category = "category";
         public const string IgnoreForCI = "ignoreforci";
+        public const string RequiresElevation = "requireselevation";
     }
 }


### PR DESCRIPTION
We'll use this in CoreFX to mark tests which require an elevated
context to run (e.g root or Administrator). Previously we conflated
this with OuterLoop.