### PR TITLE
Add mechanism to specify destination dir for supplemental test data.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -18,6 +18,13 @@
     <ExcludeLocalizationImport Condition="'$(ExcludeLocalizationImport)'=='' And !Exists('$(MSBuildProjectDirectory)/MultilingualResources/$(MSBuildProjectName).de.xlf')">true</ExcludeLocalizationImport>
   </PropertyGroup>
 
+  <!-- used by test projects that need to copy supplemental content to the output directory -->
+  <ItemDefinitionGroup Condition="'$(IsTestProject)'=='true'">
+    <SupplementalTestData>
+      <DestinationDir />
+    </SupplementalTestData>
+  </ItemDefinitionGroup>
+
   <!-- Assembly metadata indicating that an assembly is a framework (as opposed to user) assembly:
        Test projects need to not have this because of the way "IsFrameworkAssembly" APIs work to check this. -->
   <ItemGroup Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' AND '$(IsTestProject)' != 'true'" >

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -176,9 +176,20 @@
     <PropertyGroup>
       <TestNugetTargetMonikerFolder>%(TestNugetTargetMoniker.Folder)</TestNugetTargetMonikerFolder>
     </PropertyGroup>
+    <!-- if DestinationDir is defined then prefer that over RecursiveDir -->
     <ItemGroup>
-      <SupplementalTestDataTestDir Include="@(SupplementalTestData->'$(TestPath)$(TestNugetTargetMonikerFolder)/%(RecursiveDir)%(Filename)%(Extension)')" />
-      <SupplementalTestDataOutDir Include="@(SupplementalTestData->'$(OutDir)/%(RecursiveDir)%(Filename)%(Extension)')" />
+      <SupplementalTestDataTestDir
+        Include="@(SupplementalTestData->'$(TestPath)$(TestNugetTargetMonikerFolder)/%(DestinationDir)%(Filename)%(Extension)')"
+        Condition="'%(DestinationDir)' != ''" />
+      <SupplementalTestDataTestDir
+        Include="@(SupplementalTestData->'$(TestPath)$(TestNugetTargetMonikerFolder)/%(RecursiveDir)%(Filename)%(Extension)')"
+        Condition="'%(DestinationDir)' == ''" />
+      <SupplementalTestDataOutDir
+        Include="@(SupplementalTestData->'$(OutDir)/%(DestinationDir)%(Filename)%(Extension)')"
+        Condition="'%(DestinationDir)' != ''" />
+      <SupplementalTestDataOutDir
+        Include="@(SupplementalTestData->'$(OutDir)/%(RecursiveDir)%(Filename)%(Extension)')"
+        Condition="'%(DestinationDir)' == ''" />
     </ItemGroup>
     <Copy
       SourceFiles="@(SupplementalTestData)"


### PR DESCRIPTION
The current mechanism for copying supplemental test data assumes that the
RecusiveDir metadata is defined.  Added new metadata, DestinationDir, for
copying supplemental test data to be preferred over RecursiveDir.