### PR TITLE
Run ResolveProjectReferences before ResolveAssemblyReferences in ApiCompat

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
@@ -32,7 +32,7 @@
     </PropertyGroup>
 
     <MSBuild Projects="$(RefProjectForDependencies)"
-             Targets="ResolveAssemblyReferences"
+             Targets="ResolveProjectReferences;ResolveAssemblyReferences"
              RemoveProperties="OSGroup;TargetGroup"
              Condition="Exists('$(RefProjectForDependencies)')">
       <Output TaskParameter="TargetOutputs" ItemName="ReferenceAssemblyReferencePath" />


### PR DESCRIPTION
cc: @weshaggard 