### PR TITLE
Update to NuGet 3.5.0-beta2-1437

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -72,7 +72,7 @@
       <ExpectedVersion>2.1.0</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="^(?i)(NuGet\..%2A)$">
-      <ExpectedVersion>3.5.0-beta2-1430</ExpectedVersion>
+      <ExpectedVersion>3.5.0-beta2-1437</ExpectedVersion>
     </ValidationPattern>
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Versioning": "3.5.0-beta2-1430",
+    "NuGet.Versioning": "3.5.0-beta2-1437",
     "System.Reflection.Metadata": "1.1.0"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1430",
+    "NuGet.Client": "3.5.0-beta2-1437",
     "System.Reflection.Metadata": "1.0.22",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24128-00"
   },

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
@@ -4,7 +4,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1430",
+    "NuGet.Client": "3.5.0-beta2-1437",
     "NETStandard.Library": "1.5.0-rc2-24027"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.0",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1430",
+    "NuGet.Client": "3.5.0-beta2-1437",
     "System.Reflection.Metadata": "1.0.22",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
@@ -4,7 +4,7 @@
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1430",
+    "NuGet.Client": "3.5.0-beta2-1437",
     "NETStandard.Library": "1.5.0-rc2-24027",
     "Microsoft.NETCore.Targets": "1.0.1-rc2-24027",
     "xunit": "2.1.0",
@@ -15,7 +15,10 @@
   },
   "frameworks": {
     "netcoreapp1.0": {
-      "imports": [ "dnxcore50", "portable-net45+win8" ]
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
     }
   },
   "runtimes": {

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Versioning": "3.5.0-beta2-1430",
+    "NuGet.Versioning": "3.5.0-beta2-1437",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.1.0",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -81,8 +81,6 @@
       <NuProjFiles Include="$(PackagesDir)NuProj\$(NuProjVersion)\tools\**\*.*" />
     </ItemGroup>
     <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(OutputPath)\PackageFiles\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <!-- nuget strips files with the name 'project.json' so give a suffix that we'll rename in init-tools -->
-    <Copy SourceFiles="@(PackageFiles)" Condition="'%(FileName)%(Extension)' == 'project.json'" DestinationFiles="$(OutputPath)\PackageFiles\%(RecursiveDir)%(FileName)%(Extension).rename" SkipUnchangedFiles="true" />
     <Copy SourceFiles="@(NuProjFiles)" DestinationFolder="$(OutputPath)\NuProj\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -28,10 +28,6 @@ if not exist "%DOTNET_CMD%" (
 
 ROBOCOPY "%BUILDTOOLS_PACKAGE_DIR%\." "%TOOLRUNTIME_DIR%" /E
 
-:: These have a different name in the package, otherwise NuGet will strip them.
-move %BUILDTOOLS_PACKAGE_DIR%\tool-runtime\project.json.rename %BUILDTOOLS_PACKAGE_DIR%\tool-runtime\project.json
-move %BUILDTOOLS_PACKAGE_DIR%\test-runtime\project.json.rename %BUILDTOOLS_PACKAGE_DIR%\test-runtime\project.json
-
 set TOOLRUNTIME_PROJECTJSON=%BUILDTOOLS_PACKAGE_DIR%\tool-runtime\project.json
 @echo on
 call "%DOTNET_CMD%" restore "%TOOLRUNTIME_PROJECTJSON%" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -60,10 +60,6 @@ esac
 
 cp -R $__TOOLS_DIR/* $__TOOLRUNTIME_DIR
 
-# These have a different name in the package, otherwise NuGet will strip them.
-mv $__TOOLS_DIR/tool-runtime/project.json.rename $__TOOLS_DIR/tool-runtime/project.json
-mv $__TOOLS_DIR/test-runtime/project.json.rename $__TOOLS_DIR/test-runtime/project.json
-
 __TOOLRUNTIME_PROJECTJSON=$__TOOLS_DIR/tool-runtime/project.json
 echo "Running: $__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECTJSON}\" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json"
 $__DOTNET_CMD restore "${__TOOLRUNTIME_PROJECTJSON}" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -19,8 +19,8 @@
         "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-24128-00",
         "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24128-00",
         "Newtonsoft.Json": "7.0.1",
-        "NuGet.Client": "3.5.0-beta2-1430",
-        "NuGet.Versioning": "3.5.0-beta2-1430"
+        "NuGet.Client": "3.5.0-beta2-1437",
+        "NuGet.Versioning": "3.5.0-beta2-1437"
       },
       "imports": [
         "dnxcore50",

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -7,7 +7,7 @@
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Versioning": "3.5.0-beta2-1430",
+    "NuGet.Versioning": "3.5.0-beta2-1437",
     "NuProj": "0.10.4-beta-gf7fc34e7d8",
     "NETStandard.Library": "1.5.0-rc2-24027"
   },

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -3,6 +3,15 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 
+  <PropertyGroup>
+    <!-- Use the packaging task we just built to pick up the latest NuGet,
+         Disable this once we are able to update buildtools consumed by this repo
+         to one that has 843d9943ada43ff4b83f58b2d92024665f1fee23.
+         https://github.com/dotnet/buildtools/issues/780 -->
+    <PackagingTaskDir Condition="'$(BuildToolsTargets45)' != 'true'">$(BinDir)AnyOS.AnyCPU.Debug/Microsoft.DotNet.Build.Tasks.Packaging/</PackagingTaskDir>
+    <PackagingTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(BinDir)AnyOS.AnyCPU.Debug/Microsoft.DotNet.Build.Tasks.Packaging.Desktop/</PackagingTaskDir>
+  </PropertyGroup>
+
   <Import Project="Microsoft.DotNet.Build.Tasks\PackageFiles\packages.targets" Condition="'$(ImportGetNuGetPackageVersions)' != 'false'" />
   
   <Target Name="Build" DependsOnTargets="BuildPackages" />


### PR DESCRIPTION
We need the latest version to unblock pack on Unix.

Remove the workaround for project.json that I added before as it is no longer needed: fixed in latest NuGet.

/cc @weshaggard @joshfree @schellap 