### PR TITLE
Remove support for unknown parameters

### DIFF
--- a/src/Run/CommandLine.cs
+++ b/src/Run/CommandLine.cs
@@ -322,7 +322,10 @@ class CommandLine
             }, (parser, ex) =>
             {
                 Console.Error.WriteLine("Error: " + ex.Message);
-                Console.Error.WriteLine("Use -? for help.");
+                
+                Console.ForegroundColor = ConsoleColor.DarkYellow;
+                Console.WriteLine("Our dev workflow has changed! Use -? for help in the new options we have and how to pass parameters now.");
+                Console.ResetColor();
             },
             setupContent, args);
         }
@@ -784,7 +787,7 @@ class CommandLine
             if(!string.IsNullOrEmpty(globalQualifiers))
             {
                 sb.AppendLine().Append('-', maxLineWidth - 1).AppendLine();
-                sb.Append("Global settings to all commands:").AppendLine();
+                sb.Append("Global Settings:").AppendLine();
                 sb.AppendLine();
                 sb.Append(globalQualifiers);
             }
@@ -1591,11 +1594,10 @@ class CommandLine
             string appName = GetEntryAssemblyName();
             StringBuilder sb = new StringBuilder();
             sb.AppendLine();
-            string text = "The Run Commant Tool has a number of dev workflow steps associated with it, " +
-                "each with its own command and set of actions that are listed below.  " +
-                "It also provides a list of Global Settings that can be applied to the commands.";
+            string text = "The Run Commant Tool is now in charge of running the dev workflow steps. Each step has its own command and set of actions that are listed below.  " +
+                "You could also pass Global Settings to the commands.";
             Wrap(sb, text, 0, String.Empty, maxLineWidth, true);
-            text = "To pass additional parameters that are not described in the global settings, use `--`. After this command, the Run Command Tool will stop processing arguments and will pass all the information as it is to the selected command.";
+            text = "To pass additional parameters that are not described in the Global Settings section, use `--`. After this command, the Run Command Tool will stop processing arguments and will pass all the information as it is to the selected command.";
             Wrap(sb, text, 0, String.Empty, maxLineWidth, true);
             text = "The information comes from a config.json file. By default the file is in the root of the repo. Otherwise the first parameter should be the path to the config.json file.";
             Wrap(sb, text, 0, String.Empty, maxLineWidth, true);

--- a/src/Run/CommandLine.cs
+++ b/src/Run/CommandLine.cs
@@ -1126,20 +1126,10 @@ class CommandLine
                 {
                     if (IsDash(name[0]))
                     {
-                        string temp = string.Empty;
-                        string[] extraP = new string[_args.Count - i];
-                        int j = 0;
-                        if (name.Length != 1)
-                        {
-                            temp = _args[i].Substring(2);
-                            extraP[j] = temp;
-                            j ++;
-                        }
-
                         _args[i] = null;
                         i++;
-                        
-                        for (; i < _args.Count; i++, j++)
+                        string[] extraP = new string[_args.Count - i];
+                        for (int j = 0; i < _args.Count; i++, j++)
                         {
                             extraP[j] = _args[i];
                             _args[i] = null;

--- a/src/Run/CommandLine.cs
+++ b/src/Run/CommandLine.cs
@@ -630,10 +630,10 @@ class CommandLine
                 }
             }
             
-            if (unusedParameters != null)
+            if (unusedParameters.Count > 0)
             {
-                _extraparameters = string.Join(" ", unusedParameters);
-                //throw new CommandLineParserException("Extra positional parameter: " + _args[_curPosition] + ".");
+                //_extraparameters = string.Join(" ", unusedParameters);
+                throw new CommandLineParserException("Parameter not recognized: " + unusedParameters[0] + ".");
             }
                 
 
@@ -1123,6 +1123,14 @@ class CommandLine
                     if (name.Length == 1 && IsDash(name[0]))
                     {
                         _args[i] = null;
+                        i++;
+                        string[] extraP = new string[_args.Count-i];
+                        for (int j = 0; i < _args.Count; i++, j++)
+                        {
+                            extraP[j] = _args[i];
+                            _args[i] = null;
+                        }
+                        _extraparameters = string.Join(" ", extraP);
                         break;
                     }
                     if (name == "?")        // Did the user request help?

--- a/src/Run/CommandLine.cs
+++ b/src/Run/CommandLine.cs
@@ -1120,12 +1120,22 @@ class CommandLine
                 string name = ParseParameterName(arg);
                 if (name != null)
                 {
-                    if (name.Length == 1 && IsDash(name[0]))
+                    if (IsDash(name[0]))
                     {
+                        string temp = string.Empty;
+                        string[] extraP = new string[_args.Count - i];
+                        int j = 0;
+                        if (name.Length != 1)
+                        {
+                            temp = _args[i].Substring(2);
+                            extraP[j] = temp;
+                            j ++;
+                        }
+
                         _args[i] = null;
                         i++;
-                        string[] extraP = new string[_args.Count-i];
-                        for (int j = 0; i < _args.Count; i++, j++)
+                        
+                        for (; i < _args.Count; i++, j++)
                         {
                             extraP[j] = _args[i];
                             _args[i] = null;

--- a/src/Run/CommandLine.cs
+++ b/src/Run/CommandLine.cs
@@ -316,7 +316,8 @@ class CommandLine
                     //helpString = parser.GetHelp(GetConsoleWidth() - 1, parameterSetTofocusOn, true);
                 }
 
-                helpString = parser.GetHelp(GetConsoleWidth() - 1, parameterSetTofocusOn, true);
+                helpString = parser.GetIntroTextForHelp(GetConsoleWidth() - 1).ToString();
+                helpString += parser.GetHelp(GetConsoleWidth() - 1, parameterSetTofocusOn, true);
                 DisplayStringToConsole(helpString);
             }, (parser, ex) =>
             {
@@ -1585,6 +1586,26 @@ class CommandLine
             }
         }
 
+        private StringBuilder GetIntroTextForHelp(int maxLineWidth)
+        {
+            string appName = GetEntryAssemblyName();
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine();
+            string text = "The Run Commant Tool has a number of dev workflow steps associated with it, " +
+                "each with its own command and set of actions that are listed below.  " +
+                "It also provides a list of Global Settings that can be applied to the commands.";
+            Wrap(sb, text, 0, String.Empty, maxLineWidth, true);
+            text = "To pass additional parameters that are not described in the global settings, use `--`. After this command, the Run Command Tool will stop processing arguments and will pass all the information as it is to the selected command.";
+            Wrap(sb, text, 0, String.Empty, maxLineWidth, true);
+            text = "The information comes from a config.json file. By default the file is in the root of the repo. Otherwise the first parameter should be the path to the config.json file.";
+            Wrap(sb, text, 0, String.Empty, maxLineWidth, true);
+            text = "For more information about the Run Command Tool: https://github.com/dotnet/buildtools/blob/master/Documentation/RunCommand.md";
+            Wrap(sb, text, 0, String.Empty, maxLineWidth, true);
+            sb.AppendLine().AppendLine().Append("Sintaxis: run [Command] [Action] (global settings)");
+            sb.AppendLine().Append('-', maxLineWidth - 1).AppendLine();
+            return sb;
+        }
+
 
         /// <summary>
         /// Return a string giving the help for the command, word wrapped at 'maxLineWidth'
@@ -1604,22 +1625,12 @@ class CommandLine
             
             if (!hasParamSets)
                 return GetHelp(maxLineWidth, String.Empty, true);
+
             StringBuilder sb = new StringBuilder();
-
-
-            string appName = GetEntryAssemblyName();
-            sb.AppendLine();
-            string intro = "The " + appName + " has a number of dev workflow steps associated with it, " +
-                "each with its own command and set of actions. They are listed below.  " +
-                "Settings that are common to all commands are listed at the end.";
-            Wrap(sb, intro, 0, String.Empty, maxLineWidth, true);
-            sb.Append("The information comes from a config.json file. By default the file is in the root of the repo. Otherwise the first parameter should be the path to the config.json file.");
-            sb.AppendLine().AppendLine().Append("Sintaxis: executor [Command] [Action] (global settings)");
-
+                        
             // Always print the default parameter set first.
             if (_defaultParamSetEncountered)
             {
-                sb.AppendLine().Append('-', maxLineWidth - 1).AppendLine();
                 sb.Append(GetHelp(maxLineWidth, String.Empty, false));
             }
 
@@ -1627,7 +1638,6 @@ class CommandLine
             {
                 if (parameter.IsParameterSet && parameter.Name.Length != 0)
                 {
-                    sb.AppendLine().Append('-', maxLineWidth - 1).AppendLine();
                     sb.Append(GetHelp(maxLineWidth, parameter.Name, false));
                 }
             }

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -215,6 +215,10 @@ namespace Microsoft.DotNet.Execute
         {
             int namePos, valuePos;
             string tempParam, name, value;
+            if(string.IsNullOrEmpty(extraParameters))
+            {
+                return true;
+            }
 
             string[] extraA = extraParameters.Split(' ');
             foreach (string param in extraA)


### PR DESCRIPTION
Before, the Run Command Tool was concatenating all the unknown parameters that were passed by the user. When running the command, it was passing this new string and it was the responsibility of the tool (i.e. msbuild) to work with those unknown parameters.

`build.cmd cross /p:ConfigurationGroup=Debug => msbuild cross /p:ConfigurationGroup=Debug`

With this change, the Run Command Tool will throw an error when there is an unknown parameter.
To pass extra parameters to the command, the user can use `--`, meaning that all the text that is after `--` will be passed and then it would be the responsibility of the tool (i.e. msbuild) to work with them.

```
build.cmd cross /p:ConfigurationGroup=Debug => Error: Parameter not recognized: cross
build.cmd -- cross /p:ConfigurationGroup=Debug => msbuild cross /p:ConfigurationGroup=Debug
````

cc: @joperezr @Priya91 @markwilkie 