### PR TITLE
Put back expected slash in TestHostDirectory property.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -29,7 +29,7 @@
 
   <PropertyGroup Condition="'$(TestWithCore)' == 'true' And '$(TestAppX)' != 'true'">
     <TestHostExecutable>CoreRun.exe</TestHostExecutable>
-    <TestHostDirectory>$(TestPath)$(TestTFM)</TestHostDirectory>
+    <TestHostDirectory>$(TestPath)$(TestTFM)/</TestHostDirectory>
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.netcore.exe</XunitExecutable>
     <DebugTestFrameworkFolder>$(TestTFM)</DebugTestFrameworkFolder>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>


### PR DESCRIPTION
@ianhays 

Without this I get an error attempting to find CoreRun for VS test debugging.