### PR TITLE
Classifying NETCore.Jit deps as CoreRun deps

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Build.Tasks
         public override bool Execute()
         {
             HashSet<string> processedFileNames = new HashSet<string>();
-            AssemblyList corerun = new AssemblyList("Microsoft.NETCore.Runtime", "Microsoft.NETCore.TestHost", "Microsoft.NETCore.Windows.ApiSets");
+            AssemblyList corerun = new AssemblyList("Microsoft.NETCore.Runtime", "Microsoft.NETCore.TestHost", "Microsoft.NETCore.Windows.ApiSets",  "Microsoft.NETCore.Jit");
             AssemblyList xunit = new AssemblyList("xunit");
             List<string> unmatched = new List<string>();
             bool foundDuplicates = false;


### PR DESCRIPTION
This is required for coreclr perf test runs where the NETCore.Jit deps are now being packaged separately from the runtime libraries

@MattGal @karajas @lt72 