### PR TITLE
Rename "version" to "versions" when referring to dotnet/versions repository

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -14,8 +14,8 @@
                              GitHubAuthToken="$(GitHubAuthToken)"
                              GitHubUser="$(GitHubUser)"
                              GitHubEmail="$(GitHubEmail)"
-                             VersionRepo="$(VersionRepo)"
-                             VersionRepoOwner="$(VersionRepoOwner)" />
+                             VersionsRepo="$(VersionsRepo)"
+                             VersionsRepoOwner="$(VersionsRepoOwner)" />
   </Target>
 
   <!-- Task to perform automatic dependency updates. -->

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
@@ -23,8 +23,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
         public string GitHubUser { get; set; }
         public string GitHubEmail { get; set; }
 
-        public string VersionRepo { get; set; }
-        public string VersionRepoOwner { get; set; }
+        public string VersionsRepo { get; set; }
+        public string VersionsRepoOwner { get; set; }
 
         public override bool Execute()
         {
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
 
             var gitHubAuth = new GitHubAuth(GitHubAuthToken, GitHubUser, GitHubEmail);
 
-            var updater = new VersionRepoUpdater(gitHubAuth, VersionRepoOwner, VersionRepo);
+            var updater = new VersionsRepoUpdater(gitHubAuth, VersionsRepoOwner, VersionsRepo);
 
             updater.UpdateBuildInfoAsync(
                 ShippedNuGetPackage.Select(item => item.ItemSpec),

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -10,22 +10,22 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {
-    public class VersionRepoUpdater
+    public class VersionsRepoUpdater
     {
         private GitHubAuth _gitHubAuth;
         private GitHubProject _project;
 
-        public VersionRepoUpdater(
+        public VersionsRepoUpdater(
             GitHubAuth gitHubAuth,
-            string versionRepoOwner = null,
+            string versionsRepoOwner = null,
             string versionsRepo = null)
             : this(
                 gitHubAuth,
-                new GitHubProject(versionsRepo ?? "versions", versionRepoOwner))
+                new GitHubProject(versionsRepo ?? "versions", versionsRepoOwner))
         {
         }
 
-        public VersionRepoUpdater(GitHubAuth gitHubAuth, GitHubProject project)
+        public VersionsRepoUpdater(GitHubAuth gitHubAuth, GitHubProject project)
         {
             if (gitHubAuth == null)
             {

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -40,7 +40,7 @@
     <Compile Include="Dependencies\IDependencyUpdater.cs" />
     <Compile Include="BuildInfo.cs" />
     <Compile Include="Dependencies\ProjectJsonUpdater.cs" />
-    <Compile Include="Automation\VersionRepoUpdater.cs" />
+    <Compile Include="Automation\VersionsRepoUpdater.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">


### PR DESCRIPTION
Makes naming consistent with the repository name "dotnet/versions" and parameters in the existing `UpdatePublishedVersions.ps1`. I found this issue when I was removing the powershell script functionality and noticed the msbuild properties' names don't match up.

`VersionsRepoUpdater` is called `VersionRepoUpdater` in the CLI repository, but I think `Versions` makes more sense here too.

Minor change, but I wanted to make it before I worked VersionTools into the repositories, making it hard to change later.

@eerhardt It looks like CLI isn't depending on `VersionsRepoUpdater` yet--is that true, making this free to change?