### PR TITLE
Add fallback copy behavior; 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -69,7 +69,7 @@ fi
 
 if [ "$EXECUTION_DIR" != "$BASEDIR" ]; then
   echo "Copying files into execution dir."
-  ln -f $BASEDIR/* $EXECUTION_DIR || exit -1
+  ln -f $BASEDIR/* $EXECUTION_DIR || echo "Link failed, fallback to copy"; cp -run $BASEDIR/* $EXECUTION_DIR || echo "Still errors, attempting to continue"
 else
   echo "Executing in unpack directory, do not have to copy files"
 fi


### PR DESCRIPTION
- Some tests contain subdirectories in their output, which can break ln
- cp -l was what we had previously but this caused an (ignoreable error) on macs.
- This only affects remote execution as an execution dir is not supplied when running locally.

There's a couple ways to solve this, it may just be nicer to always do cp -run.

@weshaggard , opinions?