### PR TITLE
VS debugging fixes for tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -188,7 +188,7 @@
         DnuRestoreCommand - Used to restore the project packages from project.json
         PackagesDir - Packages are restored to and resolved from this location    
    -->
-  <Import Project="$(MSBuildThisFileDirectory)tests.targets" Condition="'$(IsTestProject)'=='true' and '$(ExcldueTestsImport)'!='true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)tests.targets" Condition="'$(IsTestProject)'=='true' and '$(ExcludeTestsImport)'!='true'"/>
   
   <!-- 
     Import the PackageLibs.targets which exposes targets from library projects to report what
@@ -218,7 +218,7 @@
         PackageIncludeDocs - true to include the docs next to this project's ouput.  Default
                              is true for reference assemblies, false for implementation.
    -->
-  <Import Project="$(MSBuildThisFileDirectory)PackageLibs.targets" Condition="'$(ExclduePackageLibsImport)'!='true'"/>
+  <Import Project="$(MSBuildThisFileDirectory)PackageLibs.targets" Condition="'$(ExcludePackageLibsImport)'!='true'"/>
 
   <Target Name="CheckDesignTime">
     <!--

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -204,7 +204,39 @@
     </Copy>
   </Target>
 
-  <!-- archive the test binaries along with some supporting files -->
+  <!-- Workaround for VS execution:  This will form the same list and copy the same files as
+       copied via RunTests script so VS can work when the test dir is initially clean. 
+       -->
+  <Target Name="CopyRunnerScriptFiles" Condition=" '$(BuildingInsideVisualStudio)'=='true' "
+        AfterTargets="CopySupplementalTestData">
+    <Message Text ="Copying over test dependencies since we're running inside Visual studio." />
+     <!-- This was copied from RunTestsForProject in tests.targets 
+          The RunTestsForProject target does not execute in VS context and would be confused by the script based runner.
+     -->
+    <ItemGroup>
+      <!-- Not all platforms can use the .ni.dlls that come from packages.  If TestWithoutNativeImages is specified, we'll exclude them from copy generation.
+           If we end up needing this for any other sorts of filtering, we'll want to add a list of filtered extensions to be matched on EndsWith.  -->
+      <_IncludedFileForTestsInVS Include="@(_TestCopyLocalByFileNameWithoutDuplicates)"
+                                 Condition="'$(TestWithoutNativeImages)' != 'true' Or !$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').EndsWith('.ni.dll'))" >
+        <PackageRelativePath Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.NugetPackageId)' != ''">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').Replace('$(PackagesDir)',''))</PackageRelativePath>
+        <UseAbsolutePath Condition="'$(TestWithLocalLibraries)'=='true'">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').StartsWith('$(BinDir)'))</UseAbsolutePath>
+      </_IncludedFileForTestsInVS>
+      <_DestinationsForTestsInVS Include="@(_IncludedFileForTestsInVS->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)')" />
+    </ItemGroup>
+    
+    <Copy
+      SourceFiles="@(_IncludedFileForTestsInVS  -> '%(SourcePath)')"
+      DestinationFiles="@(_DestinationsForTestsInVS)"
+      SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="true">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>    
+  </Target>
+
+    <!-- archive the test binaries along with some supporting files -->
   <Target Name="ArchiveTestBuild" Condition="'$(ArchiveTests)' == 'true'"  DependsOnTargets="RunTestsForProject">
     <PropertyGroup>
       <TestArchiveDir>$(TestWorkingDir)$(OSPlatformConfig)/archive/tests/</TestArchiveDir>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -207,11 +207,11 @@
   <!-- Workaround for VS execution:  This will form the same list and copy the same files as
        copied via RunTests script so VS can work when the test dir is initially clean. 
        -->
-  <Target Name="CopyRunnerScriptFiles" Condition=" '$(BuildingInsideVisualStudio)'=='true' "
+  <Target Name="CopyRunnerScriptFiles" Condition="'$(BuildingInsideVisualStudio)'=='true'"
         AfterTargets="CopySupplementalTestData">
-    <Message Text ="Copying over test dependencies since we're running inside Visual studio." />
      <!-- This was copied from RunTestsForProject in tests.targets 
           The RunTestsForProject target does not execute in VS context and would be confused by the script based runner.
+          _TestCopyLocalByFileNameWithoutDuplicates are the precise items that are fed to the runner script generation code.
      -->
     <ItemGroup>
       <!-- Not all platforms can use the .ni.dlls that come from packages.  If TestWithoutNativeImages is specified, we'll exclude them from copy generation.

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -127,7 +127,7 @@
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">
     <StartWorkingDirectory Condition="'$(StartWorkingDirectory)'==''">$(TestPath)$(DebugTestFrameworkFolder)</StartWorkingDirectory>
     <StartAction Condition="'$(StartAction)'==''">Program</StartAction>
-    <StartProgram Condition="'$(StartProgram)'==''">$(TestProgram)</StartProgram>
+    <StartProgram Condition="'$(StartProgram)'==''">$(TestHostDirectory)$(TestProgram)</StartProgram>
     <StartArguments Condition="'$(StartArguments)'==''">$(TestArguments) -wait -parallel none</StartArguments>
   </PropertyGroup>
 


### PR DESCRIPTION
Addresses Issues #699 and #700, with a couple typos fixed as well (searched repository, did not find other usages of the incorrectly spelled properties).

In order for the F5 scenario to work for CoreFX and other tests that use these .targets files, we need the files which are normally copied by the runner scripts (RunTests.cmd / .sh) to be copied before starting CoreRun.exe.  Running the script before debugging was a workaround, but by adding a target that executes at the end of other test copying code and only when the condition '$(BuildingInsideVisualStudio)'=='true'  is met works around this.  It uses the exact same file list generated for RunTests, and would not affect execution of the RunTests script before or after it is used.

@weshaggard @stephentoub @AtsushiKan 