### PR TITLE
Resolve correct test assets for netstandard

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -85,9 +85,9 @@
     <!-- gather the test archives for upload -->
     <ItemGroup>
       <ForUpload Include="$(TestArchivesRoot)**/*.zip" />
-      <ForUpload Include="$(AnyOSTestArchivesRoot)*.zip" />
+      <ForUpload Include="$(AnyOSTestArchivesRoot)**/*.zip" />
       <!-- Only include Unix folders if supported by the current target OS -->
-      <ForUpload Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />
+      <ForUpload Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" />
     </ItemGroup>
 
     <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" />
@@ -168,8 +168,8 @@
     <!-- create item group of functional tests -->
     <ItemGroup>
       <FunctionalTest Include="$(TestArchivesRoot)**/*.zip" />
-      <FunctionalTest Include="$(AnyOSTestArchivesRoot)*.zip" />
-      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)*.zip" />
+      <FunctionalTest Include="$(AnyOSTestArchivesRoot)**/*.zip" />
+      <FunctionalTest Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -327,9 +327,9 @@
     <WriteItemsToJson JsonFileName="%(TestListFile.BuildCompleteJson)" Items="@(BuildComplete)" />
     <!-- write out build statistics (only contains number of built projects at present) -->
     <ItemGroup>
-      <BuiltSuccessfully Include="$(TestArchivesRoot)*.zip" />
-      <BuiltSuccessfully Include="$(AnyOSTestArchivesRoot)*.zip" />
-      <BuiltSuccessfully Condition="'$(TargetsUnix)' == 'true'"  Include="$(UnixTestArchivesRoot)*.zip" />
+      <BuiltSuccessfully Include="$(TestArchivesRoot)**/*.zip" />
+      <BuiltSuccessfully Include="$(AnyOSTestArchivesRoot)**/*.zip" />
+      <BuiltSuccessfully Condition="'$(TargetsUnix)' == 'true'"  Include="$(UnixTestArchivesRoot)**/*.zip" />
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -17,6 +17,7 @@
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <Targets>Build;GetPackageAssets</Targets>
         <OutputItemType>PkgProjAsset</OutputItemType>
+        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
       </ProjectReference>
     </ItemGroup>
   </Target>
@@ -30,10 +31,9 @@
   <!-- Resolves applicable files from all files in PkgProjs. Similar to ResolveNuGetPackageAssets, except operates on a file list
        without requiring actual nupkgs, project.json, or restore -->
   <Target Name="ResolvePkgProjReferences" Condition="'@(PkgProjAsset)' != ''" DependsOnTargets="$(ResolvePkgProjReferencesDependsOn)">
-    <!-- If TestNuGetTargetMoniker is set, use that for resolving runtime assets. -->
     <GetApplicableAssetsFromPackages PackageAssets="@(PkgProjAsset)" 
-                                     TargetMoniker="$(NuGetTargetMoniker)"
-                                     RuntimeTargetMoniker="$(TestNuGetTargetMoniker)"
+                                     TargetMonikers="$(NuGetTargetMoniker)"
+                                     RuntimeTargetMonikers="@(TestNuGetTargetMoniker)"
                                      TargetRuntime="$(TestNugetRuntimeId)"
                                      RuntimeFile="$(RuntimeIdGraphDefinitionFile)">
       <Output TaskParameter="CompileAssets" ItemName="Reference" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -52,15 +52,15 @@
                                RuntimeIdentifier="$(TestNugetRuntimeId)"
                                ProjectLanguage="$(Language)"
                                ProjectLockFile="$(ProjectLockJson)"
-                               TargetMonikers="@(TestTargetFramework)">
+                               TargetMonikers="@(TestNugetTargetMoniker)">
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </PrereleaseResolveNuGetPackageAssets>
 
     <ItemGroup Condition="'$(TestWithCore)' != 'true'">
-      <!-- Filter out the copy-local set of references coming from the targeting pack packages -->
-      <TestCopyLocalToRemove Include="@(TestCopyLocal)"
+      <!-- Filter out the copy-local set of references coming from the targeting pack packages, leaving here for legacy reasons for Targeting pack-->
+<!--       <TestCopyLocalToRemove Include="@(TestCopyLocal)"
         Condition="$([System.String]::new('%(TestCopyLocal.NuGetPackageId)').StartsWith('$(_TargetingPackPrefix)'))" />
-      <TestCopyLocal Remove="@(TestCopyLocalToRemove)" />
+      <TestCopyLocal Remove="@(TestCopyLocalToRemove)" /> -->
 
       <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.exe" />
       <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.dll" />
@@ -135,18 +135,18 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <TestTargetFrameworkFolder>%(TestTargetFramework.Folder)</TestTargetFrameworkFolder>
+      <TestNugetTargetMonikerFolder>%(TestNugetTargetMoniker.Folder)</TestNugetTargetMonikerFolder>
     </PropertyGroup>
 
     <ItemGroup>
       <SourcesToCopyToTestDir Include="@(RunTestsForProjectInputs)" />
-      <DestinationsForTestDir Include="@(RunTestsForProjectInputs->'$(TestPath)$(TestTargetFrameworkFolder)\%(Filename)%(Extension)')" />
+      <DestinationsForTestDir Include="@(RunTestsForProjectInputs->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)')" />
 
       <SourcesToCopyToTestDir Include="@(ContentWithTargetPath)" />
-      <DestinationsForTestDir Include="@(ContentWithTargetPath->'$(TestPath)$(TestTargetFrameworkFolder)\%(TargetPath)')" />
+      <DestinationsForTestDir Include="@(ContentWithTargetPath->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(TargetPath)')" />
 
       <SourcesToCopyToTestDir Include="@(OverridenRuntimeContent)" />
-      <DestinationsForTestDir Include="@(OverridenRuntimeContent->'$(TestPath)$(TestTargetFrameworkFolder)\%(Filename)%(Extension)')" />
+      <DestinationsForTestDir Include="@(OverridenRuntimeContent->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)')" />
     </ItemGroup>
 
     <Copy
@@ -161,8 +161,8 @@
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
-    <Exec Condition="'$(OS)'=='Unix' and Exists('$(TestPath)%(TestTargetFramework.Folder)/corerun')"
-          Command="chmod a+x &quot;$(TestPath)%(TestTargetFramework.Folder)/corerun&quot;" />
+    <Exec Condition="'$(OS)'=='Unix' and Exists('$(TestPath)%(TestNugetTargetMoniker.Folder)/corerun')"
+          Command="chmod a+x &quot;$(TestPath)%(TestNugetTargetMoniker.Folder)/corerun&quot;" />
 
   </Target>
 
@@ -173,12 +173,12 @@
   <Target Name="CopySupplementalTestData"
           AfterTargets="CopyTestToTestDirectory"
           Inputs="@(SupplementalTestData)"
-          Outputs="%(TestTargetFramework.Folder)">
+          Outputs="%(TestNugetTargetMoniker.Folder)">
     <PropertyGroup>
-      <TestTargetFrameworkFolder>%(TestTargetFramework.Folder)</TestTargetFrameworkFolder>
+      <TestNugetTargetMonikerFolder>%(TestNugetTargetMoniker.Folder)</TestNugetTargetMonikerFolder>
     </PropertyGroup>
     <ItemGroup>
-      <SupplementalTestDataTestDir Include="@(SupplementalTestData->'$(TestPath)$(TestTargetFrameworkFolder)/%(RecursiveDir)%(Filename)%(Extension)')" />
+      <SupplementalTestDataTestDir Include="@(SupplementalTestData->'$(TestPath)$(TestNugetTargetMonikerFolder)/%(RecursiveDir)%(Filename)%(Extension)')" />
       <SupplementalTestDataOutDir Include="@(SupplementalTestData->'$(OutDir)/%(RecursiveDir)%(Filename)%(Extension)')" />
     </ItemGroup>
     <Copy
@@ -209,7 +209,7 @@
   <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'"  DependsOnTargets="RunTestsForProject">
     <PropertyGroup>
       <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>
-      <TestArchiveDir Condition="'$(TargetGroup)' != ''">$(TestArchiveDir)$(TargetGroup)/</TestArchiveDir>
+      <TestArchiveDir Condition="'$(TestTFM)' != ''">$(TestArchiveDir)$(TestTFM)/</TestArchiveDir>
       <ProjectJson Condition="!Exists('$(ProjectJson)')">$(OriginalProjectJson)</ProjectJson>
     </PropertyGroup>
     <PropertyGroup Condition="'$(TestProjectName)'==''">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -57,10 +57,6 @@
     </PrereleaseResolveNuGetPackageAssets>
 
     <ItemGroup Condition="'$(TestWithCore)' != 'true'">
-      <!-- Filter out the copy-local set of references coming from the targeting pack packages, leaving here for legacy reasons for Targeting pack-->
-<!--       <TestCopyLocalToRemove Include="@(TestCopyLocal)"
-        Condition="$([System.String]::new('%(TestCopyLocal.NuGetPackageId)').StartsWith('$(_TargetingPackPrefix)'))" />
-      <TestCopyLocal Remove="@(TestCopyLocalToRemove)" /> -->
 
       <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.exe" />
       <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.dll" />
@@ -110,6 +106,14 @@
     <ItemGroup Condition="'$(BUILDTOOLS_OVERRIDE_RUNTIME)' != ''">
       <OverridenRuntimeContent Include="$(BUILDTOOLS_OVERRIDE_RUNTIME)/*.*" />
       <TestCopyLocal Include="@(OverridenRuntimeContent)" />
+     </ItemGroup>
+    
+    <!-- Once the copying of RunTestsForProjectInputs is complete, we can remove it from the 
+    TestCopyLocal (which is the dependency list for each test) and cannot have any values
+    referring to locally built assets -->
+    <Message Condition="'@(RunTestsForProjectInputs)'!=''" Text="Overwriting the following values in TestDir : '@(RunTestsForProjectInputs)'" />
+    <ItemGroup>
+      <TestCopyLocal Remove="@(RunTestsForProjectInputs)" />
     </ItemGroup>
 
     <!-- Remove duplicates. Note that we mustn't just copy in sequence and let

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net45'">false</TestWithCore>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net46'">false</TestWithCore>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net461'">false</TestWithCore>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TargetGroup)' == 'net462'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net45'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net46'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net461'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net462'">false</TestWithCore>
     <TestWithCore Condition="'$(TestWithCore)' == ''">true</TestWithCore>
   </PropertyGroup>
 
@@ -41,25 +41,37 @@
     <DebugTestFrameworkFolder>net45</DebugTestFrameworkFolder>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TestWithCore)' == 'true'">
-    <TestTargetFramework Include=".NETCoreApp,Version=v1.0">
+  <ItemGroup>
+    <TestNugetTargetMoniker Include=".NETCoreApp,Version=v1.0" Condition="'$(TestTFM)' == 'netcoreapp1.0'">
       <Folder>netcoreapp1.0</Folder>
-    </TestTargetFramework>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TestWithCore)' != 'true'">
-    <TestTargetFramework Include=".NETFramework,Version=v4.6.2" Condition="'$(TargetGroup)' == 'net462'">
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.2" Condition="'$(TestTFM)' == 'net462'">
       <Folder>net462</Folder>
-    </TestTargetFramework>
-    <TestTargetFramework Include=".NETFramework,Version=v4.6.1" Condition="'$(TargetGroup)' == 'net461'">
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.1" Condition="'$(TestTFM)' == 'net461'">
       <Folder>net461</Folder>
-    </TestTargetFramework>
-    <TestTargetFramework Include=".NETFramework,Version=v4.6" Condition="'$(TargetGroup)' == 'net46'">
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6" Condition="'$(TestTFM)' == 'net46'">
       <Folder>net46</Folder>
-    </TestTargetFramework>
-    <TestTargetFramework Include=".NETFramework,Version=v4.5" Condition="'$(TargetGroup)' == 'net45'">
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5" Condition="'$(TestTFM)' == 'net45'">
       <Folder>net45</Folder>
-    </TestTargetFramework>
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5.1" Condition="'$(TestTFM)' == 'net451'">
+      <Folder>net451</Folder>
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include="UAP,Version=v10.0" Condition="'$(TestTFM)' == 'netcore50aot'">
+      <Folder>netcore50aot</Folder>
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETStandard,Version=v1.3" Condition="'$(TestTFM)' == 'netstandard13aot'">
+      <Folder>netstandard13aot</Folder>
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETStandard,Version=v1.5" Condition="'$(TestTFM)' == 'netstandard15aot'">
+      <Folder>netstandard15aot</Folder>
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include="UAP,Version=v10.0" Condition="'$(TestTFM)' == 'netcore50'">
+      <Folder>netcore50</Folder>
+    </TestNugetTargetMoniker>
   </ItemGroup>
 
   <!-- General xunit options -->
@@ -116,7 +128,7 @@
           DependsOnTargets="DiscoverTestInputs;CheckTestCategories"
           AfterTargets="CheckTestCategories"
           Inputs="@(RunTestsForProjectInputs)"
-          Outputs="$(TestsSuccessfulSemaphore);$(TestPath)%(TestTargetFramework.Folder)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
+          Outputs="$(TestsSuccessfulSemaphore);$(TestPath)%(TestNugetTargetMoniker.Folder)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
           >
 
     <ItemGroup>
@@ -150,7 +162,7 @@
     <PropertyGroup>
       <TestCommandLine Condition="'$(TargetOS)'!='Windows_NT'" >$(TestCommandLine.Replace('$(TestHostExecutable)', './corerun'))</TestCommandLine>
       <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
-      <OutputFolderForScriptGenerator>$(TestPath)%(TestTargetFramework.Folder)</OutputFolderForScriptGenerator>
+      <OutputFolderForScriptGenerator>$(TestPath)%(TestNugetTargetMoniker.Folder)</OutputFolderForScriptGenerator>
       <OutputPathForScriptGenerator>$(OutputFolderForScriptGenerator)/$(RunnerScriptName)</OutputPathForScriptGenerator>
       <OutputFolderForTestDependencies>$(BinDir)/TestDependencies</OutputFolderForTestDependencies>
     </PropertyGroup>
@@ -170,7 +182,7 @@
     <MakeDir Directories="$(OutputFolderForTestDependencies)" />
     <PropertyGroup>
       <_TestDependencyListRoot>$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
-      <_TestDependencyListRoot Condition="'$(TargetGroup)' != ''">$(_TestDependencyListRoot).$(TargetGroup)</_TestDependencyListRoot>
+      <_TestDependencyListRoot Condition="'$(TestTFM)' != ''">$(_TestDependencyListRoot).$(TestTFM)</_TestDependencyListRoot>
       <_TestDependencyListFileName>$(_TestDependencyListRoot).dependencylist.txt</_TestDependencyListFileName>
       <TestDependencyListFilePath>$(OutputFolderForTestDependencies)/$(_TestDependencyListFileName)</TestDependencyListFilePath>
     </PropertyGroup>
@@ -200,14 +212,14 @@
     />
 
     <Exec Condition="'$(TestDisabled)'!='true'"
-          Command="$(TestPath)%(TestTargetFramework.Folder)/$(RunnerScriptName) $(PackagesDir)"
-          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+          Command="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(RunnerScriptName) $(PackagesDir)"
+          WorkingDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)"
           CustomErrorRegularExpression="Failed: [^0]"
           ContinueOnError="true">
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
     </Exec>
 
-    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)%(TestTargetFramework.Folder)/$(EventTracerDataFile)" />
+    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(EventTracerDataFile)" />
     <Error Condition="'$(TestDisabled)'!='true' And '$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
     <Touch Condition="'$(TestRunExitCode)' == '0'" Files="$(TestsSuccessfulSemaphore)" AlwaysCreate="true" />
   </Target>
@@ -232,7 +244,7 @@
     <PropertyGroup>
       <TestsSuccessfulSemaphore Condition="'@(RunWithTraits)' != ''">$(TestsSuccessfulSemaphore).with.@(RunWithTraits, '.')</TestsSuccessfulSemaphore>
       <TestsSuccessfulSemaphore Condition="'@(RunWithoutTraits)' != ''">$(TestsSuccessfulSemaphore).without.@(RunWithoutTraits, '.')</TestsSuccessfulSemaphore>
-      <TestsSuccessfulSemaphore>$(TestPath)%(TestTargetFramework.Folder)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore>$(TestPath)%(TestNugetTargetMoniker.Folder)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
     </PropertyGroup>
 
     <Delete Condition="'$(ForceRunTests)'=='true' And Exists($(TestsSuccessfulSemaphore))"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -21,11 +21,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net45'">false</TestWithCore>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net46'">false</TestWithCore>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net461'">false</TestWithCore>
-    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' == 'net462'">false</TestWithCore>
-    <TestWithCore Condition="'$(TestWithCore)' == ''">true</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' And '$(TestTFM)' != 'netcoreapp1.0'">false</TestWithCore>
+    <TestWithCore Condition="'$(TestWithCore)' == '' ">true</TestWithCore>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestWithCore)' == 'true'">
@@ -42,8 +39,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Table to track mapping between TestNugetTargetMoniker and the corresponding TestTFM -->
     <TestNugetTargetMoniker Include=".NETCoreApp,Version=v1.0" Condition="'$(TestTFM)' == 'netcoreapp1.0'">
       <Folder>netcoreapp1.0</Folder>
+    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.3" Condition="'$(TestTFM)' == 'net463'">
+      <Folder>net462</Folder>
     </TestNugetTargetMoniker>
     <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.2" Condition="'$(TestTFM)' == 'net462'">
       <Folder>net462</Folder>
@@ -60,14 +61,12 @@
     <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5.1" Condition="'$(TestTFM)' == 'net451'">
       <Folder>net451</Folder>
     </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5.2" Condition="'$(TestTFM)' == 'net452'">
+      <Folder>net451</Folder>
+    </TestNugetTargetMoniker>
+    <!-- Project template for UWP Apps uses uap10.0, this mapping allows support for the Debug and Release scenarios -->
     <TestNugetTargetMoniker Include="UAP,Version=v10.0" Condition="'$(TestTFM)' == 'netcore50aot'">
       <Folder>netcore50aot</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETStandard,Version=v1.3" Condition="'$(TestTFM)' == 'netstandard13aot'">
-      <Folder>netstandard13aot</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETStandard,Version=v1.5" Condition="'$(TestTFM)' == 'netstandard15aot'">
-      <Folder>netstandard15aot</Folder>
     </TestNugetTargetMoniker>
     <TestNugetTargetMoniker Include="UAP,Version=v10.0" Condition="'$(TestTFM)' == 'netcore50'">
       <Folder>netcore50</Folder>

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/Microsoft.DotNet.BuildTools.TestSuite.depproj
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/Microsoft.DotNet.BuildTools.TestSuite.depproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <!-- This project is used to redist the xunit dependencies (xunit and xunit.runner.utility) for the netstandard1.0 tfm as currently xunit still packages using the old profiles -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
     <Target Name="AfterBuild">

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/Microsoft.DotNet.BuildTools.TestSuite.depproj
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/Microsoft.DotNet.BuildTools.TestSuite.depproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetRuntimeIdentifier>any</NuGetRuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+    <Target Name="AfterBuild">
+    <ItemGroup>
+        <RuntimeJson Include="runtime.json" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RuntimeJson)" DestinationFolder="$(OutputPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/project.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/project.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "xunit": "2.1.0",
+    "xunit.runner.utility": "2.1.0"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": "portable-net45+win8"
+    }
+  },
+  "runtimes": {
+    "any": {}
+  }
+}

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -1,0 +1,95 @@
+{
+    "supports": {
+        "coreFx.Test.netcoreapp1.0": {
+            "netcoreapp1.0": [
+                "win7-x86",
+                "win7-x64",
+                "osx.10.10-x64",
+                "centos.7-x64",
+                "debian.8-x64",
+                "rhel.7-x64",
+                "ubuntu.14.04-x64",
+                "ubuntu.16.04-x64",
+                "fedora.23-x64",
+                "linux-x64",
+                "opensuse.13.2-x64"
+            ]
+        },
+        "coreFx.Test.netcore50": {
+            "netcore50": [
+                "win10-x86",
+                "win10-x64",
+                "win10-arm",
+            ]
+        },
+        "coreFx.Test.netcore45": {
+            "netcore45": [
+            ]
+        },
+        "coreFx.Test.netcore451": {
+            "netcore451": [
+            ]
+        },
+        "coreFx.Test.net46": {
+            "net46": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "coreFx.Test.net461": {
+            "net461": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "coreFx.Test.net462": {
+            "net462": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "coreFx.Test.net463": {
+            "net463": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "coreFx.Test.net45": {
+            "net45": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "coreFx.Test.net451": {
+            "net451": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "coreFx.Test.net452": {
+            "net451": [
+                "",
+                "win-x86",
+                "win-x64"
+            ]
+        },
+        "coreFx.Test.wpa81": {
+            "wpa81": [
+            ]
+        },
+        "coreFx.Test.wp81": {
+            "wp8": [
+            ]
+        },
+        "coreFx.Test.wp8": {
+            "wp8": [
+            ]
+        },
+    }
+ }

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -1,33 +1,24 @@
 {
     "supports": {
-        "coreFx.Test.netcoreapp1.0": {
-            "netcoreapp1.0": [
-                "win7-x86",
-                "win7-x64",
-                "osx.10.10-x64",
-                "centos.7-x64",
-                "debian.8-x64",
-                "rhel.7-x64",
-                "ubuntu.14.04-x64",
-                "ubuntu.16.04-x64",
-                "fedora.23-x64",
-                "linux-x64",
-                "opensuse.13.2-x64"
+        "coreFx.Test.net45": {
+            "net45": [
+                "",
+                "win-x86",
+                "win-x64"
             ]
         },
-        "coreFx.Test.netcore50": {
-            "netcore50": [
-                "win10-x86",
-                "win10-x64",
-                "win10-arm",
+        "coreFx.Test.net451": {
+            "net451": [
+                "",
+                "win-x86",
+                "win-x64"
             ]
         },
-        "coreFx.Test.netcore45": {
-            "netcore45": [
-            ]
-        },
-        "coreFx.Test.netcore451": {
-            "netcore451": [
+        "coreFx.Test.net452": {
+            "net451": [
+                "",
+                "win-x86",
+                "win-x64"
             ]
         },
         "coreFx.Test.net46": {
@@ -58,37 +49,47 @@
                 "win-x64"
             ]
         },
-        "coreFx.Test.net45": {
-            "net45": [
-                "",
-                "win-x86",
-                "win-x64"
+        "coreFx.Test.netcore45": {
+            "netcore45": [
             ]
         },
-        "coreFx.Test.net451": {
-            "net451": [
-                "",
-                "win-x86",
-                "win-x64"
+        "coreFx.Test.netcore451": {
+            "netcore451": [
             ]
         },
-        "coreFx.Test.net452": {
-            "net451": [
-                "",
-                "win-x86",
-                "win-x64"
+        "coreFx.Test.netcore50": {
+            "netcore50": [
+                "win10-x86",
+                "win10-x86-aot",
+                "win10-x64",
+                "win10-x64-aot",
             ]
         },
-        "coreFx.Test.wpa81": {
-            "wpa81": [
+        "coreFx.Test.netcoreapp1.0": {
+            "netcoreapp1.0": [
+                "win7-x86",
+                "win7-x64",
+                "osx.10.10-x64",
+                "centos.7-x64",
+                "debian.8-x64",
+                "rhel.7-x64",
+                "ubuntu.14.04-x64",
+                "ubuntu.16.04-x64",
+                "fedora.23-x64",
+                "linux-x64",
+                "opensuse.13.2-x64"
+            ]
+        },
+        "coreFx.Test.wp8": {
+            "wp8": [
             ]
         },
         "coreFx.Test.wp81": {
             "wp8": [
             ]
         },
-        "coreFx.Test.wp8": {
-            "wp8": [
+        "coreFx.Test.wpa81": {
+            "wpa81": [
             ]
         },
     }

--- a/src/Microsoft.xunit.extensibility.execution.netcore/Microsoft.xunit.extensibility.execution.netcore.depproj
+++ b/src/Microsoft.xunit.extensibility.execution.netcore/Microsoft.xunit.extensibility.execution.netcore.depproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.3</NuGetTargetMoniker>
+    <NuGetRuntimeIdentifier>any</NuGetRuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+    <Target Name="AfterBuild">
+    <ItemGroup>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Microsoft.xunit.extensibility.execution.netcore/project.json
+++ b/src/Microsoft.xunit.extensibility.execution.netcore/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "xunit.extensibility.execution": "2.1.0",
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": "portable-net45+win8"
+    }
+  },
+  "runtimes": {
+    "any": {}
+  }
+}

--- a/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
@@ -11,7 +11,12 @@
     <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <summary>xUnit extensions of .NET Core test projects</summary>
-    <description>This package is a metapackage for all xunit deps.</description>
+    <description>
+        This package is a metapackage for testing in corefx.
+        It contains redisted xunit deps for netstandard and contains the 
+        runtime.json that list the supports clauses that describe TFMxRID 
+        combinations possible today in corefx.
+    </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
     </dependencies>

--- a/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.BuildTools.TestSuite</id>
+    <version>1.0.0-prerelease</version>
+    <title>xUnit suite of .NET Core test projects</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>xUnit extensions of .NET Core test projects</summary>
+    <description>This package is a metapackage for all xunit deps.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <dependencies>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.DotNet.BuildTools.TestSuite\*.dll" target="lib/netstandard1.0" />
+    <file src="Microsoft.DotNet.BuildTools.TestSuite\runtime.json"  />
+  </files>
+</package>

--- a/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
+++ b/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.5">
+    <id>Microsoft.xunit.extensibility.execution.netcore</id>
+    <version>1.0.0-prerelease</version>
+    <title>xUnit Performance Dep for Perf</title>
+     <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>
+        Extensions for the xunit-performance lib
+    </description>
+    <language>en-US</language>
+    <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
+    <licenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</licenseUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <dependencies>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.xunit.extensibility.execution.netcore\*.dll" target="lib/netstandard1.0" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
+++ b/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
@@ -3,11 +3,12 @@
   <metadata minClientVersion="2.8.5">
     <id>Microsoft.xunit.extensibility.execution.netcore</id>
     <version>1.0.0-prerelease</version>
-    <title>xUnit Performance Dep for Perf</title>
-     <authors>Microsoft</authors>
+    <title>Redist of xunit.execution.execution to target netstandard1.0</title>
+    <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <description>
-        Extensions for the xunit-performance lib
+        This is a redisted package of xunit.extensibility.execution and it's dependencies for use 
+        in the xunit-perfomance library (github.com/Microsoft/xunit-performance)
     </description>
     <language>en-US</language>
     <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
@@ -18,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.xunit.extensibility.execution.netcore\*.dll" target="lib/netstandard1.0" />
+    <file src="Microsoft.xunit.extensibility.execution.netcore\xunit.execution.dotnet.dll" target="lib/netstandard1.0" />
   </files>
 </package>

--- a/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
+++ b/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata minClientVersion="2.8.1">
-    <id>xunit.netcore.extensions</id>
+    <id>Microsoft.xunit.netcore.extensions</id>
     <version>1.0.0-prerelease</version>
     <title>xUnit extensions of .NET Core test projects</title>
     <authors>Microsoft</authors>

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -19,25 +19,25 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">
-        <dependency id="System.Collections" version="4.0.11-rc2-23923" />
-        <dependency id="System.Collections.Concurrent" version="4.0.12-rc2-23923" />
-        <dependency id="System.Console" version="4.0.0-rc2-23923" />
-        <dependency id="System.Diagnostics.Debug" version="4.0.11-rc2-23923" />
-        <dependency id="System.Globalization" version="4.0.11-rc2-23923" />
-        <dependency id="System.IO" version="4.1.0-rc2-23923" />
-        <dependency id="System.IO.FileSystem" version="4.0.1-rc2-23923" />
-        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1-rc2-23923" />
-        <dependency id="System.Linq" version="4.1.0-rc2-23923" />
-        <dependency id="System.Runtime" version="4.1.0-rc2-23923" />
-        <dependency id="System.Runtime.Extensions" version="4.1.0-rc2-23923" />
-        <dependency id="System.Text.RegularExpressions" version="4.0.12-rc2-23923" />
-        <dependency id="System.Threading" version="4.0.11-rc2-23923" />
-        <dependency id="System.Threading.Tasks" version="4.0.11-rc2-23923" />
-        <dependency id="System.Xml.XDocument" version="4.0.11-rc2-23923" />
-        <dependency id="xunit.runner.utility" version="2.1.0" />
+        <dependency id="System.Collections" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.Collections.Concurrent" version="4.0.12-rc3-24117-00" />
+        <dependency id="System.Console" version="4.0.0-rc3-24117-00" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.Globalization" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.IO" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.IO.FileSystem" version="4.0.1-rc3-24117-00" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.0.1-rc3-24117-00" />
+        <dependency id="System.Linq" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Runtime" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.12-rc3-24117-00" />
+        <dependency id="System.Threading" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.Threading.Tasks" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.Xml.XDocument" version="4.0.11-rc3-24117-00" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease"/>
         <!-- xunit.runner.utility 2.1.0 has some older packages referenced that are not listed here -->
-        <dependency id="System.Reflection" version="4.1.0-rc2-23923" />
-        <dependency id="System.Reflection.Extensions" version="4.0.1-rc2-23923" />
+        <dependency id="System.Reflection" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1-rc3-24117-00" />
       </group>
     </dependencies>
   </metadata>
@@ -45,6 +45,9 @@
     <!-- xunit runner for .NET Core -->
     <!-- don't reference anything, only provide runner as runtime asset -->
     <file src="xunit.console.netcore\_._" target="lib\netstandard1.0" />  
+    <file src="xunit.console.netcore\_._" target="lib\aspnetcore50" />
+    <file src="xunit.console.netcore\_._" target="lib\dnxcore50" />
+    <file src="xunit.console.netcore\_._" target="lib\dotnet" />
     <file src="xunit.console.netcore\xunit.console.netcore.exe" target="runtimes\any\native" />
   </files>
   

--- a/src/nuget/xunit.netcore.extensions.nuspec
+++ b/src/nuget/xunit.netcore.extensions.nuspec
@@ -15,25 +15,25 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
       <group targetFramework="netstandard1.3">
-        <dependency id="System.Diagnostics.Debug" version="4.0.11-rc2-23923" />
-        <dependency id="System.IO" version="4.1.0-rc2-23923" />
-        <dependency id="System.Linq" version="4.1.0-rc2-23923" />
-        <dependency id="System.Reflection" version="4.1.0-rc2-23923" />
-        <dependency id="System.Reflection.Primitives" version="4.0.1-rc2-23923" />
-        <dependency id="System.Runtime" version="4.1.0-rc2-23923" />
-        <dependency id="System.Runtime.Extensions" version="4.1.0-rc2-23923" />
-        <dependency id="System.Runtime.Handles" version="4.0.1-rc2-23923" />
-        <dependency id="System.Runtime.InteropServices" version="4.1.0-rc2-23923" />
-        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0-rc2-23923" />
-        <dependency id="System.Text.Encoding" version="4.0.11-rc2-23923" />
-        <dependency id="System.Threading" version="4.0.11-rc2-23923" />
-        <dependency id="System.Threading.Tasks" version="4.0.11-rc2-23923" />
-        <dependency id="xunit" version="2.1.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.IO" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Linq" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Reflection" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Reflection.Primitives" version="4.0.1-rc3-24117-00" />
+        <dependency id="System.Runtime" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Runtime.Extensions" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Runtime.Handles" version="4.0.1-rc3-24117-00" />
+        <dependency id="System.Runtime.InteropServices" version="4.1.0-rc3-24117-00" />
+        <dependency id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0-rc3-24117-00" />
+        <dependency id="System.Text.Encoding" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.Threading" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.Threading.Tasks" version="4.0.11-rc3-24117-00" />
+        <dependency id="Microsoft.DotNet.BuildTools.TestSuite" version="1.0.0-prerelease"/>
         <!-- xunit 2.1.0 has some older packages referenced that are not listed here -->
-        <dependency id="System.ObjectModel" version="4.0.12-rc2-23923" />
-        <dependency id="System.Linq.Expressions" version="4.0.11-rc2-23923" />
-        <dependency id="System.Text.RegularExpressions" version="4.0.12-rc2-23923" />
-        <dependency id="System.Reflection.Extensions" version="4.0.1-rc2-23923" />
+        <dependency id="System.ObjectModel" version="4.0.12-rc3-24117-00" />
+        <dependency id="System.Linq.Expressions" version="4.0.11-rc3-24117-00" />
+        <dependency id="System.Text.RegularExpressions" version="4.0.12-rc3-24117-00" />
+        <dependency id="System.Reflection.Extensions" version="4.0.1-rc3-24117-00" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This change will introduce 3 changes to buildtools. 

1. It allows for the restoration of xunit packages to the netstandard framework moniker. It introduces a new Microsoft.DotNet.BuildTools.TestSuite package which will be the metapackage brought down in test-runtime for all xunit dependencies. This is a set of repackaged xunit dependencies until official xunit  packages update to rc2. This package also contains the runtime.json which specifies the supported (Target Framework Moniker X Runtime Identifier) combination which will be used by test project.jsons to list their supported platforms.

2. GetApplicableAssetsFromPackages will now error out instead of falling back onto older generations during resolution of compile/runtime assets. (Change done by @ericstj )

3. This change introduces the TestTFM property, which will allow the selection of test assets for a given framework moniker. Currently this only supports netstandard1.3 supported monikers. The idea is that a test will compile in corefx for a netstandard version(currently netstandard1.3 or higher) then utilize this property to pull in the corresponding runtime assets.

/cc @tarekgh @weshaggard 