### PR TITLE
Add NuGet.ProjectModel to buildtools PackageLibs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
@@ -3,6 +3,7 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Client": "3.5.0-rc1-final",
+    "NuGet.ProjectModel": "3.5.0-rc1-final",
     "System.Reflection.Metadata": "1.0.22",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-24128-00"
   },

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
@@ -5,6 +5,7 @@
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Client": "3.5.0-rc1-final",
+    "NuGet.ProjectModel": "3.5.0-rc1-final",
     "NETStandard.Library": "1.5.0-rc2-24027"
   },
   "frameworks": {


### PR DESCRIPTION
Currently we pick up these dependencies from the Packaging projects,
make sure we add the new NuGet.ProjectModel dependency here to
get it in our package.