### PR TITLE
Adds RID arm64 to Testing runtime.json

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -17,7 +17,7 @@
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <Targets>GetPackageAssets</Targets>
         <OutputItemType>PkgProjAsset</OutputItemType>
-        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
+        <UndefineProperties>%(ProjectReference.UndefineProperties);OSGroup;TargetGroup</UndefineProperties>
       </ProjectReference>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -844,7 +844,7 @@
       <RuntimeIDs>win7-x86;win7-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;linuxmint.17-x64;opensuse.13.2-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="netcoreapp1.1">
-      <RuntimeIDs>win7-x86;win7-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;linuxmint.17-x64;opensuse.13.2-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64</RuntimeIDs>
+      <RuntimeIDs>win7-x86;win7-x64;win10-arm64;osx.10.11-x64;centos.7-x64;debian.8-x64;linuxmint.17-x64;opensuse.13.2-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64</RuntimeIDs>
     </DefaultValidateFramework>
 
     <DefaultValidateFramework Include="netcore50">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -63,6 +63,9 @@
     <TestNugetTargetMoniker Include=".NETCoreApp,Version=v1.0" Condition="'$(TestTFM)' == 'netcoreapp1.0'">
       <Folder>netcoreapp1.0</Folder>
     </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Include=".NETCoreApp,Version=v1.1" Condition="'$(TestTFM)' == 'netcoreapp1.1'">
+      <Folder>netcoreapp1.1</Folder>
+    </TestNugetTargetMoniker>
     <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.3" Condition="'$(TestTFM)' == 'net463'">
       <Folder>net462</Folder>
     </TestNugetTargetMoniker>

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -78,6 +78,20 @@
                 "fedora.23-x64",
                 "linux-x64",
                 "opensuse.13.2-x64"
+            ],
+            "netcoreapp1.1": [
+                "win7-x86",
+                "win7-x64",
+                "win10-arm64",
+                "osx.10.10-x64",
+                "centos.7-x64",
+                "debian.8-x64",
+                "rhel.7-x64",
+                "ubuntu.14.04-x64",
+                "ubuntu.16.04-x64",
+                "fedora.23-x64",
+                "linux-x64",
+                "opensuse.13.2-x64"
             ]
         },
         "coreFx.Test.netcoreapp1.1": {

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -84,6 +84,7 @@
             "netcoreapp1.1": [
                 "win7-x86",
                 "win7-x64",
+                "win10-arm64",
                 "osx.10.10-x64",
                 "centos.7-x64",
                 "debian.8-x64",


### PR DESCRIPTION
unblocks building CoreFX tests for ARM64.