### PR TITLE
Fix Newtonsoft issue with BuildTasks

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1",
     "NuGet.Versioning": "3.5.0-rc-1590",
     "System.Reflection.Metadata": "1.1.0"
   },

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/project.json
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/project.json
@@ -5,7 +5,7 @@
     "System.Security.Cryptography.Algorithms": "4.2.0-rc3-24128-00",
     "System.Reflection.Metadata": "1.3.0-rc3-24128-00",
     "NETStandard.Library": "1.5.0-rc2-24027",
-    "Newtonsoft.Json": "7.0.1"
+    "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1",
     "NuGet.Client": "3.5.0-rc-1590",
     "System.Reflection.Metadata": "1.0.22",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24128-00"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
@@ -3,7 +3,7 @@
     "System.Reflection.Metadata": "1.3.0-rc3-24128-00",
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1",
     "NuGet.Client": "3.5.0-rc-1590",
     "NETStandard.Library": "1.5.0-rc2-24027"
   },

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.0",
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1",
     "NuGet.Client": "3.5.0-rc-1590",
     "System.Reflection.Metadata": "1.0.22",
     "xunit": "2.1.0",

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1",
     "NuGet.Client": "3.5.0-rc-1590",
     "NETStandard.Library": "1.5.0-rc2-24027",
     "Microsoft.NETCore.Targets": "1.0.1-rc2-24027",


### PR DESCRIPTION
Upgrade remaining projects to newer NewtonSoft to avoid FileNotFound Exception at runtime

Tested to run using local .NET Helix run (05b56f31-df45-499a-9806-0b8fca37e4cc), and via inspection of assembly manifests for affected files.

@dagood 
@karajas 