### PR TITLE
Changing corerun to dotnetcli on msbuild.sh

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/corerun $working_tree_root/MSBuild.exe $*
+$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.exe $*
 exit $ 


### PR DESCRIPTION
cc: @joperezr 