### PR TITLE
Handle Console API NotSupported exceptions

### DIFF
--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -58,7 +58,7 @@
             ]
         },
         "coreFx.Test.netcore50": {
-            "netcore50": [
+            "uap10.0": [
                 "win10-x86",
                 "win10-x86-aot",
                 "win10-x64",

--- a/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
@@ -64,9 +64,10 @@ namespace Xunit.ConsoleClient
             lock (consoleLock)
             {
                 // TODO: Thread-safe way to figure out the default foreground color
-                Console.ForegroundColor = ConsoleColor.Red;
+                
+                Program.SetConsoleForegroundColor(ConsoleColor.Red);
                 Console.Error.WriteLine("   {0} [FAIL]", Escape(testFailed.Test.DisplayName));
-                Console.ForegroundColor = ConsoleColor.Gray;
+                Program.SetConsoleForegroundColor(ConsoleColor.Gray);
                 Console.Error.WriteLine("      {0}", ExceptionUtility.CombineMessages(testFailed).Replace(Environment.NewLine, Environment.NewLine + "      "));
 
                 WriteStackTrace(ExceptionUtility.CombineStackTraces(testFailed));
@@ -85,9 +86,9 @@ namespace Xunit.ConsoleClient
             lock (consoleLock)
             {
                 // TODO: Thread-safe way to figure out the default foreground color
-                Console.ForegroundColor = ConsoleColor.Yellow;
+                Program.SetConsoleForegroundColor(ConsoleColor.Yellow);
                 Console.Error.WriteLine("   {0} [SKIP]", Escape(testSkipped.Test.DisplayName));
-                Console.ForegroundColor = ConsoleColor.Gray;
+                Program.SetConsoleForegroundColor(ConsoleColor.Gray);
                 Console.Error.WriteLine("      {0}", Escape(testSkipped.Reason));
             }
 
@@ -171,9 +172,9 @@ namespace Xunit.ConsoleClient
         {
             lock (consoleLock)
             {
-                Console.ForegroundColor = ConsoleColor.Red;
+                Program.SetConsoleForegroundColor(ConsoleColor.Red);
                 Console.Error.WriteLine("   [{0}] {1}", failureName, Escape(failureInfo.ExceptionTypes[0]));
-                Console.ForegroundColor = ConsoleColor.Gray;
+                Program.SetConsoleForegroundColor(ConsoleColor.Gray);
                 Console.Error.WriteLine("      {0}", Escape(ExceptionUtility.CombineMessages(failureInfo)));
 
                 WriteStackTrace(ExceptionUtility.CombineStackTraces(failureInfo));
@@ -185,10 +186,10 @@ namespace Xunit.ConsoleClient
             if (String.IsNullOrWhiteSpace(stackTrace))
                 return;
 
-            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Program.SetConsoleForegroundColor(ConsoleColor.DarkGray);
             Console.Error.WriteLine("      Stack Trace:");
 
-            Console.ForegroundColor = ConsoleColor.Gray;
+            Program.SetConsoleForegroundColor(ConsoleColor.Gray);
             foreach (var stackFrame in stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
             {
                 Console.Error.WriteLine("         {0}", StackFrameTransformer.TransformFrame(stackFrame, defaultDirectory));


### PR DESCRIPTION
These changes enable consuming and using xunit.console.netcore from netcore50 and netcore50aot setups.  

Once merged, we'll need to update the versions of both this and Microsoft.DotNet.BuildTools.TestSuite to reflect this in CoreFX.