### PR TITLE
Copy generated core files on Linux to a location that won't be deleted after the run

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -28,11 +28,26 @@ function print_info_from_core_file {
   # Check for the existence of GDB on the path
   hash gdb 2>/dev/null || { echo >&2 "GDB was not found. Unable to print core file."; return; }
 
-  echo "Printing info from core file $1"
+  echo "Printing info from core file $core_file_name"
 
   # Open the dump in GDB and print the stack from each thread. We can add more
   # commands here if desired.
   gdb --batch -ex "thread apply all bt full" -ex "quit" $executable_name $core_file_name
+}
+
+function copy_core_file_to_temp_location {
+  local core_file_name=$1
+
+  local storage_location="/tmp/coredumps"
+
+  # Create the directory (this shouldn't fail even if it already exists).
+  mkdir -p $storage_location
+
+  # Only copy the file over if the directory is empty. Otherwise, do nothing.
+  if [ ! "$(ls -A $storage_location)" ]; then 
+    echo "Copying core file $core_file_name to $storage_location"
+    cp $core_file_name $storage_location
+  fi
 }
 
 if [ "$PACKAGE_DIR" == "" ]
@@ -108,10 +123,11 @@ if [ "$(uname -s)" == "Linux" ]; then
     # We don't know what the PID of the process was, so let's look at all core
     # files whose name matches core.NUMBER
     for f in core.*; do
-      [[ $f =~ core.[0-9]+ ]] && print_info_from_core_file "$f" "corerun" && rm "$f"
+      [[ $f =~ core.[0-9]+ ]] && print_info_from_core_file "$f" "corerun" && copy_core_file_to_temp_location "$f" && rm "$f"
     done
   elif [ -f core ]; then
     print_info_from_core_file "core" "corerun"
+    copy_core_file_to_temp_location "core"
     rm "core"
   fi
 fi

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -93,7 +93,6 @@ cd $EXECUTION_DIR
 [[TestRunCommands]]
 test_exitcode=$?
 echo Finished running tests.  End time=$(date +"%T").  Return value was $test_exitcode
-exit $test_exitcode
 # ========================= END Test Execution ===============================
 # ======================= BEGIN Core File Inspection =========================
 if [ "$(uname -s)" == "Linux" ]; then
@@ -117,3 +116,4 @@ if [ "$(uname -s)" == "Linux" ]; then
   fi
 fi
 # ======================== END Core File Inspection ==========================
+exit $test_exitcode


### PR DESCRIPTION
Turns out we don't have GDB installed on the CI machines yet, so the strategy of printing stacks from core files and deleting them isn't going to work. Instead, for now, let's copy the core files to a known location that won't be wiped out right after the run.

Like on OS X, we'll only store one core file there at a time in order to avoid filling up the disk.


@ellismg @sergiy-k PTAL