### PR TITLE
Removing uploading of xunit perf runner as supplemental payload

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/xunitrunner-perf/xunitrunner-perf.py
@@ -210,7 +210,7 @@ def post_process_perf_results(settings, results_location, workitem_dir, xunit_te
             log.info('Multiple directories found under '+perf_lib_dir+' picking '+os.listdir(perf_lib_dir)[0])
 
         perf_analysis_version = os.listdir(perf_lib_dir)[0]
-        xmlconvertorpath = os.path.join(payload_dir, 'Microsoft.DotNet.xunit.performance.analysis', perf_analysis_version, 'tools', 'xunit.performance.analysis.exe')
+        xmlconvertorpath = os.path.join(payload_dir, 'Microsoft.DotNet.xunit.performance.analysis', perf_analysis_version, 'lib', 'netstandard1.3', 'xunit.performance.analysis.exe')
     elif xunit_test_type == xunit.XUNIT_CONFIG_PERF_LINUX:
         perf_lib_dir = os.path.join(payload_dir, 'Microsoft.DotNet.xunit.performance.analysis.cli')
         if len(os.listdir(perf_lib_dir)) > 1:

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -19,8 +19,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)'=='Windows_NT'">
     <XunitPerfAnalysisPackageId>Microsoft.DotNet.xunit.performance.analysis</XunitPerfAnalysisPackageId>
-    <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools/xunit.performance.analysis.exe</XunitPerfAnalysisPath>
-    <XunitPerfAnalysisDir>$(PackagesDir)$(XunitPerfAnalysisPackageId)/$(XunitPerfAnalysisPackageVersion)/tools</XunitPerfAnalysisDir>
+    <XunitPerfAnalysisPath>$(PackagesDir)$(XunitPerfAnalysisPackageId)\$(XunitPerfAnalysisPackageVersion)\lib\netstandard1.3\xunit.performance.analysis.exe</XunitPerfAnalysisPath>
+    <XunitPerfAnalysisDir>$(PackagesDir)$(XunitPerfAnalysisPackageId)\$(XunitPerfAnalysisPackageVersion)\lib\netstandard1.3</XunitPerfAnalysisDir>
   </PropertyGroup>
 
 
@@ -43,13 +43,6 @@
           DestinationFolder="$(TestWorkingDir)SupplementalPayload/RunnerScripts/xunitrunner-perf"
           SkipUnchangedFiles="true"
           Condition="'$(TargetOS)'=='Linux'"/>
-    <!-- The packages Microsoft.DotNet.xunit.performance.runner.Windows and Microsoft.DotNet.xunit.performance.analysis is not being uploaded alongwith Packages.zip, hence the workaround -->
-    <Copy SourceFiles="@(XunitPerfRunnerFiles)"
-          DestinationFiles="@(XunitPerfRunnerFiles->'$(TestWorkingDir)SupplementalPayload/$(XunitPerfRunnerPackageId)/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"/>
-    <Copy SourceFiles="@(XunitPerfAnalysisFiles)"
-          DestinationFiles="@(XunitPerfAnalysisFiles->'$(TestWorkingDir)SupplementalPayload/$(XunitPerfAnalysisPackageId)/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"/>
   </Target>
 
   <!-- Executable properties -->
@@ -79,10 +72,6 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetOS)'=='Linux'" >
     <TestCommandLines Include = "$HELIX_PYTHONPATH $HELIX_CORRELATION_PAYLOAD/RunnerScripts/xunitrunner-perf/dotnetcliinstaller.py"></TestCommandLines>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
-    <TestCommandLines Include = "xcopy &quot;%PACKAGE_DIR%\$(XunitPerfRunnerPackageId)\$(XunitPerfAnalysisPackageVersion)\tools&quot; &quot;%EXECUTION_DIR%&quot; /s /y"></TestCommandLines>
-    <TestCommandLines Include = "xcopy &quot;%PACKAGE_DIR%\$(XunitPerfAnalysisPackageId)\$(XunitPerfAnalysisPackageVersion)\tools&quot; &quot;%EXECUTION_DIR%&quot; /s /y"></TestCommandLines>
   </ItemGroup>
   <ItemGroup>
     <TestCommandLines Include = "$(PerfTestCommand)"></TestCommandLines>


### PR DESCRIPTION
xunit perf packages starting version 0039 should be correctly included in Runtests.cmd and do not need to be packaged separately as SupplementalPayload
@MattGal @lt72 