### PR TITLE
Fix clean.cmd when no option is provided

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -12,7 +12,8 @@ if [%1] == [-all] (
   exit /b !ERRORLEVEL!
 )
 
-call %~dp0run.cmd clean %*
+if [%1]==[] set __args=-b
+call %~dp0run.cmd clean %__args% %*
 exit /b %ERRORLEVEL%
 
 :Usage


### PR DESCRIPTION
When no option is provided clean.cmd should run `clean -b`.

cc: @joperezr @Priya91 @tyoverby