### PR TITLE
Enhance MembersMustExistAnalyzer to check the existence of fields

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/Analyzers/MembersMustExistAnalyzer.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Analyzers/MembersMustExistAnalyzer.cs
@@ -61,6 +61,7 @@ namespace Microsoft.DotNet.CodeAnalysis.Analyzers
 
             context.RegisterCompilationEndAction(OnCompilationEnd);
             context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Method, SymbolKind.Event);
+            context.RegisterSymbolAction(AnalyzeSymbol, SymbolKind.Field, SymbolKind.Event);
         }
 
         private static IEnumerable<string> ReadRequiredAPIsFromFiles(IEnumerable<AdditionalText> additionalAnalyzerFiles)
@@ -82,7 +83,7 @@ namespace Microsoft.DotNet.CodeAnalysis.Analyzers
 
         private void AnalyzeSymbol(SymbolAnalysisContext context)
         {
-            string apiDef = Helpers.GetPublicApiName(context.Symbol);
+            string apiDef = Helpers.GetMemberName(context.Symbol);
 
             lock (_apisToEnsureExist)
             {

--- a/src/Microsoft.DotNet.CodeAnalysis/Helpers.cs
+++ b/src/Microsoft.DotNet.CodeAnalysis/Helpers.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.CodeAnalysis
                             miscellaneousOptions:
                                 SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
-        internal static string GetPublicApiName(ISymbol symbol)
+        internal static string GetMemberName(ISymbol symbol)
         {
             return symbol.ToDisplayString(s_publicApiFormat);
         }


### PR DESCRIPTION
This change enhances the MembersMustExistAnalyzer to check the existence of fields.

In order to have a decent debugging experience, some debuggers (e.g. Visual Studio) will have to inspect some fields (mostly private ones). Since private fields are not part of the contract, this dependency is pretty fragile. 

In order to strengthen this dependency, this change allows us to make sure the field exist during build. With the change, we can catch a breaking change (e.g. rename/remove of the interesting fields) as soon as we build, this should hopefully solve the problem of the fragility of the dependency.