### PR TITLE
Enabling perf tests' execution via universal script runner

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Perf.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Perf.targets
@@ -12,10 +12,10 @@
     <!-- place the JSON file in the same directory as the runner script -->
     <PerfRunnerJsonFile>$(SupplementalPayloadDir)RunnerScripts/xunitrunner-perf/$(PerfRunnerJsonFileName)</PerfRunnerJsonFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
+  <PropertyGroup Condition="'$(UseLegacyXunitPerfRunner)'=='true' AND '$(TargetsWindows)' == 'true'">
     <RunnerScript>%HELIX_CORRELATION_PAYLOAD%\RunnerScripts\xunitrunner-perf\xunitrunner-perf.py</RunnerScript>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
+  <PropertyGroup Condition="'$(UseLegacyXunitPerfRunner)'=='true' AND '$(TargetsWindows)' != 'true'">
     <RunnerScript>$HELIX_CORRELATION_PAYLOAD/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py</RunnerScript>
   </PropertyGroup>
   <!-- creates a JSON file to be uploaded as supplemental payload -->

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -16,12 +16,12 @@
   <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
     <HelixPythonPath>%HELIX_PYTHONPATH%</HelixPythonPath>
     <HelixScriptRoot>%HELIX_SCRIPT_ROOT%\</HelixScriptRoot>
-    <FuncTestRunnerScript>%HELIX_CORRELATION_PAYLOAD%\RunnerScripts\scriptrunner\scriptrunner.py</FuncTestRunnerScript>
+    <TestRunnerScript>%HELIX_CORRELATION_PAYLOAD%\RunnerScripts\scriptrunner\scriptrunner.py</TestRunnerScript>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
     <HelixPythonPath>$HELIX_PYTHONPATH</HelixPythonPath>
     <HelixScriptRoot>$HELIX_SCRIPT_ROOT/</HelixScriptRoot>
-    <FuncTestRunnerScript>$HELIX_CORRELATION_PAYLOAD/RunnerScripts/scriptrunner/scriptrunner.py</FuncTestRunnerScript>
+    <TestRunnerScript>$HELIX_CORRELATION_PAYLOAD/RunnerScripts/scriptrunner/scriptrunner.py</TestRunnerScript>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -45,7 +45,7 @@
     <FuncTestListFile>$(TestWorkingDir)$(OSPlatformConfig)/$(FuncTestListFilename)</FuncTestListFile>
     <PerfTestListFile>$(TestWorkingDir)$(OSPlatformConfig)/$(PerfTestListFilename)</PerfTestListFile>
     <BuildStatsJsonFile>$(TestWorkingDir)$(OSPlatformConfig)/BuildStats.json</BuildStatsJsonFile>
-    <RunnerScript Condition="'$(RunnerScript)' == ''">$(FuncTestRunnerScript)</RunnerScript>
+    <RunnerScript Condition="'$(RunnerScript)' == ''">$(TestRunnerScript)</RunnerScript>
     <SupplementalPayloadDir Condition="'$(SupplementalPayloadDir)' == ''">$(TestWorkingDir)SupplementalPayload/</SupplementalPayloadDir>
     <SupplementalPayloadFilename>SupplementalPayload.zip</SupplementalPayloadFilename>
     <SupplementalPayloadFile>$(ArchivesRoot)$(SupplementalPayloadFilename)</SupplementalPayloadFile>
@@ -235,15 +235,14 @@
   </Target>
 
   <Target Name="CreatePerfTestListJson" DependsOnTargets="CreateAzureStorage" Condition="'$(Performance)' == 'true'">
-    <PropertyGroup Condition="'$(TargetsWindows)' == 'true'">
-      <PerfRunner>Microsoft.DotNet.xunit.performance.runner.Windows</PerfRunner>
+    <PropertyGroup Condition="'$(TargetsWindows)' == 'true' AND '$(UseLegacyXunitPerfRunner)'!='true'">
+      <OtherRunnerScriptArgs>--script RunTests.cmd %HELIX_CORRELATION_PAYLOAD% %HELIX_WORKITEM_ROOT%\execution</OtherRunnerScriptArgs>
+
     </PropertyGroup>
-    <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
-      <PerfRunner>Microsoft.DotNet.xunit.performance.runner.cli</PerfRunner>
+    <PropertyGroup Condition="'$(TargetsWindows)' != 'true' AND '$(UseLegacyXunitPerfRunner)'!='true'">
+      <OtherRunnerScriptArgs>--script RunTests.sh $HELIX_CORRELATION_PAYLOAD $HELIX_WORKITEM_ROOT/execution</OtherRunnerScriptArgs>
     </PropertyGroup>
-    <PropertyGroup>
-      <OtherRunnerScriptArgs>--perf-runner $(PerfRunner) --osgroup $(OSGroup) $(OtherRunnerScriptArgs)</OtherRunnerScriptArgs>
-    </PropertyGroup>
+
     <!-- now gather the perf tests -->
     <ItemGroup>
       <TestBinary Include="$(BinDir)$(OSPlatformConfig)/**/*.dll" />
@@ -266,9 +265,28 @@
       <PerfTest Condition="'$(TargetsUnix)' == 'true' And Exists('$(UnixTestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip')" Include="$(UnixTestArchivesRoot)$(TestTFM)/%(PerfTestAssembly.Identity).zip" />
     </ItemGroup>
 
+    <PropertyGroup Condition="'$(TargetsUnix)' == 'true' AND '$(UseLegacyXunitPerfRunner)'!='true'">
+      <PrefixPerfCommand>chmod +x $HELIX_WORKITEM_PAYLOAD/RunTests.sh &amp;&amp;</PrefixPerfCommand>
+    </PropertyGroup>
+
+    <!-- This is to temporarily support execution through legacy xunit perf runner -->
+    <PropertyGroup Condition="'$(UseLegacyXunitPerfRunner)'=='true' AND '$(TargetsWindows)' == 'true'">
+      <PerfRunner>Microsoft.DotNet.xunit.performance.runner.Windows</PerfRunner>
+      <UseDotNetCli>false</UseDotNetCli>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(UseLegacyXunitPerfRunner)'=='true' AND '$(TargetsWindows)' != 'true'">
+      <PerfRunner>Microsoft.DotNet.xunit.performance.runner.cli</PerfRunner>
+      <UseDotNetCli>true</UseDotNetCli>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(UseLegacyXunitPerfRunner)'=='true'">
+      <OtherRunnerScriptArgs>--perf-runner $(PerfRunner) --use-dotnetcli $(UseDotNetCli) $(OtherRunnerScriptArgs)</OtherRunnerScriptArgs>
+    </PropertyGroup>
+
+
     <ItemGroup Condition="'@(PerfTestAssembly->Count())' != '0'">
       <PerfTest>
-        <Command>$(HelixPythonPath) $(RunnerScript) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
+        <Command Condition="'$(UseLegacyXunitPerfRunner)'!='true'">$(PrefixPerfCommand) $(HelixPythonPath) $(RunnerScript) $(OtherRunnerScriptArgs)</Command>
+        <Command Condition="'$(UseLegacyXunitPerfRunner)'=='true'">$(HelixPythonPath) $(RunnerScript) --dll %(Filename).dll $(OtherRunnerScriptArgs) -- $(XunitArgs)</Command>
         <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/$(RelativeBlobPathFolderContainingTests)/%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>PerfTest.%(Filename)</WorkItemId>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/csvjsonconvertor.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/csvjsonconvertor.py
@@ -1,9 +1,19 @@
+"""
+ This is a temporary solution to gather h/w info from machine
+ the package is installed on end machines running perf
+ However this runs on a limited number of platforms
+ (but supports all the flavors we currently use for testing)
+ moving forward we will need a truly cross-plat solution here
+"""
+from cpuinfo import cpuinfo
 import csv
 import getopt
 import helix.proc
 import json
 import os
 import os.path
+import platform
+import psutil
 import serialobj
 import sys
 sys.path.append(os.getenv('HELIX_SCRIPT_ROOT'))
@@ -73,19 +83,19 @@ def generate_result_object(resultvalues):
     return result
 
 # generate a test object per node; each node represents a namespace/function (recursively)
-def generate_test_object(opts, currdict, testName):
+def generate_test_object(currdict, testName, info):
     currTest = serialobj.Test()
     currTest.testName = testName
 
     for key, value in currdict.iteritems():
         test = serialobj.Test()
         if isinstance(value, dict):
-            test = generate_test_object(opts, value, key)
+            test = generate_test_object(value, key, info)
         elif isinstance(value, list):
             test.testName = key
             test.results.append(generate_result_object(value))
-            test.machine.machineName = opts['--machineName']
-            test.machine.machineDescription = opts['--machineDescription']
+            test.machine.machineName = platform.node()
+            test.machine.machineDescription = format(info['brand'])
 
         currTest.tests.append(test)
 
@@ -94,11 +104,18 @@ def generate_test_object(opts, currdict, testName):
 
 # build json using csv data and meta data
 def generate_json(opts, csvdict):
-    log.info('Attempting to generate '+opts['--jsonFile'])
+    perfsettingsjson = ''
+    with open(os.path.join(opts['--perfSettingsJson'])) as perfsettingsjson:
+        # read the perf-specific settings
+        perfsettingsjson = json.loads(perfsettingsjson.read())
+
+    jsonFilePath = opts['--jsonFile']
+    log.info('Attempting to generate '+jsonFilePath)
     rootTests = list()
 
+    info = cpuinfo.get_cpu_info()
     # recursively build nodes from the csvdict
-    rootTest = generate_test_object(opts, csvdict, opts['--branch']+' Perf Test Results')
+    rootTest = generate_test_object(csvdict, perfsettingsjson['TestProduct']+' Perf Test Results', info)
     rootTests.append(rootTest)
 
     # populate the root level meta info
@@ -108,32 +125,31 @@ def generate_json(opts, csvdict):
     machinepool = serialobj.MachinePool()
 
     architecture = serialobj.Architecture()
-    architecture.architectureName = opts['--architectureName']
+    architecture.architectureName = format(info['arch'])
     machinepool.architecture = architecture
 
     manufacturer = serialobj.Manufacturer()
-    manufacturer.manufacturerName = opts['--manufacturerName']
+    manufacturer.manufacturerName = format(info['vendor_id'])
     machinepool.manufacturer = manufacturer
 
     microarch = serialobj.MicroArch()
-    microarch.microarchName = opts['--microarchName']
+    microarch.microarchName = 'SSE2' # cannot be obtained by cpu-info; need to figure out some other way
 
     osInfo = serialobj.OSInfo()
-    osInfo.osInfoName = opts['--osInfoName']
-    osInfo.osVersion = opts['--osVersion']
+    osInfo.osInfoName = platform.system()
+    osInfo.osVersion = platform.version()
 
     machinepool.osInfo = osInfo
     machinepool.microarch = microarch
-    machinepool.NumberOfCores = opts['--numberOfCores']
-    machinepool.NumberOfLogicalProcessors = opts['--numberOfLogicalProcessors']
-    machinepool.TotalPhysicalMemory = opts['--totalPhysicalMemory']
-    machinepool.machinepoolName = opts['--machinepoolName']
-    machinepool.machinepoolDescription = opts['--machinepoolDescription']
-    machinepool.TotalPhysicalMemory = opts['--totalPhysicalMemory']
+    machinepool.NumberOfCores = psutil.cpu_count(logical=False)
+    machinepool.NumberOfLogicalProcessors = psutil.cpu_count(logical=True)
+    machinepool.TotalPhysicalMemory = psutil.virtual_memory().total/1024
+    machinepool.machinepoolName = perfsettingsjson['TargetQueue']
+    machinepool.machinepoolDescription = '...'
     run.machinepool = machinepool
 
     config = serialobj.Config()
-    config.configName = opts['--configName']
+    config.configName = perfsettingsjson['TargetQueue']
     run.config = config
 
 
@@ -144,32 +160,41 @@ def generate_json(opts, csvdict):
     job.Runs = runs
 
     user = serialobj.User()
-    user.userName = opts['--username']
-    user.userAlias = opts['--userAlias']
+    user.userName = perfsettingsjson['Creator']
+    user.userAlias = perfsettingsjson['Creator']
     job.user = user
 
+    # extract build number from buildmoniker if official build
+    buildtokens = perfsettingsjson['BuildMoniker'].split('-')
+    if len(buildtokens) < 3:
+        buildNumber = perfsettingsjson['BuildMoniker']
+    else:
+        buildNumber = buildtokens[-2] +'.'+buildtokens[-1]
+
+
     buildInfo = serialobj.BuildInfo()
-    buildInfo.buildInfoName = opts['--buildInfoName']
-    buildInfo.buildNumber = opts['--buildNumber']
-    buildInfo.branch = opts['--branch']
+    buildInfo.buildInfoName = perfsettingsjson['BuildMoniker']
+    buildInfo.buildNumber = buildNumber
+    buildInfo.branch = perfsettingsjson['TestProduct']
     job.buildInfo = buildInfo
 
     jobType = serialobj.JobType()
-    jobType.jobTypeName = opts['--jobTypeName']
+    jobType.jobTypeName = 'Private'
     job.jobType = jobType
 
     jobGroup = serialobj.JobGroup()
-    jobGroup.jobGroupName = opts['--jobGroupName']
+    jobGroup.jobGroupName = perfsettingsjson['Creator']+'-'+perfsettingsjson['TestProduct']+'-'+perfsettingsjson['Branch']+'-Perf'
     job.jobGroup = jobGroup
 
-    job.jobDescription = opts['--jobDescription']
+    job.jobDescription = '...'
     job.jobName = opts['--jobName']
 
     root = serialobj.Root()
     root.job = job
     jsonOutput = serialobj.JsonOutput()
     jsonOutput.roots.append(root)
-    with open(opts['--jsonFile'], 'w+') as opfile:
+
+    with open(jsonFilePath, 'w+') as opfile:
         opfile.write(jsonOutput.to_JSON())
         opfile.flush()
         opfile.close()
@@ -192,37 +217,17 @@ def main(args=None):
         """
             Usage::
                 csv_to_json.py
-                    --csvFile csvFile to convert to json "MyLoc\\csvfile.csv"
-                    --jsonFile output json file location "MyLoc\\jsonfile.json"
+                    --csvFile csv file path
+                    --jsonFile json file path
                     --jobName "sample job"
-                    --jobDescription sample job description
-                    --configName "sample config"
-                    --jobGroupName sample job group
-                    --jobTypeName "Private"
-                    --username "sample user"
-                    --userAlias "sampleuser"
-                    --branch "ProjectK"
-                    --buildInfoName "sample build"
-                    --buildNumber "1234"
-                    --machinepoolName "HP Z210 Workstation"
-                    --machinepoolDescription "Intel64 Family 6 Model 42 Stepping 7"
-                    --architectureName "AMD64"
-                    --manufacturerName "Intel"
-                    --microarchName "SSE2"
-                    --numberOfCores "4"
-                    --numberOfLogicalProcessors "8"
-                    --totalPhysicalMemory "16342"
-                    --osInfoName "Microsoft Windows 8.1 Pro"
-                    --osVersion "6.3.9600"
-                    --machineName "PCNAME"
-                    --machineDescription "Intel(R) Core(TM) i7-2600 CPU @ 3.40GHz"
+                    --perfSettingsJson json file containing perf-specific settings
         """
 
 
         opts = dict(optlist)
         return run_json_conversion(opts)
 
-    return command_main(_main, ['csvFile=', 'jsonFile=', 'jobName=', 'jobDescription=', 'configName=', 'jobGroupName=', 'jobTypeName=', 'username=', 'userAlias=', 'branch=', 'buildInfoName=', 'buildNumber=', 'machinepoolName=', 'machinepoolDescription=', 'architectureName=', 'manufacturerName=' , 'microarchName=', 'numberOfCores=', 'numberOfLogicalProcessors=', 'totalPhysicalMemory=', 'osInfoName=', 'osVersion=', 'machineName=', 'machineDescription='], args)
+    return command_main(_main, ['csvFile=', 'jsonFile=', 'jobName=', 'perfSettingsJson='], args)
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/dotnetcliinstaller.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/dotnetcliinstaller.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env py
+from helix.io import fix_path
+import helix.logs
+import helix.proc
+from helix.settings import settings_from_env
+import os.path
+import traceback
+
+log = helix.logs.get_logger()
+
+def prepare_linux_for_perf():
+    settings = settings_from_env()
+    correlation_dir = fix_path(settings.correlation_payload_dir)
+    dotnet_cli_dir = os.path.join(correlation_dir, "perf.dotnetcli")
+    dotnet_cli = os.path.join(dotnet_cli_dir, "dotnet")
+    # if local dotnet cli is already installed, skip
+    if not os.path.exists(dotnet_cli):
+        # install dotnet cli locally
+        log.info('Local dotnet cli install not found, launching the installation script')
+        dotnet_installer = os.path.join(correlation_dir, "RunnerScripts", "xunitrunner-perf", "ubuntu-dotnet-local-install.sh")
+        try:
+            log.info('Setting dotnet cli installation script at '+dotnet_installer+' as executable')
+            helix.proc.run_and_log_output(("chmod 777 "+dotnet_installer).split(" "))
+            log.info('Running script '+dotnet_installer)
+            helix.proc.run_and_log_output((dotnet_installer+" -d "+dotnet_cli_dir+" -v "+os.path.join(correlation_dir, "RunnerScripts", "xunitrunner-perf", "DotNetCliVersion.txt")).split(" "))
+        except:
+            log.error("Exception when running the installation scripts: " + traceback.format_exc())
+    else:
+        log.info('Local dotnet cli install found')
+
+def main(args=None):
+    prepare_linux_for_perf()
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/postprocessperfresults.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/postprocessperfresults.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env py
+import copy
+import helix.depcheck
+import helix.logs
+import helix.proc
+import helix.azure_storage
+import helix.event
+from helix.io import fix_path
+from helix.settings import settings_from_env
+import json
+import os.path
+import traceback
+
+log = helix.logs.get_logger()
+
+def _upload_file(file_path, settings):
+    try:
+        event_client = helix.event.create_from_uri(settings.event_uri)
+        fc = helix.azure_storage.get_upload_client(settings)
+        url = fc.upload(file_path, os.path.basename(file_path))
+        log.info('Uploaded file at location {}'.format(url))
+    except ValueError, e:
+        event_client = helix.event.create_from_uri(settings.event_uri)
+        event_client.error(settings, "FailedUpload", "Failed to upload " + file_path + "after retry", None)
+
+def post_process_perf_results():
+    settings = settings_from_env()
+    perf_settings_json = ''
+    perf_settings_json_file = os.path.join(fix_path(settings.correlation_payload_dir), 'RunnerScripts', 'xunitrunner-perf', 'xunitrunner-perf.json')
+    with open(perf_settings_json_file) as perf_settings_json:
+        # read the perf-specific settings
+        perf_settings_json = json.loads(perf_settings_json.read())
+
+    json_file = os.path.join(settings.workitem_working_dir, perf_settings_json['TestProduct']+'-'+settings.workitem_id+'.json')
+    json_file = json_file.encode('ascii', 'ignore')
+    csv_file = os.path.join(settings.workitem_working_dir, 'execution', 'testResults.csv')
+    json_cmd = sys.executable+' '+os.path.join(fix_path(settings.correlation_payload_dir), 'RunnerScripts', 'xunitrunner-perf', 'csvjsonconvertor.py')+' --jobName '+settings.correlation_id+' --csvFile '+csv_file+' --jsonFile '+json_file+' --perfSettingsJson '+perf_settings_json_file
+    try:
+        return_code = helix.proc.run_and_log_output(
+                json_cmd.split(' '),
+                cwd=os.path.join(fix_path(settings.workitem_working_dir), 'execution'),
+                env=None
+            )
+    except:
+            log.error("Exception when running the installation scripts: " + traceback.format_exc())
+
+    log.info('Uploading {}'.format(csv_file))
+    result_url = _upload_file(csv_file, settings)
+    log.info('Location {}'.format(result_url))
+
+    # Upload json with rest of the results
+    log.info('Uploaded {} to results container'.format(json_file))
+    result_url = _upload_file(json_file, settings)
+    log.info('Location {}'.format(result_url))
+
+    # create deep copy and set perf container keys
+
+    perf_settings = copy.deepcopy(settings)
+    perf_settings.output_uri = perf_settings_json['RootURI']
+    perf_settings.output_write_token = perf_settings_json['WriteToken']
+    perf_settings.output_read_token = perf_settings_json['ReadToken']
+    log.info('Uploaded {} to perf container'.format(json_file))
+    # Upload json to the perf specific container
+    result_url = _upload_file(json_file, perf_settings)
+    log.info('Location {}'.format(result_url))
+
+
+def main(args=None):
+    post_process_perf_results()
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -3,17 +3,13 @@
 
   <!-- Perf Runner NuGet package paths -->
   <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
-    <PerfDotNetCliDir>$(TestPath)../perf.dotnetcli</PerfDotNetCliDir>
+    <PerfDotNetCliDir>$PACKAGE_DIR/perf.dotnetcli</PerfDotNetCliDir>
     <PerfDotNetCliInstaller>$(ToolsDir)/RunnerScripts/xunitrunner-perf/ubuntu-dotnet-local-install.sh</PerfDotNetCliInstaller>
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.cli</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfAnalysisPackageVersion)</XunitPerfRunnerPackageDir>
-    <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.runner.cli.dll</XunitPerfRunnerPath>
   </PropertyGroup>
   <!-- Perf Runner NuGet package paths -->
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfRunnerPackageId>Microsoft.DotNet.xunit.performance.runner.Windows</XunitPerfRunnerPackageId>
-    <XunitPerfRunnerPackageDir>$(PackagesDir)$(XunitPerfRunnerPackageId)/$(XunitPerfAnalysisPackageVersion)</XunitPerfRunnerPackageDir>
-    <XunitPerfRunnerPath>$(TestPath)$(DebugTestFrameworkFolder)/xunit.performance.run.exe</XunitPerfRunnerPath>
   </PropertyGroup>
 
   <!-- Perf Analysis NuGet package paths -->
@@ -24,80 +20,81 @@
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
     <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
+    <XunitPerfAnalysisDir>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools</XunitPerfAnalysisDir>
   </PropertyGroup>
 
 
   <!-- Installing dotnet cli version that can execute the xunit perf test runner -->
   <Target Name="InstallDotnetCliForPerfExecution" Condition="'$(TargetOS)'=='Linux' AND '$(Performance)'=='true' AND !Exists('$(PerfDotNetCliDir)/dotnet') AND '$(OsEnvironment)'=='Unix'" AfterTargets="CopyXunitExecutionFiles" >
     <Exec Command="chmod +x $(PerfDotNetCliInstaller)" />
-    <Exec Command="$(PerfDotNetCliInstaller) -d $(PerfDotNetCliDir) -v $(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/DotNetCliVersion.txt" ContinueOnError="true"/>
+    <Exec Command="$(PerfDotNetCliInstaller) -d $(PackagesDir)/perf.dotnetcli -v $(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/DotNetCliVersion.txt" ContinueOnError="true"/>
   </Target>
+
+  <ItemGroup>
+    <XunitPerfRunnerFiles Include ="$(PackagesDir)$(XunitPerfRunnerPackageId)/**/*.*" />
+    <XunitPerfAnalysisFiles Include ="$(PackagesDir)$(XunitPerfAnalysisPackageId)/**/*.*" />
+  </ItemGroup>
+
   <!-- Copy over the performance runners to the test directory-->
   <Target Name="CopyXunitExecutionFiles" AfterTargets="CopyTestToTestDirectory" Condition="'$(Performance)' == 'true'">
     <Error Condition="'$(XunitPerfAnalysisPackageVersion)' == ''" Text="Xunit performance package version was not specified" />
     <Error Condition="!Exists('$(XunitPerfAnalysisPath)')" Text="Xunit performance package was not found" />
-    <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.run.exe" />
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.metrics.dll" />
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.logger.exe" />
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.performance.core.dll" />
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/xunit.runner.utility.desktop.dll" />
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/ProcDomain.dll" />
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll" />
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/tools/*/*.*" />
-      <XunitPerfRunnerFiles Include ="$(PackagesDir)$(XunitPerfRunnerPackageId)/**/*.*" />
-      <XunitPerfAnalysisFiles Include ="$(PackagesDir)$(XunitPerfAnalysisPackageId)/**/*.*" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(TargetOS)'=='Linux'">
-      <PerfRunners Include="$(XunitPerfRunnerPackageDir)/lib/netstandard1.3/Microsoft.DotNet.xunit.performance.runner.cli.dll" />
-      <PerfRunners Include="$(XunitPerfAnalysisPath)" />
-    </ItemGroup>
-    <Copy SourceFiles="@(PerfRunners)"
-          DestinationFiles="@(PerfRunners->'$(TestPath)$(DebugTestFrameworkFolder)/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true" />
-
+    <Copy SourceFiles="$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/DotNetCliVersion.txt"
+          DestinationFolder="$(TestWorkingDir)SupplementalPayload/RunnerScripts/xunitrunner-perf"
+          SkipUnchangedFiles="true"
+          Condition="'$(TargetOS)'=='Linux'"/>
     <!-- The packages Microsoft.DotNet.xunit.performance.runner.Windows and Microsoft.DotNet.xunit.performance.analysis is not being uploaded alongwith Packages.zip, hence the workaround -->
     <Copy SourceFiles="@(XunitPerfRunnerFiles)"
           DestinationFiles="@(XunitPerfRunnerFiles->'$(TestWorkingDir)SupplementalPayload/$(XunitPerfRunnerPackageId)/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"/>
-    <Copy SourceFiles="$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/lib/netstandard1.3/DotNetCliVersion.txt"
-          DestinationFolder="$(TestWorkingDir)SupplementalPayload/RunnerScripts/xunitrunner-perf"
-          SkipUnchangedFiles="true" Condition="'$(TargetOS)'=='Linux'"/>
     <Copy SourceFiles="@(XunitPerfAnalysisFiles)"
           DestinationFiles="@(XunitPerfAnalysisFiles->'$(TestWorkingDir)SupplementalPayload/$(XunitPerfAnalysisPackageId)/%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="true"/>
-
   </Target>
 
   <!-- Executable properties -->
   <PropertyGroup>
-    <PerfRunId Condition="'$(PerfRunId)' == '' AND '$(TargetOS)'=='Windows_NT'">$(TargetFileName)-WindowsCore</PerfRunId>
-    <PerfRunId Condition="'$(PerfRunId)' == '' AND '$(TargetOS)'=='Linux'">$(TargetFileName)-LinuxCore</PerfRunId>
+    <PerfRunId Condition="'$(PerfRunId)' == ''">testResults</PerfRunId>
     <AnalysisReportFileName>$(PerfRunId)-analysis.html</AnalysisReportFileName>
+    <TestHostExecutable Condition="'$(TargetOS)'!='Windows_NT'">./corerun</TestHostExecutable>
     <XunitRunnerArgs>$(TargetFileName) -trait Benchmark=true -runnerhost $(TestHostExecutable) -runner $(XunitExecutable) -runid $(PerfRunId) -verbose</XunitRunnerArgs>
-    <PerfRunOutputFile>$(TestPath)$(DebugTestFrameworkFolder)/$(PerfRunId).xml</PerfRunOutputFile>
+    <PerfRunOutputFile Condition="'$(TargetOS)'=='Windows_NT'">%EXECUTION_DIR%\testResults.xml</PerfRunOutputFile>
+    <PerfRunOutputFile Condition="'$(TargetOS)'=='Linux'">$EXECUTION_DIR/testResults.xml</PerfRunOutputFile>
     <XunitAnalysisReportArgs>$(PerfRunOutputFile) -html $(AnalysisReportFileName) $(AdditionalXunitAnalysisArgs)</XunitAnalysisReportArgs>
-    <XunitAnalysisCsvArgs>$(PerfRunOutputFile) -csv test_results.csv</XunitAnalysisCsvArgs>
+    <XunitAnalysisCsvArgs>$(PerfRunOutputFile) -csv testResults.csv</XunitAnalysisCsvArgs>
+    <AnalyzePerfResults Condition="'$(AnalyzePerfResults)' != 'false'">true</AnalyzePerfResults>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)'=='Linux'">
     <PerfTestCommandDotnetExecutable>$(PerfDotNetCliDir)/dotnet</PerfTestCommandDotnetExecutable>
-    <PerfAnalysisReportCommandLine>$(PerfDotNetCliDir)/dotnet $(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisReportArgs)</PerfAnalysisReportCommandLine>
-    <PerfAnalysisCsvCommandLine>$(PerfDotNetCliDir)/dotnet $(TestPath)$(DebugTestFrameworkFolder)/Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommandLine>
+    <PerfAnalysisReportCommand>$(PerfTestCommandDotnetExecutable) $(PackagesDir)/$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisReportArgs)</PerfAnalysisReportCommand>
+    <PerfAnalysisCsvCommand>$(PerfTestCommandDotnetExecutable) Microsoft.DotNet.xunit.performance.analysis.cli.dll $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommand>
+    <PerfTestCommand>$(PerfTestCommandDotnetExecutable) Microsoft.DotNet.xunit.performance.runner.cli.dll $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommand>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <PerfTestCommandDotnetExecutable></PerfTestCommandDotnetExecutable>
-    <PerfAnalysisReportCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisReportArgs)</PerfAnalysisReportCommandLine>
-    <PerfAnalysisCsvCommandLine>$(XunitPerfAnalysisPath) $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommandLine>
+    <PerfAnalysisReportCommand>$(XunitPerfAnalysisPath) $(XunitAnalysisReportArgs)</PerfAnalysisReportCommand>
+    <PerfAnalysisCsvCommand>xunit.performance.analysis.exe $(XunitAnalysisCsvArgs)</PerfAnalysisCsvCommand>
+    <PerfTestCommand>$(PerfTestCommandDotnetExecutable) xunit.performance.run.exe $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommand>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <PerfTestCommandLine>$(PerfTestCommandDotnetExecutable) $(XunitPerfRunnerPath) $(XunitRunnerArgs) $(AdditionalPerfTestArgs)</PerfTestCommandLine>
-    <AnalyzePerfResults Condition="'$(AnalyzePerfResults)' != 'false'">true</AnalyzePerfResults>
-    <TestCommandLine>$(PerfTestCommandLine)</TestCommandLine>
-  </PropertyGroup>
-
-    <!-- Optimizations to configure Xunit for performance -->
+  <ItemGroup Condition="'$(TargetOS)'=='Linux'" >
+    <TestCommandLines Include = "$HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/RunnerScripts/xunitrunner-perf/dotnetcliinstaller.py"></TestCommandLines>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
+    <TestCommandLines Include = "xcopy &quot;%PACKAGE_DIR%\$(XunitPerfRunnerPackageId)\$(XunitPerfAnalysisPackageVersion)\tools&quot; &quot;%EXECUTION_DIR%&quot; /s /y"></TestCommandLines>
+    <TestCommandLines Include = "xcopy &quot;%PACKAGE_DIR%\$(XunitPerfAnalysisPackageId)\$(XunitPerfAnalysisPackageVersion)\tools&quot; &quot;%EXECUTION_DIR%&quot; /s /y"></TestCommandLines>
+  </ItemGroup>
+  <ItemGroup>
+    <TestCommandLines Include = "$(PerfTestCommand)"></TestCommandLines>
+    <TestCommandLines Include = "$(PerfAnalysisCsvCommand)"></TestCommandLines>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)'=='Linux'" >
+    <TestCommandLines Include = "$HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/RunnerScripts/xunitrunner-perf/postprocessperfresults.py"></TestCommandLines>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
+    <TestCommandLines Include = "%HELIX_PYTHONPATH% %HELIX_CORRELATION_PAYLOAD%\RunnerScripts\xunitrunner-perf\postprocessperfresults.py"></TestCommandLines>
+  </ItemGroup>
+  <!-- Optimizations to configure Xunit for performance -->
   <ItemGroup Condition="'$(IncludePerformanceTests)' == 'true'">
     <AssemblyInfoUsings Include="using Microsoft.Xunit.Performance%3B" />
     <AssemblyInfoLines Include="[assembly:OptimizeForBenchmarks]" />
@@ -106,15 +103,12 @@
   <Target Name="AnalyzePerfResults"
           AfterTargets="RunTestsForProject"
           Condition="'$(AnalyzePerfResults)' == 'true' and Exists('$(PerfRunOutputFile)')">
-    <Exec Command="$(PerfAnalysisReportCommandLine)"
-          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
+    <Exec Command="$(PerfAnalysisReportCommand)"
+          WorkingDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)"
           ContinueOnError="false">
       <Output PropertyName="PerfTestRunExitCode" TaskParameter="ExitCode" />
     </Exec>
     <Message Text="Performance test analysis report is available at $(TestPath)$(DebugTestFrameworkFolder)/$(AnalysisReportFileName)" />
-    <Exec Command="$(PerfAnalysisCsvCommandLine)"
-          WorkingDirectory="$(TestPath)%(TestTargetFramework.Folder)"
-          ContinueOnError="false" />
   </Target>
 
   <Target Name="WarnForDebugPerfConfiguration"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -37,8 +37,8 @@
 
   <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
     <TestILCVersion>1.4.24208-prerelease</TestILCVersion>
-    <!-- Workaround:  On .NET execution, these paths will hit 263 characters during unzipping and fail 
-         Unfortunately this means slightly different content of Runtests.cmd local vs Helix, but without lots of 
+    <!-- Workaround:  On .NET execution, these paths will hit 263 characters during unzipping and fail
+         Unfortunately this means slightly different content of Runtests.cmd local vs Helix, but without lots of
          long-path trickery this is the only current options.
     -->
     <TestILCFolder Condition="'$(EnableCloudTest)' != 'true'">%PACKAGE_DIR%\Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
@@ -102,7 +102,7 @@
 
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
 
-    <XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>    
+    <XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>
 
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
     <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
@@ -114,7 +114,7 @@
     <TestProgram Condition="'$(TestHostExecutable)'==''">$(XunitExecutable)</TestProgram>
     <TestArguments Condition="'$(TestHostExecutable)'==''">$(XunitArguments)</TestArguments>
 
-    <TestCommandLine>$(TestProgram) $(TestArguments) {XunitTraitOptions}</TestCommandLine>
+    <TestCommandLine Condition="'$(Performance)'!='true'">$(TestProgram) $(TestArguments) {XunitTraitOptions}</TestCommandLine>
   </PropertyGroup>
 
   <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
@@ -174,9 +174,9 @@
 
     <!-- Replace the {XunitTraitOptions} place holder with the actual traits.  We use the place holder
          because code coverage needs to have a bit of the test command line after the traits (it adds ending quotes
-         to one of its options).  Simply appending the traits would break code coverage. 
+         to one of its options).  Simply appending the traits would break code coverage.
          Additionally, replace CoreRun.exe with ./corerun on Non-Windows OSes (this is the only difference in the command)
-         Future refactoring will allow us to construct this correctly initially, but we don't always know the TargetOS 
+         Future refactoring will allow us to construct this correctly initially, but we don't always know the TargetOS
          when the properties are set currently.
          -->
 
@@ -191,7 +191,7 @@
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
 
     <ItemGroup>
-      <!-- Not all platforms can use the .ni.dlls that come from packages.  If TestWithoutNativeImages is specified, we'll exclude them from copy generation.  
+      <!-- Not all platforms can use the .ni.dlls that come from packages.  If TestWithoutNativeImages is specified, we'll exclude them from copy generation.
            If we end up needing this for any other sorts of filtering, we'll want to add a list of filtered extensions to be matched on EndsWith.  -->
       <IncludedFileForRunnerScript Include="@(_TestCopyLocalByFileNameWithoutDuplicates)"
                                    Condition="'$(TestWithoutNativeImages)' != 'true' Or !$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').EndsWith('.ni.dll'))" >
@@ -214,14 +214,15 @@
       Overwrite="true"
       Encoding="Ascii" />
 
-    <Message Text="Generating JSON-Processed $(OutDir)assemblylist.txt for legacy execution" />
+    <Message Text="Generating JSON-Processed $(OutDir)assemblylist.txt for legacy execution" Condition="'$(UseLegacyXunitPerfRunner)'=='true'" />
     <GenerateAssemblyList
       InputListLocation="$(TestDependencyListFilePath)"
       OutputListLocation="$(OutDir)assemblylist.txt"
+      Condition="'$(UseLegacyXunitPerfRunner)'=='true'"
      />
 
     <!-- For .NET Native compilation, we first need to generate a native executable if possible. -->
-    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'" >
+    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(Performance)'!='true'" >
       <TestCommandLines Include="copy /y $(TestILCFolder)\default.rd.xml  %EXECUTION_DIR%" />
       <TestCommandLines Include="$(TestILCFolder)\ilc.exe -usecustomframework -ExeName xunit.console.netcore.exe -in %EXECUTION_DIR% -out %EXECUTION_DIR%\native -usedefaultpinvoke -buildtype ret -v diag || exit /b %ERRORLEVEL%"/>
       <TestCommandLines Include="copy /y $(TestILCFolder)\CRT\vcruntime140_app.dll %EXECUTION_DIR%\native" />
@@ -237,9 +238,9 @@
 
     <!-- Currently all netcore50 implementations of System.Console actually write to a noop stream -->
     <!-- Workaround is to have the exe detect this and use Console.SetOut to write to a text file. -->
-    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'" >
+    <ItemGroup Condition="'$(UseDotNetNativeToolchain)' == 'true' AND '$(Performance)'!='true'" >
       <TestCommandLines Include="type Xunit.Console.Output.txt" />
-      <TestCommandLines Include="copy /y testResults.xml %EXECUTION_DIR%\" />      
+      <TestCommandLines Include="copy /y testResults.xml %EXECUTION_DIR%\" />
     </ItemGroup>
 
     <GenerateTestExecutionScripts


### PR DESCRIPTION
- install dotnet cli for linux via commands in runtests.sh
- copy over xunit perf runner packages as supplemental payload
- skip generation of assembly list when using the universal script runner
- use flag UseLegacyXunitPerfRunner to ensure backward compatibility with the old xunit perf runner since CoreCLR still relies on it
- refactored csvtojsonconvertor to allow easier command line execution from runtests.sh/cmd
- refactored/cleaned up xunitrunner-perf.py
@MattGal @lt72 
