### PR TITLE
Downloading dotnet-install.sh to temporary location

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh
@@ -46,8 +46,8 @@ then
 fi
 
 echo "Initiating local dotnet install"
-wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh
-chmod 777 dotnet-install.sh
-versionnum=$(cat $VERFILE)
 mkdir $DESTDIR
-source dotnet-install.sh -i $DESTDIR -v $versionnum
+wget https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh -P $DESTDIR
+chmod 777 $DESTDIR/dotnet-install.sh
+versionnum=$(cat $VERFILE)
+source $DESTDIR/dotnet-install.sh -i $DESTDIR -v $versionnum


### PR DESCRIPTION
Downloading the dotnet cli installation script to a temporary location (the directory where dotnet cli will be installed). This ensures that the installation script is not lying around in the repo in case we try to run perf tests locally on a linux machine and also prevents accidental check-in of this file.
@MattGal 