### PR TITLE
Add file with correlation id to test drop

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -378,5 +378,24 @@
       EventHubSharedAccessKeyName="$(BuildIsOfficialEventHubSharedAccessKeyName)"
       EventHubSharedAccessKey="$(BuildIsOfficialEventHubSharedAccessKey)"
       EventData="%(TestListFile.OfficialBuildJson)"/>
+    <!-- Upload the Correlation Id to the test drop container for tracking purposes-->
+    <PropertyGroup>
+      <CorrelationFileName>correlation_id-$(ConfigurationGroup)-$(TestNugetRuntimeId).txt</CorrelationFileName>
+    </PropertyGroup>
+    <ItemGroup>
+      <CorrelationFile Include="$(TestArchivesRoot)$(CorrelationFileName)">
+        <RelativeBlobPath>Tracking/$(CorrelationFileName)</RelativeBlobPath>
+      </CorrelationFile>
+    </ItemGroup>
+    <WriteLinesToFile
+        File="@(CorrelationFile)"
+        Lines="$(GeneratedCorrelationId)"
+        Overwrite="true" />
+    <UploadToAzure Condition=" '$(HelixApiAccessKey)' != '' "
+        AccountKey="$(CloudDropAccessToken)"
+        AccountName="$(CloudDropAccountName)"
+        ContainerName="$(ContainerName)"
+        Items="@(CorrelationFile)"
+        Overwrite="true" />
   </Target>
 </Project>


### PR DESCRIPTION
To be able to track the test progress of tests in Helix we need the correlation id. Currently the only way to read it is during build time, when executing this target. This change uploads a file that contains the correlation id to the same place as the test drop builds are placed making it accessible to retrieve at a later time.

@chcosta @jhendrixMSFT 