### PR TITLE
VSO Agent cleanup

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 }
                 nameLength = nameLength + 2;
 
-                string columnFormat = "      {0,-" + nameLength.ToString() + "} {1,-30:N0} {2,-22}";
+                string columnFormat = "      {0,-" + nameLength.ToString() + "} {1,30:N0} {2,-22}";
                 Console.WriteLine(string.Format(columnFormat, "Folder name", "Size (bytes)", "Last Modified DateTime"));
                 foreach (var workingDirectory in workingDirectories)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Build.Tasks
             var totalWorkingDirectories = workingDirectories != null ? workingDirectories.Length : 0;
 
             Console.WriteLine("  Agent info");
-            Console.WriteLine($"    Total size of agent directory: {string.Format("{0:N0}", GetDirectoryAttributes(AgentDirectory).Item1)}");
+            Console.WriteLine($"    Total size of agent directory: {string.Format("{0:N0}", GetDirectoryAttributes(AgentDirectory).Item1)} bytes");
             Console.WriteLine($"    Total agent working directories: {totalWorkingDirectories}");
 
             if (totalWorkingDirectories > 0)

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -109,10 +109,7 @@ namespace Microsoft.DotNet.Build.Tasks
             foreach(FileInfo fileInfo in fileInfos)
             {
                 totalSize += fileInfo.Length;
-                if(fileInfo.LastWriteTime > lastModifiedDateTime)
-                {
-                    lastModifiedDateTime = fileInfo.LastWriteTime;
-                }
+                lastModifiedDateTime = fileInfo.LastWriteTime > lastModifiedDateTime ? fileInfo.LastWriteTime : lastModifiedDateTime;
             }
             string[] directories = Directory.GetDirectories(directory);
 
@@ -120,10 +117,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 Tuple<long, DateTime> directoryAttributes = GetDirectoryAttributes(dir);
                 totalSize += directoryAttributes.Item1;
-                if(directoryAttributes.Item2 > lastModifiedDateTime)
-                {
-                    lastModifiedDateTime = directoryAttributes.Item2;
-                }
+                lastModifiedDateTime = directoryAttributes.Item2 > lastModifiedDateTime ? directoryAttributes.Item2 : lastModifiedDateTime;
             }
             return Tuple.Create(totalSize, lastModifiedDateTime);
         }

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -1,0 +1,156 @@
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class CleanupVSTSAgent : Microsoft.Build.Utilities.Task
+    {
+        [Required]
+        public string AgentDirectory { get; set; }
+
+        [Required]
+        public double RetentionDays { get; set; }
+
+        public int? Retries { get; set; }
+
+        public int? SleepTimeInMilliseconds { get; set; }
+
+        private static readonly int s_DefaultRetries = 5;
+        private static readonly int s_DefaultSleepTime = 10000;
+
+        public override bool Execute()
+        {
+            if(!Retries.HasValue)
+            {
+                Retries = s_DefaultRetries;
+            }
+            if(!SleepTimeInMilliseconds.HasValue)
+            {
+                SleepTimeInMilliseconds = s_DefaultSleepTime;
+            }
+
+            return CleanupAgentsAsync().Result;
+        }
+        private async System.Threading.Tasks.Task<bool> CleanupAgentsAsync()
+        {
+            bool returnStatus = true;
+            DateTime now = DateTime.Now;
+
+            // Cleanup the agents that the VSTS agent is tracking
+            string[] sourceFolderJsons = Directory.GetFiles(Path.Combine(AgentDirectory, "_work", "SourceRootMapping"), "SourceFolder.json", SearchOption.AllDirectories);
+            HashSet<string> knownDirectories = new HashSet<string>();
+            List<System.Threading.Tasks.Task<bool>> cleanupTasks = new List<System.Threading.Tasks.Task<bool>>();
+
+            Console.WriteLine($"Found {sourceFolderJsons.Length} known agent working directories. ");
+
+            foreach (var sourceFolderJson in sourceFolderJsons)
+            {
+                Console.WriteLine($"Examining {sourceFolderJson} ...");
+
+                Tuple<string, string, DateTime> agentInfo = GetAgentInfoAsync(sourceFolderJson).Result;
+                string workDirectory = Path.Combine(AgentDirectory, "_work", agentInfo.Item2);
+                knownDirectories.Add(workDirectory);
+
+                TimeSpan span = new TimeSpan(now.Ticks - agentInfo.Item3.Ticks);
+
+                if (span.TotalDays > RetentionDays)
+                {
+                    cleanupTasks.Add(CleanupAgentAsync(workDirectory, Path.GetDirectoryName(agentInfo.Item1)));
+                }
+                else
+                {
+                    Console.WriteLine($"Skipping cleanup for {sourceFolderJson}, it is newer than {RetentionDays} days old, last run date is '{agentInfo.Item3.ToString()}'");
+                }
+            }
+
+            System.Threading.Tasks.Task.WaitAll(cleanupTasks.ToArray());
+            foreach(var cleanupTask in cleanupTasks)
+            {
+                returnStatus &= cleanupTask.Result;
+            }
+
+            // Attempt to cleanup any working folders which the VSTS agent doesn't know about.
+            Console.WriteLine("Looking for additional '_work' directories which are unknown to the agent.");
+            Regex workingDirectoryRegex = new Regex(@"\\\d+$");
+            var workingDirectories = Directory.GetDirectories(Path.Combine(AgentDirectory, "_work"), "*", SearchOption.TopDirectoryOnly).Where(w => workingDirectoryRegex.IsMatch(w));
+            foreach (var workingDirectory in workingDirectories)
+            {
+                if (!knownDirectories.Contains(workingDirectory))
+                {
+                    returnStatus &= await CleanupAgentDirectoryAsync(workingDirectory, 0).ConfigureAwait(false);
+                }
+            }
+            return returnStatus;
+        }
+
+        private async System.Threading.Tasks.Task<bool> CleanupAgentAsync(string workDirectory, string sourceFolderJson)
+        {
+            bool returnStatus = await CleanupAgentDirectoryAsync(workDirectory, 0);
+            returnStatus &= await CleanupAgentDirectoryAsync(sourceFolderJson, 0).ConfigureAwait(false);
+            return returnStatus;
+        }
+
+        private async System.Threading.Tasks.Task<bool> CleanupAgentDirectoryAsync(string directory, int attempts)
+        {
+            try
+            {
+                if (Directory.Exists(directory))
+                {
+                    Console.Write($"Attempting to cleanup {directory} ... ");
+                    Directory.Delete(directory, true);
+                    Console.WriteLine("Success");
+                }
+                else
+                {
+                    Console.WriteLine($"Specified directory, {directory}, does not exist");
+                }
+                return true;
+            }
+            catch (Exception e)
+            {
+                attempts++;
+                Console.WriteLine($"Failed in cleanup attempt... {Retries - attempts} retries left.");
+                Console.WriteLine(e.Message);
+                Console.WriteLine(e.StackTrace);
+                if(attempts < Retries)
+                {
+                    Console.WriteLine($"Will retry again in {SleepTimeInMilliseconds} ms");
+                    await System.Threading.Tasks.Task.Delay(SleepTimeInMilliseconds.Value);
+                    return await CleanupAgentDirectoryAsync(directory, attempts).ConfigureAwait(false);
+                }
+            }
+            Console.WriteLine("Failed to cleanup agent");
+            return false;
+        }
+
+        private async System.Threading.Tasks.Task<Tuple<string, string, DateTime>> GetAgentInfoAsync(string sourceFolderJson)
+        {
+            Regex getValueRegex = new Regex(".*\": \"(?<value>[^\"]+)\"");
+
+            DateTime lastRunOn = DateTime.Now;
+            string agentBuildDirectory = null;
+            using (Stream stream = File.OpenRead(sourceFolderJson))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                while(!reader.EndOfStream)
+                {
+                    string line = await reader.ReadLineAsync();
+                    if(line.Contains("lastRunOn"))
+                    {
+                        lastRunOn = DateTime.Parse(getValueRegex.Match(line).Groups["value"].Value.ToString());
+                    }
+                    else if(line.Contains("agent_builddirectory"))
+                    {
+                        agentBuildDirectory = getValueRegex.Match(line).Groups["value"].Value.ToString();
+                    }
+                }
+            }
+            return new Tuple<string, string, DateTime>(sourceFolderJson, agentBuildDirectory, lastRunOn);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -80,7 +80,6 @@ namespace Microsoft.DotNet.Build.Tasks
             Console.WriteLine($"    Total size of agent directory: {string.Format("{0:N0}", GetDirectoryAttributes(AgentDirectory).Item1)}");
             Console.WriteLine($"    Total agent working directories: {totalWorkingDirectories}");
 
-
             if (totalWorkingDirectories > 0)
             {
                 int nameLength = 0;

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -25,6 +25,11 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
+            if(!Directory.Exists(AgentDirectory))
+            {
+                Console.WriteLine($"Agent directory specified, {AgentDirectory} does not exist.");
+                return false;
+            }
             if(!Retries.HasValue)
             {
                 Retries = s_DefaultRetries;
@@ -52,7 +57,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 Console.WriteLine($"Examining {sourceFolderJson} ...");
 
-                Tuple<string, string, DateTime> agentInfo = GetAgentInfoAsync(sourceFolderJson).Result;
+                Tuple<string, string, DateTime> agentInfo = await GetAgentInfoAsync(sourceFolderJson);
                 string workDirectory = Path.Combine(AgentDirectory, "_work", agentInfo.Item2);
                 knownDirectories.Add(workDirectory);
 

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -87,9 +87,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 {
                     nameLength = directoryName.Length > nameLength ? directoryName.Length : nameLength;
                 }
-                nameLength = nameLength + 2;
-
-                string columnFormat = "      {0,-" + nameLength.ToString() + "} {1,30:N0} {2,-22}";
+                int sizeLength = string.Format("{0:N0}", driveInfo.TotalSize).Length;
+                string columnFormat = "      {0,-" + nameLength.ToString() + "}  {1," + sizeLength.ToString() + ":N0}  {2}";
                 Console.WriteLine(string.Format(columnFormat, "Folder name", "Size (bytes)", "Last Modified DateTime"));
                 foreach (var workingDirectory in workingDirectories)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinClashLogger.cs" />
+    <Compile Include="CleanupVSTSAgent.cs" />
     <Compile Include="Delegates.cs" />
     <Compile Include="ExceptionFromResource.cs" />
     <Compile Include="ExecWithMutex.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -8,11 +8,15 @@
 
   <PropertyGroup>
     <RetentionDays Condition="'$(RetentionDays)' == ''">1</RetentionDays>
+    <DoClean Condition="'$(DoClean)' == ''">false</DoClean>
+    <DoReport Condition="'$(DoReport)' == ''">true</DoReport>
   </PropertyGroup>
 
   <Target Name="Clean">
     <Error Condition="'$(AgentDirectory)' == ''" Text="No value specified for 'AgentDirectory'." />
     <CleanupVSTSAgent AgentDirectory="$(AgentDirectory)"
-                      RetentionDays="$(RetentionDays)" />
+                      RetentionDays="$(RetentionDays)"
+                      Clean="$(DoClean)"
+                      Report="$(DoReport)"/>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Clean">
+  <PropertyGroup>
+    <BuildToolsTargets45 Condition="'$(OS)' == 'Windows_NT'">true</BuildToolsTargets45>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Build.Common.props))\Build.Common.props" />
+  <UsingTask TaskName="CleanupVSTSAgent" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+<!-- Inputs:
+       AgentDirectory
+       RetentionDays
+-->
+  <PropertyGroup>
+    <RetentionDays Condition="'$(RetentionDays)' == ''">5</RetentionDays>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SourceFolderJsons Include="$(AgentDirectory)/_work/SourceRootMapping/**/SourceFolder.json" />
+  </ItemGroup>
+
+  <Target Name="Clean">
+    <Error Condition="'$(AgentDirectory)' == ''" Text="No value specified for 'AgentDirectory'." />
+    <CleanupVSTSAgent AgentDirectory="$(AgentDirectory)"
+                      RetentionDays="$(RetentionDays)" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -6,10 +6,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Build.Common.props))\Build.Common.props" />
   <UsingTask TaskName="CleanupVSTSAgent" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
-<!-- Inputs:
-       AgentDirectory
-       RetentionDays
--->
   <PropertyGroup>
     <RetentionDays Condition="'$(RetentionDays)' == ''">5</RetentionDays>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -7,7 +7,7 @@
   <UsingTask TaskName="CleanupVSTSAgent" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
-    <RetentionDays Condition="'$(RetentionDays)' == ''">5</RetentionDays>
+    <RetentionDays Condition="'$(RetentionDays)' == ''">1</RetentionDays>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -10,10 +10,6 @@
     <RetentionDays Condition="'$(RetentionDays)' == ''">1</RetentionDays>
   </PropertyGroup>
 
-  <ItemGroup>
-    <SourceFolderJsons Include="$(AgentDirectory)/_work/SourceRootMapping/**/SourceFolder.json" />
-  </ItemGroup>
-
   <Target Name="Clean">
     <Error Condition="'$(AgentDirectory)' == ''" Text="No value specified for 'AgentDirectory'." />
     <CleanupVSTSAgent AgentDirectory="$(AgentDirectory)"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -16,6 +16,7 @@
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0",
         "System.Diagnostics.TraceSource": "4.0.0",
+        "System.IO.FileSystem.DriveInfo": "4.0.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "Newtonsoft.Json": "9.0.1",
         "NETStandard.Library": {


### PR DESCRIPTION
Adding a python script which allows us to cleanup our VSO agents' working folders on our windows, mac, and Linux machines.  We already have python as a pre-req for our builds.  This should help us eliminate the disk space issues we occasionally hit on our build machines.

My fork appears to be in an annoying state where I'm still getting additional commits with my PR's, which are no-op (ie, "Port GetRuntimeTargets and GetRuntimeJsonValues for Package Testing").  I'll probably delete my fork and create a new one, but for now, please ignore the additional commits and just focus on the files changed.

I've never written Python before, but I validated that the below code at least does what I expect. :)

/cc @weshaggard @jhendrixMSFT @wtgodbe 
