### PR TITLE
Don't run build on pkgproj references

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -15,7 +15,7 @@
     <ItemGroup>
       <ProjectReference Condition="'%(Extension)'=='.pkgproj'">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-        <Targets>Build;GetPackageAssets</Targets>
+        <Targets>GetPackageAssets</Targets>
         <OutputItemType>PkgProjAsset</OutputItemType>
         <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
       </ProjectReference>


### PR DESCRIPTION
We'll want to be able to test without building a package.

We're thinking to control package builds for the repo via the
packages.builds file and we don't want a test build to trigger
nupkg build for something we aren't shipping.

/cc @weshaggard @karajas 