### PR TITLE
BuildTools Changes to support native compilation.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -132,6 +132,11 @@
         <RelativeBlobPath>$(SupplementalPayloadFilename)</RelativeBlobPath>
       </SupplementalPayload>
     </ItemGroup>
+    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'" >
+      <SupplementalPayload Include="$(TestILCZipFile)">
+        <RelativeBlobPath>$([System.IO.Path]::GetFileName('$(TestILCZipFile)'))</RelativeBlobPath>
+      </SupplementalPayload>
+    </ItemGroup>
   </Target>
 
   <!-- create Azure containers and file shares -->

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -49,6 +49,13 @@
     <SupplementalPayloadDir Condition="'$(SupplementalPayloadDir)' == ''">$(TestWorkingDir)SupplementalPayload/</SupplementalPayloadDir>
     <SupplementalPayloadFilename>SupplementalPayload.zip</SupplementalPayloadFilename>
     <SupplementalPayloadFile>$(ArchivesRoot)$(SupplementalPayloadFilename)</SupplementalPayloadFile>
+
+    <!-- Workaround to bring the whole Test ILC folder if required  -->
+    <TestILCVersion>1.4.24208-prerelease</TestILCVersion>
+    <TestILCFolder>$(PackagesDir)Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
+
+    <TestILCZipFileName>TestILC.zip</TestILCZipFileName>
+    <TestILCZipFile>$(ArchivesRoot)$(TestILCZipFileName)</TestILCZipFile>
     <OverwriteOnUpload Condition="'$(OverwriteOnUpload)' == ''">false</OverwriteOnUpload>
     <TimeoutInSeconds Condition="'$(TimeoutInSeconds)' == ''">600</TimeoutInSeconds>
     <HelixApiEndpoint>https://helixview.azurewebsites.net/api/jobs</HelixApiEndpoint>
@@ -95,10 +102,10 @@
     <Message Text="Using OS-Specific test archives from: $(TestArchivesRoot)" />
     <Message Text="Using AnyOS test archives from: $(AnyOSTestArchivesRoot)" />
     <Message Condition="'$(TargetsUnix)' == 'true'"  Text="Using Unix test archives from: $(UnixTestArchivesRoot)" />
-    
+
     <PropertyGroup>
-        <RelativeBlobPathFolderContainingTests Condition="'$(TestTFM)' != ''" >Tests/$(TestTFM)</RelativeBlobPathFolderContainingTests>
-        <RelativeBlobPathFolderContainingTests Condition="'$(TestTFM)' == ''" >Tests</RelativeBlobPathFolderContainingTests>
+      <RelativeBlobPathFolderContainingTests Condition="'$(TestTFM)' != ''" >Tests/$(TestTFM)</RelativeBlobPathFolderContainingTests>
+      <RelativeBlobPathFolderContainingTests Condition="'$(TestTFM)' == ''" >Tests</RelativeBlobPathFolderContainingTests>
     </PropertyGroup>
 
     <!-- verify the test archives were created -->
@@ -132,6 +139,13 @@
         <RelativeBlobPath>$(SupplementalPayloadFilename)</RelativeBlobPath>
       </SupplementalPayload>
     </ItemGroup>
+
+    <ZipFileCreateFromDirectory
+      Condition="'$(UseDotNetNativeToolchain)' == 'true'"
+      SourceDirectory="$(TestILCFolder)"
+      DestinationArchive="$(TestILCZipFile)"
+      IncludeBaseDirectory="true"
+      OverwriteDestination="true" />
     <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'" >
       <SupplementalPayload Include="$(TestILCZipFile)">
         <RelativeBlobPath>$([System.IO.Path]::GetFileName('$(TestILCZipFile)'))</RelativeBlobPath>
@@ -244,7 +258,7 @@
     <GetPerfTestAssemblies TestBinaries="@(TestBinary)" GetFullPaths="false">
       <Output TaskParameter="PerfTestAssemblies" ItemName="PerfTestAssembly" />
     </GetPerfTestAssemblies>
-    
+
     <!-- don't add any items to the group if no perf tests were found -->
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest Condition="Exists('$(TestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip')" Include="$(TestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip" />

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Build.Tasks
             StringBuilder testRunCommands = new StringBuilder();
             foreach (string runCommand in TestCommands)
             {
-                testRunCommands.AppendLine($"call {runCommand}");
+                testRunCommands.AppendLine($"{runCommand}");
                 testRunEchoes.AppendLine($"echo {runCommand}");
             }
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
@@ -3,7 +3,7 @@ SETLOCAL
 
 SET PACKAGE_DIR=%1
 SET EXECUTION_DIR=%2
-
+set PACKAGE_DIR=%PACKAGE_DIR:/=\%
 IF DEFINED PACKAGE_DIR ( echo Using %PACKAGE_DIR% as folder for resolving package dependencies.) ELSE (
 echo Please specify an package source directory using PACKAGEROOT parameter
 goto ShowUsage

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -34,7 +34,8 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
-    <TestILCFolder>%PACKAGE_DIR%\TestILC\1.0.0</TestILCFolder>
+    <TestILCVersion>1.4.24208-prerelease</TestILCVersion>
+    <TestILCFolder>%PACKAGE_DIR%\Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
     <TestHostExecutable></TestHostExecutable>
     <XunitExecutable>xunit.console.netcore.exe</XunitExecutable>
   </PropertyGroup>
@@ -92,6 +93,8 @@
     <XunitOptions>$(XunitOptions) -xml $(XunitResultsFileName)</XunitOptions>
 
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
+
+    <XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>    
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
     <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
@@ -213,7 +216,7 @@
     <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'" >
       <TestCommandLines Include="copy /y $(TestILCFolder)\default.rd.xml  %EXECUTION_DIR%" />
       <TestCommandLines Include="$(TestILCFolder)\ilc.exe -usecustomframework -ExeName xunit.console.netcore.exe -in %EXECUTION_DIR% -out %EXECUTION_DIR%\native -usedefaultpinvoke -buildtype ret -v diag || exit /b %ERRORLEVEL%"/>
-      <TestCommandLines Include="copy /y $(TestILCFolder)\ProductIlc\lib\MSCRT\vcruntime140_app.dll %EXECUTION_DIR%\native" />
+      <TestCommandLines Include="copy /y $(TestILCFolder)\CRT\vcruntime140_app.dll %EXECUTION_DIR%\native" />
       <TestCommandLines Include="echo > %EXECUTION_DIR%\native\$(XunitTestAssembly)"/>
       <TestCommandLines Include="cd native"/>
     </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -33,12 +33,19 @@
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
+    <TestILCFolder>%PACKAGE_DIR%\TestILC\1.0.0</TestILCFolder>
+    <TestHostExecutable></TestHostExecutable>
+    <XunitExecutable>xunit.console.netcore.exe</XunitExecutable>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TestWithCore)' != 'true' And '$(TestAppX)' != 'true'">
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.exe</XunitExecutable>
     <DebugTestFrameworkFolder>net45</DebugTestFrameworkFolder>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TestAppX)' == 'true'">
+    <TestHostExecutable></TestHostExecutable>
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.uwp.exe</XunitExecutable>
   </PropertyGroup>
 
@@ -181,7 +188,7 @@
         <UseAbsolutePath Condition="'$(TestWithLocalLibraries)'=='true'">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').StartsWith('$(BinDir)'))</UseAbsolutePath>
       </IncludedFileForRunnerScript>
     </ItemGroup>
-    
+
     <MakeDir Directories="$(OutputFolderForTestDependencies)" />
     <PropertyGroup>
       <_TestDependencyListRoot>$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
@@ -195,16 +202,33 @@
       Lines="@(IncludedFileForRunnerScript -> '%(PackageRelativePath)')"
       Overwrite="true"
       Encoding="Ascii" />
-    
+
     <Message Text="Generating JSON-Processed $(OutDir)assemblylist.txt for legacy execution" />
     <GenerateAssemblyList
       InputListLocation="$(TestDependencyListFilePath)"
       OutputListLocation="$(OutDir)assemblylist.txt"
      />
 
-    <!-- Add commands for before / after test execution here.  -->
+    <!-- For .NET Native compilation, we first need to generate a native executable if possible. -->
+    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'" >
+      <TestCommandLines Include="copy /y $(TestILCFolder)\default.rd.xml  %EXECUTION_DIR%" />
+      <TestCommandLines Include="$(TestILCFolder)\ilc.exe -usecustomframework -ExeName xunit.console.netcore.exe -in %EXECUTION_DIR% -out %EXECUTION_DIR%\native -usedefaultpinvoke -buildtype ret -v diag || exit /b %ERRORLEVEL%"/>
+      <TestCommandLines Include="copy /y $(TestILCFolder)\ProductIlc\lib\MSCRT\vcruntime140_app.dll %EXECUTION_DIR%\native" />
+      <TestCommandLines Include="echo > %EXECUTION_DIR%\native\$(XunitTestAssembly)"/>
+      <TestCommandLines Include="cd native"/>
+    </ItemGroup>
+
     <ItemGroup>
-      <TestCommandLines Include="$(TestCommandLine)"/>
+      <!-- On Windows, call prevents the test command from making execution end prematurely -->
+      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT'" Include="call $(TestCommandLine)"/>
+      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="$(TestCommandLine)"/>
+    </ItemGroup>
+
+    <!-- Currently all netcore50 implementations of System.Console actually write to a noop stream -->
+    <!-- Workaround is to have the exe detect this and use Console.SetOut to write to a text file. -->
+    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'" >
+      <TestCommandLines Include="type Xunit.Console.Output.txt" />
+      <TestCommandLines Include="copy /y testResults.xml %EXECUTION_DIR%\" />      
     </ItemGroup>
 
     <GenerateTestExecutionScripts

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -35,7 +35,13 @@
 
   <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
     <TestILCVersion>1.4.24208-prerelease</TestILCVersion>
-    <TestILCFolder>%PACKAGE_DIR%\Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
+    <!-- Workaround:  On .NET execution, these paths will hit 263 characters during unzipping and fail 
+         Unfortunately this means slightly different content of Runtests.cmd local vs Helix, but without lots of 
+         long-path trickery this is the only current options.
+    -->
+    <TestILCFolder Condition="'$(EnableCloudTest)' != 'true'">%PACKAGE_DIR%\Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
+    <!-- CloudTest.targets will zip up the TestILC folder from within the package path above to this folder.-->
+    <TestILCFolder Condition="'$(EnableCloudTest)' == 'true'">%PACKAGE_DIR%\TestILC</TestILCFolder>
     <TestHostExecutable></TestHostExecutable>
     <XunitExecutable>xunit.console.netcore.exe</XunitExecutable>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileCreateFromDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileCreateFromDirectory.cs
@@ -31,6 +31,11 @@ namespace Microsoft.DotNet.Build.Tasks
         public bool OverwriteDestination { get; set; }
 
         /// <summary>
+        /// If zipping an entire folder without exclusion patterns, whether to include the folder in the archive.
+        /// </summary>
+        public bool IncludeBaseDirectory { get; set; }
+
+        /// <summary>
         /// An item group of regular expressions for content to exclude from the archive.
         /// </summary>
         public ITaskItem[] ExcludePatterns { get; set; }
@@ -58,7 +63,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 if (ExcludePatterns == null)
                 {
-                    ZipFile.CreateFromDirectory(SourceDirectory, DestinationArchive);
+                    ZipFile.CreateFromDirectory(SourceDirectory, DestinationArchive, CompressionLevel.Optimal, IncludeBaseDirectory);
                 }
                 else
                 {

--- a/src/xunit.console.netcore/CommandLine.cs
+++ b/src/xunit.console.netcore/CommandLine.cs
@@ -31,11 +31,14 @@ namespace Xunit.ConsoleClient
 
         public bool? ParallelizeTestCollections { get; set; }
 
+        public bool RedirectOutput { get; protected set; }
+
         public bool ShowProgress { get; protected set; }
 
         public bool TeamCity { get; protected set; }
 
         public bool Wait { get; protected set; }
+
 
         static XunitProject GetProjectFile(List<Tuple<string, string>> assemblies)
         {
@@ -163,6 +166,11 @@ namespace Xunit.ConsoleClient
                 {
                     GuardNoOptionValue(option);
                     AppVeyor = true;
+                }
+                else if (optionName == "-redirectoutput")
+                {
+                    GuardNoOptionValue(option);
+                    RedirectOutput = true;
                 }
                 else if (optionName == "-showprogress")
                 {

--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -13,7 +13,6 @@ namespace Xunit.ConsoleClient
     {
         volatile static bool cancel;
         static bool failed;
-        static bool hitPlatformNotSupported = false;
         static readonly ConcurrentDictionary<string, ExecutionSummary> completionMessages = new ConcurrentDictionary<string, ExecutionSummary>();
 
         [STAThread]
@@ -21,22 +20,7 @@ namespace Xunit.ConsoleClient
         {
             try
             {
-                SetConsoleForegroundColor(ConsoleColor.White);
-
-                // Workaround for NetCore50 (UWP) implementations:
-                // If we can't set Foreground color, we're running against a version that will be no-op'ing
-                // standard output stream.  If this is the case, just redirect console output.
-                //
-                // Since these things are just coincidental If there's ever a version of System.Console that throws for color but
-                // actually allows console output, we'll need to make this optional.
-                if (hitPlatformNotSupported)
-                {
-                    StreamWriter textFileOutput = new StreamWriter(new FileStream("Xunit.Console.Output.txt", FileMode.Create))
-                    {
-                        AutoFlush = true
-                    };
-                    Console.SetOut(textFileOutput);
-                }
+                Console.ForegroundColor = ConsoleColor.White;
 #if !NETCORE
                 var netVersion = Environment.Version;
 #else
@@ -45,7 +29,7 @@ namespace Xunit.ConsoleClient
                 Console.WriteLine("xUnit.net console test runner ({0}-bit .NET {1})", IntPtr.Size * 8, netVersion);
                 Console.WriteLine("Copyright (C) 2014 Outercurve Foundation.");
                 Console.WriteLine();
-                SetConsoleForegroundColor(ConsoleColor.Gray);
+                Console.ForegroundColor = ConsoleColor.Gray;
 
                 if (args.Length == 0 || args[0] == "-?")
                 {
@@ -81,6 +65,24 @@ namespace Xunit.ConsoleClient
 
                 var commandLine = CommandLine.Parse(args);
 
+                if (commandLine.RedirectOutput)
+                {
+                    // Workaround for NetCore50 (UWP) implementations:
+                    // When running against a version that will be no-op'ing the  
+                    // standard output stream, we will just redirect console output to a well known file name.
+                    //
+                    // This allows the most recent run's output to be logged.  Could allow customization if it's interesting later.
+                    StreamWriter textFileOutput = new StreamWriter(new FileStream("Xunit.Console.Output.txt", FileMode.Create))
+                    {
+                        AutoFlush = true
+                    };
+                    Console.SetOut(textFileOutput);
+                    // Repeat output for consistency.
+                    Console.WriteLine("xUnit.net console test runner ({0}-bit .NET {1})", IntPtr.Size * 8, netVersion);
+                    Console.WriteLine("Copyright (C) 2014 Outercurve Foundation.");
+                    Console.WriteLine();
+                }
+
                 var failCount = RunProject(defaultDirectory, commandLine.Project, commandLine.TeamCity, commandLine.AppVeyor, commandLine.ShowProgress,
                                            commandLine.ParallelizeAssemblies, commandLine.ParallelizeTestCollections,
                                            commandLine.MaxParallelThreads);
@@ -107,7 +109,7 @@ namespace Xunit.ConsoleClient
             }
             finally
             {
-                ResetConsoleColor();
+                Console.ResetColor();
             }
         }
 
@@ -163,6 +165,8 @@ namespace Xunit.ConsoleClient
             Console.WriteLine("  -class \"name\"          : run all methods in a given test class (should be fully");
             Console.WriteLine("                         : specified; i.e., 'MyNamespace.MyClass')");
             Console.WriteLine("                         : if specified more than once, acts as an OR operation");
+            Console.WriteLine("  -redirectoutput        : Redirect calls to Console APIs to file output,");
+            Console.WriteLine("                         : for platforms where console output is a noop.");
 
             TransformFactory.AvailableTransforms.ForEach(
                 transform => Console.WriteLine("  {0} : {1}",
@@ -211,10 +215,10 @@ namespace Xunit.ConsoleClient
 
                 if (completionMessages.Count > 0)
                 {
-                    SetConsoleForegroundColor(ConsoleColor.White);
+                    Console.ForegroundColor = ConsoleColor.White;
                     Console.WriteLine();
                     Console.WriteLine("=== TEST EXECUTION SUMMARY ===");
-                    SetConsoleForegroundColor(ConsoleColor.Gray);
+                    Console.ForegroundColor = ConsoleColor.Gray;
 
                     var totalTestsRun = completionMessages.Values.Sum(summary => summary.Total);
                     var totalTestsFailed = completionMessages.Values.Sum(summary => summary.Failed);
@@ -327,9 +331,9 @@ namespace Xunit.ConsoleClient
                     {
                         lock (consoleLock)
                         {
-                            SetConsoleForegroundColor(ConsoleColor.DarkYellow);
+                            Console.ForegroundColor = ConsoleColor.DarkYellow;
                             Console.WriteLine("Info:        {0} has no tests to run", Path.GetFileNameWithoutExtension(assembly.AssemblyFilename));
-                            SetConsoleForegroundColor(ConsoleColor.Gray);
+                            Console.ForegroundColor = ConsoleColor.Gray;
                         }
                     }
                     else
@@ -355,48 +359,12 @@ namespace Xunit.ConsoleClient
 
             lock (consoleLock)
             {
-                SetConsoleForegroundColor(ConsoleColor.Red);
+                Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("File not found: {0}", fileName);
-                SetConsoleForegroundColor(ConsoleColor.Gray);
+                Console.ForegroundColor = ConsoleColor.Gray;
             }
 
             return false;
-        }
-
-        public static void SetConsoleForegroundColor(ConsoleColor value)
-        {
-            if (hitPlatformNotSupported)
-            {
-                return;
-            }
-
-            try
-            {
-                Console.ForegroundColor = value;
-            }
-            catch (PlatformNotSupportedException)
-            {
-                hitPlatformNotSupported = true;
-                Debug.WriteLine("Ignoring PlatformNotSupportedException from Console PAL");
-            }
-        }
-
-        public static void ResetConsoleColor()
-        {
-            if (hitPlatformNotSupported)
-            {
-                return;
-            }
-
-            try
-            {
-                Console.ResetColor();
-            }
-            catch (PlatformNotSupportedException)
-            {
-                hitPlatformNotSupported = true;
-                Debug.WriteLine("Ignoring PlatformNotSupportedException from Console PAL");
-            }
         }
     }
 }

--- a/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
@@ -65,9 +65,9 @@ namespace Xunit.ConsoleClient
             {
                 // TODO: Thread-safe way to figure out the default foreground color
                 
-                Program.SetConsoleForegroundColor(ConsoleColor.Red);
+                Console.ForegroundColor = ConsoleColor.Red;
                 Console.Error.WriteLine("   {0} [FAIL]", Escape(testFailed.Test.DisplayName));
-                Program.SetConsoleForegroundColor(ConsoleColor.Gray);
+                Console.ForegroundColor = ConsoleColor.Gray;
                 Console.Error.WriteLine("      {0}", ExceptionUtility.CombineMessages(testFailed).Replace(Environment.NewLine, Environment.NewLine + "      "));
 
                 WriteStackTrace(ExceptionUtility.CombineStackTraces(testFailed));
@@ -86,9 +86,9 @@ namespace Xunit.ConsoleClient
             lock (consoleLock)
             {
                 // TODO: Thread-safe way to figure out the default foreground color
-                Program.SetConsoleForegroundColor(ConsoleColor.Yellow);
+                Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.Error.WriteLine("   {0} [SKIP]", Escape(testSkipped.Test.DisplayName));
-                Program.SetConsoleForegroundColor(ConsoleColor.Gray);
+                Console.ForegroundColor = ConsoleColor.Gray;
                 Console.Error.WriteLine("      {0}", Escape(testSkipped.Reason));
             }
 
@@ -172,9 +172,9 @@ namespace Xunit.ConsoleClient
         {
             lock (consoleLock)
             {
-                Program.SetConsoleForegroundColor(ConsoleColor.Red);
+                Console.ForegroundColor = ConsoleColor.Red;
                 Console.Error.WriteLine("   [{0}] {1}", failureName, Escape(failureInfo.ExceptionTypes[0]));
-                Program.SetConsoleForegroundColor(ConsoleColor.Gray);
+                Console.ForegroundColor = ConsoleColor.Gray;
                 Console.Error.WriteLine("      {0}", Escape(ExceptionUtility.CombineMessages(failureInfo)));
 
                 WriteStackTrace(ExceptionUtility.CombineStackTraces(failureInfo));
@@ -186,10 +186,10 @@ namespace Xunit.ConsoleClient
             if (String.IsNullOrWhiteSpace(stackTrace))
                 return;
 
-            Program.SetConsoleForegroundColor(ConsoleColor.DarkGray);
+            Console.ForegroundColor = ConsoleColor.DarkGray;
             Console.Error.WriteLine("      Stack Trace:");
 
-            Program.SetConsoleForegroundColor(ConsoleColor.Gray);
+            Console.ForegroundColor = ConsoleColor.Gray;
             foreach (var stackFrame in stackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.None))
             {
                 Console.Error.WriteLine("         {0}", StackFrameTransformer.TransformFrame(stackFrame, defaultDirectory));


### PR DESCRIPTION
@crummel , @karajas 

- Support zipping up TestILC package's "TestILC" content folder as a .NET Helix Payload.
- Remove injection of "call" before every command in script (moves this to build task).  Sometimes this caused undesired side effects.
- Work around disabled console output by writing to a text file when specified, and swallow PlatformNotSupported exceptions for CancelKeyPress.
