### PR TITLE
Significantly reduce the amount of time spent in DesignTimeBuilds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -258,13 +258,12 @@
        This helps minimize the number of project evaluations and targets that build in order
        to determine the contents of the package-->
   <Target Name="ExpandProjectReferences"
-          DependsOnTargets="SplitProjectReferences"
-          Condition="'$(DesignTimeBuild)' == 'false'">
+          DependsOnTargets="SplitProjectReferences">
 
     <!-- Only rebuild project references when specified -->
     <MSBuild Targets="Build"
              BuildInParallel="$(BuildInParallel)"
-             Condition="'$(BuildPackageLibraryReferences)' == 'true'"
+             Condition="'$(BuildPackageLibraryReferences)' == 'true' AND '$(DesignTimeBuild)' == 'false'"
              Projects="@(_NonPkgProjProjectReference)"
              Properties="$(ProjectProperties)"
              ContinueOnError="WarnAndContinue"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -258,7 +258,8 @@
        This helps minimize the number of project evaluations and targets that build in order
        to determine the contents of the package-->
   <Target Name="ExpandProjectReferences"
-          DependsOnTargets="SplitProjectReferences">
+          DependsOnTargets="SplitProjectReferences"
+          Condition="'$(DesignTimeBuild)' == 'false'">
 
     <!-- Only rebuild project references when specified -->
     <MSBuild Targets="Build"


### PR DESCRIPTION
Before, renaming a file took 30s+, now takes less than 1s. Delay in opening projects is also almost completely gone

<details>
<summary>Previous Design Time Build Log</summary>
```
115 ms  HarvestStablePackage                       1 calls
118 ms  ResolveAssemblyReferences                  9 calls
124 ms  OpenSourceSign                             3 calls
212 ms  GetLatestCommitHash                        4 calls
1152 ms  RestorePackages                            2 calls
2055 ms  ValidateApiCompatForSrc                    2 calls
3067 ms  FillPartialFacade                          2 calls
5396 ms  CoreCompile                                8 calls
13395 ms  BuildAllProjects                           1 calls
23182 ms  ExpandProjectReferences                    1 calls
```
</details>

<details>
<summary>New Design Time Build Log</summary>
```
2 ms  ValidatePackageVersions                    1 calls
4 ms  GetPackageFiles                            1 calls
6 ms  CoreCompile                                1 calls
7 ms  ResolvePkgProjReferences                   1 calls
9 ms  FilterTargetingPackResolvedNugetPackages   1 calls
16 ms  ResolveAssemblyReferences                  1 calls
78 ms  GetLatestCommitHash                        1 calls
126 ms  HarvestStablePackage                       1 calls
144 ms  ResolveNuGetPackages                       1 calls
1043 ms  ResolveProjectReferences                   1 calls
```
</details>

Fixes dotnet/corefx#10666

The log end summary is above. If you chaps have any ideas about other optimisations, I'm all ears.

/cc @weshaggard @davkean @Pilchie