### PR TITLE
Address CoreFX issue # 8634

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
@@ -40,7 +40,10 @@ EXIT /B %ERRORLEVEL%
 IF EXIST %2 (
 exit /b 0
 )
-mklink /H %2 %1 > NUL
+mklink /H %2 %1 > NUL 2>&1
+IF %ERRORLEVEL% == 1 (
+copy /y %1 %2 > NUL 2>&1
+)
 exit /b %ERRORLEVEL%
 :: =====================================
 :ShowUsage


### PR DESCRIPTION
Fix for https://github.com/dotnet/corefx/issues/8634 from @krwq .  Also adding @weshaggard  to comment.

If mklink fails, it will now fall back to copying the files (and logs that it did so).   I explored doing this with symbolic links, but this did not work properly with CoreRun.exe. 