### PR TITLE
Enable Validation of Xamarin frameworks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoAndroid,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoAndroid,Version=v1.0/FrameworkList.xml
@@ -26,6 +26,7 @@
 <File AssemblyName="System.Diagnostics.TraceEvent" />
 <File AssemblyName="System.Diagnostics.TraceSource" />
 <File AssemblyName="System.Diagnostics.Tracing" />
+<File AssemblyName="System.Drawing.Primitives" />
 <File AssemblyName="System.Dynamic.Runtime" />
 <File AssemblyName="System.Globalization" />
 <File AssemblyName="System.Globalization.Calendars" />
@@ -52,6 +53,7 @@
 <File AssemblyName="System.Net.Mail" />
 <File AssemblyName="System.Net.NameResolution" />
 <File AssemblyName="System.Net.NetworkInformation" />
+<File AssemblyName="System.Net.Ping" />
 <File AssemblyName="System.Net.Primitives" />
 <File AssemblyName="System.Net.Requests" />
 <File AssemblyName="System.Net.Security" />
@@ -66,6 +68,8 @@
 <File AssemblyName="System.Reflection" />
 <File AssemblyName="System.Reflection.DispatchProxy" />
 <File AssemblyName="System.Reflection.Emit" />
+<File AssemblyName="System.Reflection.Emit.Lightweight" />
+<File AssemblyName="System.Reflection.Emit.ILGeneration" />
 <File AssemblyName="System.Reflection.Extensions" />
 <File AssemblyName="System.Reflection.Primitives" />
 <File AssemblyName="System.Reflection.TypeExtensions" />
@@ -77,7 +81,9 @@
 <File AssemblyName="System.Runtime.Handles" />
 <File AssemblyName="System.Runtime.InteropServices" />
 <File AssemblyName="System.Runtime.InteropServices.RuntimeInformation" />
+<File AssemblyName="System.Runtime.InteropServices.WindowsRuntime" />
 <File AssemblyName="System.Runtime.Numerics" />
+<File AssemblyName="System.Runtime.Serialization.Formatters" />
 <File AssemblyName="System.Runtime.Serialization.Json" />
 <File AssemblyName="System.Runtime.Serialization.Primitives" />
 <File AssemblyName="System.Runtime.Serialization.Xml" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoTouch,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoTouch,Version=v1.0/FrameworkList.xml
@@ -26,6 +26,7 @@
   <File AssemblyName="System.Diagnostics.TraceEvent" />
   <File AssemblyName="System.Diagnostics.TraceSource" />
   <File AssemblyName="System.Diagnostics.Tracing" />
+  <File AssemblyName="System.Drawing.Primitives" />
   <File AssemblyName="System.Dynamic.Runtime" />
   <File AssemblyName="System.Globalization" />
   <File AssemblyName="System.Globalization.Calendars" />
@@ -52,6 +53,7 @@
   <File AssemblyName="System.Net.Mail" />
   <File AssemblyName="System.Net.NameResolution" />
   <File AssemblyName="System.Net.NetworkInformation" />
+  <File AssemblyName="System.Net.Ping" />
   <File AssemblyName="System.Net.Primitives" />
   <File AssemblyName="System.Net.Requests" />
   <File AssemblyName="System.Net.Security" />
@@ -76,7 +78,9 @@
   <File AssemblyName="System.Runtime.Handles" />
   <File AssemblyName="System.Runtime.InteropServices" />
   <File AssemblyName="System.Runtime.InteropServices.RuntimeInformation" />
+  <File AssemblyName="System.Runtime.InteropServices.WindowsRuntime" />
   <File AssemblyName="System.Runtime.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization.Formatters" />
   <File AssemblyName="System.Runtime.Serialization.Json" />
   <File AssemblyName="System.Runtime.Serialization.Primitives" />
   <File AssemblyName="System.Runtime.Serialization.Xml" />
@@ -109,4 +113,7 @@
   <File AssemblyName="System.Xml.XPath.XDocument" />
   <File AssemblyName="System.Xml.XPath.XmlDocument" />
   <File AssemblyName="System.Xml.Xsl.Primitives" />
+  <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
+  <File AssemblyName="System.Reflection.Emit.Lightweight" />
+  <File AssemblyName="System.Reflection.Emit.ILGeneration" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.Mac,Version=v2.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.Mac,Version=v2.0/FrameworkList.xml
@@ -26,6 +26,7 @@
 <File AssemblyName="System.Diagnostics.TraceEvent" />
 <File AssemblyName="System.Diagnostics.TraceSource" />
 <File AssemblyName="System.Diagnostics.Tracing" />
+<File AssemblyName="System.Drawing.Primitives" />
 <File AssemblyName="System.Dynamic.Runtime" />
 <File AssemblyName="System.Globalization" />
 <File AssemblyName="System.Globalization.Calendars" />
@@ -52,6 +53,7 @@
 <File AssemblyName="System.Net.Mail" />
 <File AssemblyName="System.Net.NameResolution" />
 <File AssemblyName="System.Net.NetworkInformation" />
+<File AssemblyName="System.Net.Ping" />
 <File AssemblyName="System.Net.Primitives" />
 <File AssemblyName="System.Net.Requests" />
 <File AssemblyName="System.Net.Security" />
@@ -66,6 +68,8 @@
 <File AssemblyName="System.Reflection" />
 <File AssemblyName="System.Reflection.DispatchProxy" />
 <File AssemblyName="System.Reflection.Emit" />
+<File AssemblyName="System.Reflection.Emit.Lightweight" />
+<File AssemblyName="System.Reflection.Emit.ILGeneration" />
 <File AssemblyName="System.Reflection.Extensions" />
 <File AssemblyName="System.Reflection.Primitives" />
 <File AssemblyName="System.Reflection.TypeExtensions" />
@@ -77,7 +81,9 @@
 <File AssemblyName="System.Runtime.Handles" />
 <File AssemblyName="System.Runtime.InteropServices" />
 <File AssemblyName="System.Runtime.InteropServices.RuntimeInformation" />
+<File AssemblyName="System.Runtime.InteropServices.WindowsRuntime" />
 <File AssemblyName="System.Runtime.Numerics" />
+<File AssemblyName="System.Runtime.Serialization.Formatters" />
 <File AssemblyName="System.Runtime.Serialization.Json" />
 <File AssemblyName="System.Runtime.Serialization.Primitives" />
 <File AssemblyName="System.Runtime.Serialization.Xml" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
@@ -26,6 +26,7 @@
   <File AssemblyName="System.Diagnostics.TraceEvent" />
   <File AssemblyName="System.Diagnostics.TraceSource" />
   <File AssemblyName="System.Diagnostics.Tracing" />
+  <File AssemblyName="System.Drawing.Primitives" />
   <File AssemblyName="System.Dynamic.Runtime" />
   <File AssemblyName="System.Globalization" />
   <File AssemblyName="System.Globalization.Calendars" />
@@ -52,6 +53,7 @@
   <File AssemblyName="System.Net.Mail" />
   <File AssemblyName="System.Net.NameResolution" />
   <File AssemblyName="System.Net.NetworkInformation" />
+  <File AssemblyName="System.Net.Ping" />
   <File AssemblyName="System.Net.Primitives" />
   <File AssemblyName="System.Net.Requests" />
   <File AssemblyName="System.Net.Security" />
@@ -76,7 +78,9 @@
   <File AssemblyName="System.Runtime.Handles" />
   <File AssemblyName="System.Runtime.InteropServices" />
   <File AssemblyName="System.Runtime.InteropServices.RuntimeInformation" />
+  <File AssemblyName="System.Runtime.InteropServices.WindowsRuntime" />
   <File AssemblyName="System.Runtime.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization.Formatters" />
   <File AssemblyName="System.Runtime.Serialization.Json" />
   <File AssemblyName="System.Runtime.Serialization.Primitives" />
   <File AssemblyName="System.Runtime.Serialization.Xml" />
@@ -109,4 +113,7 @@
   <File AssemblyName="System.Xml.XPath.XDocument" />
   <File AssemblyName="System.Xml.XPath.XmlDocument" />
   <File AssemblyName="System.Xml.Xsl.Primitives" />
+  <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
+  <File AssemblyName="System.Reflection.Emit.Lightweight" />
+  <File AssemblyName="System.Reflection.Emit.ILGeneration" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
@@ -26,6 +26,7 @@
   <File AssemblyName="System.Diagnostics.TraceEvent" />
   <File AssemblyName="System.Diagnostics.TraceSource" />
   <File AssemblyName="System.Diagnostics.Tracing" />
+  <File AssemblyName="System.Drawing.Primitives" />
   <File AssemblyName="System.Dynamic.Runtime" />
   <File AssemblyName="System.Globalization" />
   <File AssemblyName="System.Globalization.Calendars" />
@@ -52,6 +53,7 @@
   <File AssemblyName="System.Net.Mail" />
   <File AssemblyName="System.Net.NameResolution" />
   <File AssemblyName="System.Net.NetworkInformation" />
+  <File AssemblyName="System.Net.Ping" />
   <File AssemblyName="System.Net.Primitives" />
   <File AssemblyName="System.Net.Requests" />
   <File AssemblyName="System.Net.Security" />
@@ -76,7 +78,9 @@
   <File AssemblyName="System.Runtime.Handles" />
   <File AssemblyName="System.Runtime.InteropServices" />
   <File AssemblyName="System.Runtime.InteropServices.RuntimeInformation" />
+  <File AssemblyName="System.Runtime.InteropServices.WindowsRuntime" />
   <File AssemblyName="System.Runtime.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization.Formatters" />
   <File AssemblyName="System.Runtime.Serialization.Json" />
   <File AssemblyName="System.Runtime.Serialization.Primitives" />
   <File AssemblyName="System.Runtime.Serialization.Xml" />
@@ -109,4 +113,7 @@
   <File AssemblyName="System.Xml.XPath.XDocument" />
   <File AssemblyName="System.Xml.XPath.XmlDocument" />
   <File AssemblyName="System.Xml.Xsl.Primitives" />
+  <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
+  <File AssemblyName="System.Reflection.Emit.Lightweight" />
+  <File AssemblyName="System.Reflection.Emit.ILGeneration" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.iOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.iOS,Version=v1.0/FrameworkList.xml
@@ -26,6 +26,7 @@
   <File AssemblyName="System.Diagnostics.TraceEvent" />
   <File AssemblyName="System.Diagnostics.TraceSource" />
   <File AssemblyName="System.Diagnostics.Tracing" />
+  <File AssemblyName="System.Drawing.Primitives" />
   <File AssemblyName="System.Dynamic.Runtime" />
   <File AssemblyName="System.Globalization" />
   <File AssemblyName="System.Globalization.Calendars" />
@@ -52,6 +53,7 @@
   <File AssemblyName="System.Net.Mail" />
   <File AssemblyName="System.Net.NameResolution" />
   <File AssemblyName="System.Net.NetworkInformation" />
+  <File AssemblyName="System.Net.Ping" />
   <File AssemblyName="System.Net.Primitives" />
   <File AssemblyName="System.Net.Requests" />
   <File AssemblyName="System.Net.Security" />
@@ -76,7 +78,9 @@
   <File AssemblyName="System.Runtime.Handles" />
   <File AssemblyName="System.Runtime.InteropServices" />
   <File AssemblyName="System.Runtime.InteropServices.RuntimeInformation" />
+  <File AssemblyName="System.Runtime.InteropServices.WindowsRuntime" />
   <File AssemblyName="System.Runtime.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization.Formatters" />
   <File AssemblyName="System.Runtime.Serialization.Json" />
   <File AssemblyName="System.Runtime.Serialization.Primitives" />
   <File AssemblyName="System.Runtime.Serialization.Xml" />
@@ -109,4 +113,7 @@
   <File AssemblyName="System.Xml.XPath.XDocument" />
   <File AssemblyName="System.Xml.XPath.XmlDocument" />
   <File AssemblyName="System.Xml.Xsl.Primitives" />
+  <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
+  <File AssemblyName="System.Reflection.Emit.Lightweight" />
+  <File AssemblyName="System.Reflection.Emit.ILGeneration" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -889,7 +889,36 @@
     </DefaultValidateFramework>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(ExcludeXamarinValidationFrameworks)' != 'true'">
+    <DefaultValidateFramework Include="MonoAndroid10">
+      <!-- Intentionally empty, no RIDs defined for MonoAndroid10-->
+      <RuntimeIDs></RuntimeIDs>
+    </DefaultValidateFramework>
+    <DefaultValidateFramework Include="MonoTouch10">
+      <!-- Intentionally empty, no RIDs defined for MonoTouch10-->
+      <RuntimeIDs></RuntimeIDs>
+    </DefaultValidateFramework>
+    <DefaultValidateFramework Include="xamarinios10">
+      <!-- Intentionally empty, no RIDs defined for xamarinios10-->
+      <RuntimeIDs></RuntimeIDs>
+    </DefaultValidateFramework>
+    <DefaultValidateFramework Include="xamarinmac20">
+      <!-- Intentionally empty, no RIDs defined for xamarinmac20-->
+      <RuntimeIDs></RuntimeIDs>
+    </DefaultValidateFramework>
+    <DefaultValidateFramework Include="xamarintvos10">
+      <!-- Intentionally empty, no RIDs defined for xamarintvos10-->
+      <RuntimeIDs></RuntimeIDs>
+    </DefaultValidateFramework>
+    <DefaultValidateFramework Include="xamarinwatchos10">
+      <!-- Intentionally empty, no RIDs defined for xamarinwatchos10-->
+      <RuntimeIDs></RuntimeIDs>
+    </DefaultValidateFramework>
+  </ItemGroup>
+
   <PropertyGroup>
+    <AllXamarinFrameworks Condition="'$(AllXamarinFrameworks)' == ''">MonoAndroid10;MonoTouch10;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10</AllXamarinFrameworks>
+    
     <!-- Skip validation of runtime packages, they will be validated in the context of their reference package -->
     <SkipValidatePackage Condition="'$(SkipValidateTargetFrameworks)' == '' AND '$(PackageTargetRuntime)' != ''">true</SkipValidatePackage>
     <SkipSupportCheck Condition="'$(SkipSupportCheck)' == '' AND ($(Id.StartsWith('System.Private.')) OR $(Id.StartsWith('Microsoft.NETCore.')))">true</SkipSupportCheck>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -728,7 +728,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                                 Log.LogMessage(LogImportance.Low, $"Framework {fx} supported {ContractName} as inbox but the current supported version {supportedVersion} is higher in major.minor than inbox version {inboxVersion}.  Assuming out of box.");
                                 continue;
                             }
-                            else if (supportedVersion != null && supportedVersion < inboxVersion)
+                            else if (supportedVersion != null && supportedVersion < inboxVersion && inboxVersion != s_maxVersion)
                             {
                                 // Lower version
                                 Log.LogError($"Framework {fx} supports {ContractName} as inbox but the current supported version {supportedVersion} is lower than the inbox version {inboxVersion}");


### PR DESCRIPTION
This change turns on validation of Xamarin frameworks and updates our
inbox assembly lists to represent the files which must be provided by
the xamarin SDK (either because they already are, or because they
contain types which overlap with types already in their SDK).

/cc @mhutch @migueldeicaza @marek-safar