### PR TITLE
Make Tool Host Overridable for Internal Builds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/toolruntime.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/toolruntime.targets
@@ -11,7 +11,7 @@
     <ToolHost>dotnet</ToolHost>
 
     <ToolRuntimePath Condition="'$(ToolRuntimePath)' == ''">$(ProjectDir)Tools/</ToolRuntimePath>
-    <ToolHostCmd>"$(ToolRuntimePath)dotnetcli/$(ToolHost)"</ToolHostCmd>
+    <ToolHostCmd Condition="'$(ToolHostCmd)'==''">"$(ToolRuntimePath)dotnetcli/$(ToolHost)"</ToolHostCmd>
     <!-- If COMPLUS_InstallRoot is set clear it before calling the ToolHost otherwise some root activations like PDB COM activation will fail -->
     <ToolHostCmd Condition="'$(COMPLUS_InstallRoot)' != ''">(set COMPLUS_InstallRoot=) &amp; $(ToolHostCmd)</ToolHostCmd>
   </PropertyGroup>


### PR DESCRIPTION
cc: @weshaggard 

We need to make the Tool Host overridable because internal builds have to run it from a different location.