### PR TITLE
Use InvariantCulture for writing constants in MS.CCI.Extensions

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 else if (double.IsNaN(val))
                     Write("0.0 / 0.0");
                 else
-                    Write(((double)value).ToString("R"));
+                    Write(((double)value).ToString("R", CultureInfo.InvariantCulture));
             }
             else if (value is float)
             {
@@ -281,7 +281,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 else if (float.IsNaN(val))
                     Write("0.0f / 0.0f");
                 else
-                    Write(((float)value).ToString("R") + "f");
+                    Write(((float)value).ToString("R", CultureInfo.InvariantCulture) + "f");
             }
             else if (value is bool)
             {


### PR DESCRIPTION
Before it'd use the current culture when writing the constant value, which results in float/double
using `,` as the decimal separator in cultures where this is the default.

The generated code is invalid C# and doesn't compile. Fixing the problem by using culture-neutral formatting.

Sample code:

```
public class TestLib
{
    public const double PI = 3.141592;
}
```