### PR TITLE
Change AfterTargets value for GenerateFullCoverageReport

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -65,7 +65,7 @@
   </Target>
 
   <PropertyGroup Condition="'$(GenerateFullCoverageReport)'=='true'">
-    <GenerateFullCoverageReportAfterTargets Condition="'$(GenerateFullCoverageReportAfterTargets)'==''">Test</GenerateFullCoverageReportAfterTargets>
+    <GenerateFullCoverageReportAfterTargets Condition="'$(GenerateFullCoverageReportAfterTargets)'==''">TestAllProjects</GenerateFullCoverageReportAfterTargets>
   </PropertyGroup>
 
   <!-- Generate coverage report for all the projects. -->


### PR DESCRIPTION
The FullCoverage report at some point recently stopped getting the Target that calls it invoked.  I made the below change in my repo and was able to get it working again.   There may be other Jenkins issues affecting this, as if incremental build happens, coverage measurement does not.

@stephentoub 