### PR TITLE
Search for TestTFM directories in CloudTest.targets if they exist

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -83,6 +83,7 @@
     <Error Condition="'$(SkipNotifyEvent)' != 'true' and '$(HelixApiAccessKey)' == '' and '$(EventHubInfoMissing)' == 'true' " Text="HelixApiAccessKey must be set to start Helix jobs" />
 
     <!-- gather the test archives for upload -->
+    <!-- This will include every zip in the test archive, to allow CoreCLR tests for perf which don't have a TestTFM directory -->
     <ItemGroup>
       <ForUpload Include="$(TestArchivesRoot)**/*.zip" />
       <ForUpload Include="$(AnyOSTestArchivesRoot)**/*.zip" />
@@ -90,9 +91,15 @@
       <ForUpload Condition="'$(TargetsUnix)' == 'true'" Include="$(UnixTestArchivesRoot)**/*.zip" />
     </ItemGroup>
 
+    <Message Condition="'$(TestTFM)' != ''" Text="Using test archives for TFM: $(TestTFM)" />
     <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" />
     <Message Text="Using AnyOS test archives from: $(AnyOSTestArchivesRoot)" />
     <Message Condition="'$(TargetsUnix)' == 'true'"  Text="Using Unix test archives from: $(UnixTestArchivesRoot)" />
+    
+    <PropertyGroup>
+        <RelativeBlobPathFolderContainingTests Condition="'$(TestTFM)' != ''" >Tests/$(TestTFM)</RelativeBlobPathFolderContainingTests>
+        <RelativeBlobPathFolderContainingTests Condition="'$(TestTFM)' == ''" >Tests</RelativeBlobPathFolderContainingTests>
+    </PropertyGroup>
 
     <!-- verify the test archives were created -->
     <Error Condition="'@(ForUpload->Count())' == '0'" Text="Didn't find any test archives in supplied folders." />
@@ -230,22 +237,32 @@
     <GetPerfTestAssemblies TestBinaries="@(TestBinary)" GetFullPaths="false">
       <Output TaskParameter="PerfTestAssemblies" ItemName="PerfTestAssembly" />
     </GetPerfTestAssemblies>
+    
     <!-- don't add any items to the group if no perf tests were found -->
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
-      <PerfTest Condition="Exists('$(TestArchivesRoot)%(PerfTestAssembly.Identity).zip')" Include="$(TestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
-      <PerfTest Condition="Exists('$(AnyOSTestArchivesRoot)%(PerfTestAssembly.Identity).zip')" Include="$(AnyOSTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
-      <PerfTest Condition="'$(TargetsUnix)' == 'true' And Exists('$(UnixTestArchivesRoot)%(PerfTestAssembly.Identity).zip')" Include="$(UnixTestArchivesRoot)%(PerfTestAssembly.Identity).zip" />
+      <PerfTest Condition="Exists('$(TestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip')" Include="$(TestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip" />
+      <PerfTest Condition="Exists('$(AnyOSTestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip')" Include="$(AnyOSTestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip" />
+      <PerfTest Condition="'$(TargetsUnix)' == 'true' And Exists('$(UnixTestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip')" Include="$(UnixTestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip" />
     </ItemGroup>
+
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest>
         <Command>$(HelixPythonPath) $(RunnerScript) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
         <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
-        <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
+        <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/$(RelativeBlobPathFolderContainingTests)/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>PerfTest.%(Filename)</WorkItemId>
         <TimeoutInSeconds>$(TimeoutInSeconds)</TimeoutInSeconds>
       </PerfTest>
     </ItemGroup>
     <WriteItemsToJson JsonFileName="$(PerfTestListFile)" Items="@(PerfTest)" />
+    <!-- add test lists to the list of items for upload depending on whether TestTFM was specified or not-->
+    <ItemGroup>
+      <!-- Removing all zips and allowing only perf test assemblies to be uploaded -->
+      <ForUpload Condition="'$(Performance)' == 'true'" Remove="@(ForUpload)"/>
+      <ForUpload Condition="'$(Performance)' == 'true'" Include="@(PerfTest)">
+        <RelativeBlobPath>$(Platform)$(ConfigurationGroup)/$(RelativeBlobPathFolderContainingTests)/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)</RelativeBlobPath>
+      </ForUpload>
+    </ItemGroup>
     <!-- add test lists to the list of items for upload -->
     <ItemGroup>
       <ForUpload Include="$(PerfTestListFile)">

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
@@ -88,7 +88,11 @@ def _prepare_linux_env_for_perf(correlation_dir, xunit_perf_drop, test_location,
     if len(os.listdir(xunit_perf_deps)) > 1:
         log.info('Multiple directories found under '+xunit_perf_deps+' picking '+os.listdir(xunit_perf_deps)[0])
     xunit_perf_deps = os.path.join(xunit_perf_deps, os.listdir(xunit_perf_deps)[0])
-    xunit_perf_deps = os.path.join(xunit_perf_deps, "lib", "dotnet")
+    if os.path.exists(os.path.join(xunit_perf_deps, "lib", "netstandard1.3")):
+        log.info('Using the netstandard1.3 folder which has the same deps in the dotnet folder just repackaged')
+        xunit_perf_deps = os.path.join(xunit_perf_deps, "lib", "netstandard1.3")
+    else:
+        xunit_perf_deps = os.path.join(xunit_perf_deps, "lib", "dotnet")
     log.info('Copying xunit perf dependencies from '+xunit_perf_deps)
     _copy_files_to_dest(xunit_perf_deps, test_location)
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -6,14 +6,14 @@
     <PerfDotNetCliDir>$(TestPath)../perf.dotnetcli</PerfDotNetCliDir>
     <PerfDotNetCliInstaller>$(ToolsDir)/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh</PerfDotNetCliInstaller>
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.cli</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0037</XunitPerfRunnerPackageVersion>
     <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
     <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.runner.cli.dll</XunitPerfRunnerPath>
   </PropertyGroup>
   <!-- Perf Runner NuGet package paths -->
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfRunnerPackageVersion>
+    <XunitPerfRunnerPackageVersion Condition="'$(XunitPerfRunnerPackageVersion)' == ''">1.0.0-alpha-build0037</XunitPerfRunnerPackageVersion>
     <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfRunnerPackageVersion)</XunitPerfRunnerPackageDir>
     <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/xunit.performance.run.exe</XunitPerfRunnerPath>
   </PropertyGroup>
@@ -21,12 +21,12 @@
   <!-- Perf Analysis NuGet package paths -->
   <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis.cli</XunitPerfAnalysisPackageId>
-    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0037</XunitPerfAnalysisPackageVersion>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.analysis.cli.dll</XunitPerfAnalysisPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
-    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0035</XunitPerfAnalysisPackageVersion>
+    <XunitPerfAnalysisPackageVersion Condition="'$(XunitPerfAnalysisPackageVersion)' == ''">1.0.0-alpha-build0037</XunitPerfAnalysisPackageVersion>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
   </PropertyGroup>
 


### PR DESCRIPTION
 This change introduces the following changes
 - Uploads only perf assemblies during CloudTest build for perf.
 - Search for matching TestTFM directories if the TestTFM variable is set in CloudTest.targets if exists (only in corefx). If it is not set, continue uploading from the same directory.
 - Update perf version to 0036 (which can restore for netstandard1.3)

@dsgouda @MattGal 