### PR TITLE
Update Xamarin profiles - WCF contracts + classic

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoAndroid,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoAndroid,Version=v1.0/FrameworkList.xml
@@ -96,8 +96,11 @@
 <File AssemblyName="System.Security.Cryptography.X509Certificates" />
 <File AssemblyName="System.Security.Principal" />
 <File AssemblyName="System.Security.SecureString" />
+<File AssemblyName="System.ServiceModel.Duplex" />
 <File AssemblyName="System.ServiceModel.Http" />
+<File AssemblyName="System.ServiceModel.NetTcp" />
 <File AssemblyName="System.ServiceModel.Primitives" />
+<File AssemblyName="System.ServiceModel.Security" />
 <File AssemblyName="System.Text.Encoding" />
 <File AssemblyName="System.Text.Encoding.CodePages" />
 <File AssemblyName="System.Text.Encoding.Extensions" />
@@ -117,4 +120,29 @@
 <File AssemblyName="System.Xml.XPath.XmlDocument" />
 <File AssemblyName="System.Xml.Xsl.Primitives" />
 
+<!-- classic assemblies that don't overlap with contracts -->
+<File AssemblyName="mscorlib" />
+<File AssemblyName="SMDiagnostics" />
+<File AssemblyName="System.ComponentModel.Composition" />
+<File AssemblyName="System.ComponentModel.DataAnnotations" />
+<File AssemblyName="System.Core" />
+<File AssemblyName="System.Data" />
+<File AssemblyName="System.Data.Services.Client" />
+<File AssemblyName="System" />
+<File AssemblyName="System.EnterpriseServices" />
+<File AssemblyName="System.IO.Compression.FileSystem" />
+<File AssemblyName="System.Json" />
+<File AssemblyName="System.Net" />
+<File AssemblyName="System.Net.Http.WebRequest" />
+<File AssemblyName="System.Numerics" />
+<File AssemblyName="System.Runtime.Serialization" />
+<File AssemblyName="System.ServiceModel" />
+<File AssemblyName="System.ServiceModel.Internals" />
+<File AssemblyName="System.ServiceModel.Web" />
+<File AssemblyName="System.Transactions" />
+<File AssemblyName="System.Web.Services" />
+<File AssemblyName="System.Windows" />
+<File AssemblyName="System.Xml" />
+<File AssemblyName="System.Xml.Linq" />
+<File AssemblyName="System.Xml.Serialization" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoTouch,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/MonoTouch,Version=v1.0/FrameworkList.xml
@@ -93,8 +93,11 @@
   <File AssemblyName="System.Security.Cryptography.X509Certificates" />
   <File AssemblyName="System.Security.Principal" />
   <File AssemblyName="System.Security.SecureString" />
+  <File AssemblyName="System.ServiceModel.Duplex" />
   <File AssemblyName="System.ServiceModel.Http" />
+  <File AssemblyName="System.ServiceModel.NetTcp" />
   <File AssemblyName="System.ServiceModel.Primitives" />
+  <File AssemblyName="System.ServiceModel.Security" />
   <File AssemblyName="System.Text.Encoding" />
   <File AssemblyName="System.Text.Encoding.CodePages" />
   <File AssemblyName="System.Text.Encoding.Extensions" />
@@ -116,4 +119,27 @@
   <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
   <File AssemblyName="System.Reflection.Emit.Lightweight" />
   <File AssemblyName="System.Reflection.Emit.ILGeneration" />
+
+  <!-- classic assemblies that don't overlap with contracts -->
+  <File AssemblyName="mscorlib" />
+  <File AssemblyName="System.ComponentModel.Composition" />
+  <File AssemblyName="System.ComponentModel.DataAnnotations" />
+  <File AssemblyName="System.Core" />
+  <File AssemblyName="System.Data" />
+  <File AssemblyName="System.Data.Services.Client" />
+  <File AssemblyName="System" />
+  <File AssemblyName="System.IO.Compression.FileSystem" />
+  <File AssemblyName="System.Json" />
+  <File AssemblyName="System.Net" />
+  <File AssemblyName="System.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization" />
+  <File AssemblyName="System.ServiceModel" />
+  <File AssemblyName="System.ServiceModel.Internals" />
+  <File AssemblyName="System.ServiceModel.Web" />
+  <File AssemblyName="System.Transactions" />
+  <File AssemblyName="System.Web.Services" />
+  <File AssemblyName="System.Windows" />
+  <File AssemblyName="System.Xml" />
+  <File AssemblyName="System.Xml.Linq" />
+  <File AssemblyName="System.Xml.Serialization" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.Mac,Version=v2.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.Mac,Version=v2.0/FrameworkList.xml
@@ -96,8 +96,11 @@
 <File AssemblyName="System.Security.Cryptography.X509Certificates" />
 <File AssemblyName="System.Security.SecureString" />
 <File AssemblyName="System.Security.Principal" />
+<File AssemblyName="System.ServiceModel.Duplex" />
 <File AssemblyName="System.ServiceModel.Http" />
+<File AssemblyName="System.ServiceModel.NetTcp" />
 <File AssemblyName="System.ServiceModel.Primitives" />
+<File AssemblyName="System.ServiceModel.Security" />
 <File AssemblyName="System.Text.Encoding" />
 <File AssemblyName="System.Text.Encoding.CodePages" />
 <File AssemblyName="System.Text.Encoding.Extensions" />
@@ -117,4 +120,26 @@
 <File AssemblyName="System.Xml.XPath.XmlDocument" />
 <File AssemblyName="System.Xml.Xsl.Primitives" />
 
+<!-- classic assemblies that don't overlap with contracts -->
+<File AssemblyName="mscorlib" />
+<File AssemblyName="System.ComponentModel.Composition" />
+<File AssemblyName="System.ComponentModel.DataAnnotations" />
+<File AssemblyName="System.Core" />
+<File AssemblyName="System.Data" />
+<File AssemblyName="System.Data.Services.Client" />
+<File AssemblyName="System" />
+<File AssemblyName="System.IO.Compression.FileSystem" />
+<File AssemblyName="System.Json" />
+<File AssemblyName="System.Net" />
+<File AssemblyName="System.Numerics" />
+<File AssemblyName="System.Runtime.Serialization" />
+<File AssemblyName="System.ServiceModel" />
+<File AssemblyName="System.ServiceModel.Internals" />
+<File AssemblyName="System.ServiceModel.Web" />
+<File AssemblyName="System.Transactions" />
+<File AssemblyName="System.Web.Services" />
+<File AssemblyName="System.Windows" />
+<File AssemblyName="System.Xml" />
+<File AssemblyName="System.Xml.Linq" />
+<File AssemblyName="System.Xml.Serialization" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.TVOS,Version=v1.0/FrameworkList.xml
@@ -93,8 +93,11 @@
   <File AssemblyName="System.Security.Cryptography.X509Certificates" />
   <File AssemblyName="System.Security.Principal" />
   <File AssemblyName="System.Security.SecureString" />
+  <File AssemblyName="System.ServiceModel.Duplex" />
   <File AssemblyName="System.ServiceModel.Http" />
+  <File AssemblyName="System.ServiceModel.NetTcp" />
   <File AssemblyName="System.ServiceModel.Primitives" />
+  <File AssemblyName="System.ServiceModel.Security" />
   <File AssemblyName="System.Text.Encoding" />
   <File AssemblyName="System.Text.Encoding.CodePages" />
   <File AssemblyName="System.Text.Encoding.Extensions" />
@@ -116,4 +119,27 @@
   <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
   <File AssemblyName="System.Reflection.Emit.Lightweight" />
   <File AssemblyName="System.Reflection.Emit.ILGeneration" />
+
+  <!-- classic assemblies that don't overlap with contracts -->
+  <File AssemblyName="mscorlib" />
+  <File AssemblyName="System.ComponentModel.Composition" />
+  <File AssemblyName="System.ComponentModel.DataAnnotations" />
+  <File AssemblyName="System.Core" />
+  <File AssemblyName="System.Data" />
+  <File AssemblyName="System.Data.Services.Client" />
+  <File AssemblyName="System" />
+  <File AssemblyName="System.IO.Compression.FileSystem" />
+  <File AssemblyName="System.Json" />
+  <File AssemblyName="System.Net" />
+  <File AssemblyName="System.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization" />
+  <File AssemblyName="System.ServiceModel" />
+  <File AssemblyName="System.ServiceModel.Internals" />
+  <File AssemblyName="System.ServiceModel.Web" />
+  <File AssemblyName="System.Transactions" />
+  <File AssemblyName="System.Web.Services" />
+  <File AssemblyName="System.Windows" />
+  <File AssemblyName="System.Xml" />
+  <File AssemblyName="System.Xml.Linq" />
+  <File AssemblyName="System.Xml.Serialization" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.WatchOS,Version=v1.0/FrameworkList.xml
@@ -93,8 +93,11 @@
   <File AssemblyName="System.Security.Cryptography.X509Certificates" />
   <File AssemblyName="System.Security.Principal" />
   <File AssemblyName="System.Security.SecureString" />
+  <File AssemblyName="System.ServiceModel.Duplex" />
   <File AssemblyName="System.ServiceModel.Http" />
+  <File AssemblyName="System.ServiceModel.NetTcp" />
   <File AssemblyName="System.ServiceModel.Primitives" />
+  <File AssemblyName="System.ServiceModel.Security" />
   <File AssemblyName="System.Text.Encoding" />
   <File AssemblyName="System.Text.Encoding.CodePages" />
   <File AssemblyName="System.Text.Encoding.Extensions" />
@@ -116,4 +119,27 @@
   <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
   <File AssemblyName="System.Reflection.Emit.Lightweight" />
   <File AssemblyName="System.Reflection.Emit.ILGeneration" />
+
+  <!-- classic assemblies that don't overlap with contracts -->
+  <File AssemblyName="mscorlib" />
+  <File AssemblyName="System.ComponentModel.Composition" />
+  <File AssemblyName="System.ComponentModel.DataAnnotations" />
+  <File AssemblyName="System.Core" />
+  <File AssemblyName="System.Data" />
+  <File AssemblyName="System.Data.Services.Client" />
+  <File AssemblyName="System" />
+  <File AssemblyName="System.IO.Compression.FileSystem" />
+  <File AssemblyName="System.Json" />
+  <File AssemblyName="System.Net" />
+  <File AssemblyName="System.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization" />
+  <File AssemblyName="System.ServiceModel" />
+  <File AssemblyName="System.ServiceModel.Internals" />
+  <File AssemblyName="System.ServiceModel.Web" />
+  <File AssemblyName="System.Transactions" />
+  <File AssemblyName="System.Web.Services" />
+  <File AssemblyName="System.Windows" />
+  <File AssemblyName="System.Xml" />
+  <File AssemblyName="System.Xml.Linq" />
+  <File AssemblyName="System.Xml.Serialization" />
 </FileList>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.iOS,Version=v1.0/FrameworkList.xml
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FrameworkLists/Xamarin.iOS,Version=v1.0/FrameworkList.xml
@@ -93,8 +93,11 @@
   <File AssemblyName="System.Security.Cryptography.X509Certificates" />
   <File AssemblyName="System.Security.Principal" />
   <File AssemblyName="System.Security.SecureString" />
+  <File AssemblyName="System.ServiceModel.Duplex" />
   <File AssemblyName="System.ServiceModel.Http" />
+  <File AssemblyName="System.ServiceModel.NetTcp" />
   <File AssemblyName="System.ServiceModel.Primitives" />
+  <File AssemblyName="System.ServiceModel.Security" />
   <File AssemblyName="System.Text.Encoding" />
   <File AssemblyName="System.Text.Encoding.CodePages" />
   <File AssemblyName="System.Text.Encoding.Extensions" />
@@ -116,4 +119,27 @@
   <!-- not actually supported but must be treated as inbox since they are part of a PCL profile this supports -->
   <File AssemblyName="System.Reflection.Emit.Lightweight" />
   <File AssemblyName="System.Reflection.Emit.ILGeneration" />
+
+  <!-- classic assemblies that don't overlap with contracts -->
+  <File AssemblyName="mscorlib" />
+  <File AssemblyName="System.ComponentModel.Composition" />
+  <File AssemblyName="System.ComponentModel.DataAnnotations" />
+  <File AssemblyName="System.Core" />
+  <File AssemblyName="System.Data" />
+  <File AssemblyName="System.Data.Services.Client" />
+  <File AssemblyName="System" />
+  <File AssemblyName="System.IO.Compression.FileSystem" />
+  <File AssemblyName="System.Json" />
+  <File AssemblyName="System.Net" />
+  <File AssemblyName="System.Numerics" />
+  <File AssemblyName="System.Runtime.Serialization" />
+  <File AssemblyName="System.ServiceModel" />
+  <File AssemblyName="System.ServiceModel.Internals" />
+  <File AssemblyName="System.ServiceModel.Web" />
+  <File AssemblyName="System.Transactions" />
+  <File AssemblyName="System.Web.Services" />
+  <File AssemblyName="System.Windows" />
+  <File AssemblyName="System.Xml" />
+  <File AssemblyName="System.Xml.Linq" />
+  <File AssemblyName="System.Xml.Serialization" />
 </FileList>


### PR DESCRIPTION
Xamarin has added facades for these WCF contracts which were already
part of PCL profiles that were supported.

Additionally I am including the list of classic assemblies which are
important as we start to add support for classic surface area to .NET
Core.

We need this to unblock our builds today since we're failing validation
for WCF and System.Json.

/cc @mhutch @marek-safar @StephenBonikowsky 