### PR TITLE
Add a way to config VersionTools task to upgrade full version for a package id

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependencies.cs
@@ -99,13 +99,30 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
             {
                 foreach (ITaskItem step in XmlUpdateStep)
                 {
-                    yield return new FileRegexReleaseUpdater
+                    string buildInfoName = step.GetMetadata("BuildInfoName");
+                    string packageId = step.GetMetadata("PackageId");
+
+                    FileRegexUpdater updater;
+
+                    if (!string.IsNullOrEmpty(buildInfoName))
                     {
-                        Path = step.GetMetadata("Path"),
-                        Regex = new Regex($@"<{step.GetMetadata("ElementName")}>(?<version>.*)<"),
-                        VersionGroupName = "version",
-                        BuildInfoName = step.GetMetadata("BuildInfoName")
-                    };
+                        updater = new FileRegexReleaseUpdater
+                        {
+                            BuildInfoName = buildInfoName
+                        };
+                    }
+                    else
+                    {
+                        updater = new FileRegexPackageUpdater
+                        {
+                            PackageId = packageId
+                        };
+                    }
+                    updater.Path = step.GetMetadata("Path");
+                    updater.Regex = new Regex($@"<{step.GetMetadata("ElementName")}>(?<version>.*)<");
+                    updater.VersionGroupName = "version";
+
+                    yield return updater;
                 }
             }
         }


### PR DESCRIPTION
This enables upgrading things like [`CoreClrPackageVersion`](https://github.com/dotnet/coreclr/blob/0bb191d/tests/dir.props#L47), so we can use the VersionTools msbuild task to upgrade coreclr.

/cc @eerhardt @weshaggard 