### PR TITLE
Changed writers to output "throw null;" in empty method bodies

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -196,16 +196,11 @@ namespace Microsoft.Cci.Writers.CSharp
             else if (method.ContainingTypeDefinition.IsValueType && method.IsConstructor)
             {
                 // Structs cannot have empty constructors so we need to output this dummy body
-                Write("throw new ");
-                if (_forCompilationIncludeGlobalprefix)
-                    Write("global::");
-                Write("System.NotImplementedException(); ");
+                Write("throw null;");
             }
             else if (!TypeHelper.TypesAreEquivalent(method.Type, method.ContainingTypeDefinition.PlatformType.SystemVoid))
             {
-                WriteKeyword("return");
-                WriteDefaultOf(method.Type);
-                WriteSymbol(";", true);
+                WriteKeyword("throw null;");
             }
 
             WriteSymbol("}");


### PR DESCRIPTION
We had a discussion about this offline. throw null results in simpler source and smaller IL.