### PR TITLE
Fix RunTests.sh copy behavior on OSX

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -69,7 +69,7 @@ fi
 
 if [ "$EXECUTION_DIR" != "$BASEDIR" ]; then
   echo "Copying files into execution dir."
-  cp -l -f -R $BASEDIR/* $EXECUTION_DIR
+  ln -f $BASEDIR/* $EXECUTION_DIR || exit -1
 else
   echo "Executing in unpack directory, do not have to copy files"
 fi


### PR DESCRIPTION
@jhendrixMSFT @karajas 

For the scenario where the execution directory is not the same as the one the test + script lives in, switch to a command that works on both Linux + OSX.

This didn't affect .NET Helix because there is still code copying it to the destination already, but it may as well work properly and not put unnecessary errors on the log.