### PR TITLE
Ensure that all locally built assemblies are not included in the dependency list

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -216,6 +216,11 @@
     <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
     <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
   </PropertyGroup>
+  
+  <!-- Default Test platform to deploy the netstandard compiled tests to -->
+  <PropertyGroup>
+    <TestTFM Condition="'$(TestTFM)'==''">netcoreapp1.0</TestTFM>
+  </PropertyGroup>
 
   <!-- Disable some standard properties for building our projects -->
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
@@ -40,9 +40,9 @@
        This is required because the publishtest.targets used by buildtools isn't handling 
        paths with subdirectories (it assumes all assets are copied to test output folder).
        https://github.com/dotnet/buildtools/issues/343 -->
-  <Target Name="CopyFrameworkLists" AfterTargets="CopyTestToTestDirectory" Inputs="%(TestTargetFramework.Folder)" Outputs="none">
+  <Target Name="CopyFrameworkLists" AfterTargets="CopyTestToTestDirectory" Inputs="%(TestTargetFramework.Folder)$(TestTFM)" Outputs="none">
     <PropertyGroup>
-      <_testDirectory>$(TestPath)%(TestTargetFramework.Folder)</_testDirectory>
+      <_testDirectory>$(TestPath)%(TestTargetFramework.Folder)$(TestTFM)</_testDirectory>
     </PropertyGroup>
     <ItemGroup>
       <_frameworkList Include="..\src\FrameworkLists\**\*.xml">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -108,14 +108,6 @@
       <OverridenRuntimeContent Include="$(BUILDTOOLS_OVERRIDE_RUNTIME)/*.*" />
       <TestCopyLocal Include="@(OverridenRuntimeContent)" />
      </ItemGroup>
-    
-    <!-- Once the copying of RunTestsForProjectInputs is complete, we can remove it from the 
-    TestCopyLocal (which is the dependency list for each test) and cannot have any values
-    referring to locally built assets -->
-    <Message Condition="'@(RunTestsForProjectInputs)'!=''" Text="Overwriting the following values in TestDir : '@(RunTestsForProjectInputs)'" />
-    <ItemGroup>
-      <TestCopyLocal Remove="@(RunTestsForProjectInputs)" />
-    </ItemGroup>
 
     <!-- Remove duplicates. Note that we mustn't just copy in sequence and let
          the last one win that way because it will cause copies to occur on

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -182,6 +182,19 @@
       </IncludedFileForRunnerScript>
     </ItemGroup>
     
+    <!-- Introduce workaround for Dependency list to prevent copying local assemblies now that test csproj references pkgproj
+         This will remove all bin directory assemblies when TestWithLocalLibraries is false and local files are found.
+         This was added to allow the version of buildtools (that the buildtools repo depends on to be built) to be updated.  -->
+    <ItemGroup>
+      <IncludedFileForRunnerScriptRemove Include="@(IncludedFileForRunnerScript)"
+                                   Condition="$([System.String]::Copy('%(IncludedFileForRunnerScript.PackageRelativePath)').StartsWith('$(BinDir.Substring(0, $(BinDir.IndexOf('/'))))'))" >
+      </IncludedFileForRunnerScriptRemove>
+    </ItemGroup>
+    
+    <ItemGroup>
+      <IncludedFileForRunnerScript Condition="'$(TestWithLocalLibraries)'!='true'" Remove="@(IncludedFileForRunnerScriptRemove)" />
+    </ItemGroup>
+    
     <MakeDir Directories="$(OutputFolderForTestDependencies)" />
     <PropertyGroup>
       <_TestDependencyListRoot>$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>


### PR DESCRIPTION
This change is to prevent locally built assemblies being included in the dependency list. This happens during the test csproj to pkgproj reference change being introduced in corefx. The dependency list should only have package dependencies when TestWithLocalLibraries is false.

/cc @MattGal @maririos 