### PR TITLE
Use ConfigurationGroup specific packaging task

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -8,8 +8,8 @@
          Disable this once we are able to update buildtools consumed by this repo
          to one that has 843d9943ada43ff4b83f58b2d92024665f1fee23.
          https://github.com/dotnet/buildtools/issues/780 -->
-    <PackagingTaskDir Condition="'$(BuildToolsTargets45)' != 'true'">$(BinDir)AnyOS.AnyCPU.$(Configuration)/Microsoft.DotNet.Build.Tasks.Packaging/</PackagingTaskDir>
-    <PackagingTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(BinDir)AnyOS.AnyCPU.$(Configuration)/Microsoft.DotNet.Build.Tasks.Packaging.Desktop/</PackagingTaskDir>
+    <PackagingTaskDir Condition="'$(BuildToolsTargets45)' != 'true'">$(BinDir)AnyOS.AnyCPU.$(ConfigurationGroup)/Microsoft.DotNet.Build.Tasks.Packaging/</PackagingTaskDir>
+    <PackagingTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(BinDir)AnyOS.AnyCPU.$(ConfigurationGroup)/Microsoft.DotNet.Build.Tasks.Packaging.Desktop/</PackagingTaskDir>
   </PropertyGroup>
 
   <Import Project="Microsoft.DotNet.Build.Tasks\PackageFiles\packages.targets" Condition="'$(ImportGetNuGetPackageVersions)' != 'false'" />


### PR DESCRIPTION
Official build sets ConfigurationGroup and not Configuration.