### PR TITLE
Fix for building test projects in VS and rebuildandtest on command line

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -10,7 +10,7 @@
   <UsingTask TaskName="ValidatePackageTargetFramework" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetApplicableAssetsFromPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
-  <Target Name="UpdatePkgProjProjectReferences" BeforeTargets="BeforeResolveReferences">
+  <Target Name="UpdatePkgProjProjectReferences" BeforeTargets="AssignProjectConfiguration">
     <!-- Update PkgProj references to call the GetPackageAssets target -->
     <ItemGroup>
       <ProjectReference Condition="'%(Extension)'=='.pkgproj'">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -982,6 +982,14 @@
   <!-- Required by Common.Targets when evaluating projectReferences -->
   <Target Name="GetNativeManifest" />
   <Target Name="GetCopyToOutputDirectoryItems" />
+  
+  <!-- When building in VS, ResolveProjectReferences only calls GetTargetPath 
+       and expects that to return the same set of items as Targets defined by 
+       ProjectReference.Targets metadata.  -->
+  <Target Name="GetTargetPath" 
+          DependsOnTargets="GetPackageAssets"  
+          Returns="@(PackageAsset)" />
+ 
   <!-- App packaging support -->
   <!-- 
     Following two targets are needed to be present in every project being built


### PR DESCRIPTION
This is a fix for corefx to allow test projects that now reference the pkgprojs to build in VS.
MS.Common.Targets hardcodes GetTargetPath when resolving projectrefs in the IDE.
Currently VS(+Nuget Extensions 3.5 beta) doesn't understand the p2p reference to the test-runtime, so the nuget restore must be done via msbuild.

This also resolves rebuildandtest on commandline msbuild, by mapping it to the first usage of ProjectReference in a target which happens on both the Build and Rebuild paths.

Changes done with @ericstj 's help.

/cc @weshaggard 