### PR TITLE
Set coredump_filter to include shared library code.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -95,7 +95,15 @@ if [ "$(uname -s)" == "Darwin" ]; then
 elif [ "$(uname -s)" == "Linux" ]; then
   # On Linux, we'll enable core file generation unconditionally, and if a dump
   # is generated, we will print some useful information from it and delete the
-  # dump immediately. 
+  # dump immediately.
+
+  if [ -e /proc/self/coredump_filter ]; then
+      # Include memory in private and shared file-backed mappings in the dump.
+      # This ensures that we can see disassembly from our shared libraries when
+      # inspecting the contents of the dump. See 'man core' for details.
+      echo 0x3F > /proc/self/coredump_filter
+  fi
+
   ulimit -c unlimited
 fi
 # ========================= END Core File Setup ==============================


### PR DESCRIPTION
This change makes it so the core files generated in CI test runs on Linux will include memory in the shared libraries we load (such as libcoreclr.so). We didn't need it when the plan was just to print stacks when there was a crash in CI, but now that we're actually keeping the dumps sometimes, it's obviously useful for debugging purposes.

@sergiy-k @ellismg PTAL