### PR TITLE
When reading a file to verify dependencies, use FileAccess.Read

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Util/FileUtils.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/FileUtils.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.VersionTools.Util
             // Attempt to preserve the file's encoding, using a UTF-8 encoding with no BOM if the
             // file's encoding cannot be detected. 
             using (StreamReader reader = new StreamReader(
-                new FileStream(path, FileMode.Open),
+                new FileStream(path, FileMode.Open, FileAccess.Read),
                 new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
                 detectEncodingFromByteOrderMarks: true))
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/buildtools/issues/964

I confirmed that a verify using this change works with a read-only `project.json` and `dependenices.props` (and still detects invalid dependencies), and that `UpgradeDependencies` hits errors when trying to upgrade read-only files.

@naamunds @AtsushiKan 
(FYI @eerhardt)