### PR TITLE
Add support for PostExecutionTestCommandLines

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -243,6 +243,10 @@
       <TestCommandLines Include="copy /y testResults.xml %EXECUTION_DIR%\" />
     </ItemGroup>
 
+    <!-- Do not put anything between this Item Group and the GenerateTestExecutionScripts invocation -->
+    <ItemGroup>
+      <TestCommandLines Include="@(PostExecutionTestCommandLines)" />
+    </ItemGroup>
     <GenerateTestExecutionScripts
       TestCommands="@(TestCommandLines)"
       TestDependencies="@(IncludedFileForRunnerScript)"


### PR DESCRIPTION
Allows sequential commands to be run after a test completes.  These can perform cleanup, call post-run scripts, etc.

@hongdai 