### PR TITLE
Fix passthrough setting

### DIFF
--- a/src/Run/CommandLine.cs
+++ b/src/Run/CommandLine.cs
@@ -1263,7 +1263,7 @@ class CommandLine
                         throw new CommandLineParserException("Use " + name + ":" + value + " if " + value +
                             " is meant to be value rather than a named parameter");
                     _args[valuePos] = null;*/
-                    value = "true";
+                    value = string.IsNullOrEmpty(defaultValue) ? "true" : defaultValue;
                 }
                 ret = ParseValue(value, type, name);
                 if (type.IsArray)


### PR DESCRIPTION
When a setting was directly passed by the user, the assigned value was always true. Now it assigns the default value of the setting.

Fix issue: #958 

cc: @weshaggard  @joperezr 