### PR TITLE
Add dependency auto-upgrade scripts to share in dotnet projects

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/versions/UpdateDependencies.ps1
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/versions/UpdateDependencies.ps1
@@ -1,0 +1,142 @@
+﻿#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# This script updates the dir.props file with the latest build version,
+# optionally runs the project.json auto-upgrade target, and then optionally
+# creates a GitHub Pull Request for the change.
+
+param(
+    [Parameter(Mandatory=$true)][string]$VersionFileUrl,
+    [Parameter(Mandatory=$true)][string[]]$DirPropsVersionElements,
+    [string]$RepositoryRoot = '.',
+
+    [string]$GitHubUser,
+    [string]$GitHubEmail,
+    [string]$GitHubPassword,
+    [string]$GitHubOriginOwner=$GitHubUser,
+    [string]$GitHubUpstreamOwner='dotnet', 
+    [string]$GitHubUpstreamBranch='master',
+    [string]$GitHubProject,
+    # a semi-colon delimited list of GitHub users to notify on the PR
+    [string]$GitHubPullRequestNotifications='',
+
+    # Run build.cmd to apply the version upgrade to project.json files.
+    [switch]$UpdateInvalidPackageVersions,
+    # Create a pull request based on the GitHub parameters.
+    [switch]$SubmitPullRequest)
+
+$LatestVersion = Invoke-WebRequest $VersionFileUrl -UseBasicParsing
+$LatestVersion = $LatestVersion.ToString().Trim()
+
+# Make a nicely formatted string of the dir props version elements. Short names, joined by commas.
+$DirPropsVersionNames = ($DirPropsVersionElements | %{ $_ -replace 'ExpectedPrerelease', '' }) -join ', '
+
+# Updates the dir.props file with the latest build number
+function UpdateValidDependencyVersionsFile
+{
+    if (!$LatestVersion)
+    {
+        Write-Error "Unable to find latest dependency version at $VersionFileUrl ($DirPropsVersionNames)"
+        return $false
+    }
+
+    $DirPropsContent = Get-Content $RepositoryRoot\dir.props | % {
+        $line = $_
+        $DirPropsVersionElements | % {
+            $line = $line -replace `
+                "<$_>.*</$_>", `
+                "<$_>$LatestVersion</$_>"
+        }
+        $line
+    }
+    Set-Content $RepositoryRoot\dir.props $DirPropsContent
+
+    return $true
+}
+
+# Updates all the project.json files with out of date version numbers
+function RunUpdatePackageDependencyVersions
+{
+    cmd /c $RepositoryRoot\build.cmd managed /t:UpdateInvalidPackageVersions | Out-Host
+
+    return $LASTEXITCODE -eq 0
+}
+
+# Creates a Pull Request for the updated version numbers
+function CreatePullRequest
+{
+    $GitStatus = git status --porcelain
+    if ([string]::IsNullOrWhiteSpace($GitStatus))
+    {
+        Write-Warning "Dependencies are currently up to date"
+        return $true
+    }
+
+    $CommitMessage = "Updating $DirPropsVersionNames dependencies to $LatestVersion"
+
+    $env:GIT_COMMITTER_NAME = $GitHubUser
+    $env:GIT_COMMITTER_EMAIL = $GitHubEmail
+    git commit -a -m "$CommitMessage" --author "$GitHubUser <$GitHubEmail>" | Out-Host
+
+    $RemoteUrl = "github.com/$GitHubOriginOwner/$GitHubProject.git"
+    $RemoteBranchName = "UpdateDependencies$([DateTime]::UtcNow.ToString('yyyyMMddhhmmss'))"
+    $RefSpec = "HEAD:refs/heads/$RemoteBranchName"
+
+    Write-Host "git push https://$RemoteUrl $RefSpec"
+    # pipe this to null so the password secret isn't in the logs
+    git push "https://$($GitHubUser):$GitHubPassword@$RemoteUrl" $RefSpec 2>&1 | Out-Null
+
+    if ($GitHubPullRequestNotifications)
+    {
+        $PRNotifications = $GitHubPullRequestNotifications.Split(';', [StringSplitOptions]::RemoveEmptyEntries) -join ' @'
+        $PRBody = "/cc @$PRNotifications"
+    }
+    else
+    {
+        $PRBody = ''
+    }
+
+    $CreatePRBody = @"
+    {
+        "title": "$CommitMessage",
+        "body": "$PRBody",
+        "head": "$($GitHubOriginOwner):$RemoteBranchName",
+        "base": "$GitHubUpstreamBranch"
+    }
+"@
+
+    $CreatePRHeaders = @{'Accept'='application/vnd.github.v3+json'; 'Authorization'="token $GitHubPassword"}
+
+    try
+    {
+        Invoke-WebRequest https://api.github.com/repos/$GitHubUpstreamOwner/$GitHubProject/pulls -UseBasicParsing -Method Post -Body $CreatePRBody -Headers $CreatePRHeaders
+    }
+    catch
+    {
+        Write-Error $_.ToString()
+        return $false
+    }
+
+    return $true
+}
+
+if (!(UpdateValidDependencyVersionsFile))
+{
+    Exit -1
+}
+
+if ($UpdateInvalidPackageVersions -and !(RunUpdatePackageDependencyVersions))
+{
+    Exit -1
+}
+
+if ($SubmitPullRequest -and !(CreatePullRequest))
+{
+    Exit -1
+}
+
+Write-Host -ForegroundColor Green "Successfully updated dependencies from the latest build numbers"
+
+exit $LastExitCode

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/versions/UpdatePublishedVersions.ps1
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/versions/UpdatePublishedVersions.ps1
@@ -1,0 +1,143 @@
+﻿#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# This script updates the dotnet/versions repository based on a set of packages. It directly
+# commits the changes using GitHub APIs.
+
+param(
+    [Parameter(Mandatory=$true)][string]$gitHubUser,
+    [Parameter(Mandatory=$true)][string]$gitHubEmail,
+    [Parameter(Mandatory=$true)][string]$gitHubAuthToken,
+    [Parameter(Mandatory=$true)][string]$versionsRepoOwner,
+    [Parameter(Mandatory=$true)][string]$versionsRepo,
+    [Parameter(Mandatory=$true)][string]$versionsRepoPath,
+    # A pattern matching all packages in the set that the versions repository should be set to.
+    [Parameter(Mandatory=$true)][string]$nupkgPath,
+    # Print out the new file contents, but don't change the versions repository.
+    [switch]$dryRun)
+
+function ConvertPathTo-Package([string]$path)
+{
+    # Find the package ID and version using a regex. This matches the semantic version
+    # and assumes everything to the left is the id or a path to the package directory.
+    $matched = $path -match '^(.*\\)?(.*?)\.(([0-9]+\.)?[0-9]+\.[0-9]+(-([A-z0-9-]+))?)\.(symbols\.)?nupkg$'
+    if ($matched)
+    {
+        $packageInfo = @{
+            Path = $path
+            Name = $matches[2]
+            Version = $matches[3]
+            Prerelease = $matches[6]
+        }
+        $packageInfo.NameVersion = "$($packageInfo.Name) $($packageInfo.Version)"
+        return $packageInfo
+    }
+    else
+    {
+        throw "Couldn't find name and version from path $path."
+    }
+}
+
+# Updates a GitHub file with the specified file contents
+function Update-GitHub-File(
+    [string]$user = $gitHubUser,
+    [string]$email = $gitHubEmail,
+    [string]$authToken = $gitHubAuthToken,
+    [string]$owner = $versionsRepoOwner,
+    [string]$repo = $versionsRepo,
+    [string]$path,
+    [string]$newFileContent,
+    [string]$commitMessage)
+{
+    function message([string]$message)
+    {
+        Write-Host -ForegroundColor Green "*** $message ***"
+    }
+
+    $headers = @{
+        'Accept' = 'application/vnd.github.v3+json'
+        'Authorization' = "token $authToken"
+    }
+
+    $fileUrl = "https://api.github.com/repos/$owner/$repo/contents/$path"
+
+    message "Getting the `"sha`" of the current contents of file '$owner/$repo/$path'"
+
+    $currentFile = Invoke-WebRequest $fileUrl -UseBasicParsing -Headers $headers
+    $currentSha = (ConvertFrom-Json $currentFile.Content).sha
+
+    message "Got `"sha`" value of '$currentSha'"
+
+    message "Request to update file '$owner/$repo/$path' contents to:"
+    Write-Host $newFileContent
+
+    if ($dryRun)
+    {
+        message 'Not sending request: dry run.'
+        return
+    }
+
+    # Base64 encode the string
+    function ToBase64([string]$value)
+    {
+       return [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($value))
+    }
+
+    $updateFileBody = 
+@"
+{
+  "message": "$commitMessage",
+  "committer": {
+    "name": "$user",
+    "email": "$email"
+  },
+  "content": "$(ToBase64 $newFileContent)",
+  "sha": "$currentSha"
+}
+"@
+
+    message 'Sending request...'
+    $putResponse = Invoke-WebRequest $fileUrl -UseBasicParsing -Method PUT -Body $updateFileBody -Headers $headers
+
+    if ($putResponse.StatusCode -ge 200 -and $putResponse.StatusCode -lt 300)
+    {
+        message 'Successfully updated the file'
+    }
+}
+
+# Store result of Get-ChildItem before piping to ConvertPathTo-Package. When directly piping, exceptions are ignored.
+$packagePaths = Get-ChildItem $nupkgPath
+$packages = $packagePaths | %{ ConvertPathTo-Package $_ }
+
+$prereleaseVersion = ''
+foreach ($package in $packages)
+{
+    if ($package.Prerelease)
+    {
+        $prereleaseVersion = $package.Prerelease
+        break
+    }
+}
+
+if (!$prereleaseVersion)
+{
+    throw "Could not find a Prerelease version in '$newPackages'"
+}
+
+$versionFilePath = "$versionsRepoPath/Latest.txt"
+$versionFileContent = "$prereleaseVersion`n"
+
+Update-GitHub-File `
+    -path $versionFilePath `
+    -newFileContent $versionFileContent `
+    -commitMessage "Update '$versionFilePath' with $prereleaseVersion" 
+
+$packageInfoFilePath = "$versionsRepoPath/Latest_Packages.txt"
+$packageInfoFileContent = ($packages | %{ $_.NameVersion } | Sort-Object) -join "`r`n"
+
+Update-GitHub-File `
+    -path $packageInfoFilePath `
+    -newFileContent $packageInfoFileContent `
+    -commitMessage "Adding package info to '$packageInfoFilePath' for $prereleaseVersion" 


### PR DESCRIPTION
`UpdatePublishedVersions` is from CoreFX/CoreCLR/WCF (identical). `UpdateDependencies` is from CoreFX with a small amount of added configurability for WCF and CoreCLR: make the `build.cmd` and PR both opt-in.

This is step 1 in https://github.com/dotnet/buildtools/issues/823. Next is switching to use this script from `Tools\...` in the build pipeline and Maestro build definitions. (Nothing will break in the mean time because this is additive.)

/cc @weshaggard @jhendrixMSFT @ericstj @eerhardt