### PR TITLE
Enable running tests in our CI builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -6,7 +6,7 @@ def project = GithubProject
 def branch = GithubBranchName
 
 // Define build string
-def buildString = '''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd /p:SkipTests=true'''
+def buildString = '''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd'''
 
 // Generate the builds for debug and release
 


### PR DESCRIPTION
Our CI was building the Build Tools repo without running the tests.
Now that we have test to run, we want to build and run them.

cc: @joperezr @karajas @mmitche 