### PR TITLE
Remove the local dependencies from project references/package references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -69,13 +69,6 @@
       </TestCopyLocal>
     </ItemGroup>
 
-    <!-- We may have an indirect package reference that we want to replace with a project reference.
-          Those are part of RunTestsForProjectInputs. The order that we append to TestCopyLocal is
-          significant, later entries override earlier entries. -->
-    <ItemGroup>
-      <TestCopyLocal Include="@(RunTestsForProjectInputs)" Exclude="@(PackagesConfigs)" />
-    </ItemGroup>
-
     <GetTargetMachineInfo Condition="'$(TestWithLocalLibraries)'=='true'">
       <Output Condition="'$(TargetArch)'==''" TaskParameter="TargetArch" PropertyName="TargetArch" />
       <Output Condition="'$(TargetOS)'==''" TaskParameter="TargetOS" PropertyName="TargetOS" />


### PR DESCRIPTION
resolution from being included in the dependency list.

This was an extra step that was adding local dependencies to the dependency list. The resolution of the package references and project references is now done in https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets#L90-L108 

/cc @MattGal 