### PR TITLE
TarGzFileExtractToDirectory

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/TarGzFileCreateFromDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/TarGzFileCreateFromDirectory.cs
@@ -74,11 +74,6 @@ namespace Microsoft.DotNet.Build.Tasks
             return retVal;
         }
 
-        public override bool Execute()
-        {
-            return base.Execute();
-        }
-
         protected override string ToolName
         {
             get { return "tar"; }

--- a/src/Microsoft.DotNet.Build.Tasks/TarGzFileExtractToDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/TarGzFileExtractToDirectory.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class TarGzFileExtractToDirectory : ToolTask
+    {
+        /// <summary>
+        /// The path to the archive to extract.
+        /// </summary>
+        [Required]
+        public string SourceArchive { get; set; }
+
+        /// <summary>
+        /// The path of the directory to which the archive should be extracted.
+        /// </summary>
+        [Required]
+        public string DestinationDirectory { get; set; }
+
+        /// <summary>
+        /// Indicates if the destination directory should be cleaned if it already exists.
+        /// </summary>
+        public bool OverwriteDestination { get; set; }
+
+        protected override bool ValidateParameters()
+        {
+            base.ValidateParameters();
+
+            var retVal = true;
+
+            if (Directory.Exists(DestinationDirectory))
+            {
+                if (OverwriteDestination == true)
+                {
+                    Log.LogMessage(MessageImportance.Low, "'{0}' already exists, trying to delete before unzipping...", DestinationDirectory);
+                    Directory.Delete(DestinationDirectory, recursive: true);
+                }
+                else
+                {
+                    Log.LogWarning("'{0}' already exists. Did you forget to set '{1}' to true?", DestinationDirectory, nameof(OverwriteDestination));
+
+                    retVal = false;
+                }
+            }
+
+            if (!File.Exists(SourceArchive))
+            {
+                Log.LogError($"SourceArchive '{SourceArchive} does not exist.");
+
+                retVal = false;
+            }
+
+            if (retVal)
+            {
+                Log.LogMessage($"Creating Directory {DestinationDirectory}");
+                Directory.CreateDirectory(DestinationDirectory);
+            }
+            
+            return retVal;
+        }
+
+        public override bool Execute()
+        {
+            bool retVal = base.Execute();
+
+            if (!retVal)
+            {
+                Log.LogMessage($"Deleting Directory {DestinationDirectory}");
+                Directory.Delete(DestinationDirectory);
+            }
+
+            return retVal;
+        }
+
+        protected override string ToolName
+        {
+            get { return "tar"; }
+        }
+
+        protected override MessageImportance StandardOutputLoggingImportance
+        {
+            get { return MessageImportance.High; } // or else the output doesn't get logged by default
+        }
+
+        protected override string GenerateFullPathToTool()
+        {
+            return "tar";
+        }
+
+        protected override string GenerateCommandLineCommands()
+        {
+            return $"xf {GetSourceArchive()} -C {GetDestinationDirectory()}";
+        }
+        
+        private string GetSourceArchive()
+        {
+            return SourceArchive;
+        }
+
+        private string GetDestinationDirectory()
+        {
+            return DestinationDirectory;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileExtractToDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileExtractToDirectory.cs
@@ -13,19 +13,19 @@ namespace Microsoft.DotNet.Build.Tasks
     public sealed class ZipFileExtractToDirectory : Task
     {
         /// <summary>
-        /// The path to the directory to be archived.
+        /// The path to the archive to extract.
         /// </summary>
         [Required]
         public string SourceArchive { get; set; }
 
         /// <summary>
-        /// The path of the archive to be created.
+        /// The path of the directory to which the archive should be extracted.
         /// </summary>
         [Required]
         public string DestinationDirectory { get; set; }
 
         /// <summary>
-        /// Indicates if the destination archive should be overwritten if it already exists.
+        /// Indicates if the destination directory should be cleaned if it already exists.
         /// </summary>
         public bool OverwriteDestination { get; set; }
 


### PR DESCRIPTION
Adds TarGzFileExtractToDirectory
Also cleans up unnecessary override in TarGzFileCreateFromDirectory and out-of-date comments in ZipFileExtractToDirectory
