### PR TITLE
updating packageresolve.targets to allow dissabling the local copy of references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -88,7 +88,7 @@
     <ItemGroup>
       <!-- Intersect project-refs with package-refs -->
       <_ReferenceFileNamesToRemove Include="@(Reference)" Condition="'@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
-      <!-- If local copy is dissabled remove all references, otherwise remove only project refrerences -->
+      <!-- If local copy is disabled remove all references, otherwise remove only project refrerences -->
       <_ReferenceCopyLocalPathsFileNamesToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'$(DisableReferenceCopyLocal)' == 'true' OR '@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
 
       <Reference Remove="@(_ReferenceFileNamesToRemove)" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -88,7 +88,8 @@
     <ItemGroup>
       <!-- Intersect project-refs with package-refs -->
       <_ReferenceFileNamesToRemove Include="@(Reference)" Condition="'@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
-      <_ReferenceCopyLocalPathsFileNamesToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
+      <!-- If local copy is dissabled remove all references, otherwise remove only project refrerences -->
+      <_ReferenceCopyLocalPathsFileNamesToRemove Include="@(ReferenceCopyLocalPaths)" Condition="'$(DisableReferenceCopyLocal)' == 'true' OR '@(_ResolvedProjectReferencePaths->'%(FileName)%(Extension)')' == '%(FileName)%(Extension)'" />
 
       <Reference Remove="@(_ReferenceFileNamesToRemove)" />
       <ReferenceCopyLocalPaths Remove="@(_ReferenceCopyLocalPathsFileNamesToRemove)"/>


### PR DESCRIPTION
  -added a property, DisableReferenceCopyLocal, which can be user supplied to dissable copying package references locally