### PR TITLE
Enable core dump generation on Linux in Unix RunnerTemplate

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -13,6 +13,28 @@ else
 fi
 }
 
+function print_info_from_core_file {
+  local core_file_name=$1
+  local executable_name=$2
+
+  if ! [ -e $executable_name ]; then
+    echo "Unable to find executable $executable_name"
+    return
+  elif ! [ -e $core_file_name ]; then
+    echo "Unable to find core file $core_file_name"
+    return
+  fi
+
+  # Check for the existence of GDB on the path
+  hash gdb 2>/dev/null || { echo >&2 "GDB was not found. Unable to print core file."; return; }
+
+  echo "Printing info from core file $1"
+
+  # Open the dump in GDB and print the stack from each thread. We can add more
+  # commands here if desired.
+  gdb --batch -ex "thread apply all bt full" -ex "quit" $executable_name $core_file_name
+}
+
 if [ "$PACKAGE_DIR" == "" ]
 then
 echo error: PACKAGE_DIR is not defined.  Usage: $0 PackageRoot ExecutionDir
@@ -49,11 +71,17 @@ echo "Finished linking needed files, moving to running tests."
 
 # ========================= BEGIN Core File Setup ============================
 if [ "$(uname -s)" == "Darwin" ]; then
-  # If there are no core files already in /cores/, we'll enable core dump
-  # generation for this shell.
+  # On OS X, we will enable core dump generation only if there are no core 
+  # files already in /cores/ at this point. This is being done to prevent
+  # inadvertently flooding the CI machines with dumps.
   if [ "$(ls -A /cores)" ]; then 
     ulimit -c unlimited
   fi
+elif [ "$(uname -s)" == "Linux" ]; then
+  # On Linux, we'll enable core file generation unconditionally, and if a dump
+  # is generated, we will print some useful information from it and delete the
+  # dump immediately. 
+  ulimit -c unlimited
 fi
 # ========================= END Core File Setup ==============================
 
@@ -67,3 +95,25 @@ test_exitcode=$?
 echo Finished running tests.  End time=$(date +"%T").  Return value was $test_exitcode
 exit $test_exitcode
 # ========================= END Test Execution ===============================
+# ======================= BEGIN Core File Inspection =========================
+if [ "$(uname -s)" == "Linux" ]; then
+  # Depending on distro/configuration, the core files may either be named "core"
+  # or "core.<PID>" by default. We read /proc/sys/kernel/core_uses_pid to 
+  # determine which it is.
+  core_name_uses_pid=0
+  if [ -e /proc/sys/kernel/core_uses_pid ] && [ "1" == $(cat /proc/sys/kernel/core_uses_pid) ]; then
+    core_name_uses_pid=1
+  fi
+
+  if [ $core_name_uses_pid == "1" ]; then
+    # We don't know what the PID of the process was, so let's look at all core
+    # files whose name matches core.NUMBER
+    for f in core.*; do
+      [[ $f =~ core.[0-9]+ ]] && print_info_from_core_file "$f" "corerun" && rm "$f"
+    done
+  elif [ -f core ]; then
+    print_info_from_core_file "core" "corerun"
+    rm "core"
+  fi
+fi
+# ======================== END Core File Inspection ==========================


### PR DESCRIPTION
This change should enable core file generation on Linux when running tests. To prevent flooding CI machines with dumps, we will print the backtrace for each thread from the dump and delete it immediately. The idea here is to see something more useful than "Segmentation fault" when something crashes. It will be nice to have the core files transferred somewhere rather than just deleted, but this is a reasonable starting point (and a vast improvement over the current state of affairs).

The reason for using GDB is that LLDB-3.6 (which is what's on many or most of our CI machines) seems to have a bug on Linux where operations like `bt` and `thread list` don't work in batch mode. If/when we unify all the machines to a working LLDB version with a compatible SOS, we should switch to that instead.

We can consider printing register contents and other information as well once we know that this works.

@ellismg @sergiy-k @ericstj PTAL.