### PR TITLE
Disabling dotnet installation on non-unix build machines

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -32,7 +32,7 @@
 
 
   <!-- Installing dotnet cli version that can execute the xunit perf test runner -->
-  <Target Name="InstallDotnetCliForPerfExection" Condition="'$(TargetOS)'=='Linux' AND '$(Performance)'=='true' AND !Exists('$(PerfDotNetCliDir)/dotnet')" AfterTargets="CopyXunitExecutionFiles" >
+  <Target Name="InstallDotnetCliForPerfExecution" Condition="'$(TargetOS)'=='Linux' AND '$(Performance)'=='true' AND !Exists('$(PerfDotNetCliDir)/dotnet') AND '$(OsEnvironment)'=='Unix'" AfterTargets="CopyXunitExecutionFiles" >
     <Exec Command="chmod +x $(PerfDotNetCliInstaller)" />
     <Exec Command="$(PerfDotNetCliInstaller) -d $(PerfDotNetCliDir) -v $(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/DotNetCliVersion.txt" ContinueOnError="true"/>
   </Target>


### PR DESCRIPTION
When building on windows build machine and targeting linux, build tools tries to install dotnet cli on windows, disabling this since we don't want to run linux tests locally on a windows machine and we don't want linux commands to be executed on a windows machine

@jhendrixMSFT @MattGal @lt72 
