### PR TITLE
[release/1.0.0] EnsureOOBFramework should promote impl deps

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -193,6 +193,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         private List<ManifestFile> GetManifestFiles()
         {
             return (from f in Files.NullAsEmpty()
+                    where !f.GetMetadata(Metadata.FileTarget).StartsWith("$none$", StringComparison.OrdinalIgnoreCase)
                     select new ManifestFile()
                     {
                         Source = f.GetMetadata(Metadata.FileSource),

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -407,7 +407,9 @@
        precedence than platform specific implementations of any version and we
        put a place-holder in the platform specific folder when an asset is inbox. -->
   <ItemGroup>
-    <OutOfBoxFramework Include="netcore50"/>
+    <OutOfBoxFramework Include="netcore50">
+      <RuntimeId>win10</RuntimeId>
+    </OutOfBoxFramework>
   </ItemGroup>
   <Target Name="EnsureOOBFramework"
           DependsOnTargets="AddPlaceholders;ConvertItems">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/EnsureOOBFrameworkTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/EnsureOOBFrameworkTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\binaries\x86ret\NETCore\Manifests\System.Threading\runtime.json", "", "")
             };
 
-            string[] oobFx = new[] { "netcore50" };
+            ITaskItem[] oobFx = new[] { new TaskItem("netcore50") };
 
             EnsureOOBFramework task = new EnsureOOBFramework()
             {
@@ -80,9 +80,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             Assert.Equal(0, _log.ErrorsLogged);
             Assert.Equal(0, _log.WarningsLogged);
             Assert.Equal(11, task.AdditionalFiles.Length);
-            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetPath").Contains(oobFx[0]));
+            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetPath").Contains(oobFx[0].ItemSpec));
             Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetPath").StartsWith("ref"));
-            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetFramework").Equals(oobFx[0]));
+            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetFramework").Equals(oobFx[0].ItemSpec));
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/xamarinmac20", "xamarinmac20")
             };
 
-            string[] oobFx = new[] { "netcore50" };
+            ITaskItem[] oobFx = new[] { new TaskItem("netcore50") };
 
             EnsureOOBFramework task = new EnsureOOBFramework()
             {
@@ -143,8 +143,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             Assert.Equal(0, _log.ErrorsLogged);
             Assert.Equal(0, _log.WarningsLogged);
             Assert.Equal(12, task.AdditionalFiles.Length);
-            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetPath").Contains(oobFx[0]));
-            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetFramework").Equals(oobFx[0]));
+            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetPath").Contains(oobFx[0].ItemSpec));
+            Assert.All(task.AdditionalFiles, f => f.GetMetadata("TargetFramework").Equals(oobFx[0].ItemSpec));
         }
 
         [Fact]
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "lib/xamarinmac20", "xamarinmac20")
             };
 
-            string[] oobFx = new[] { "netcore50" };
+            ITaskItem[] oobFx = new[] { new TaskItem("netcore50") };
 
             EnsureOOBFramework task = new EnsureOOBFramework()
             {
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/xamarinmac20", "xamarinmac20")
             };
 
-            string[] oobFx = new[] { "netcore50" };
+            ITaskItem[] oobFx = new[] { new TaskItem("netcore50") };
 
             EnsureOOBFramework task = new EnsureOOBFramework()
             {
@@ -251,7 +251,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/net45", "")
 };
 
-            string[] oobFx = new[] { "netcore50" };
+            ITaskItem[] oobFx = new[] { new TaskItem("netcore50") };
 
             EnsureOOBFramework task = new EnsureOOBFramework()
             {
@@ -281,7 +281,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/netstandard", "netstandard")
             };
 
-            string[] oobFx = new[] { "netcore50" };
+            ITaskItem[] oobFx = new[] { new TaskItem("netcore50") };
 
             EnsureOOBFramework task = new EnsureOOBFramework()
             {
@@ -312,7 +312,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateItem(@"D:\K2\src\NDP\FxCore\src\Packages\_._", "ref/netstandard", "netstandard")
             };
 
-            string[] oobFx = new[] { "netcore50" };
+            ITaskItem[] oobFx = new[] { new TaskItem("netcore50") };
 
             EnsureOOBFramework task = new EnsureOOBFramework()
             {


### PR DESCRIPTION
EnsureOOBFramework makes sure that an oob implementation will always
take precedence over a placeholder in the case we have a framework that
transitioned from targeting-pack to package as was the case with
netcore50.

The problem here is that if it promotes only one of the ref or lib we'll
only get the dependencies from that asset, since the other asset's
dependencies will be in the less specific dependency group.

This became a problem when we started merging runtime specific
assets into the same packages as the ref: the fat package work.
Since a netstandard lib that is rid specific will be preferred over the
placeholder that is not rid specific we didn't need to copy the
implementation.   The result was the dependencies would only
be in the netstandard group.

To fix this I added a phase to find the actual implementation and copy
it to a 'netcore50' framework item.  I left a marker in the targetpath
of the copied items so that we wouldn't package the duplicate.

Longer term I'd like to rewrite how we do all the dependency harvesting
so that it is less brittle.  I think the right way to do this would be
to do actuall asset selection for TFM + TFM/RID tuples as appropriate
for all supported app models, get the actual assets that nuget will
select and harvest the dependencies at that point.

Port of 2c958d3472ec3fb925c9d142c4c91bd4731a780c.

/cc @weshaggard 