### PR TITLE
Add S.P.CoreLib to the ignore list for generation validation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -205,7 +205,7 @@
           Condition="'$(PackageTargetFramework)' != '' AND '$(SkipValidatePackageTargetFramework)' != 'true'"
           AfterTargets="ResolveReferences">
     <ItemGroup Condition="'@(ValidateIgnoreReference)' == ''">
-      <ValidateIgnoreReference Include="mscorlib;System.Private.Uri;Windows" />
+      <ValidateIgnoreReference Include="mscorlib;System.Private.CoreLib;System.Private.Uri;Windows" />
     </ItemGroup>
 
     <ValidatePackageTargetFramework AssemblyName="$(AssemblyName)"


### PR DESCRIPTION
When we start referencing S.P.CoreLib generation validation starts complaining about it. So we need to add it to the ignore list similar to mscorlib. 

cc @stephentoub @ericstj

