### PR TITLE
Add support for private TestILC 

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -53,7 +53,9 @@
 
     <!-- Workaround to bring the whole Test ILC folder if required  -->
     <TestILCVersion>1.4.24208-prerelease</TestILCVersion>
+      
     <TestILCFolder>$(PackagesDir)Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
+    <TestILCFolder Condition="'$(CustomTestILCFolder)' != ''">$(CustomTestILCFolder)</TestILCFolder>
 
     <TestILCZipFileName>TestILC.zip</TestILCZipFileName>
     <TestILCZipFile>$(ArchivesRoot)$(TestILCZipFileName)</TestILCZipFile>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -44,6 +44,8 @@
     <TestILCFolder Condition="'$(EnableCloudTest)' != 'true'">%PACKAGE_DIR%\Microsoft.DotNet.TestILC\$(TestILCVersion)\contentFiles\any\any\TestILC</TestILCFolder>
     <!-- CloudTest.targets will zip up the TestILC folder from within the package path above to this folder.-->
     <TestILCFolder Condition="'$(EnableCloudTest)' == 'true'">%PACKAGE_DIR%\TestILC</TestILCFolder>
+    <TestILCFolder Condition="'$(EnableCloudTest)' != 'true' AND '$(CustomTestILCFolder)' != ''">$(CustomTestILCFolder)</TestILCFolder>
+  
     <TestHostExecutable></TestHostExecutable>
     <XunitExecutable>xunit.console.netcore.exe</XunitExecutable>
   </PropertyGroup>


### PR DESCRIPTION
Add a property, CustomTestILCFolder, that allows overwriting the folder used for ILC for both local and .NET Helix runs

@SedarG 
