### PR TITLE
Correct the casing of Microsoft.Net.Compilers.netcore

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -9,7 +9,7 @@
         "Microsoft.Build.Utilities.Core": "0.1.0-preview-00024-160610",
         "Microsoft.Build.Targets": "0.1.0-preview-00024-160610",
         "Microsoft.Build": "0.1.0-preview-00024-160610",
-        "Microsoft.Net.Compilers.NetCore": "1.3.0-beta1-20160429-01",
+        "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160429-01",
         "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
         "Microsoft.Cci": "4.0.0-rc3-24128-00",
         "Microsoft.Composition": "1.0.30",


### PR DESCRIPTION
This is breaking with new NuGet in the CLI.

@dagood @weshaggard 