### PR TITLE
Add if file "_version.h" exist condition

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -125,7 +125,7 @@
       Inputs="$(MSBuildProjectFile)"
       Outputs="$(NativeVersionHeaderFile)"
       DependsOnTargets="CreateVersionFileDuringBuild;GetLatestCommitHash"
-      Condition="'$(NativeVersionHeaderFile)'!='' and '$(GenerateVersionHeader)'=='true'">
+      Condition="'$(NativeVersionHeaderFile)'!='' and '$(GenerateVersionHeader)'=='true' and !Exists($(NativeVersionHeaderFile))">
 
     <ItemGroup>
       <!-- Defining versioning variables -->


### PR DESCRIPTION
When we are building the native binaries in CoreFx, we have a condition in the script that checks if the file `_verison.h` is present. If it is not present then it would run the `GenerateVersionHeader` target.
```
if not exist "%__binDir%\obj\_version.h" (
    msbuild "%~dp0build.proj" /nologo /t:GenerateVersionHeader /p:GenerateNativeVersionInfo=true
)
```

With this change I'm deleting the condition from the script and adding it to the version.targets file.

cc: @joperezr 