### PR TITLE
Add some conditional core dump generation for OS X to Unix RunnerTemplate

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -27,7 +27,7 @@ fi
 
 echo Executing in $EXECUTION_DIR
 
-# ========================= BEGIN Copying files  =============================== 
+# ========================= BEGIN Copying files  =============================
 if [ ! -d "$EXECUTION_DIR" ]
 then
     mkdir $EXECUTION_DIR
@@ -45,9 +45,19 @@ echo Hard linking dependent files...
 [[CopyFilesCommands]]
 
 echo "Finished linking needed files, moving to running tests."
-# ========================= END Copying files  =================================
+# ========================= END Copying files  ===============================
 
-# ========================= BEGIN Test Execution ============================= 
+# ========================= BEGIN Core File Setup ============================
+if [ "$(uname -s)" == "Darwin" ]; then
+  # If there are no core files already in /cores/, we'll enable core dump
+  # generation for this shell.
+  if [ "$(ls -A /cores)" ]; then 
+    ulimit -c unlimited
+  fi
+fi
+# ========================= END Core File Setup ==============================
+
+# ========================= BEGIN Test Execution =============================
 echo Running tests... Start time: $(date +"%T")
 echo Commands:
 [[TestRunCommandsEcho]]
@@ -56,4 +66,4 @@ cd $EXECUTION_DIR
 test_exitcode=$?
 echo Finished running tests.  End time=$(date +"%T").  Return value was $test_exitcode
 exit $test_exitcode
-# ========================= END Test Execution =================================
+# ========================= END Test Execution ===============================


### PR DESCRIPTION
This change should enable (limited) core file generation on OS X when running tests. To prevent flooding CI machines with dumps, we will only enable core file generation for a test run if, at the time the test run is started, the "/cores" directory on the machine is empty.

The reason for this change is that CoreFX CI runs have occasionally been hitting mysterious segfaults lately, and having some dumps would be really useful for investigating what could be going on.

@ellismg @ericstj @MattGal PTAL. I've made this change in what seems to be an appropriate and safe place (for instance, we'll definitely know what OS we're on at that point), but my entire experience with this test running infrastructure is limited to the past couple of hours :smile:.