### PR TITLE
[WIP] Add Serviceable element to NuSpec

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
+using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
@@ -65,6 +66,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public bool DevelopmentDependency { get; set; }
 
+        public bool Serviceable { get; set; }
+
         public string Tags { get; set; }
 
         public ITaskItem[] Dependencies { get; set; }
@@ -109,6 +112,23 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             using (var file = File.Create(OutputFileName))
             {
                 manifest.Save(file, false);
+
+                if (Serviceable)
+                {
+                    // temporary workaround until we have NuGet support
+                    // read the nuspec
+                    file.Seek(0, SeekOrigin.Begin);
+                    var document = XDocument.Load(file);
+
+                    // add serviceable element under metadata
+                    var ns = document.Root.GetDefaultNamespace();
+                    var metadata = document.Root.Element(ns + "metadata");
+                    metadata.Add(new XElement(ns + "serviceable", "true"));
+
+                    // replace contents
+                    file.SetLength(0);
+                    document.Save(file);
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -56,6 +56,7 @@
     <Copyright>&#169; Microsoft Corporation.  All rights reserved.</Copyright>
     <Tags></Tags>
     <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <Serviceable Condition="'$(Serviceable)' == ''">true</Serviceable>
     <!-- we depend on nuget v2.12 / v3.4 behavior NuGet doesn't support two different min client versions
          so we declare 2.12 and mention in package description that when using 3.x we require 3.4 or later -->
     <MinClientVersion3 Condition="'$(MinClientVersion3)' == '' and '$(MinClientVersion)' == ''">3.4</MinClientVersion3>
@@ -1019,7 +1020,8 @@
                     Dependencies="@(Dependency)"
                     References="@(Reference)"
                     FrameworkReferences="@(FrameworkReference)"
-                    Files="@(PackageFile)"/>
+                    Files="@(PackageFile)"
+                    Serviceable="$(Serviceable)"/>
   </Target>
 
   <Target Name="CreatePackage"


### PR DESCRIPTION
This is a temporary implementation of adding the Serviceable element to
all NuSpecs.  This will be used by the CLI host to determine if it
should write breadcrumbs for our packages.