### PR TITLE
Add a task to help workaround dotnet/corefx#5230

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -53,6 +53,7 @@
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="WriteSigningRequired.cs" />
+    <Compile Include="WriteVisualBasicDefineResponseFile.cs" />
     <Compile Include="ZipFileCreateFromDependencyLists.cs" />
     <Compile Include="ZipFileExtractToDirectory.cs" />
     <Compile Include="ZipFileCreateFromDirectory.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -102,6 +102,26 @@
     </PropertyGroup>
   </Target>
 
+  <!--
+    Cross Platform MSBuild has some logic to replace \ with / when invoking commands to fix up path differences between Windows and
+    *NIX. The define command line argument syntax for VB requires that we both surround some items with quotes and escape the quotes with
+    backslashes. However, due to the above MSBuild logic, this causes an invalid command line to be generated when running on *NIX.
+
+    Microsoft/msbuild#422 tracks an actual fix in MSBuild, but for now we work around the issue by using a custom task that
+    transforms the set of defines we are going to use into a response file we can pass along to the Vbc task along with an
+    empty set of defines.
+  -->
+  <UsingTask TaskName="WriteVisualBasicDefineResponseFile"  AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <Target Name="ConvertDefinesToResonseFile" BeforeTargets="CoreCompile" Condition="'$(MSBuildProjectExtension)' == '.vbproj'">
+    <WriteVisualBasicDefineResponseFile DefineConstants="$(FinalDefineConstants)"
+                                        File="$(IntermediateOutputPath)/defines.rsp" />
+    <PropertyGroup>
+      <CompilerResponseFile>$(IntermediateOutputPath)/defines.rsp;$(CompilerResponseFile)</CompilerResponseFile>
+      <FinalDefineConstants></FinalDefineConstants>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="ConvertCommonMetadataToAdditionalProperties" BeforeTargets="AssignProjectConfiguration">
     <!-- list each append as a seperate item to force re-evaluation of AdditionalProperties metadata -->
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/WriteVisualBasicDefineResponseFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/WriteVisualBasicDefineResponseFile.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using System.IO;
+
+/// <summary>
+/// Writes a response file that sets the define flag to the Visual Basic complier
+/// based on what constants should be defined. This is needed due to 
+/// https://github.com/Microsoft/msbuild/issues/422 which prevents us from
+/// using the native MSBuild logic to invoke the build for our VB Projects when
+/// running on Unix platforms.
+/// </summary>
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class WriteVisualBasicDefineResponseFile : Task
+    {
+        /// <summary>
+        /// The set of DefineConstants that would be passed to the Vbc Task.
+        /// </summary>
+        [Required]
+        public string DefineConstants { get; set; }
+
+        /// <summary>
+        /// The response file to generate. If this file already exists, it is overwritten.
+        /// </summary>
+        [Required]
+        public string File { get; set; }
+
+        public override bool Execute()
+        {
+            using (var streamWriter = new StreamWriter(System.IO.File.OpenWrite(File)))
+            {
+                streamWriter.Write("/define:\"");
+                streamWriter.Write(DefineConstants.Replace("\"", "\\\""));
+                streamWriter.Write("\"");
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This task generates a response file we can use to pass the correct set of
defines to the complier without having to worry about MSBuild converting
back slashes to forward slashes when running on Unix systems.