### PR TITLE
Add dependency auto-upgrade and versions repo update to buildtools

### DIFF
--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -49,6 +49,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.console.uwp", "xunit.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.uwp", "xunit.runner.uwp\xunit.runner.uwp.csproj", "{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.VersionTools", "Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj", "{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -319,6 +321,26 @@ Global
 		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.ActiveCfg = Debug|Any CPU
 		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.Build.0 = Debug|Any CPU
 		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.Deploy.0 = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|ARM.Build.0 = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|x64.Build.0 = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|x86.Build.0 = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|ARM.ActiveCfg = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|ARM.Build.0 = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|x64.ActiveCfg = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|x64.Build.0 = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|x86.ActiveCfg = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -46,6 +46,10 @@
     <Compile Include="SignTypeItem.cs" />
     <Compile Include="UpdatePackageDependencyVersion.cs" />
     <Compile Include="ValidateExactRestore.cs" />
+    <Compile Include="VersionTools\MsBuildTraceListener.cs" />
+    <Compile Include="VersionTools\TraceListenerCollectionExtensions.cs" />
+    <Compile Include="VersionTools\UpdateDependencies.cs" />
+    <Compile Include="VersionTools\UpdatePublishedVersions.cs" />
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="WriteSigningRequired.cs" />
@@ -68,6 +72,13 @@
   <ItemGroup>
     <None Include="project.json" />
     <None Include="PackageFiles\**\*.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj">
+      <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
+      <Name>Microsoft.DotNet.VersionTools</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <ItemGroup Condition="'$(ShippedNuGetPackageGlobPath)'!=''">
+    <ShippedNuGetPackage Include="$(ShippedNuGetPackageGlobPath)" />
+  </ItemGroup>
+
+  <Target Name="UpdatePublishedVersions">
+    <UpdatePublishedVersions ShippedNuGetPackage="@(ShippedNuGetPackage)"
+                             VersionsRepoPath="$(VersionsRepoPath)"
+                             GitHubAuthToken="$(GitHubAuthToken)"
+                             GitHubUser="$(GitHubUser)"
+                             GitHubEmail="$(GitHubEmail)"
+                             VersionRepo="$(VersionRepo)"
+                             VersionRepoOwner="$(VersionRepoOwner)" />
+  </Target>
+
+  <UsingTask TaskName="UpdateDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <Target Name="UpdateDependencies">
+    <UpdateDependencies DependencyBuildInfo="@(DependencyBuildInfo)"
+                        ProjectJsonFiles="@(ProjectJsonFiles)"
+                        XmlUpdateStep="@(XmlUpdateStep)"
+                        ProjectRepo="$(ProjectRepo)"
+                        ProjectRepoOwner="$(ProjectRepoOwner)"
+                        ProjectRepoBranch="$(ProjectRepoBranch)"
+                        GitHubAuthToken="$(GitHubAuthToken)"
+                        GitHubUser="$(GitHubUser)"
+                        GitHubEmail="$(GitHubEmail)"
+                        GitHubAuthor="$(GitHubAuthor)"
+                        NotifyGitHubUsers="@(NotifyGitHubUsers)" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -13,11 +13,14 @@
         "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
         "Microsoft.Cci": "4.0.0-rc3-24128-00",
         "Microsoft.Composition": "1.0.30",
+        "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc3-24128-00",
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24128-00",
-        "Newtonsoft.Json": "7.0.1",
+        "System.Diagnostics.TraceSource": "4.0.0",
+        "System.Net.Http": "4.1.0",
+        "System.Runtime.Serialization.Primitives": "4.1.1",
+        "Newtonsoft.Json": "9.0.1",
         "NETStandard.Library": {
-          "version": "1.6.0-rc3-24128-00",
+          "version": "1.6.0",
           "exclude": "runtime"
         }
       },
@@ -27,7 +30,6 @@
       ]
     },
     "net45": {
-
       "dependencies": {
         "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc3-24128-00"
       }

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/MsBuildTraceListener.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/MsBuildTraceListener.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Diagnostics;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.Tasks.VersionTools
+{
+    public class MsBuildTraceListener : TraceListener
+    {
+        private TaskLoggingHelper _log;
+        private TraceEventType _eventType;
+        private StringBuilder _partialLine = new StringBuilder();
+
+        public MsBuildTraceListener(TaskLoggingHelper log, TraceEventType eventType)
+        {
+            _log = log;
+            _eventType = eventType;
+
+            Filter = new TraceEventTypeFilter
+            {
+                ShouldTraceType = eventType
+            };
+        }
+
+        public override void Write(string message)
+        {
+            _partialLine.Append(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            string fullMessage = _partialLine + message;
+            _partialLine.Clear();
+
+            switch (_eventType)
+            {
+                case TraceEventType.Error:
+                    _log.LogError(fullMessage);
+                    break;
+                case TraceEventType.Warning:
+                    _log.LogWarning(fullMessage);
+                    break;
+                case TraceEventType.Critical:
+                    _log.LogMessage(MessageImportance.High, fullMessage);
+                    break;
+                case TraceEventType.Information:
+                    _log.LogMessage(MessageImportance.Normal, fullMessage);
+                    break;
+                case TraceEventType.Verbose:
+                    _log.LogMessage(MessageImportance.Low, fullMessage);
+                    break;
+            }
+        }
+
+        public override void Flush()
+        {
+            base.Flush();
+            if (_partialLine.Length > 0)
+            {
+                WriteLine(string.Empty);
+            }
+        }
+
+        private class TraceEventTypeFilter : TraceFilter
+        {
+            public TraceEventType ShouldTraceType { get; set; }
+
+            public override bool ShouldTrace(
+                TraceEventCache cache,
+                string source,
+                TraceEventType eventType,
+                int id,
+                string formatOrMessage,
+                object[] args,
+                object data1,
+                object[] data)
+            {
+                return eventType == ShouldTraceType;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/TraceListenerCollectionExtensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/TraceListenerCollectionExtensions.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.VersionTools
+{
+    public static class TraceListenerCollectionExtensions
+    {
+        /// <summary>
+        /// Adds listeners to Trace that pass output into the given msbuild logger, making Trace
+        /// calls visible in build output. VersionTools, for example, uses Trace. Returns the
+        /// listeners to pass to RemoveMsBuildTraceListeners when the code using Trace is complete.
+        /// </summary>
+        public static MsBuildTraceListener[] AddMsBuildTraceListeners(
+            this TraceListenerCollection listenerCollection,
+            TaskLoggingHelper log)
+        {
+            var newListeners = new[]
+            {
+                TraceEventType.Error,
+                TraceEventType.Warning,
+                TraceEventType.Critical,
+                TraceEventType.Information,
+                TraceEventType.Verbose
+            }.Select(t => new MsBuildTraceListener(log, t)).ToArray();
+
+            listenerCollection.AddRange(newListeners);
+            return newListeners;
+        }
+
+        /// <summary>
+        /// Removes the given listeners from Trace. This cleans up static state to avoid
+        /// accidentally routing unrelated Trace data to msbuild logs.
+        /// 
+        /// Calls Flush on each listener in case the last call was Write.
+        /// </summary>
+        public static void RemoveMsBuildTraceListeners(
+            this TraceListenerCollection listenerCollection,
+            IEnumerable<MsBuildTraceListener> traceListeners)
+        {
+            foreach (MsBuildTraceListener listener in traceListeners)
+            {
+                listenerCollection.Remove(listener);
+                listener.Flush();
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependencies.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.VersionTools;
+using Microsoft.DotNet.VersionTools.Automation;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.DotNet.VersionTools.Dependencies;
+
+namespace Microsoft.DotNet.Build.Tasks.VersionTools
+{
+    public class UpdateDependencies : Task
+    {
+        [Required]
+        public ITaskItem[] DependencyBuildInfo { get; set; }
+
+        public ITaskItem[] ProjectJsonFiles { get; set; }
+
+        public ITaskItem[] XmlUpdateStep { get; set; }
+
+        public string ProjectRepo { get; set; }
+        public string ProjectRepoOwner { get; set; }
+        public string ProjectRepoBranch { get; set; }
+
+        [Required]
+        public string GitHubAuthToken { get; set; }
+        public string GitHubUser { get; set; }
+        public string GitHubEmail { get; set; }
+
+        /// <summary>
+        /// The git author of the update commit. Defaults to the same as GitHubUser.
+        /// </summary>
+        public string GitHubAuthor { get; set; }
+
+        public ITaskItem[] NotifyGitHubUsers { get; set; }
+
+        public override bool Execute()
+        {
+            MsBuildTraceListener[] listeners = Trace.Listeners.AddMsBuildTraceListeners(Log);
+
+            IDependencyUpdater[] updaters = GetDependencyUpdaters().ToArray();
+            BuildInfo[] buildInfos = GetBuildInfos().ToArray();
+
+            var gitHubAuth = new GitHubAuth(GitHubAuthToken, GitHubUser, GitHubEmail);
+
+            var updater = new DependencyUpdater(
+                gitHubAuth,
+                ProjectRepo,
+                ProjectRepoOwner,
+                ProjectRepoBranch,
+                GitHubAuthor ?? GitHubUser,
+                NotifyGitHubUsers?.Select(item => item.ItemSpec));
+
+            updater.UpdateAndSubmitPullRequestAsync(updaters, buildInfos).Wait();
+
+            Trace.Listeners.RemoveMsBuildTraceListeners(listeners);
+
+            return true;
+        }
+
+        private IEnumerable<IDependencyUpdater> GetDependencyUpdaters()
+        {
+            if (ProjectJsonFiles?.Any() ?? false)
+            {
+                yield return new ProjectJsonUpdater(ProjectJsonFiles.Select(item => item.ItemSpec));
+            }
+
+            if (XmlUpdateStep != null)
+            {
+                foreach (ITaskItem step in XmlUpdateStep)
+                {
+                    yield return new FileRegexReleaseUpdater
+                    {
+                        Path = step.GetMetadata("Path"),
+                        Regex = new Regex($@"<{step.GetMetadata("ElementName")}>(?<version>.*)<"),
+                        VersionGroupName = "version",
+                        BuildInfoName = step.GetMetadata("BuildInfoName")
+                    };
+                }
+            }
+        }
+
+        private IEnumerable<BuildInfo> GetBuildInfos()
+        {
+            return DependencyBuildInfo.Select(buildInfoItem => BuildInfo.Get(
+                buildInfoItem.ItemSpec,
+                buildInfoItem.GetMetadata("RawUrl")));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.VersionTools.Automation;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.VersionTools
+{
+    public class UpdatePublishedVersions : Task
+    {
+        [Required]
+        public ITaskItem[] ShippedNuGetPackage { get; set; }
+
+        [Required]
+        public string VersionsRepoPath { get; set; }
+
+        [Required]
+        public string GitHubAuthToken { get; set; }
+        public string GitHubUser { get; set; }
+        public string GitHubEmail { get; set; }
+
+        public string VersionRepo { get; set; }
+        public string VersionRepoOwner { get; set; }
+
+        public override bool Execute()
+        {
+            MsBuildTraceListener[] listeners = Trace.Listeners.AddMsBuildTraceListeners(Log);
+
+            var gitHubAuth = new GitHubAuth(GitHubAuthToken, GitHubUser, GitHubEmail);
+
+            var updater = new VersionRepoUpdater(gitHubAuth, VersionRepoOwner, VersionRepo);
+
+            updater.UpdateBuildInfoAsync(
+                ShippedNuGetPackage.Select(item => item.ItemSpec),
+                VersionsRepoPath)
+                .Wait();
+
+            Trace.Listeners.RemoveMsBuildTraceListeners(listeners);
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -3,13 +3,14 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
-    "NETStandard.Library": "1.5.0-rc2-24027",
-    "Newtonsoft.Json": "7.0.1",
+    "NETStandard.Library": "1.6.0",
+    "Newtonsoft.Json": "9.0.1",
     "NuGet.Packaging": "3.5.0-rc-1590",
     "NuGet.Versioning": "3.5.0-rc-1590",
     "NuProj": "0.10.4-beta-gf7fc34e7d8",
-    "System.Dynamic.Runtime": "4.0.11-rc3-24128-00",
-    "System.Reflection.Metadata": "1.3.0-rc3-24128-00",
+    "System.Diagnostics.TraceSource": "4.0.0",
+    "System.Dynamic.Runtime": "4.0.11",
+    "System.Reflection.Metadata": "1.3.0",
     "System.Xml.XPath.XmlDocument": "4.0.0"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.VersionTools.net45/Microsoft.DotNet.VersionTools.net45.csproj
+++ b/src/Microsoft.DotNet.VersionTools.net45/Microsoft.DotNet.VersionTools.net45.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
+    <ImportedProjectRelativePath>..\Microsoft.DotNet.VersionTools\</ImportedProjectRelativePath>
+    <ProjectGuid>{B4C96AEE-C686-485A-B809-DAD65B141DE2}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.VersionTools.csproj" />
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.VersionTools.net45/project.json
+++ b/src/Microsoft.DotNet.VersionTools.net45/project.json
@@ -1,11 +1,9 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Packaging": "3.5.0-rc-1590",
     "NuGet.Versioning": "3.5.0-rc-1590",
-    "System.Collections.Immutable": "1.1.37",
-    "System.Reflection.Metadata": "1.1.0",
+    "Microsoft.NETCore.Platforms": "1.0.1",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdater.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.VersionTools.Dependencies;
+
+namespace Microsoft.DotNet.VersionTools.Automation
+{
+    public class DependencyUpdater
+    {
+        private GitHubAuth _gitHubAuth;
+        private string _projectRepo;
+        private string _projectRepoOwner;
+        private string _projectRepoBranch;
+        private string _gitAuthorName;
+        private IEnumerable<string> _notifyGitHubUsers;
+
+        public string CommitMessageOverride { get; set; }
+
+        public DependencyUpdater(
+            GitHubAuth gitHubAuth,
+            string projectRepo,
+            string projectRepoOwner = null,
+            string projectRepoBranch = null,
+            string gitAuthorName = null,
+            IEnumerable<string> notifyGitHubUsers = null)
+        {
+            if (gitHubAuth == null)
+            {
+                throw new ArgumentNullException(nameof(gitHubAuth));
+            }
+            _gitHubAuth = gitHubAuth;
+
+            if (projectRepo == null)
+            {
+                throw new ArgumentNullException(nameof(projectRepo));
+            }
+            _projectRepo = projectRepo;
+
+            _projectRepoOwner = projectRepoOwner ?? "dotnet";
+            _projectRepoBranch = projectRepoBranch ?? "master";
+            _gitAuthorName = gitAuthorName ?? "dotnet-bot";
+            _notifyGitHubUsers = notifyGitHubUsers;
+        }
+
+        /// <summary>
+        /// Runs the updaters given using buildInfo sources, and returns the build infos used
+        /// during the update. The returned enumerable has no duplicate entries.
+        /// </summary>
+        public IEnumerable<BuildInfo> Update(
+            IEnumerable<IDependencyUpdater> updaters,
+            IEnumerable<BuildInfo> buildInfos)
+        {
+            IEnumerable<BuildInfo> usedBuildInfos = Enumerable.Empty<BuildInfo>();
+
+            foreach (IDependencyUpdater updater in updaters)
+            {
+                IEnumerable<BuildInfo> newUsedBuildInfos = updater.Update(buildInfos);
+                usedBuildInfos = usedBuildInfos.Union(newUsedBuildInfos);
+            }
+
+            return usedBuildInfos.ToArray();
+        }
+
+        public async Task UpdateAndSubmitPullRequestAsync(
+            IEnumerable<IDependencyUpdater> updaters,
+            IEnumerable<BuildInfo> buildInfos)
+        {
+            IEnumerable<BuildInfo> usedBuildInfos = Update(updaters, buildInfos);
+
+            string commitMessage = CommitMessageOverride;
+            if (string.IsNullOrWhiteSpace(commitMessage))
+            {
+                string updatedDependencyNames = string.Join(", ", usedBuildInfos.Select(d => d.Name));
+                string updatedDependencyVersions = string.Join(", ", usedBuildInfos.Select(d => d.LatestReleaseVersion));
+
+                commitMessage = $"Update {updatedDependencyNames} to {updatedDependencyVersions}";
+                if (usedBuildInfos.Count() > 1)
+                {
+                    commitMessage += ", respectively";
+                }
+            }
+
+            // Ensure changes were performed as expected.
+            bool hasModifiedFiles = GitHasChanges();
+            bool hasUsedBuildInfo = usedBuildInfos.Any();
+            if (hasModifiedFiles != hasUsedBuildInfo)
+            {
+                Trace.TraceError(
+                    "'git status' does not match DependencyInfo information. " +
+                    $"Git has modified files: {hasModifiedFiles}. " +
+                    $"DependencyInfo is updated: {hasUsedBuildInfo}.");
+                return;
+            }
+            if (!hasModifiedFiles)
+            {
+                Trace.TraceWarning("Dependencies are currently up to date");
+                return;
+            }
+
+            string remoteBranchName = $"UpdateDependencies{DateTime.UtcNow.ToString("yyyyMMddhhmmss")}";
+
+            PushNewCommit(commitMessage, remoteBranchName);
+
+            await SubmitPullRequestAsync(commitMessage, remoteBranchName);
+        }
+
+        private bool GitHasChanges()
+        {
+            CommandResult statusResult = Git("status", "--porcelain")
+                .CaptureStdOut()
+                .Execute();
+            statusResult.EnsureSuccessful();
+
+            return !string.IsNullOrWhiteSpace(statusResult.StdOut);
+        }
+
+        private void PushNewCommit(string commitMessage, string remoteBranchName)
+        {
+            // Set committer in process rather than through command start options because net45 doesn't have environment options.
+            Environment.SetEnvironmentVariable("GIT_COMMITTER_NAME", _gitAuthorName);
+            Environment.SetEnvironmentVariable("GIT_COMMITTER_EMAIL", _gitHubAuth.Email);
+
+            Git("commit", "-a", "-m", commitMessage, "--author", $"{_gitAuthorName} <{_gitHubAuth.Email}>")
+                .Execute()
+                .EnsureSuccessful();
+
+            string remoteUrl = $"github.com/{_gitHubAuth.User}/{_projectRepo}.git";
+            string refSpec = $"HEAD:refs/heads/{remoteBranchName}";
+
+            string logMessage = $"git push https://{remoteUrl} {refSpec}";
+            Trace.TraceInformation($"EXEC {logMessage}");
+
+            CommandResult pushResult =
+                Git("push", $"https://{_gitHubAuth.User}:{_gitHubAuth.AuthToken}@{remoteUrl}", refSpec)
+                    .QuietBuildReporter()  // we don't want secrets showing up in our logs
+                    .CaptureStdErr() // git push will write to StdErr upon success, disable that
+                    .CaptureStdOut()
+                    .Execute();
+
+            var message = logMessage + $" exited with {pushResult.ExitCode}";
+            if (pushResult.ExitCode == 0)
+            {
+                Trace.TraceInformation($"EXEC success: {message}");
+            }
+            else
+            {
+                Trace.TraceError($"EXEC failure: {message}");
+            }
+
+            pushResult.EnsureSuccessful(suppressOutput: true);
+        }
+
+        private async Task SubmitPullRequestAsync(string title, string remoteBranchName)
+        {
+            string description = "Automated update based on dotnet/versions repository.";
+            if (_notifyGitHubUsers != null)
+            {
+                description += $"\n\n/cc @{string.Join(" @", _notifyGitHubUsers)}";
+            }
+
+            using (GitHubHttpClient client = new GitHubHttpClient(_gitHubAuth))
+            {
+                await client.PostGitHubPullRequestAsync(
+                    title,
+                    description,
+                    originOwner: _gitHubAuth.User,
+                    originBranch: remoteBranchName,
+                    upstreamOwner: _projectRepoOwner,
+                    upstreamBranch: _projectRepoBranch,
+                    project: _projectRepo);
+            }
+        }
+
+        private static Command Git(params string[] args) => Command.Create("git", args);
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubAuth.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubAuth.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.VersionTools.Automation
+{
+    public class GitHubAuth
+    {
+        public string AuthToken { get; }
+        public string User { get; }
+        public string Email { get; }
+
+        public GitHubAuth(
+            string authToken,
+            string user = null,
+            string email = null)
+        {
+            if (authToken == null)
+            {
+                throw new ArgumentNullException(nameof(authToken));
+            }
+            AuthToken = authToken;
+            User = user ?? "dotnet-bot";
+            Email = email ?? "dotnet-bot@microsoft.com";
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubHttpClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubHttpClient.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.VersionTools.Automation
+{
+    public class GitHubHttpClient : HttpClient
+    {
+        private GitHubAuth _auth;
+
+        public GitHubHttpClient(GitHubAuth auth)
+        {
+            DefaultRequestHeaders.Add("Accept", "application/vnd.github.v3+json");
+            DefaultRequestHeaders.Add("Authorization", $"token {auth.AuthToken}");
+            DefaultRequestHeaders.Add("User-Agent", auth.User);
+            _auth = auth;
+        }
+
+        public async Task PutGitHubFileAsync(
+            string fileUrl,
+            string commitMessage,
+            string newFileContents)
+        {
+            Trace.TraceInformation($"Getting the 'sha' of the current contents of file '{fileUrl}'");
+
+            string currentFile = await GetStringAsync(fileUrl);
+            string currentSha = JObject.Parse(currentFile)["sha"].ToString();
+
+            Trace.TraceInformation($"Got 'sha' value of '{currentSha}'");
+
+            Trace.TraceInformation($"Request to update file '{fileUrl}' contents to:");
+            Trace.TraceInformation(newFileContents);
+
+            string updateFileBody = JsonConvert.SerializeObject(new
+            {
+                message = commitMessage,
+                committer = new
+                {
+                    name = _auth.User,
+                    email = _auth.Email
+                },
+                content = ToBase64(newFileContents),
+                sha = currentSha
+            }, Formatting.Indented);
+
+            var bodyContent = new StringContent(updateFileBody);
+            using (HttpResponseMessage response = await PutAsync(fileUrl, bodyContent))
+            {
+                response.EnsureSuccessStatusCode();
+                Trace.TraceInformation("Updated the file successfully.");
+            }
+        }
+
+        public async Task PostGitHubPullRequestAsync(
+            string title,
+            string description,
+            string originOwner,
+            string originBranch,
+            string upstreamOwner,
+            string upstreamBranch,
+            string project)
+        {
+            string createPrBody = JsonConvert.SerializeObject(new
+            {
+                title = title,
+                body = description,
+                head = $"{originOwner}:{originBranch}",
+                @base = upstreamBranch
+            }, Formatting.Indented);
+
+            string pullUrl = $"https://api.github.com/repos/{upstreamOwner}/{project}/pulls";
+
+            var bodyContent = new StringContent(createPrBody);
+            using (HttpResponseMessage response = await PostAsync(pullUrl, bodyContent))
+            {
+                response.EnsureSuccessStatusCode();
+
+                Trace.TraceInformation($"Created pull request.");
+
+                JObject responseContent = JObject.Parse(await response.Content.ReadAsStringAsync());
+                string htmlUrl = responseContent["html_url"].ToString();
+
+                Trace.TraceInformation($"Pull request page link: {htmlUrl}");
+            }
+        }
+
+        private static string ToBase64(string value)
+        {
+            return Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Automation/NupkgNameInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/NupkgNameInfo.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+
+namespace Microsoft.DotNet.VersionTools.Automation
+{
+    class NupkgNameInfo
+    {
+        public NupkgNameInfo(string path)
+        {
+            using (PackageArchiveReader archiveReader = new PackageArchiveReader(path))
+            {
+                PackageIdentity identity = archiveReader.GetIdentity();
+                Id = identity.Id;
+                Version = identity.Version.ToString();
+                Prerelease = identity.Version.Release;
+            }
+            SymbolPackage = path.EndsWith(".symbols.nupkg");
+        }
+
+        public string Id { get; set; }
+        public string Version { get; set; }
+        public string Prerelease { get; set; }
+        public bool SymbolPackage { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionRepoUpdater.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.VersionTools.Automation
+{
+    public class VersionRepoUpdater
+    {
+        private GitHubAuth _gitHubAuth;
+        private string _versionsRepoOwner;
+        private string _versionsRepo;
+
+        public VersionRepoUpdater(
+            GitHubAuth gitHubAuth,
+            string versionRepoOwner = null,
+            string versionsRepo = null)
+        {
+            if (gitHubAuth == null)
+            {
+                throw new ArgumentNullException(nameof(gitHubAuth));
+            }
+            _gitHubAuth = gitHubAuth;
+
+            _versionsRepoOwner = versionRepoOwner ?? "dotnet";
+            _versionsRepo = versionsRepo ?? "versions";
+        }
+
+        /// <param name="updateLatestVersion">If true, updates Latest.txt with a prerelease moniker. If there isn't one, makes the file empty.</param>
+        /// <param name="updateLatestPackageList">If true, updates Latest_Packages.txt.</param>
+        public async Task UpdateBuildInfoAsync(
+            IEnumerable<string> packagePaths,
+            string versionsRepoPath,
+            bool updateLatestPackageList = true,
+            bool updateLatestVersion = true)
+        {
+            if (packagePaths == null)
+            {
+                throw new ArgumentNullException(nameof(packagePaths));
+            }
+            if (versionsRepoPath == null)
+            {
+                throw new ArgumentNullException(nameof(versionsRepoPath));
+            }
+
+            NupkgNameInfo[] packages = packagePaths
+                .Select(path => new NupkgNameInfo(path))
+                // Ignore symbol packages.
+                .Where(t => !t.SymbolPackage)
+                .ToArray();
+
+            string prereleaseVersion = packages
+                .Select(t => t.Prerelease)
+                .FirstOrDefault(prerelease => !string.IsNullOrEmpty(prerelease))
+                ?? "";
+
+            if (updateLatestPackageList)
+            {
+                string packageInfoFileContent = string.Join(
+                    Environment.NewLine,
+                    packages
+                        .OrderBy(t => t.Id)
+                        .Select(t => $"{t.Id} {t.Version}"));
+
+                string packageInfoFilePath = $"{versionsRepoPath}/Latest_Packages.txt";
+                string message = $"Updating Latest_Packages.txt at {versionsRepoPath} for {prereleaseVersion}";
+
+                await UpdateGitHubFileAsync(packageInfoFilePath, packageInfoFileContent, message);
+            }
+
+            if (updateLatestVersion)
+            {
+                string latestFilePath = $"{versionsRepoPath}/Latest.txt";
+
+                string message = $"Updating Latest.txt at {versionsRepoPath}";
+                if (string.IsNullOrEmpty(prereleaseVersion))
+                {
+                    message += ". No prerelease versions published.";
+                }
+                else
+                {
+                    message += $" for {prereleaseVersion}";
+                }
+
+                await UpdateGitHubFileAsync(latestFilePath, prereleaseVersion, message);
+            }
+        }
+
+        private async Task UpdateGitHubFileAsync(string path, string newFileContent, string commitMessage)
+        {
+            using (GitHubHttpClient client = new GitHubHttpClient(_gitHubAuth))
+            {
+                string fileUrl = $"https://api.github.com/repos/{_versionsRepoOwner}/{_versionsRepo}/contents/{path}";
+
+                await client.PutGitHubFileAsync(fileUrl, commitMessage, newFileContent);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.VersionTools
+{
+    public class BuildInfo
+    {
+        public string Name { get; set; }
+
+        public IEnumerable<PackageIdentity> LatestPackages { get; set; }
+
+        public string LatestReleaseVersion { get; set; }
+
+        public static BuildInfo Get(
+            string name,
+            string rawBuildInfoBaseUrl,
+            bool fetchLatestReleaseFile = true)
+        {
+            using (var client = new HttpClient())
+            {
+                return GetAsync(
+                    client,
+                    name,
+                    rawBuildInfoBaseUrl,
+                    fetchLatestReleaseFile).Result;
+            }
+        }
+
+        public static async Task<BuildInfo> GetAsync(
+            HttpClient client,
+            string name,
+            string rawBuildInfoBaseUrl,
+            bool fetchLatestReleaseFile = true)
+        {
+            var packages = new List<PackageIdentity>();
+
+            string rawLatestUrl = $"{rawBuildInfoBaseUrl}/Latest.txt";
+            string rawLatestPackagesUrl = $"{rawBuildInfoBaseUrl}/Latest_Packages.txt";
+
+            using (Stream versionsStream = await client.GetStreamAsync(rawLatestPackagesUrl))
+            using (StreamReader reader = new StreamReader(versionsStream))
+            {
+                string currentLine;
+                while ((currentLine = await reader.ReadLineAsync()) != null)
+                {
+                    int spaceIndex = currentLine.IndexOf(' ');
+
+                    string id = currentLine.Substring(0, spaceIndex);
+                    var version = new NuGetVersion(currentLine.Substring(spaceIndex + 1));
+
+                    packages.Add(new PackageIdentity(id, version));
+                }
+            }
+
+            string releaseVersion;
+
+            if (fetchLatestReleaseFile)
+            {
+                releaseVersion = (await client.GetStringAsync(rawLatestUrl)).Trim();
+            }
+            else
+            {
+                releaseVersion = packages
+                    .Where(p => p.Version.IsPrerelease)
+                    .Select(p => p.Version.Release)
+                    .FirstOrDefault()
+                    ??
+                    // if there are no prerelease versions, just grab the first version
+                    packages
+                        .Select(p => p.Version.ToNormalizedString())
+                        .FirstOrDefault();
+            }
+
+            return new BuildInfo
+            {
+                Name = name,
+                LatestPackages = packages,
+                LatestReleaseVersion = releaseVersion
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexPackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexPackageUpdater.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public class FileRegexPackageUpdater : FileRegexUpdater
+    {
+        public string PackageId { get; set; }
+
+        protected override string TryGetDesiredValue(
+            IEnumerable<BuildInfo> buildInfos,
+            out IEnumerable<BuildInfo> usedBuildInfos)
+        {
+            var newVersion = buildInfos
+                .SelectMany(d => d.LatestPackages.Select(p => new
+                {
+                    Package = p,
+                    BuildInfo = d
+                }))
+                .FirstOrDefault(p => p.Package.Id == PackageId);
+
+            if (newVersion == null)
+            {
+                usedBuildInfos = Enumerable.Empty<BuildInfo>();
+
+                Trace.TraceError($"Could not find package version information for '{PackageId}'");
+                return $"DEPENDENCY '{PackageId}' NOT FOUND";
+            }
+
+            usedBuildInfos = new[] { newVersion.BuildInfo };
+
+            return newVersion.Package.Version.ToNormalizedString();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexReleaseUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexReleaseUpdater.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public class FileRegexReleaseUpdater : FileRegexUpdater
+    {
+        public string BuildInfoName { get; set; }
+
+        protected override string TryGetDesiredValue(
+            IEnumerable<BuildInfo> buildInfos,
+            out IEnumerable<BuildInfo> usedBuildInfos)
+        {
+            BuildInfo project = buildInfos.SingleOrDefault(d => d.Name == BuildInfoName);
+
+            if (project == null)
+            {
+                usedBuildInfos = Enumerable.Empty<BuildInfo>();
+
+                Trace.TraceError($"Could not find build info for project named {BuildInfoName}");
+                return $"PROJECT '{BuildInfoName}' NOT FOUND";
+            }
+
+            usedBuildInfos = new[] { project };
+
+            return project.LatestReleaseVersion;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public abstract class FileRegexUpdater : IDependencyUpdater
+    {
+        public string Path { get; set; }
+        public Regex Regex { get; set; }
+        public string VersionGroupName { get; set; }
+
+        public IEnumerable<BuildInfo> Update(IEnumerable<BuildInfo> buildInfos)
+        {
+            IEnumerable<BuildInfo> usedBuildInfos;
+            string newValue = TryGetDesiredValue(buildInfos, out usedBuildInfos);
+
+            if (newValue == null)
+            {
+                Trace.TraceError($"Could not find version information to change '{Path}' with '{Regex}'");
+                return Enumerable.Empty<BuildInfo>();
+            }
+
+            ReplaceFileContents(
+                Path,
+                contents => ReplaceGroupValue(Regex, contents, VersionGroupName, newValue));
+
+            return usedBuildInfos;
+        }
+
+        protected abstract string TryGetDesiredValue(
+            IEnumerable<BuildInfo> buildInfos,
+            out IEnumerable<BuildInfo> usedBuildInfos);
+
+        private static string ReplaceGroupValue(Regex regex, string input, string groupName, string newValue)
+        {
+            return regex.Replace(input, m =>
+            {
+                string replacedValue = m.Value;
+                Group group = m.Groups[groupName];
+                int startIndex = group.Index - m.Index;
+
+                replacedValue = replacedValue.Remove(startIndex, group.Length);
+                replacedValue = replacedValue.Insert(startIndex, newValue);
+
+                return replacedValue;
+            });
+        }
+
+        private static void ReplaceFileContents(string path, Func<string, string> replacement)
+        {
+            string contents = File.ReadAllText(path);
+
+            contents = replacement(contents);
+
+            File.WriteAllText(path, contents, Encoding.UTF8);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/IDependencyUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/IDependencyUpdater.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    /// <summary>
+    /// A tool that uses buildInfos to perform an update.
+    /// </summary>
+    public interface IDependencyUpdater
+    {
+        /// <summary>
+        /// Updates based on the given build infos and returns build infos used during update.
+        /// </summary>
+        IEnumerable<BuildInfo> Update(IEnumerable<BuildInfo> buildInfos);
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/ProjectJsonUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/ProjectJsonUpdater.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public class ProjectJsonUpdater : IDependencyUpdater
+    {
+        public IEnumerable<string> ProjectJsonPaths { get; }
+
+        public bool SkipStableVersions { get; set; } = true;
+
+        public ProjectJsonUpdater(IEnumerable<string> projectJsonPaths)
+        {
+            ProjectJsonPaths = projectJsonPaths;
+        }
+
+        public IEnumerable<BuildInfo> Update(IEnumerable<BuildInfo> buildInfos)
+        {
+            foreach (string projectJsonFile in ProjectJsonPaths)
+            {
+                JObject projectRoot;
+                try
+                {
+                    projectRoot = ReadProject(projectJsonFile);
+                }
+                catch (Exception e)
+                {
+                    Trace.TraceWarning($"Non-fatal exception occurred reading '{projectJsonFile}'. Skipping file. Exception: {e}. ");
+                    continue;
+                }
+
+                if (projectRoot == null)
+                {
+                    Trace.TraceWarning($"A non valid JSON file was encountered '{projectJsonFile}'. Skipping file.");
+                    continue;
+                }
+
+                BuildInfo[] buildInfosUsed = FindAllDependencyProperties(projectRoot)
+                    .Select(dependencyProperty => ReplaceDependencyVersion(projectJsonFile, dependencyProperty, buildInfos))
+                    .Where(buildInfo => buildInfo != null)
+                    .ToArray();
+
+                if (buildInfosUsed.Any())
+                {
+                    Trace.TraceInformation($"Writing changes to {projectJsonFile}");
+                    WriteProject(projectRoot, projectJsonFile);
+
+                    foreach (var buildInfo in buildInfosUsed)
+                    {
+                        yield return buildInfo;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Replaces the single dependency with the updated version, if it matches any of the
+        /// dependencies that need to be updated. Stops on the first updated value found.
+        /// </summary>
+        /// <returns>The BuildInfo used to change the value, or null if there was no change.</returns>
+        private BuildInfo ReplaceDependencyVersion(
+            string projectJsonFile,
+            JProperty dependencyProperty,
+            IEnumerable<BuildInfo> buildInfos)
+        {
+            string id = dependencyProperty.Name;
+            foreach (BuildInfo buildInfo in buildInfos)
+            {
+                foreach (PackageIdentity packageInfo in buildInfo.LatestPackages)
+                {
+                    if (id != packageInfo.Id)
+                    {
+                        continue;
+                    }
+
+                    string oldVersion;
+                    if (dependencyProperty.Value is JObject)
+                    {
+                        oldVersion = (string)dependencyProperty.Value["version"];
+                    }
+                    else
+                    {
+                        oldVersion = (string)dependencyProperty.Value;
+                    }
+                    VersionRange parsedOldVersionRange;
+                    if (!VersionRange.TryParse(oldVersion, out parsedOldVersionRange))
+                    {
+                        Trace.TraceWarning($"Couldn't parse '{oldVersion}' for package '{id}' in '{projectJsonFile}'. Skipping.");
+                        continue;
+                    }
+                    NuGetVersion oldNuGetVersion = parsedOldVersionRange.MinVersion;
+
+                    if (SkipStableVersions && !oldNuGetVersion.IsPrerelease)
+                    {
+                        continue;
+                    }
+
+                    if (oldNuGetVersion != packageInfo.Version)
+                    {
+                        string newVersion = packageInfo.Version.ToNormalizedString();
+                        if (dependencyProperty.Value is JObject)
+                        {
+                            dependencyProperty.Value["version"] = newVersion;
+                        }
+                        else
+                        {
+                            dependencyProperty.Value = newVersion;
+                        }
+
+                        return buildInfo;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static JObject ReadProject(string projectJsonPath)
+        {
+            using (TextReader projectFileReader = File.OpenText(projectJsonPath))
+            {
+                var projectJsonReader = new JsonTextReader(projectFileReader);
+
+                var serializer = new JsonSerializer();
+                return serializer.Deserialize<JObject>(projectJsonReader);
+            }
+        }
+
+        private static void WriteProject(JObject projectRoot, string projectJsonPath)
+        {
+            string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
+
+            File.WriteAllText(projectJsonPath, projectJson + Environment.NewLine);
+        }
+
+        private static IEnumerable<JProperty> FindAllDependencyProperties(JObject projectJsonRoot)
+        {
+            return projectJsonRoot
+                .Descendants()
+                .OfType<JProperty>()
+                .Where(property => property.Name == "dependencies")
+                .Select(property => property.Value)
+                .SelectMany(o => o.Children<JProperty>());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.DotNet.VersionTools</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.VersionTools</AssemblyName>
+    <CLSCompliant>false</CLSCompliant>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Automation\GitHubHttpClient.cs" />
+    <Compile Include="Automation\DependencyUpdater.cs" />
+    <Compile Include="Dependencies\FileRegexPackageUpdater.cs" />
+    <Compile Include="Dependencies\FileRegexReleaseUpdater.cs" />
+    <Compile Include="Util\ArgumentEscaper.cs" />
+    <Compile Include="Util\Command.cs" />
+    <Compile Include="Util\CommandResult.cs" />
+    <Compile Include="Automation\GitHubAuth.cs" />
+    <Compile Include="Automation\NupkgNameInfo.cs" />
+    <Compile Include="Dependencies\FileRegexUpdater.cs" />
+    <Compile Include="Dependencies\IDependencyUpdater.cs" />
+    <Compile Include="BuildInfo.cs" />
+    <Compile Include="Dependencies\ProjectJsonUpdater.cs" />
+    <Compile Include="Automation\VersionRepoUpdater.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Target Name="AfterBuild">
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.VersionTools/Util/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/ArgumentEscaper.cs
@@ -1,0 +1,205 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.VersionTools.Util
+{
+    static class ArgumentEscaper
+    {
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static string EscapeAndConcatenateArgArrayForProcessStart(IEnumerable<string> args)
+        {
+            return string.Join(" ", EscapeArgArray(args));
+        }
+
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static string EscapeAndConcatenateArgArrayForCmdProcessStart(IEnumerable<string> args)
+        {
+            return string.Join(" ", EscapeArgArrayForCmd(args));
+        }
+
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private static IEnumerable<string> EscapeArgArray(IEnumerable<string> args)
+        {
+            var escapedArgs = new List<string>();
+
+            foreach (var arg in args)
+            {
+                escapedArgs.Add(EscapeArg(arg));
+            }
+
+            return escapedArgs;
+        }
+
+        /// <summary>
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would 
+        /// be to do this only for cmd metacharacters.
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private static IEnumerable<string> EscapeArgArrayForCmd(IEnumerable<string> arguments)
+        {
+            var escapedArgs = new List<string>();
+
+            foreach (var arg in arguments)
+            {
+                escapedArgs.Add(EscapeArgForCmd(arg));
+            }
+
+            return escapedArgs;
+        }
+
+        private static string EscapeArg(string arg)
+        {
+            var sb = new StringBuilder();
+
+            var quoted = ShouldSurroundWithQuotes(arg);
+            if (quoted) sb.Append("\"");
+
+            for (int i = 0; i < arg.Length; ++i)
+            {
+                var backslashCount = 0;
+
+                // Consume All Backslashes
+                while (i < arg.Length && arg[i] == '\\')
+                {
+                    backslashCount++;
+                    i++;
+                }
+
+                // Escape any backslashes at the end of the arg
+                // This ensures the outside quote is interpreted as
+                // an argument delimiter
+                if (i == arg.Length)
+                {
+                    sb.Append('\\', 2 * backslashCount);
+                }
+
+                // Escape any preceding backslashes and the quote
+                else if (arg[i] == '"')
+                {
+                    sb.Append('\\', (2 * backslashCount) + 1);
+                    sb.Append('"');
+                }
+
+                // Output any consumed backslashes and the character
+                else
+                {
+                    sb.Append('\\', backslashCount);
+                    sb.Append(arg[i]);
+                }
+            }
+
+            if (quoted) sb.Append("\"");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Prepare as single argument to 
+        /// roundtrip properly through cmd.
+        /// 
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would 
+        /// be to do this only for cmd metacharacters.
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private static string EscapeArgForCmd(string argument)
+        {
+            var sb = new StringBuilder();
+
+            var quoted = ShouldSurroundWithQuotes(argument);
+
+            if (quoted) sb.Append("^\"");
+
+            foreach (var character in argument)
+            {
+
+                if (character == '"')
+                {
+
+                    sb.Append('^');
+                    sb.Append('"');
+                    sb.Append('^');
+                    sb.Append(character);
+                }
+                else
+                {
+                    sb.Append("^");
+                    sb.Append(character);
+                }
+            }
+
+            if (quoted) sb.Append("^\"");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Prepare as single argument to 
+        /// roundtrip properly through cmd.
+        /// 
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would 
+        /// be to do this only for cmd metacharacters.
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        internal static bool ShouldSurroundWithQuotes(string argument)
+        {
+            // Don't quote already quoted strings
+            if (argument.StartsWith("\"", StringComparison.Ordinal) &&
+                    argument.EndsWith("\"", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // Only quote if whitespace exists in the string
+            if (argument.Contains(" ") || argument.Contains("\t") || argument.Contains("\n"))
+            {
+                return true;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Util/Command.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/Command.cs
@@ -1,0 +1,349 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.DotNet.VersionTools.Util
+{
+    class Command
+    {
+        public static readonly string[] RunnableSuffixes = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? new string[] { ".exe", ".cmd", ".bat" }
+            : new string[] { string.Empty };
+
+        private Process _process;
+
+        private Action<string> _statusForward;
+
+        private StringWriter _stdOutCapture;
+        private StringWriter _stdErrCapture;
+
+        private Action<string> _stdOutForward;
+        private Action<string> _stdErrForward;
+
+        private Action<string> _stdOutHandler;
+        private Action<string> _stdErrHandler;
+
+        private bool _running = false;
+        private bool _quietBuildReporter = false;
+
+        private Command(string executable, string args)
+        {
+            // Set the things we need
+            var psi = new ProcessStartInfo()
+            {
+                FileName = executable,
+                Arguments = args
+            };
+
+            _process = new Process()
+            {
+                StartInfo = psi
+            };
+        }
+
+        public static Command Create(string executable, params string[] args)
+        {
+            return Create(executable, ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args));
+        }
+
+        public static Command Create(string executable, IEnumerable<string> args)
+        {
+            return Create(executable, ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args));
+        }
+
+        public static Command Create(string executable, string args)
+        {
+            ResolveExecutablePath(ref executable, ref args);
+
+            return new Command(executable, args);
+        }
+
+        private static void ResolveExecutablePath(ref string executable, ref string args)
+        {
+            // On Windows, we want to avoid using "cmd" if possible (it mangles the colors, and a bunch of other things)
+            // So, do a quick path search to see if we can just directly invoke it
+            var useCmd = ShouldUseCmd(executable);
+
+            if (useCmd)
+            {
+                var comSpec = System.Environment.GetEnvironmentVariable("ComSpec");
+
+                // cmd doesn't like "foo.exe ", so we need to ensure that if
+                // args is empty, we just run "foo.exe"
+                if (!string.IsNullOrEmpty(args))
+                {
+                    executable = (executable + " " + args).Replace("\"", "\\\"");
+                }
+                args = $"/C \"{executable}\"";
+                executable = comSpec;
+            }
+        }
+
+        private static bool ShouldUseCmd(string executable)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var extension = Path.GetExtension(executable);
+                if (!string.IsNullOrEmpty(extension))
+                {
+                    return !string.Equals(extension, ".exe", StringComparison.Ordinal);
+                }
+                else if (executable.Contains(Path.DirectorySeparatorChar))
+                {
+                    // It's a relative path without an extension
+                    if (File.Exists(executable + ".exe"))
+                    {
+                        // It refers to an exe!
+                        return false;
+                    }
+                }
+                else
+                {
+                    // Search the path to see if we can find it 
+                    foreach (var path in System.Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator))
+                    {
+                        var candidate = Path.Combine(path, executable + ".exe");
+                        if (File.Exists(candidate))
+                        {
+                            // We found an exe!
+                            return false;
+                        }
+                    }
+                }
+
+                // It's a non-exe :(
+                return true;
+            }
+
+            // Non-windows never uses cmd
+            return false;
+        }
+
+        public Command QuietBuildReporter()
+        {
+            _quietBuildReporter = true;
+            return this;
+        }
+
+        public CommandResult Execute()
+        {
+            ThrowIfRunning();
+            _running = true;
+
+            if (_process.StartInfo.RedirectStandardOutput)
+            {
+                _process.OutputDataReceived += (sender, args) =>
+                {
+                    ProcessData(args.Data, _stdOutCapture, _stdOutForward, _stdOutHandler);
+                };
+            }
+
+            if (_process.StartInfo.RedirectStandardError)
+            {
+                _process.ErrorDataReceived += (sender, args) =>
+                {
+                    ProcessData(args.Data, _stdErrCapture, _stdErrForward, _stdErrHandler);
+                };
+            }
+
+            _process.EnableRaisingEvents = true;
+
+            if (_process.StartInfo.RedirectStandardOutput ||
+                _process.StartInfo.RedirectStandardInput ||
+                _process.StartInfo.RedirectStandardError)
+            {
+                _process.StartInfo.UseShellExecute = false;
+            }
+
+            var sw = Stopwatch.StartNew();
+            ReportExecBegin();
+
+            _process.Start();
+
+            if (_process.StartInfo.RedirectStandardOutput)
+            {
+                _process.BeginOutputReadLine();
+            }
+
+            if (_process.StartInfo.RedirectStandardError)
+            {
+                _process.BeginErrorReadLine();
+            }
+
+            _process.WaitForExit();
+
+            var exitCode = _process.ExitCode;
+
+            ReportExecEnd(exitCode);
+
+            return new CommandResult(
+                _process.StartInfo,
+                exitCode,
+                _stdOutCapture?.GetStringBuilder()?.ToString(),
+                _stdErrCapture?.GetStringBuilder()?.ToString());
+        }
+
+        public Command WorkingDirectory(string projectDirectory)
+        {
+            _process.StartInfo.WorkingDirectory = projectDirectory;
+            return this;
+        }
+
+        public Command ForwardStatus(TextWriter to = null)
+        {
+            ThrowIfRunning();
+            if (to == null)
+            {
+                _statusForward = Console.WriteLine;
+            }
+            else
+            {
+                _statusForward = to.WriteLine;
+            }
+            return this;
+        }
+
+        public Command CaptureStdOut()
+        {
+            ThrowIfRunning();
+            _process.StartInfo.RedirectStandardOutput = true;
+            _stdOutCapture = new StringWriter();
+            return this;
+        }
+
+        public Command CaptureStdErr()
+        {
+            ThrowIfRunning();
+            _process.StartInfo.RedirectStandardError = true;
+            _stdErrCapture = new StringWriter();
+            return this;
+        }
+
+        public Command ForwardStdOut(TextWriter to = null)
+        {
+            ThrowIfRunning();
+            _process.StartInfo.RedirectStandardOutput = true;
+            if (to == null)
+            {
+                _stdOutForward = Console.WriteLine;
+            }
+            else
+            {
+                _stdOutForward = to.WriteLine;
+            }
+            return this;
+        }
+
+        public Command ForwardStdErr(TextWriter to = null)
+        {
+            ThrowIfRunning();
+            _process.StartInfo.RedirectStandardError = true;
+            if (to == null)
+            {
+                _stdErrForward = Console.WriteLine;
+            }
+            else
+            {
+                _stdErrForward = to.WriteLine;
+            }
+            return this;
+        }
+
+        public Command OnOutputLine(Action<string> handler)
+        {
+            ThrowIfRunning();
+            _process.StartInfo.RedirectStandardOutput = true;
+            if (_stdOutHandler != null)
+            {
+                throw new InvalidOperationException("Already handling stdout!");
+            }
+            _stdOutHandler = handler;
+            return this;
+        }
+
+        public Command OnErrorLine(Action<string> handler)
+        {
+            ThrowIfRunning();
+            _process.StartInfo.RedirectStandardError = true;
+            if (_stdErrHandler != null)
+            {
+                throw new InvalidOperationException("Already handling stderr!");
+            }
+            _stdErrHandler = handler;
+            return this;
+        }
+
+        private string FormatProcessInfo(ProcessStartInfo info, bool includeWorkingDirectory)
+        {
+            string prefix = includeWorkingDirectory ?
+                $"{info.WorkingDirectory}> {info.FileName}" :
+                info.FileName;
+
+            if (string.IsNullOrWhiteSpace(info.Arguments))
+            {
+                return prefix;
+            }
+
+            return prefix + " " + info.Arguments;
+        }
+
+        private void ReportExecBegin()
+        {
+            if (!_quietBuildReporter && _statusForward != null)
+            {
+                _statusForward($"[EXEC Begin] {FormatProcessInfo(_process.StartInfo, includeWorkingDirectory: false)}");
+            }
+        }
+
+        private void ReportExecEnd(int exitCode)
+        {
+            if (!_quietBuildReporter && _statusForward != null)
+            {
+                bool success = exitCode == 0;
+
+                var message = $"{FormatProcessInfo(_process.StartInfo, includeWorkingDirectory: !success)} exited with {exitCode}";
+
+                _statusForward($"[EXEC End] {message}");
+            }
+        }
+
+        private void ThrowIfRunning([CallerMemberName] string memberName = null)
+        {
+            if (_running)
+            {
+                throw new InvalidOperationException($"Unable to invoke {memberName} after the command has been run");
+            }
+        }
+
+        private void ProcessData(string data, StringWriter capture, Action<string> forward, Action<string> handler)
+        {
+            if (data == null)
+            {
+                return;
+            }
+
+            if (capture != null)
+            {
+                capture.WriteLine(data);
+            }
+
+            if (forward != null)
+            {
+                forward(data);
+            }
+
+            if (handler != null)
+            {
+                handler(data);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Util/CommandResult.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/CommandResult.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.VersionTools.Util
+{
+    struct CommandResult
+    {
+        public static readonly CommandResult Empty = new CommandResult();
+
+        public ProcessStartInfo StartInfo { get; }
+        public int ExitCode { get; }
+        public string StdOut { get; }
+        public string StdErr { get; }
+
+        public CommandResult(ProcessStartInfo startInfo, int exitCode, string stdOut, string stdErr)
+        {
+            StartInfo = startInfo;
+            ExitCode = exitCode;
+            StdOut = stdOut;
+            StdErr = stdErr;
+        }
+
+        public void EnsureSuccessful(bool suppressOutput = false)
+        {
+            if (ExitCode != 0)
+            {
+                StringBuilder message = new StringBuilder($"Command failed with exit code {ExitCode}: {StartInfo.FileName} {StartInfo.Arguments}");
+
+                if (!suppressOutput)
+                {
+                    if (!string.IsNullOrEmpty(StdOut))
+                    {
+                        message.AppendLine($"{Environment.NewLine}Standard Output:{Environment.NewLine}{StdOut}");
+                    }
+
+                    if (!string.IsNullOrEmpty(StdErr))
+                    {
+                        message.AppendLine($"{Environment.NewLine}Standard Error:{Environment.NewLine}{StdErr}");
+                    }
+                }
+
+                throw new Exception(message.ToString());
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/project.json
+++ b/src/Microsoft.DotNet.VersionTools/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "NETStandard.Library": "1.6.0",
+    "Newtonsoft.Json": "9.0.1",
+    "NuGet.Packaging": "3.5.0-rc-1590",
+    "NuGet.Versioning": "3.5.0-rc-1590",
+    "System.Diagnostics.Process": "4.1.0",
+    "System.Diagnostics.TraceSource": "4.0.0"
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -42,5 +42,7 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net45" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net45" />
+    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
+    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net45" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.VersionTools.nuspec
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.VersionTools</id>
+    <version>1.0.26-prerelease</version>
+    <title>Microsoft DotNet VersionTools</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>.NET Core Framework Version Tools</summary>
+    <description>This package provides utilities to help .NET Core builds interact with the versions repository. These contents are provided in Microsoft.DotNet.Buildtools, so you should not need to reference this package from your project unless you do not use BuildTools.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+      <group targetFramework="netstandard1.5">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="NuGet.Packaging" version="3.5.0-beta2-1456" />
+        <dependency id="NuGet.Versioning" version="3.5.0-beta2-1456" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />  
+  </files>
+</package>


### PR DESCRIPTION
Created a new project for "VersionTools" that so far includes auto-upgrade and build-info update. Started with the files in https://github.com/dotnet/cli/tree/rel/1.0.0/build_projects/update-dependencies and [`Command.cs` and `CommandResult.cs`](https://github.com/dotnet/cli/tree/rel/1.0.0/build_projects/Microsoft.DotNet.Cli.Build.Framework), then refactored and added a few features to work with coreclr/corefx requirements. The library should be sharable as an independent package with a little extra work. (For context, @eerhardt's comment on this approach: https://github.com/dotnet/buildtools/pull/848#issuecomment-229671100)

Added a .targets file and two msbuild tasks to integrate with corefx/coreclr/wcf. Example configuration: https://github.com/dagood/corefx/commit/50ad7f7

Test PR the upgrade task made: https://github.com/dagood/corefx/pull/2 (includes two commits I had for debugging: it committed and pushed the last one).

Once threaded through the builds, this will resolve https://github.com/dotnet/buildtools/issues/823 (share upgrade+update scripts), partially https://github.com/dotnet/buildtools/issues/835 (all in one PR), and the upgrade part of https://github.com/dotnet/buildtools/issues/732 (full package versions).

/cc @weshaggard @eerhardt