### PR TITLE
Update NuGet to 3.5.0-beta2-1456

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -72,7 +72,7 @@
       <ExpectedVersion>2.1.0</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="^(?i)(NuGet\..%2A)$">
-      <ExpectedVersion>3.5.0-beta2-1437</ExpectedVersion>
+      <ExpectedVersion>3.5.0-beta2-1456</ExpectedVersion>
     </ValidationPattern>
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Versioning": "3.5.0-beta2-1437",
+    "NuGet.Versioning": "3.5.0-beta2-1456",
     "System.Reflection.Metadata": "1.1.0"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1437",
+    "NuGet.Client": "3.5.0-beta2-1456",
     "System.Reflection.Metadata": "1.0.22",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24128-00"
   },

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
@@ -4,7 +4,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1437",
+    "NuGet.Client": "3.5.0-beta2-1456",
     "NETStandard.Library": "1.5.0-rc2-24027"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.0",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1437",
+    "NuGet.Client": "3.5.0-beta2-1456",
     "System.Reflection.Metadata": "1.0.22",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
@@ -4,7 +4,7 @@
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Client": "3.5.0-beta2-1437",
+    "NuGet.Client": "3.5.0-beta2-1456",
     "NETStandard.Library": "1.5.0-rc2-24027",
     "Microsoft.NETCore.Targets": "1.0.1-rc2-24027",
     "xunit": "2.1.0",

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Versioning": "3.5.0-beta2-1437",
+    "NuGet.Versioning": "3.5.0-beta2-1456",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.1.0",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -15,12 +15,12 @@
         "Microsoft.Composition": "1.0.30",
         "Microsoft.NETCore.App": "1.0.0-rc3-002857",
         "Microsoft.NETCore.TestHost": "1.0.0-rc3-24123-01",
-        "NETStandard.Library": "1.6.0-rc3-24128-00",
+        "NETStandard.Library": "1.6.0-rc3-24208-04",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-24128-00",
         "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24128-00",
         "Newtonsoft.Json": "7.0.1",
-        "NuGet.Client": "3.5.0-beta2-1437",
-        "NuGet.Versioning": "3.5.0-beta2-1437"
+        "NuGet.Client": "3.5.0-beta2-1456",
+        "NuGet.Versioning": "3.5.0-beta2-1456"
       },
       "imports": [
         "dnxcore50",

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -7,7 +7,7 @@
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Versioning": "3.5.0-beta2-1437",
+    "NuGet.Versioning": "3.5.0-beta2-1456",
     "NuProj": "0.10.4-beta-gf7fc34e7d8",
     "NETStandard.Library": "1.5.0-rc2-24027"
   },


### PR DESCRIPTION
This fixes a regression caused by the Serviceable attribute addition.

/cc @weshaggard 