### PR TITLE
Remove execution directory from RunTests scripts

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -233,8 +233,8 @@
 
     <ItemGroup>
       <FunctionalTest>
-        <Command Condition="'$(TargetsWindows)' == 'true'">$(HelixPythonPath) $(RunnerScript) --script RunTests.cmd %HELIX_CORRELATION_PAYLOAD% %HELIX_WORKITEM_ROOT%\execution</Command>
-        <Command Condition="'$(TargetsWindows)' != 'true'"> chmod +x $HELIX_WORKITEM_PAYLOAD/RunTests.sh &amp;&amp; $(HelixPythonPath) $(RunnerScript) --script RunTests.sh $HELIX_CORRELATION_PAYLOAD $HELIX_WORKITEM_ROOT/execution</Command>
+        <Command Condition="'$(TargetsWindows)' == 'true'">$(HelixPythonPath) $(RunnerScript) --script RunTests.cmd %HELIX_CORRELATION_PAYLOAD%</Command>
+        <Command Condition="'$(TargetsWindows)' != 'true'"> chmod +x $HELIX_WORKITEM_PAYLOAD/RunTests.sh &amp;&amp; $(HelixPythonPath) $(RunnerScript) --script RunTests.sh $HELIX_CORRELATION_PAYLOAD</Command>
         <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
         <PayloadUri>$(DropUri)$(Platform)$(ConfigurationGroup)/Tests/$([System.String]::Copy('%(RecursiveDir)').Replace('\', '/'))%(Filename)%(Extension)$(DropUriReadOnlyToken)</PayloadUri>
         <WorkItemId>%(Filename)</WorkItemId>
@@ -261,11 +261,11 @@
 
   <Target Name="CreatePerfTestListJson" DependsOnTargets="CreateAzureStorage" Condition="'$(Performance)' == 'true'">
     <PropertyGroup Condition="'$(TargetsWindows)' == 'true' AND '$(UseLegacyXunitPerfRunner)'!='true'">
-      <OtherRunnerScriptArgs>--script RunTests.cmd %HELIX_CORRELATION_PAYLOAD% %HELIX_WORKITEM_ROOT%\execution</OtherRunnerScriptArgs>
-
+      <OtherRunnerScriptArgs>--script RunTests.cmd %HELIX_CORRELATION_PAYLOAD%</OtherRunnerScriptArgs>
     </PropertyGroup>
+    
     <PropertyGroup Condition="'$(TargetsWindows)' != 'true' AND '$(UseLegacyXunitPerfRunner)'!='true'">
-      <OtherRunnerScriptArgs>--script RunTests.sh $HELIX_CORRELATION_PAYLOAD $HELIX_WORKITEM_ROOT/execution</OtherRunnerScriptArgs>
+      <OtherRunnerScriptArgs>--script RunTests.sh $HELIX_CORRELATION_PAYLOAD</OtherRunnerScriptArgs>
     </PropertyGroup>
 
     <!-- now gather the perf tests -->

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
@@ -36,8 +36,6 @@ def main(args=None):
 
         unpack_dir = fix_path(settings.workitem_payload_dir)
 
-        exec_dir = os.path.join(fix_path(settings.workitem_working_dir), 'execution')
-
         execution_args = [os.path.join(unpack_dir, script_to_execute)] + args
 
         return_code = helix.proc.run_and_log_output(
@@ -46,7 +44,15 @@ def main(args=None):
             env=None
         )
         event_client = helix.event.create_from_uri(settings.event_uri)
-        results_location = os.path.join(exec_dir, 'testResults.xml')
+        results_location = os.path.join(unpack_dir, 'testResults.xml')
+
+        # In case testResults.xml was put somewhere else, try to find it anywhere in this directory before failing
+        if not os.path.exists(results_location):
+            for root, dirs, files in os.walk(settings.workitem_working_dir):
+                for file_name in files:
+                    if file_name == 'testResults.xml':
+                        results_location = os.path.join(root, file_name)
+
         if os.path.exists(results_location):
             log.info("Uploading results from {}".format(results_location))
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -1,8 +1,7 @@
 ﻿#!/usr/bin/env bash
 
 export PACKAGE_DIR=$1
-export EXECUTION_DIR=$2
-export BASEDIR=$(dirname "$0")
+export EXECUTION_DIR=$(dirname "$0")
 
 function copy_and_check {
   if ! [ -f $2 ]; then
@@ -54,26 +53,9 @@ exit -1
 fi
 echo Using $PACKAGE_DIR as folder for resolving package dependencies.
 
-if [ "$EXECUTION_DIR" = "" ]
-then
-export EXECUTION_DIR=$BASEDIR
-fi
-
 echo Executing in $EXECUTION_DIR
 
 # ========================= BEGIN Copying files  =============================
-if [ ! -d "$EXECUTION_DIR" ]
-then
-    mkdir $EXECUTION_DIR
-fi
-
-if [ "$EXECUTION_DIR" != "$BASEDIR" ]; then
-  echo "Copying files into execution dir."
-  ln -f $BASEDIR/* $EXECUTION_DIR || exit -1
-else
-  echo "Executing in unpack directory, do not have to copy files"
-fi
-
 echo Hard linking dependent files... 
 # Format here is: cp -l $PACKAGE_DIR/<File Path> $/EXECUTION_DIR/<File Path> || exit $?
 [[CopyFilesCommands]]

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
@@ -2,21 +2,15 @@
 SETLOCAL
 
 SET PACKAGE_DIR=%1
-SET EXECUTION_DIR=%2
 set PACKAGE_DIR=%PACKAGE_DIR:/=\%
 IF DEFINED PACKAGE_DIR ( echo Using %PACKAGE_DIR% as folder for resolving package dependencies.) ELSE (
 echo Please specify an package source directory using PACKAGEROOT parameter
 goto ShowUsage
 )
-if "%EXECUTION_DIR%" == "" (set EXECUTION_DIR=%~dp0)
+set EXECUTION_DIR=%~dp0
 echo Executing in %EXECUTION_DIR% 
 
 :: ========================= BEGIN Copying files  =============================== 
-IF NOT EXIST %EXECUTION_DIR% ( md %EXECUTION_DIR%)
-IF /I "%~dp0" NEQ "%EXECUTION_DIR%" (
-xcopy /e /q /y %~dp0*.* %EXECUTION_DIR%
-)
-
 echo Hard linking dependent files... 
 :: Format here is: call :copyandcheck Path1 Path2 || GOTO EOF
 [[CopyFilesCommands]]
@@ -58,9 +52,8 @@ exit /b %ERRORLEVEL%
 echo.
 echo Usage:
 echo.
-echo %0 {Package root} {execution directory} 
+echo %0 {Package root}
 echo.
 echo Parameters:
 echo Package Root :        (Mandatory) Root path containing unzipped Nuget Packages, such as c:\GIT\corefx\packages
-echo Execution Directory : (Optional)  Directory to link files into for execution.  Defaults to same directory RunTests.cmd is in.
 EXIT /B -1


### PR DESCRIPTION
@jhendrixMSFT @weshaggard 
Alternate fix for https://github.com/dotnet/buildtools/pull/940.   Now, runner scripts don't copy over everything to an alternate directory on execution, they simply run as is (1 argument only). 

In case someone manages to run their script and produce a testResults.xml in an unexpected location, I also added support to scriptrunner to walk the entire work item directory looking for testResults.xml if it happens to be missing. 