### PR TITLE
Fix issue of not finding the props file when OfficialBuildId is passed in

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BuildVersion.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BuildVersion.targets
@@ -1,7 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
   <PropertyGroup>
-    <TodayTimeStamp>$([System.DateTime]::Now.ToString(yyyyMMdd))</TodayTimeStamp>
+    <!-- If OfficialBuildId is passed in, then use it as Today's TimeStamp, else default to today -->
+    <TodayTimeStamp Condition="'$(OfficialBuildId)'!=''">$(OfficialBuildId)</TodayTimeStamp>
+    <TodayTimeStamp Condition="'$(TodayTimeStamp)'==''">$([System.DateTime]::Now.ToString(yyyyMMdd))</TodayTimeStamp>
     <BuildVersionFilePath>$(BaseIntermediateOutputPath)</BuildVersionFilePath>
     <BuildVersionFile Condition="'$(BuildVersionFile)'==''">$(BuildVersionFilePath)BuildVersion-$(TodayTimeStamp).props</BuildVersionFile>
   </PropertyGroup>


### PR DESCRIPTION
cc: @Chrisboh @jhendrixMSFT @chcosta 

This fixes the issue of some builds failing whenever the props was generated using date.now, since that varies during the time of your build. The problem with this, is that now we will depend on `$(OfficialBuildId)` property to get passed in for every step of the Build Pipeline flow so that we know where to load the props file from. I don't love this approach, but I can't really think of a better way to handle this. 