### PR TITLE
Attribute, operators, extern modifier fixes

### DIFF
--- a/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/PublicOnlyCciFilter.cs
@@ -63,8 +63,22 @@ namespace Microsoft.Cci.Filters
             if (this.ExcludeAttributes)
                 return false;
 
-            // Always return the custom attributes if ExcludeAttributes is not set
-            // the PublicOnly mainly concerns the types and members.
+            // Ignore attributes not visible outside the assembly
+            var attributeDef = attribute.Type.GetDefinitionOrNull();
+            if (attributeDef != null && !attributeDef.IsVisibleOutsideAssembly())
+                return false;
+
+            // Ignore attributes with typeof argument of a type invisible outside the assembly
+            foreach(var arg in attribute.Arguments.OfType<IMetadataTypeOf>())
+            {
+                var typeDef = arg.TypeToGet.GetDefinitionOrNull();
+                if (typeDef == null)
+                    continue;
+
+                if (!typeDef.IsVisibleOutsideAssembly())
+                    return false;
+            }
+
             return true;
         }
     }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -50,6 +50,13 @@ namespace Microsoft.Cci.Writers.CSharp
             WriteEmptyBody();
         }
 
+        private void WriteTypeName(ITypeReference type, ITypeReference containingType, bool isDynamic = false)
+        {
+            var useKeywords = containingType.GetTypeName() != type.GetTypeName();
+
+            WriteTypeName(type, isDynamic: isDynamic, useTypeKeywords: useKeywords);
+        }
+
         private void WriteMethodDefinitionSignature(IMethodDefinition method, string name)
         {
             bool isOperator = method.IsConversionOperator();
@@ -58,7 +65,7 @@ namespace Microsoft.Cci.Writers.CSharp
             {
                 WriteAttributes(method.ReturnValueAttributes, true);
                 // We are ignoring custom modifiers right now, we might need to add them later.
-                WriteTypeName(method.Type, isDynamic: IsDynamic(method.ReturnValueAttributes));
+                WriteTypeName(method.Type, method.ContainingType, isDynamic: IsDynamic(method.ReturnValueAttributes));
             }
 
             WriteIdentifier(name);
@@ -66,19 +73,20 @@ namespace Microsoft.Cci.Writers.CSharp
             if (isOperator)
             {
                 WriteSpace();
-                WriteTypeName(method.Type);
+
+                WriteTypeName(method.Type, method.ContainingType);
             }
 
             Contract.Assert(!(method is IGenericMethodInstance), "Currently don't support generic method instances");
             if (method.IsGeneric)
                 WriteGenericParameters(method.GenericParameters);
 
-            WriteParameters(method.Parameters, extensionMethod: method.IsExtensionMethod(), acceptsExtraArguments: method.AcceptsExtraArguments);
+            WriteParameters(method.Parameters, method.ContainingType, extensionMethod: method.IsExtensionMethod(), acceptsExtraArguments: method.AcceptsExtraArguments);
             if (method.IsGeneric && !method.IsOverride() && !method.IsExplicitInterfaceMethod())
                 WriteGenericContraints(method.GenericParameters);
         }
 
-        private void WriteParameters(IEnumerable<IParameterDefinition> parameters, bool property = false, bool extensionMethod = false, bool acceptsExtraArguments = false)
+        private void WriteParameters(IEnumerable<IParameterDefinition> parameters, ITypeReference containingType, bool property = false, bool extensionMethod = false, bool acceptsExtraArguments = false)
         {
             string start = property ? "[" : "(";
             string end = property ? "]" : ")";
@@ -86,7 +94,7 @@ namespace Microsoft.Cci.Writers.CSharp
             WriteSymbol(start);
             _writer.WriteList(parameters, p =>
             {
-                WriteParameter(p, extensionMethod);
+                WriteParameter(p, containingType, extensionMethod);
                 extensionMethod = false;
             });
 
@@ -101,7 +109,7 @@ namespace Microsoft.Cci.Writers.CSharp
             WriteSymbol(end);
         }
 
-        private void WriteParameter(IParameterDefinition parameter, bool extensionMethod)
+        private void WriteParameter(IParameterDefinition parameter, ITypeReference containingType, bool extensionMethod)
         {
             WriteAttributes(parameter.Attributes, true);
 
@@ -126,7 +134,7 @@ namespace Microsoft.Cci.Writers.CSharp
                     WriteKeyword("ref");
             }
 
-            WriteTypeName(parameter.Type, isDynamic: IsDynamic(parameter.Attributes));
+            WriteTypeName(parameter.Type, containingType, isDynamic: IsDynamic(parameter.Attributes));
             WriteIdentifier(parameter.Name);
             if (parameter.IsOptional && parameter.HasDefaultValue)
             {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -157,6 +157,9 @@ namespace Microsoft.Cci.Writers.CSharp
             if (method.IsStatic)
                 WriteKeyword("static");
 
+            if (method.IsPlatformInvoke)
+                WriteKeyword("extern");
+
             if (method.IsVirtual)
             {
                 if (method.IsNewSlot)
@@ -179,7 +182,7 @@ namespace Microsoft.Cci.Writers.CSharp
 
         private void WriteMethodBody(IMethodDefinition method)
         {
-            if (method.IsAbstract || !_forCompilation)
+            if (method.IsAbstract || !_forCompilation || method.IsPlatformInvoke)
             {
                 WriteSymbol(";");
                 return;

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 var parameters = new List<IParameterDefinition>(accessor.Parameters);
                 if (accessor == setter) // If setter remove value parameter.
                     parameters.RemoveAt(parameters.Count - 1);
-                WriteParameters(parameters, true);
+                WriteParameters(parameters, property.ContainingType, true);
             }
             else
             {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteTypeName(invoke.Type);
                 WriteIdentifier(namedType.Name);
                 if (type.IsGeneric) WriteGenericParameters(type.GenericParameters);
-                WriteParameters(invoke.Parameters);
+                WriteParameters(invoke.Parameters, invoke.ContainingType);
                 if (type.IsGeneric) WriteGenericContraints(type.GenericParameters);
                 WriteSymbol(";");
             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Cci.Writers.CSharp
             _writer.Write(literal);
         }
 
-        private void WriteTypeName(ITypeReference type, bool noSpace = false, bool isDynamic = false)
+        private void WriteTypeName(ITypeReference type, bool noSpace = false, bool isDynamic = false, bool useTypeKeywords = true)
         {
             if (isDynamic)
             {
@@ -212,7 +212,10 @@ namespace Microsoft.Cci.Writers.CSharp
                 return;
             }
 
-            NameFormattingOptions namingOptions = NameFormattingOptions.TypeParameters | NameFormattingOptions.UseTypeKeywords;
+            NameFormattingOptions namingOptions = NameFormattingOptions.TypeParameters;
+
+            if (useTypeKeywords)
+                namingOptions |= NameFormattingOptions.UseTypeKeywords;
 
             if (_forCompilationIncludeGlobalprefix)
                 namingOptions |= NameFormattingOptions.UseGlobalPrefix;


### PR DESCRIPTION
Fixes 3 issues found while compiling generated code for v4.6.1 mscorlib.dll.

Attributes not visible outside the assembly are now filtered.
Attributes using arguments with typeof expression of a type not visible
outside assembly are also filtered.

When we are generating structs for builtin types such as System.Double, we
cannot use the keyword double while declaring operators.

This fixes bad generated methods such as:
public static decimal operator +(decimal d1, decimal d2) { throw null; }
public static implicit operator decimal (char value) { throw null; }

This changes the generator to not replace a type for its keyword when we
are generating the type itself.

DllImportAttribute was added to methods without modifier extern,
this would cause an error while compiling them.

Fixes:
https://github.com/dotnet/buildtools/issues/869
https://github.com/dotnet/buildtools/issues/904
https://github.com/dotnet/buildtools/issues/658
