### PR TITLE
Fix logic for when to enable core file generation on OS X.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -74,7 +74,7 @@ if [ "$(uname -s)" == "Darwin" ]; then
   # On OS X, we will enable core dump generation only if there are no core 
   # files already in /cores/ at this point. This is being done to prevent
   # inadvertently flooding the CI machines with dumps.
-  if [ "$(ls -A /cores)" ]; then 
+  if [ ! "$(ls -A /cores)" ]; then 
     ulimit -c unlimited
   fi
 elif [ "$(uname -s)" == "Linux" ]; then


### PR DESCRIPTION
Looks like there's no facepalm emoji on GitHub, so this will have to do:

:smile: :palm_tree: 

@ellismg @sergiy-k 