### PR TITLE
Add RepoUtil sources to the build tools repo.

### DIFF
--- a/src/RepoUtil.Desktop/App.config
+++ b/src/RepoUtil.Desktop/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+    </startup>
+</configuration>

--- a/src/RepoUtil.Desktop/RepoUtil.Desktop.csproj
+++ b/src/RepoUtil.Desktop/RepoUtil.Desktop.csproj
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>RepoUtil</RootNamespace>
+    <AssemblyName>RepoUtil</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
+    <RepoUtilSrc>..\RepoUtil</RepoUtilSrc>
+    <ProjectGuid>{CFF34D7E-1221-44C2-B9C6-F19F61817063}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(RepoUtilSrc)\ChangeCommand.cs" />
+    <Compile Include="$(RepoUtilSrc)\ConflictingPackagesException.cs" />
+    <Compile Include="$(RepoUtilSrc)\Constants.cs" />
+    <Compile Include="$(RepoUtilSrc)\ConsumesCommand.cs" />
+    <Compile Include="$(RepoUtilSrc)\FileName.cs" />
+    <Compile Include="$(RepoUtilSrc)\GenerateData.cs" />
+    <Compile Include="$(RepoUtilSrc)\GenerateUtil.cs" />
+    <Compile Include="$(RepoUtilSrc)\ICommand.cs" />
+    <Compile Include="$(RepoUtilSrc)\NuGetConfigUtil.cs" />
+    <Compile Include="$(RepoUtilSrc)\NuGetFeed.cs" />
+    <Compile Include="$(RepoUtilSrc)\NuGetPackage.cs" />
+    <Compile Include="$(RepoUtilSrc)\NuGetPackageChange.cs" />
+    <Compile Include="$(RepoUtilSrc)\NuGetPackageSource.cs" />
+    <Compile Include="$(RepoUtilSrc)\NuSpecUtil.cs" />
+    <Compile Include="$(RepoUtilSrc)\ProducesCommand.cs" />
+    <Compile Include="$(RepoUtilSrc)\Program.cs" />
+    <Compile Include="$(RepoUtilSrc)\ProjectJsonUtil.cs" />
+    <Compile Include="$(RepoUtilSrc)\RepoConfig.cs" />
+    <Compile Include="$(RepoUtilSrc)\RepoData.cs" />
+    <Compile Include="$(RepoUtilSrc)\UsageCommand.cs" />
+    <Compile Include="$(RepoUtilSrc)\ViewCommand.cs" />
+    <Compile Include="$(RepoUtilSrc)\VerifyCommand.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/RepoUtil.Desktop/project.json
+++ b/src/RepoUtil.Desktop/project.json
@@ -1,10 +1,14 @@
 {
+  "supports": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "Newtonsoft.Json": "9.0.1",
     "System.Collections.Immutable": "1.2.0"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    ".NETFramework,Version=v4.6": {}
+  },
+  "runtimes": {
+    "win": {},
+    "win7": {}
   }
 }

--- a/src/RepoUtil/ChangeCommand.cs
+++ b/src/RepoUtil/ChangeCommand.cs
@@ -1,0 +1,222 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace RepoUtil
+{
+    /// <summary>
+    /// Responsible for changing the repo to use a new set of NuGet packages.
+    /// </summary>
+    internal sealed class ChangeCommand : ICommand
+    {
+        private readonly RepoData _repoData;
+
+        internal ChangeCommand(RepoData repoData)
+        {
+            _repoData = repoData;
+        }
+
+        public bool Run(TextWriter writer, string[] args)
+        {
+            List<NuGetPackage> changes;
+            if (!TryParseChangeSource(writer, args, out changes))
+            {
+                return false;
+            }
+
+            ChangeAll(changes);
+            return true;
+        }
+
+        /// <summary>
+        /// Parse out the arguments that can be provided to the 'change' command.
+        /// </summary>
+        private static bool TryParseChangeSource(TextWriter writer, string[] args, out List<NuGetPackage> changes)
+        {
+            changes = new List<NuGetPackage>();
+            var allGood = true;
+            var index = 0;
+            while (index < args.Length && allGood)
+            {
+                var arg = args[index];
+                index++;
+
+                switch (arg.ToLower())
+                {
+                    case "-version":
+                        if (index < args.Length)
+                        {
+                            allGood = TryParseVersionSource(writer, args[index], changes);
+                            index++;
+                        }
+                        else
+                        {
+                            Console.WriteLine($"The -version switch needs a value");
+                            allGood = false;
+                        }
+                        break;
+                    default:
+                        if (!TryParsePackage(writer, arg, changes))
+                        {
+                            allGood = false;
+                        }
+                        break;
+                }
+            }
+
+            return allGood;
+        }
+
+        /// <summary>
+        /// Parse out a file that has the format used on the dotnet/versions repo.  Essentially every entry in the file
+        /// will be a package name, space, version.
+        /// </summary>
+        private static bool TryParseVersionSource(TextWriter writer, string path, List<NuGetPackage> changes)
+        {
+            try
+            {
+                foreach (var line in File.ReadAllLines(path))
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    if (!TryParsePackage(writer, line, changes))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                writer.WriteLine($"Error parsing {path}: {ex.ToString()}");
+                writer.WriteLine(ex.StackTrace);
+                changes = null;
+                return false;
+            }
+        }
+
+        private static bool TryParsePackage(TextWriter writer, string packageLine, List<NuGetPackage> changes)
+        {
+            var match = Regex.Match(packageLine, @"([^\s]*)\s*(.*)");
+            if (match.Success)
+            {
+                var package = new NuGetPackage(
+                    match.Groups[1].Value,
+                    match.Groups[2].Value);
+                changes.Add(package);
+                return true;
+            }
+
+            match = Regex.Match(packageLine, @"([^\s]*)\s*-\s*(.*)");
+            if (match.Success)
+            {
+                var package = new NuGetPackage(
+                    match.Groups[1].Value,
+                    match.Groups[2].Value);
+                changes.Add(package);
+                return true;
+            }
+
+            writer.WriteLine($"Unable to parse package {packageLine}");
+            return false;
+        }
+
+        /// <summary>
+        /// Change the state of the repo to use the specified packages.
+        /// </summary>
+        internal void ChangeAll(IEnumerable<NuGetPackage> packages)
+        {
+            var changeList = CalculateChanges(packages);
+            var map = ImmutableDictionary<NuGetPackage, NuGetPackage>.Empty;
+            foreach (var package in changeList)
+            {
+                map = map.Add(package.OldPackage, package.NewPackage);
+            }
+            ChangeAllCore(map);
+        }
+
+        /// <summary>
+        /// Produce the set of <see cref="NuGetPackageChange"/> values for the set of updated 
+        /// nuget package references.
+        /// </summary>
+        private List<NuGetPackageChange> CalculateChanges(IEnumerable<NuGetPackage> packages)
+        {
+            var map = _repoData
+                .FloatingPackages
+                .ToDictionary(x => x.Name, Constants.NugetPackageNameComparer);
+            var list = new List<NuGetPackageChange>();
+
+            Console.WriteLine("Calculating the changes");
+            foreach (var package in packages)
+            {
+                NuGetPackage existingPackage;
+                if (!map.TryGetValue(package.Name, out existingPackage))
+                {
+                    Console.WriteLine($"\tSkipping {package.Name} as it's not a floating package in this repo.");
+                }
+
+                list.Add(new NuGetPackageChange(package.Name, oldVersion: existingPackage.Version, newVersion: package.Version));
+            }
+
+            return list;
+        }
+
+        /// <summary>
+        /// Change the repo to respect the new version for the specified set of NuGet packages
+        /// </summary>
+        private void ChangeAllCore(ImmutableDictionary<NuGetPackage, NuGetPackage> changeMap)
+        {
+            ChangeProjectJsonFiles(changeMap);
+
+            // Calculate the new set of packages based on the changed information.
+            var list = new List<NuGetPackage>();
+            foreach (var cur in _repoData.FloatingBuildPackages)
+            {
+                NuGetPackage newPackage;
+                if (changeMap.TryGetValue(cur, out newPackage))
+                {
+                    list.Add(newPackage);
+                }
+                else
+                {
+                    list.Add(cur);
+                }
+            }
+
+            ChangeGeneratedFiles(list);
+        }
+
+        private void ChangeProjectJsonFiles(ImmutableDictionary<NuGetPackage, NuGetPackage> changeMap)
+        {
+            Console.WriteLine("Changing project.json files");
+            foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(_repoData.SourcesPath))
+            {
+                if (ProjectJsonUtil.ChangeDependencies(filePath, changeMap))
+                {
+                    Console.WriteLine($"\t{filePath} updated");
+                }
+            }
+        }
+
+        private void ChangeGeneratedFiles(IEnumerable<NuGetPackage> floatingPackages)
+        {
+            var msbuildData = _repoData.RepoConfig.MSBuildGenerateData;
+            if (msbuildData.HasValue)
+            {
+                var fileName = new FileName(_repoData.SourcesPath, msbuildData.Value.RelativeFileName);
+                var packages = GenerateUtil.GetFilteredPackages(msbuildData.Value, _repoData);
+                GenerateUtil.WriteMSBuildContent(fileName, packages);
+            }
+        }
+    }
+}

--- a/src/RepoUtil/ConflictingPackagesException.cs
+++ b/src/RepoUtil/ConflictingPackagesException.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace RepoUtil
+{
+    internal class ConflictingPackagesException : Exception
+    {
+        public ConflictingPackagesException(List<NuGetPackageConflict> conflictingPackages) :
+            base("Creation failed because of conflicting package versions.")
+        {
+            ConflictingPackages = conflictingPackages.ToImmutableArray();
+        }
+
+        public ImmutableArray<NuGetPackageConflict> ConflictingPackages { get; }
+    }
+}

--- a/src/RepoUtil/Constants.cs
+++ b/src/RepoUtil/Constants.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace RepoUtil
+{
+    internal static class Constants
+    {
+        /// <summary>
+        /// NuGet package names are not case sensitive.
+        /// </summary>
+        internal static readonly StringComparer NugetPackageNameComparer = StringComparer.OrdinalIgnoreCase;
+
+        /// <summary>
+        /// NuGet package versions case sensitivity is not documented anywhere that could be found.  Assuming
+        /// case insensitive for now.
+        /// </summary>
+        internal static readonly StringComparer NugetPackageVersionComparer = StringComparer.OrdinalIgnoreCase;
+    }
+}

--- a/src/RepoUtil/ConsumesCommand.cs
+++ b/src/RepoUtil/ConsumesCommand.cs
@@ -1,0 +1,107 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace RepoUtil
+{
+    internal sealed class ConsumesCommand : ICommand
+    {
+        private readonly RepoData _repoData;
+
+        internal ConsumesCommand(RepoData repoData)
+        {
+            _repoData = repoData;
+        }
+
+        public bool Run(TextWriter writer, string[] args)
+        {
+            var obj = GoCore();
+            var text = obj.ToString(Formatting.Indented);
+            writer.WriteLine(text);
+            return true;
+        }
+
+        private JObject GoCore()
+        {
+            var obj = new JObject();
+            obj.Add(GetNuGetFeeds());
+            obj.Add(GetFixedPackages());
+            obj.Add(GetBuildPackages());
+            obj.Add(GetToolsetPackages());
+            return obj;
+        }
+
+        private JProperty GetNuGetFeeds()
+        {
+            var obj = new JObject();
+            foreach (var nugetFeed in _repoData.NuGetFeeds)
+            {
+                obj.Add(GetProperty(nugetFeed));
+            }
+            return new JProperty("nugetFeeds", obj);
+        }
+
+        private JProperty GetFixedPackages()
+        {
+            var obj = new JObject();
+            foreach (var package in _repoData.FixedPackages.GroupBy(x => x.Name))
+            {
+                obj.Add(GetProperty(package.Key, package.Select(x => x.Version)));
+            }
+            return new JProperty("fixed", obj);
+        }
+
+        private JProperty GetBuildPackages()
+        {
+            return GetFloatingPackages("build", _repoData.FloatingBuildPackages);
+        }
+
+        private JProperty GetToolsetPackages()
+        {
+            return GetFloatingPackages("toolset", _repoData.FloatingToolsetPackages);
+        }
+
+        private JProperty GetFloatingPackages(string name, IEnumerable<NuGetPackage> packages)
+        {
+            var obj = new JObject();
+            foreach (var package in packages)
+            {
+                obj.Add(GetProperty(package));
+            }
+
+            return new JProperty(name, obj);
+        }
+
+        private static JProperty GetProperty(NuGetFeed feed)
+        {
+            return new JProperty(feed.Name, feed.Url);
+        }
+
+        private static JProperty GetProperty(NuGetPackage package)
+        {
+            return new JProperty(package.Name, package.Version);
+        }
+
+        private static JProperty GetProperty(string packageName, IEnumerable<string> versions)
+        {
+            if (versions.Count() == 1)
+            {
+                return GetProperty(new NuGetPackage(packageName, versions.Single()));
+            }
+
+            var content = JArray.FromObject(versions.ToArray());
+            return new JProperty(packageName, content);
+        }
+
+        private static string GetKey(NuGetPackage nugetRef)
+        {
+            return $"{nugetRef.Name}:{nugetRef.Version}";
+        }
+    }
+}

--- a/src/RepoUtil/FileName.cs
+++ b/src/RepoUtil/FileName.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace RepoUtil
+{
+    internal struct FileName : IEquatable<FileName>
+    {
+        internal string Name { get; }
+        internal string FullPath { get; }
+        internal string RelativePath { get; }
+
+        internal FileName(string rootPath, string relativePath)
+        {
+            Name = Path.GetFileName(relativePath);
+            FullPath = Path.Combine(rootPath, relativePath);
+            RelativePath = relativePath;
+        }
+
+        internal static FileName FromFullPath(string rootPath, string fullPath)
+        {
+            fullPath = fullPath.Substring(rootPath.Length + 1);
+            return new FileName(rootPath, fullPath);
+        }
+
+        public static bool operator ==(FileName left, FileName right) => left.FullPath == right.FullPath;
+        public static bool operator !=(FileName left, FileName right) => !(left == right);
+        public bool Equals(FileName other) => this == other;
+        public override int GetHashCode() => FullPath.GetHashCode();
+        public override string ToString() => RelativePath;
+        public override bool Equals(object obj) => obj is FileName && Equals((FileName)obj);
+    }
+}

--- a/src/RepoUtil/GenerateData.cs
+++ b/src/RepoUtil/GenerateData.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+
+namespace RepoUtil
+{
+    /// <summary>
+    /// The repo tool will generate include files, props, etc ... that containt NuGet versions.  This struct contains
+    /// information about where to generate and what packages should match.
+    /// </summary>
+    internal struct GenerateData
+    {
+        internal string RelativeFileName { get; }
+        internal ImmutableArray<Regex> Packages { get; }
+
+        internal GenerateData(string relativeFileName, ImmutableArray<Regex> packages)
+        {
+            RelativeFileName = relativeFileName;
+            Packages = packages;
+        }
+    }
+}

--- a/src/RepoUtil/GenerateUtil.cs
+++ b/src/RepoUtil/GenerateUtil.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace RepoUtil
+{
+    /// <summary>
+    /// Used for generating supporting files in the repo.  It will spit out named constants in props file 
+    /// instead of having developers hard code version numbers.
+    /// </summary>
+    internal static class GenerateUtil
+    {
+        internal static XNamespace MSBuildNamespace { get; } = XNamespace.Get("http://schemas.microsoft.com/developer/msbuild/2003");
+        internal static Encoding Encoding { get; } = Encoding.UTF8;
+
+        /// <summary>
+        /// Get the subset of packages which match the specified filter for the generated file.
+        /// </summary>
+        internal static List<NuGetPackage> GetFilteredPackages(GenerateData generateData, RepoData repoData)
+        {
+            // Fixed packages are never included in generated output.  Doing so would create conflicts because it's
+            // possible for two versions to exist for the same package.  Take for example System.Collections.Immuatble
+            // which is both fixed and floating in Roslyn.
+            return repoData
+                .FloatingPackages
+                .Where(x => generateData.Packages.Any(y => y.IsMatch(x.Name)))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Get any regex entries that match no packages.  Such entries are stale.
+        /// </summary>
+        internal static List<Regex> GetStaleRegex(GenerateData generateData, RepoData repoData)
+        {
+            return generateData
+                .Packages
+                .Where(r => repoData.FloatingPackages.All(p => !r.IsMatch(p.Name)))
+                .ToList();
+        }
+
+        internal static void WriteMSBuildContent(FileName fileName, IEnumerable<NuGetPackage> packages)
+        {
+            Console.WriteLine($"Generating MSBuild props file {fileName}");
+            using (var stream = File.Open(fileName.FullPath, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                WriteMSBuildContent(stream, packages);
+            }
+        }
+
+        private static void WriteMSBuildContent(Stream stream, IEnumerable<NuGetPackage> packages)
+        {
+            using (var writer = XmlWriter.Create(stream, new XmlWriterSettings() { Indent = true, Encoding = Encoding }))
+            {
+                var document = GenerateMSBuildXml(packages);
+                document.WriteTo(writer);
+            }
+        }
+
+        internal static string GenerateMSBuildContent(IEnumerable<NuGetPackage> allPackages)
+        {
+            using (var stream = new MemoryStream())
+            {
+                WriteMSBuildContent(stream, allPackages);
+
+                stream.Position = 0;
+                using (var reader = new StreamReader(stream, Encoding))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generate the MSBuild props file which contains named values for the NuGet versions.
+        /// </summary>
+        internal static XDocument GenerateMSBuildXml(IEnumerable<NuGetPackage> allPackages)
+        {
+            var ns = MSBuildNamespace;
+            var doc = new XDocument(new XElement(ns + "Project"));
+            doc.Root.Add(new XAttribute("ToolsVersion", "4.0"));
+            doc.Root.Add(new XComment(@"Generated file, do not directly edit.  Run ""RepoUtil change"" to regenerate"));
+
+            var group = new XElement(ns + "PropertyGroup");
+            foreach (var package in allPackages)
+            {
+                var name = PackageNameToXElementName(package.Name);
+                var elem = new XElement(ns + name);
+                elem.Value = package.Version;
+                group.Add(elem);
+            }
+
+            doc.Root.Add(group);
+            return doc;
+        }
+
+        private static string PackageNameToXElementName(string name)
+        {
+            return name.Replace(".", "") + "Version";
+        }
+    }
+}

--- a/src/RepoUtil/ICommand.cs
+++ b/src/RepoUtil/ICommand.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+namespace RepoUtil
+{
+    internal interface ICommand
+    {
+        bool Run(TextWriter writer, string[] args);
+    }
+}

--- a/src/RepoUtil/NuGetConfigUtil.cs
+++ b/src/RepoUtil/NuGetConfigUtil.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Xml.Linq;
+
+namespace RepoUtil
+{
+    internal static class NuGetConfigUtil
+    {
+        internal static List<NuGetFeed> GetNuGetFeeds(string nugetConfigFile)
+        {
+            var nugetConfig = XElement.Load(nugetConfigFile);
+            var nugetFeeds =
+                from el in nugetConfig.Descendants("packageSources").Descendants("add")
+                select new NuGetFeed(el.Attribute("key").Value, new Uri(el.Attribute("value").Value));
+
+            return nugetFeeds.ToList();
+        }
+
+        internal static IEnumerable<string> GetNuGetConfigFiles(string sourcesPath)
+        {
+            return Directory.EnumerateFiles(sourcesPath, "nuget*config", SearchOption.AllDirectories);
+        }
+    }
+}

--- a/src/RepoUtil/NuGetFeed.cs
+++ b/src/RepoUtil/NuGetFeed.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace RepoUtil
+{
+    internal struct NuGetFeed : IEquatable<NuGetFeed>
+    {
+        internal string Name { get; }
+        internal Uri Url { get; }
+
+        internal NuGetFeed(string name, Uri url)
+        {
+            Name = name;
+            Url = url;
+        }
+
+        public static bool operator ==(NuGetFeed left, NuGetFeed right) =>
+            StringComparer.OrdinalIgnoreCase.Equals(left.Name, right.Name) &&
+            left.Url == right.Url;
+        public static bool operator !=(NuGetFeed left, NuGetFeed right) => !(left == right);
+        public override bool Equals(object obj) => obj is NuGetFeed && Equals((NuGetFeed)obj);
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+        public override string ToString() => $"{Name}-{Url}";
+        public bool Equals(NuGetFeed other) => this == other;
+    }
+}

--- a/src/RepoUtil/NuGetPackage.cs
+++ b/src/RepoUtil/NuGetPackage.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace RepoUtil
+{
+    internal struct NuGetPackage : IEquatable<NuGetPackage>
+    {
+        internal string Name { get; }
+        internal string Version { get; }
+
+        internal NuGetPackage(string name, string version)
+        {
+            Name = name;
+            Version = version;
+        }
+
+        public static bool operator ==(NuGetPackage left, NuGetPackage right) =>
+            Constants.NugetPackageNameComparer.Equals(left.Name, right.Name) &&
+            Constants.NugetPackageVersionComparer.Equals(left.Version, right.Version);
+        public static bool operator !=(NuGetPackage left, NuGetPackage right) => !(left == right);
+        public override bool Equals(object obj) => obj is NuGetPackage && Equals((NuGetPackage)obj);
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+        public override string ToString() => $"{Name}-{Version}";
+        public bool Equals(NuGetPackage other) => this == other;
+    }
+}

--- a/src/RepoUtil/NuGetPackageChange.cs
+++ b/src/RepoUtil/NuGetPackageChange.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace RepoUtil
+{
+    internal sealed class NuGetPackageChange
+    {
+        internal string Name { get; }
+        internal string OldVersion { get; }
+        internal string NewVersion { get; }
+        internal NuGetPackage OldPackage => new NuGetPackage(Name, OldVersion);
+        internal NuGetPackage NewPackage => new NuGetPackage(Name, NewVersion);
+
+        internal NuGetPackageChange(string name, string oldVersion, string newVersion)
+        {
+            Name = name;
+            OldVersion = oldVersion;
+            NewVersion = newVersion;
+        }
+
+        public override string ToString() => $"{Name} from {OldVersion} to {NewVersion}";
+    }
+}

--- a/src/RepoUtil/NuGetPackageSource.cs
+++ b/src/RepoUtil/NuGetPackageSource.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace RepoUtil
+{
+    internal struct NuGetPackageSource
+    {
+        internal NuGetPackage NuGetPackage { get; }
+        internal FileName FileName { get; }
+
+        internal NuGetPackageSource(NuGetPackage package, FileName fileName)
+        {
+            NuGetPackage = package;
+            FileName = fileName;
+        }
+    }
+
+    internal struct NuGetPackageConflict
+    {
+        internal NuGetPackageSource Original { get; }
+        internal NuGetPackageSource Conflict { get; }
+        internal string PackageName => Original.NuGetPackage.Name;
+
+        internal NuGetPackageConflict(NuGetPackageSource original, NuGetPackageSource conflict)
+        {
+            Debug.Assert(Constants.NugetPackageNameComparer.Equals(original.NuGetPackage.Name, conflict.NuGetPackage.Name));
+            Original = original;
+            Conflict = conflict;
+        }
+    }
+}

--- a/src/RepoUtil/NuSpecUtil.cs
+++ b/src/RepoUtil/NuSpecUtil.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace RepoUtil
+{
+    internal static class NuSpecUtil
+    {
+        internal static IEnumerable<FileName> GetNuSpecFiles(string sourcesPath)
+        {
+            return Directory
+                .EnumerateFiles(sourcesPath, "*.nuspec", SearchOption.AllDirectories)
+                .Select(x => FileName.FromFullPath(sourcesPath, x));
+        }
+
+        internal static string GetId(string nuspecFilePath)
+        {
+            var doc = XDocument.Load(nuspecFilePath);
+            var ns = XNamespace.Get("http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd");
+            var id = doc
+                .Element(ns.GetName("package"))
+                .Element(ns.GetName("metadata"))
+                .Element(ns.GetName("id"))
+                .Value;
+            return id;
+        }
+    }
+}

--- a/src/RepoUtil/ProducesCommand.cs
+++ b/src/RepoUtil/ProducesCommand.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Linq;
+
+namespace RepoUtil
+{
+    internal class ProducesCommand : ICommand
+    {
+        private readonly RepoConfig _repoConfig;
+        private readonly string _sourcesPath;
+
+        internal ProducesCommand(RepoConfig repoConfig, string sourcesPath)
+        {
+            _repoConfig = repoConfig;
+            _sourcesPath = sourcesPath;
+        }
+
+        public bool Run(TextWriter writer, string[] args)
+        {
+            foreach (var fileName in NuSpecUtil.GetNuSpecFiles(_sourcesPath))
+            {
+                if (_repoConfig.NuSpecExcludes.Any(x => x.IsMatch(fileName.RelativePath)))
+                {
+                    continue;
+                }
+
+                var id = NuSpecUtil.GetId(fileName.FullPath);
+                writer.WriteLine(id);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/RepoUtil/Program.cs
+++ b/src/RepoUtil/Program.cs
@@ -1,0 +1,180 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace RepoUtil
+{
+    internal static class Program
+    {
+        private sealed class ParsedArgs
+        {
+            internal string RepoDataPath { get; set; }
+            internal string SourcesPath { get; set; }
+            internal string[] RemainingArgs { get; set; }
+        }
+
+        private delegate ICommand CreateCommand(RepoConfig repoConfig, string sourcesPath);
+
+        internal static int Main(string[] args)
+        {
+            int result = 1;
+            try
+            {
+                if (Run(args))
+                    result = 0;
+            }
+            catch (ConflictingPackagesException ex)
+            {
+                Console.WriteLine(ex.Message);
+                foreach (var package in ex.ConflictingPackages)
+                {
+                    Console.WriteLine(package.PackageName);
+                    Console.WriteLine($"\t{package.Conflict.NuGetPackage.Version} - {package.Conflict.FileName}");
+                    Console.WriteLine($"\t{package.Original.NuGetPackage.Version} - {package.Original.FileName}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Something unexpected happened.");
+                Console.WriteLine(ex.ToString());
+            }
+
+            return result;
+        }
+
+        private static bool Run(string[] args)
+        {
+            ParsedArgs parsedArgs;
+            CreateCommand func;
+            if (!TryParseCommandLine(args, out parsedArgs, out func))
+            {
+                return false;
+            }
+
+            RepoConfig repoConfig = null;
+            if (!string.IsNullOrEmpty(parsedArgs.RepoDataPath))
+                repoConfig = RepoConfig.ReadFrom(parsedArgs.RepoDataPath);
+            var command = func(repoConfig, parsedArgs.SourcesPath);
+            return command.Run(Console.Out, parsedArgs.RemainingArgs);
+        }
+
+        private static bool TryParseCommandLine(string[] args, out ParsedArgs parsedArgs, out CreateCommand func)
+        {
+            func = null;
+            parsedArgs = new ParsedArgs();
+
+            // Setup the default values
+            parsedArgs.SourcesPath = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
+
+            var index = 0;
+            if (!TryParseCommon(args, ref index, parsedArgs))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(parsedArgs.RepoDataPath))
+                throw new ArgumentException("The -repoDataPath switch is required.");
+
+            if (!TryParseCommand(args, ref index, out func))
+            {
+                return false;
+            }
+
+            parsedArgs.RemainingArgs = index >= args.Length
+                ? Array.Empty<string>()
+                : args.Skip(index).ToArray();
+            return true;
+        }
+
+        private static bool TryParseCommon(string[] args, ref int index, ParsedArgs parsedArgs)
+        {
+            while (index < args.Length)
+            {
+                var arg = args[index];
+                if (arg[0] != '-')
+                {
+                    return true;
+                }
+
+                index++;
+                switch (arg.ToLower())
+                {
+                    case "-sourcespath":
+                        {
+                            if (index < args.Length)
+                            {
+                                parsedArgs.SourcesPath = args[index];
+                                index++;
+                            }
+                            else
+                            {
+                                Console.WriteLine($"The -sourcesPath switch needs a value");
+                                return false;
+                            }
+                            break;
+                        }
+                    case "-repodatapath":
+                        {
+                            if (index < args.Length)
+                            {
+                                parsedArgs.RepoDataPath = args[index];
+                                index++;
+                            }
+                            else
+                            {
+                                Console.WriteLine($"The -repoDataPath switch needs a value");
+                                return false;
+                            }
+                            break;
+                        }
+                    default:
+                        Console.Write($"Option {arg} is unrecognized");
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryParseCommand(string[] args, ref int index, out CreateCommand func)
+        {
+            func = null;
+
+            if (index >= args.Length)
+            {
+                Console.WriteLine("Need a command to run");
+                return false;
+            }
+
+            var name = args[index];
+            switch (name)
+            {
+                case "verify":
+                    func = (c, s) => new VerifyCommand(c, s);
+                    break;
+                case "view":
+                    func = (c, s) => new ViewCommand(c, s);
+                    break;
+                case "consumes":
+                    func = (c, s) => new ConsumesCommand(RepoData.Create(c, s));
+                    break;
+                case "change":
+                    func = (c, s) => new ChangeCommand(RepoData.Create(c, s));
+                    break;
+                case "produces":
+                    func = (c, s) => new ProducesCommand(c, s);
+                    break;
+                default:
+                    Console.Write($"Command {name} is not recognized");
+                    return false;
+            }
+
+            index++;
+            return true;
+        }
+    }
+}

--- a/src/RepoUtil/ProjectJsonUtil.cs
+++ b/src/RepoUtil/ProjectJsonUtil.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
+using System.Collections.Immutable;
+
+namespace RepoUtil
+{
+    internal static class ProjectJsonUtil
+    {
+        /// <summary>
+        /// Does the specified project.json file need to be tracked by our repo util? 
+        /// </summary>
+        internal static bool NeedsTracking(string filePath)
+        {
+            return GetDependencies(filePath).Length > 0;
+        }
+
+        internal static ImmutableArray<NuGetPackage> GetDependencies(string filePath)
+        {
+            // Need to track any file that has dependencies
+            var obj = JObject.Parse(File.ReadAllText(filePath));
+            var dependencies = (JObject)obj["dependencies"];
+            if (dependencies == null)
+            {
+                return ImmutableArray<NuGetPackage>.Empty;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<NuGetPackage>();
+            foreach (var dependency in dependencies.Properties())
+            {
+                builder.Add(ParseDependency(dependency));
+            }
+
+            return builder.ToImmutable();
+        }
+
+        /// <summary>
+        /// Change the NuGet dependencies in the file to match the new packages.
+        /// </summary>
+        internal static bool ChangeDependencies(string filePath, ImmutableDictionary<NuGetPackage, NuGetPackage> changeMap)
+        {
+            var obj = JObject.Parse(File.ReadAllText(filePath), new JsonLoadSettings() { CommentHandling = CommentHandling.Load });
+            var dependencies = (JObject)obj["dependencies"];
+            if (dependencies == null)
+            {
+                return false;
+            }
+
+            var changed = false;
+            foreach (var prop in dependencies.Properties())
+            {
+                var currentPackage = ParseDependency(prop);
+                NuGetPackage newPackage;
+                if (!changeMap.TryGetValue(currentPackage, out newPackage))
+                {
+                    continue;
+                }
+
+                ChangeDependency(prop, newPackage.Version);
+                changed = true;
+            }
+
+            if (!changed)
+            {
+                return false;
+            }
+
+            var data = JsonConvert.SerializeObject(obj, Formatting.Indented);
+            File.WriteAllText(filePath, data);
+            return true;
+        }
+
+        private static void ChangeDependency(JProperty prop, string version)
+        {
+            if (prop.Value.Type == JTokenType.String)
+            {
+                prop.Value = version;
+            }
+            else
+            {
+                var obj = (JObject)prop.Value;
+                obj["version"] = version;
+            }
+        }
+
+        /// <summary>
+        /// Parse out a dependency entry from the project.json file.
+        /// </summary>
+        internal static NuGetPackage ParseDependency(JProperty prop)
+        {
+            var name = prop.Name;
+
+            string version;
+            if (prop.Value.Type == JTokenType.String)
+            {
+                version = (string)prop.Value;
+            }
+            else
+            {
+                version = ((JObject)prop.Value).Value<string>("version");
+            }
+
+            return new NuGetPackage(name, version);
+        }
+
+        internal static bool VerifyTracked(string sourcesPath, IEnumerable<FileName> fileNames)
+        {
+            var set = new HashSet<FileName>(fileNames);
+            var allGood = true;
+
+            foreach (var file in Directory.EnumerateFiles(sourcesPath, "project.json", SearchOption.AllDirectories))
+            {
+                var relativeName = file.Substring(sourcesPath.Length + 1);
+                var fileName = new FileName(sourcesPath, relativeName);
+                if (set.Contains(fileName) || !NeedsTracking(file))
+                {
+                    continue;
+                }
+
+                Console.WriteLine($"Need to track {fileName}");
+                allGood = false;
+            }
+
+            return allGood;
+        }
+
+        internal static IEnumerable<string> GetProjectJsonFiles(string sourcesPath)
+        {
+            return Directory.EnumerateFiles(sourcesPath, "*project.json", SearchOption.AllDirectories);
+        }
+    }
+}

--- a/src/RepoUtil/README.md
+++ b/src/RepoUtil/README.md
@@ -1,0 +1,71 @@
+# RepoUtil
+
+## Usage
+
+This is a tool used to manage the inputs and outputs of our repo.  In particular, it is used to manage our use of NuGet packages.  It helps to automate the otherwise tedious process of updating NuGet references by:
+
+- Fixing up project.json files
+- Generating helper files with specified package versions. Example [Dependencies.props](https://github.com/dotnet/roslyn/blob/master/build/Targets/Dependencies.props)
+
+The tool works by using all of our project.json files as the primary source of truth for the repo.  All files with the name pattern `*project.json` are considered to be NuGet assets and will be scanned for NuGet references.  
+
+This will impose a minimum of requirements on our NuGet packages.  In particular the tool assumes that all references to a given NuGet package should occur at the same version.  If the tool sees a package being used with different versions it will issue an error.  
+
+There are valid cases where a package is used at more than one version in the repo.  Typically because it's being deployed as an asset, used as a tool, etc ...  In those cases an entry can be added to [RepoData.json](https://github.com/dotnet/roslyn/blob/master/src/Tools/RepoUtil/RepoData.json)) in the fixed table to call out that usage:
+
+``` json
+"fixed" {
+    "Microsoft.VSSDK.BuildTools": [ "14.3.25407", "15.0.25201-Dev15Preview2" ]
+}
+```
+
+## Commands
+
+This tool operates by having a set of sub commands that it executes
+
+### change
+
+The `change` command has two main purposes:
+
+1. Update a NuGet package reference to a new version 
+2. Regenerate all of the supporting files
+
+In order to change a single reference simply pass the new package as an argument:
+
+``` cmd
+RepoUtil change "System.Collections.Immutable 1.3.0"
+```
+
+For large number of packages a file can be used to list out all of the packages.  
+
+``` cmd
+RepoUtil change -version e:\path\to\file.txt
+```
+
+To regenerate all of the supporting files without updating any packages just use `change` without any arguments
+
+``` cmd
+RepoUtil change
+```
+
+### verify
+
+The `verify` command will simply analyze the state of the repo and ensure all of the NuGet dependencies are up to date:
+
+- All packages are referenced at the same version.
+- All the generated files are up to date.
+- etc ... 
+
+
+All packages must fall into one of the following categories:
+
+- Normal: Packages which are expected to be updated.  
+- Fixed: Package + version which are referenced at a version that should never change. 
+
+All uses of a normal package in the repo must have the same version.  For example every use of System.Collections.Immutable.
+
+An example of a normal package is System.Collections.Immutable.  This package changes
+
+### consumes
+
+The `consumes` command produces a json file describing all of the NuGet packages consumed by the repo.  It essentially aggregates all of the project.json files and adds a bit of metadata on top of them. 

--- a/src/RepoUtil/RepoConfig.cs
+++ b/src/RepoUtil/RepoConfig.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace RepoUtil
+{
+    /// <summary>
+    /// Packages in the repo fall into the following groups:
+    /// 
+    /// Fixed Packages:
+    /// 
+    /// These are packages which should never change.  In other words if there was a scenario where a new version of the 
+    /// package was available the reference should not update to the new version.  For all time it should remain at the 
+    /// specified version.
+    ///
+    /// Because they are fixed it's possible to have multiple vesions of the same package.  For instance it's okay to 
+    /// have many versions of Newtonsoft.Json referenced here because there is no need to unify.  Or at least it's stated
+    /// that we don't need to unify.
+    ///
+    /// Floating Packages:
+    /// 
+    /// These are packages which are expected to change when new versions are available.  These are tools, dependencies, etc ...
+    /// which are expected to evolve over time and we need to move forward with those dependencies. 
+    /// 
+    /// Generally these fall into two categories:
+    ///
+    ///     Build Dependencies
+    ///     Toolset Dependencies
+    ///
+    /// This distinction is necessary to help break circular references for repos when constructing build graphs.
+    /// </summary>
+    internal class RepoConfig
+    {
+        internal ImmutableArray<NuGetPackage> FixedPackages { get; }
+        internal ImmutableArray<string> ToolsetPackages { get; }
+        internal ImmutableArray<Regex> NuSpecExcludes { get; }
+        internal ImmutableArray<Regex> ProjectJsonExcludes { get; }
+        internal GenerateData? MSBuildGenerateData { get; }
+
+        internal RepoConfig(
+            IEnumerable<NuGetPackage> fixedPackages, 
+            IEnumerable<string> toolsetPackages, 
+            IEnumerable<Regex> nuspecExcludes,
+            IEnumerable<Regex> projectJsonExcludes,
+            GenerateData? msbuildGenerateData)
+        {
+            Debug.Assert(toolsetPackages.Distinct().Count() == toolsetPackages.Count());
+            MSBuildGenerateData = msbuildGenerateData;
+            FixedPackages = fixedPackages.OrderBy(x => x.Name).ToImmutableArray();
+            NuSpecExcludes = nuspecExcludes.ToImmutableArray();
+            ProjectJsonExcludes = projectJsonExcludes.ToImmutableArray();
+            ToolsetPackages = toolsetPackages.OrderBy(x => x).ToImmutableArray();
+
+            var map = new Dictionary<string, List<string>>();
+            foreach (var nugetRef in fixedPackages)
+            {
+                List<string> list;
+                if (!map.TryGetValue(nugetRef.Name, out list))
+                {
+                    list = new List<string>(capacity: 1);
+                    map[nugetRef.Name] = list;
+                }
+
+                list.Add(nugetRef.Version);
+            }
+        }
+
+        internal static RepoConfig ReadFrom(string jsonFilePath)
+        {
+            // Need to track any file that has dependencies
+            var obj = JObject.Parse(File.ReadAllText(jsonFilePath));
+            var fixedPackages = (JObject)obj["fixedPackages"];
+            var fixedPackagesList = ImmutableArray.CreateBuilder<NuGetPackage>();
+            foreach (var prop in fixedPackages.Properties())
+            {
+                if (prop.Value.Type == JTokenType.String)
+                {
+                    var version = (string)prop.Value;
+                    var nugetRef = new NuGetPackage(prop.Name, version);
+                    fixedPackagesList.Add(nugetRef);
+                }
+                else
+                {
+                    foreach (var version in ((JArray)prop.Value).Values<string>())
+                    {
+                        var nugetRef = new NuGetPackage(prop.Name, version);
+                        fixedPackagesList.Add(nugetRef);
+                    }
+                }
+            }
+
+            var toolsetPackagesProp = obj.Property("toolsetPackages");
+            var toolsetPackages = ((JArray)toolsetPackagesProp.Value).Values<string>();
+
+            GenerateData? msbuildGenerateData = null;
+            var generateObj = (JObject)obj.Property("generate").Value;
+            if (generateObj != null)
+            {
+                msbuildGenerateData = ReadGenerateData(generateObj, "msbuild");
+            }
+
+            var nuspecExcludes = new List<Regex>();
+            var nuspecExcludesProp = obj.Property("nuspecExcludes");
+            if (nuspecExcludesProp != null)
+            {
+                nuspecExcludes.AddRange(((JArray)nuspecExcludesProp.Value).Values<string>().Select(x => new Regex(x)));
+            }
+
+            var projectJsonExcludes = new List<Regex>();
+            var projectJsonExcludesProp = obj.Property("projectJsonExcludes");
+            if (projectJsonExcludesProp != null)
+            {
+                projectJsonExcludes.AddRange(((JArray)projectJsonExcludesProp.Value).Values<string>().Select(x => new Regex(x)));
+            }
+
+            return new RepoConfig(
+                fixedPackagesList,
+                toolsetPackages,
+                nuspecExcludes,
+                projectJsonExcludes,
+                msbuildGenerateData);
+        }
+
+        private static GenerateData? ReadGenerateData(JObject obj, string propName)
+        {
+            var prop = obj.Property(propName);
+            if (prop == null)
+            {
+                return null;
+            }
+
+            return ReadGenerateData((JObject)prop.Value);
+        }
+
+        private static GenerateData ReadGenerateData(JObject obj)
+        {
+            var relativeFilePath = (string)obj.Property("path").Value;
+            var builder = ImmutableArray.CreateBuilder<Regex>();
+            var array = (JArray)obj.Property("values").Value;
+            foreach (var item in array.Values<string>())
+            {
+                builder.Add(new Regex(item));
+            }
+
+            return new GenerateData(relativeFilePath, builder.ToImmutable());
+        }
+    }
+}

--- a/src/RepoUtil/RepoData.cs
+++ b/src/RepoUtil/RepoData.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace RepoUtil
+{
+    internal sealed class RepoData
+    {
+        internal string SourcesPath { get; }
+        internal RepoConfig RepoConfig { get; }
+        internal ImmutableArray<NuGetFeed> NuGetFeeds { get; }
+        internal ImmutableArray<NuGetPackage> FloatingBuildPackages { get; }
+        internal ImmutableArray<NuGetPackage> FloatingToolsetPackages { get; }
+        internal ImmutableArray<NuGetPackage> FloatingPackages { get; }
+        internal ImmutableArray<NuGetPackage> FixedPackages => RepoConfig.FixedPackages;
+        internal ImmutableArray<NuGetPackage> AllPackages { get; }
+
+        private RepoData(RepoConfig config, string sourcesPath, IEnumerable<NuGetFeed> nugetFeeds, IEnumerable<NuGetPackage> floatingPackages)
+        {
+            SourcesPath = sourcesPath;
+            RepoConfig = config;
+            NuGetFeeds = nugetFeeds.ToImmutableArray();
+            FloatingToolsetPackages = floatingPackages
+                .Where(x => RepoConfig.ToolsetPackages.Contains(x.Name, Constants.NugetPackageNameComparer))
+                .OrderBy(x => x.Name)
+                .ToImmutableArray();
+            FloatingBuildPackages = floatingPackages
+                .Where(x => !RepoConfig.ToolsetPackages.Contains(x.Name, Constants.NugetPackageNameComparer))
+                .OrderBy(x => x.Name)
+                .ToImmutableArray();
+            FloatingPackages = floatingPackages
+                .OrderBy(x => x.Name)
+                .ToImmutableArray();
+            AllPackages = Combine(FloatingBuildPackages, FloatingToolsetPackages, FixedPackages);
+        }
+
+        private static ImmutableArray<NuGetPackage> Combine(params ImmutableArray<NuGetPackage>[] args)
+        {
+            return args
+                .SelectMany(x => x)
+                .OrderBy(x => x.Name)
+                .ToImmutableArray();
+        }
+
+        /// <summary>
+        /// The raw RepoData contains only the fixed + toolset packages that we need to track.  This method will examine the current
+        /// state of the repo and add in the current data.  If any conflicting package definitions are detected this method 
+        /// will throw.
+        /// </summary>
+        internal static RepoData Create(RepoConfig config, string sourcesPath)
+        {
+            List<NuGetPackageConflict> conflicts;
+            var repoData = Create(config, sourcesPath, out conflicts);
+            if (conflicts?.Count > 0)
+            {
+                throw new ConflictingPackagesException(conflicts);
+            }
+
+            return repoData;
+        }
+
+        internal static RepoData Create(RepoConfig config, string sourcesPath, out List<NuGetPackageConflict> conflicts)
+        {
+            var nugetFeeds = new List<NuGetFeed>();
+            foreach (var nugetConfig in NuGetConfigUtil.GetNuGetConfigFiles(sourcesPath))
+            {
+                var nugetFeed = NuGetConfigUtil.GetNuGetFeeds(nugetConfig);
+                nugetFeeds.AddRange(nugetFeed);
+            }
+
+            conflicts = null;
+
+            var fixedPackageSet = new HashSet<NuGetPackage>(config.FixedPackages);
+            var floatingPackageMap = new Dictionary<string, NuGetPackageSource>(Constants.NugetPackageNameComparer);
+            foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(sourcesPath))
+            {
+                if (config.ProjectJsonExcludes.Any(x => x.IsMatch(filePath)))
+                {
+                    continue;
+                }
+
+                var fileName = FileName.FromFullPath(sourcesPath, filePath);
+                foreach (var package in ProjectJsonUtil.GetDependencies(filePath))
+                {
+                    if (fixedPackageSet.Contains(package))
+                    {
+                        continue;
+                    }
+
+                    // If this is the first time we've seen the package then record where it was found.  Need the source
+                    // information to provide better error messages later.
+                    var packageSource = new NuGetPackageSource(package, fileName);
+                    NuGetPackageSource originalSource;
+                    if (floatingPackageMap.TryGetValue(package.Name, out originalSource))
+                    {
+                        if (originalSource.NuGetPackage.Version != package.Version)
+                        {
+                            var conflict = new NuGetPackageConflict(original: originalSource, conflict: packageSource);
+                            conflicts = conflicts ?? new List<NuGetPackageConflict>();
+                            conflicts.Add(conflict);
+                        }
+                    }
+                    else
+                    {
+                        floatingPackageMap.Add(package.Name, packageSource);
+                    }
+                }
+            }
+
+            return new RepoData(config, sourcesPath, nugetFeeds, floatingPackageMap.Values.Select(x => x.NuGetPackage));
+        }
+    }
+}

--- a/src/RepoUtil/RepoUtil.csproj
+++ b/src/RepoUtil/RepoUtil.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>RepoUtil</RootNamespace>
+    <AssemblyName>repoutil</AssemblyName>
+    <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
+    <ProjectGuid>{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <Compile Include="ChangeCommand.cs" />
+    <Compile Include="ConflictingPackagesException.cs" />
+    <Compile Include="Constants.cs" />
+    <Compile Include="ConsumesCommand.cs" />
+    <Compile Include="FileName.cs" />
+    <Compile Include="GenerateData.cs" />
+    <Compile Include="GenerateUtil.cs" />
+    <Compile Include="ICommand.cs" />
+    <Compile Include="NuGetConfigUtil.cs" />
+    <Compile Include="NuGetFeed.cs" />
+    <Compile Include="NuGetPackage.cs" />
+    <Compile Include="NuGetPackageChange.cs" />
+    <Compile Include="NuGetPackageSource.cs" />
+    <Compile Include="NuSpecUtil.cs" />
+    <Compile Include="ProducesCommand.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="ProjectJsonUtil.cs" />
+    <Compile Include="RepoConfig.cs" />
+    <Compile Include="RepoData.cs" />
+    <Compile Include="UsageCommand.cs" />
+    <Compile Include="ViewCommand.cs" />
+    <Compile Include="VerifyCommand.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="repoutil.runtimeconfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/RepoUtil/RepoUtil.csproj
+++ b/src/RepoUtil/RepoUtil.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>RepoUtil</RootNamespace>
-    <AssemblyName>repoutil</AssemblyName>
+    <AssemblyName>RepoUtil</AssemblyName>
     <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
     <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
     <ProjectGuid>{1CA184D3-89CB-4074-BEC5-F8AEBA657D41}</ProjectGuid>
@@ -36,7 +36,7 @@
     <Compile Include="VerifyCommand.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="repoutil.runtimeconfig.json">
+    <None Include="RepoUtil.runtimeconfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="project.json" />

--- a/src/RepoUtil/UsageCommand.cs
+++ b/src/RepoUtil/UsageCommand.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace RepoUtil
+{
+    internal class UsageCommand : ICommand
+    {
+        public bool Run(TextWriter writer, string[] args)
+        {
+            Usage(writer);
+            return true;
+        }
+
+        internal static void Usage(TextWriter writer = null)
+        {
+            writer = writer ?? Console.Out;
+            var text = @"
+  verify: check the state of the repo
+  consumes: output the conent consumed by this repo
+  produces: output the content produced by this repo
+  change: change the dependencies.
+";
+            writer.WriteLine(text);
+        }
+    }
+}

--- a/src/RepoUtil/VerifyCommand.cs
+++ b/src/RepoUtil/VerifyCommand.cs
@@ -1,0 +1,128 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace RepoUtil
+{
+    /// <summary>
+    /// This utility is used to verify the repo is in a consistent state with respect to NuGet references. 
+    /// </summary>
+    internal sealed class VerifyCommand : ICommand
+    {
+        private readonly string _sourcesPath;
+        private readonly RepoConfig _repoConfig;
+
+        internal VerifyCommand(RepoConfig repoConfig, string sourcesPath)
+        {
+            _repoConfig = repoConfig;
+            _sourcesPath = sourcesPath;
+        }
+
+        public bool Run(TextWriter writer, string[] args)
+        {
+            RepoData repoData;
+            if (VerifyProjectJsonContents(writer, out repoData) &&
+                VerifyRepoConfig(writer) &&
+                VerifyGeneratedFiles(writer, repoData))
+            {
+                return true;
+            }
+
+            writer.WriteLine($"Error! RepoUtil verification failed.");
+            return false;
+        }
+
+        /// <summary>
+        /// Verify the packages listed in project.json are well formed.  Packages should all either have the same version or 
+        /// be explicitly fixed in the config file.
+        /// </summary>
+        private bool VerifyProjectJsonContents(TextWriter writer, out RepoData repoData)
+        {
+            writer.WriteLine($"Verifying project.json contents");
+
+            List<NuGetPackageConflict> conflicts;
+            repoData = RepoData.Create(_repoConfig, _sourcesPath, out conflicts);
+            if (conflicts?.Count > 0)
+            { 
+                foreach (var conflict in conflicts)
+                {
+                    writer.WriteLine($"Error! Package {conflict.PackageName} has different versions:");
+                    writer.WriteLine($"\t{conflict.Original.FileName} at {conflict.Original.NuGetPackage.Version}");
+                    writer.WriteLine($"\t{conflict.Conflict.FileName} at {conflict.Conflict.NuGetPackage.Version}");
+                    writer.WriteLine($"The versions must be the same or one must be explicitly listed as fixed in RepoData.json");
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Verify that all of the data contained in the repo configuration is valid.  In particular that it hasn't gotten
+        /// stale and referring to invalid packages.
+        /// </summary>
+        /// <param name="writer"></param>
+        private bool VerifyRepoConfig(TextWriter writer)
+        {
+            writer.WriteLine($"Verifying RepoData.json");
+            var packages = ProjectJsonUtil
+                .GetProjectJsonFiles(_sourcesPath)
+                .SelectMany(x => ProjectJsonUtil.GetDependencies(x));
+            var set = new HashSet<NuGetPackage>(packages);
+            var allGood = true;
+
+            foreach (var package in _repoConfig.FixedPackages)
+            {
+                if (!set.Contains(package))
+                {
+                    writer.WriteLine($"Error: Fixed package {package.Name} - {package.Version} is not used anywhere");
+                    allGood = false;
+                }
+            }
+
+            return allGood;
+        }
+
+        private bool VerifyGeneratedFiles(TextWriter writer, RepoData repoData)
+        {
+            var allGood = true;
+            writer.WriteLine($"Verifying generated files");
+            if (_repoConfig.MSBuildGenerateData.HasValue)
+            {
+                var data = _repoConfig.MSBuildGenerateData.Value;
+                var packages = GenerateUtil.GetFilteredPackages(data, repoData);
+
+                // Need to verify the contents of the generated file are correct.
+                var fileName = new FileName(_sourcesPath, data.RelativeFileName);
+                var actualContent = File.ReadAllText(fileName.FullPath, GenerateUtil.Encoding);
+                var expectedContent = GenerateUtil.GenerateMSBuildContent(packages);
+                if (actualContent != expectedContent)
+                {
+                    writer.WriteLine($"{fileName.RelativePath} does not have the expected contents");
+                    allGood = false;
+                }
+
+                if (!allGood)
+                {
+                    writer.WriteLine($@"Generated contents out of date. Run ""RepoUtil.change"" to correct");
+                    return false;
+                }
+
+                // Verify none of the regex entries are stale.
+                var staleRegexList = GenerateUtil.GetStaleRegex(data, repoData);
+                foreach (var regex in staleRegexList)
+                {
+                    writer.WriteLine($"Regex {regex} matches no packages");
+                    allGood = false;
+                }
+            }
+
+            return allGood;
+        }
+    }
+}

--- a/src/RepoUtil/ViewCommand.cs
+++ b/src/RepoUtil/ViewCommand.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace RepoUtil
+{
+    /// <summary>
+    /// This utility is used to verify the repo is in a consistent state with respect to NuGet references. 
+    /// </summary>
+    internal sealed class ViewCommand : ICommand
+    {
+        private readonly string _sourcesPath;
+        private readonly RepoConfig _repoConfig;
+
+        internal ViewCommand(RepoConfig repoConfig, string sourcesPath)
+        {
+            _repoConfig = repoConfig;
+            _sourcesPath = sourcesPath;
+        }
+
+        public bool Run(TextWriter writer, string[] args)
+        {
+            var list = args
+                .Select(x => new Regex(x))
+                .ToList();
+            if (list.Count == 0)
+            {
+                list.Add(new Regex(".*"));
+            }
+
+            var map = new Dictionary<NuGetPackage, List<FileName>>();
+            foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(_sourcesPath))
+            {
+                var fileName = FileName.FromFullPath(_sourcesPath, filePath);
+                foreach (var package in ProjectJsonUtil.GetDependencies(fileName.FullPath))
+                {
+                    if (list.All(x => !x.IsMatch(package.Name)))
+                    {
+                        continue;
+                    }
+
+                    List<FileName> nameList;
+                    if (!map.TryGetValue(package, out nameList))
+                    {
+                        nameList = new List<FileName>();
+                        map[package] = nameList;
+                    }
+
+                    nameList.Add(fileName);
+                }
+            }
+
+            foreach (var pair in map.OrderBy(x => x.Key.Name))
+            {
+                var package = pair.Key;
+                writer.WriteLine($"{package.Name} - {package.Version}");
+                foreach (var fileName in pair.Value)
+                {
+                    writer.WriteLine($"\t{fileName.RelativePath}");
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Verify the packages listed in project.json are well formed.  Packages should all either have the same version or 
+        /// be explicitly fixed in the config file.
+        /// </summary>
+        private bool VerifyProjectJsonContents(TextWriter writer, out RepoData repoData)
+        {
+            writer.WriteLine($"Verifying project.json contents");
+
+            List<NuGetPackageConflict> conflicts;
+            repoData = RepoData.Create(_repoConfig, _sourcesPath, out conflicts);
+            if (conflicts?.Count > 0)
+            { 
+                foreach (var conflict in conflicts)
+                {
+                    writer.WriteLine($"Error! Package {conflict.PackageName} has different versions:");
+                    writer.WriteLine($"\t{conflict.Original.FileName} at {conflict.Original.NuGetPackage.Version}");
+                    writer.WriteLine($"\t{conflict.Conflict.FileName} at {conflict.Conflict.NuGetPackage.Version}");
+                    writer.WriteLine($"The versions must be the same or one must be explicitly listed as fixed in RepoData.json");
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Verify that all of the data contained in the repo configuration is valid.  In particular that it hasn't gotten
+        /// stale and referring to invalid packages.
+        /// </summary>
+        /// <param name="writer"></param>
+        private bool VerifyRepoConfig(TextWriter writer)
+        {
+            writer.WriteLine($"Verifying RepoData.json");
+            var packages = ProjectJsonUtil
+                .GetProjectJsonFiles(_sourcesPath)
+                .SelectMany(x => ProjectJsonUtil.GetDependencies(x));
+            var set = new HashSet<NuGetPackage>(packages);
+            var allGood = true;
+
+            foreach (var package in _repoConfig.FixedPackages)
+            {
+                if (!set.Contains(package))
+                {
+                    writer.WriteLine($"Error: Fixed package {package.Name} - {package.Version} is not used anywhere");
+                    allGood = false;
+                }
+            }
+
+            return allGood;
+        }
+
+        private bool VerifyGeneratedFiles(TextWriter writer, RepoData repoData)
+        {
+            var allGood = true;
+            writer.WriteLine($"Verifying generated files");
+            if (_repoConfig.MSBuildGenerateData.HasValue)
+            {
+                var data = _repoConfig.MSBuildGenerateData.Value;
+                var packages = GenerateUtil.GetFilteredPackages(data, repoData);
+
+                // Need to verify the contents of the generated file are correct.
+                var fileName = new FileName(_sourcesPath, data.RelativeFileName);
+                var actualContent = File.ReadAllText(fileName.FullPath, GenerateUtil.Encoding);
+                var expectedContent = GenerateUtil.GenerateMSBuildContent(packages);
+                if (actualContent != expectedContent)
+                {
+                    writer.WriteLine($"{fileName.RelativePath} does not have the expected contents");
+                    allGood = false;
+                }
+
+                if (!allGood)
+                {
+                    writer.WriteLine($@"Generated contents out of date. Run ""RepoUtil.change"" to correct");
+                    return false;
+                }
+
+                // Verify none of the regex entries are stale.
+                var staleRegexList = GenerateUtil.GetStaleRegex(data, repoData);
+                foreach (var regex in staleRegexList)
+                {
+                    writer.WriteLine($"Regex {regex} matches no packages");
+                    allGood = false;
+                }
+            }
+
+            return allGood;
+        }
+    }
+}

--- a/src/RepoUtil/project.json
+++ b/src/RepoUtil/project.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0-rc2-3002702",
+      "type": "platform"
+    },
+    "Newtonsoft.Json": "8.0.3",
+    "System.Collections.Immutable": "1.2.0"
+  },
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "dnxcore50"
+    }
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
+}

--- a/src/RepoUtil/repoutil.runtimeconfig.json
+++ b/src/RepoUtil/repoutil.runtimeconfig.json
@@ -1,0 +1,8 @@
+{
+  "runtimeOptions": {
+    "framework": {
+      "name": "Microsoft.NETCore.App",
+      "version": "1.0.0-rc3-002733"
+    }
+  }
+}

--- a/src/nuget/Microsoft.DotNet.BuildTools.RepoUtil.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.RepoUtil.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.BuildTools.RepoUtil</id>
+    <version>1.0.0-prerelease</version>
+    <title>Repository Produces/Consumes Utility (RepoUtil)</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>A tool that can be used to generate and verify internal and external dependency information.</summary>
+    <description>This package provides utilities for implementing the repository produces/consumes API.  You should not need to reference this package from your project.  This tool requires .NET Core 1.0 or later.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+      <!--
+        Currently we redistribute the dependencies locally since nuget
+        has no support for treating packages as build dependencies.
+      -->
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="RepoUtil\repoutil.exe" target="tools" />
+    <file src="RepoUtil\repoutil.runtimeconfig.json" target="tools" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.RepoUtil.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.RepoUtil.nuspec
@@ -22,7 +22,11 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="RepoUtil\repoutil.exe" target="tools" />
-    <file src="RepoUtil\repoutil.runtimeconfig.json" target="tools" />
+    <file src="RepoUtil\RepoUtil.exe" target="tools\netcoreapp1.0" />
+    <file src="RepoUtil\RepoUtil.runtimeconfig.json" target="tools\netcoreapp1.0" />
+    <file src="RepoUtil\*.dll" target="tools\netcoreapp1.0" />
+    <file src="RepoUtil.Desktop\RepoUtil.exe" target="tools\net46" />
+    <file src="RepoUtil.Desktop\RepoUtil.exe.config" target="tools\net46" />
+    <file src="RepoUtil.Desktop\*.dll" target="tools\net46" />
   </files>
 </package>


### PR DESCRIPTION
We have a tool, RepoUtil, created by the Roslyn team for implementing the
produces and consumes repo APIs.  Since this is meant to be a general
purpose tool to be consumed by various repos I'm moving the sources to the
build tools repo.  I have also added nuget package authoring for this tool
so that it can easily be consumed by other repos.  In the process I have
converted the tool to be a .NET Core app.