### PR TITLE
Returning exit code of the DefineParameters function

### DIFF
--- a/src/Run/Executor.cs
+++ b/src/Run/Executor.cs
@@ -159,6 +159,7 @@ namespace Microsoft.DotNet.Execute
                 }
                 return jsonSetup.ExecuteCommand(executor.CommandSelectedByUser, paramSelected);
             }
+            //There was an error when parsing the user input, Define Parameters is in charge of printing an error message.
             return 1;
         }
     }

--- a/src/Run/Executor.cs
+++ b/src/Run/Executor.cs
@@ -144,25 +144,22 @@ namespace Microsoft.DotNet.Execute
                 Console.Error.WriteLine("Error: Could not load Json configuration file.");
                 return 1;
             }
-            else
-            {
-                string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows": "unix";
+            string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows": "unix";
 
-                jsonSetup.prepareValues(os, executor.SettingParameters, executor.configFilePath);
-                if (executor.DefineParameters(parseArgs, jsonSetup))
+            jsonSetup.prepareValues(os, executor.SettingParameters, executor.configFilePath);
+            if (executor.DefineParameters(parseArgs, jsonSetup))
+            {
+                List<string> paramSelected = new List<string>();
+                foreach (KeyValuePair<string, string> param in executor.CommandParameters[executor.CommandSelectedByUser])
                 {
-                    List<string> paramSelected = new List<string>();
-                    foreach(KeyValuePair<string, string> param in executor.CommandParameters[executor.CommandSelectedByUser])
+                    if (!string.IsNullOrEmpty(param.Value))
                     {
-                        if (!string.IsNullOrEmpty(param.Value))
-                        {
-                            paramSelected.Add(param.Key);
-                        }
+                        paramSelected.Add(param.Key);
                     }
-                    return jsonSetup.ExecuteCommand(executor.CommandSelectedByUser, paramSelected);
                 }
+                return jsonSetup.ExecuteCommand(executor.CommandSelectedByUser, paramSelected);
             }
-            return 0;
+            return 1;
         }
     }
 }


### PR DESCRIPTION
If there was a failure when parsing arguments, the Run Command Tool was returning 0 as the exit code.

With this change the tool returns the correct exit code.

cc: @Priya91 @joperezr 