### PR TITLE
Rename RepoUtil package to RepoUtils.

### DIFF
--- a/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata minClientVersion="2.8.1">
-    <id>Microsoft.DotNet.BuildTools.RepoUtil</id>
+    <id>Microsoft.DotNet.BuildTools.RepoUtils</id>
     <version>1.0.0-prerelease</version>
-    <title>Repository Produces/Consumes Utility (RepoUtil)</title>
+    <title>Repository Produces/Consumes Utilities</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
     <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
-    <summary>A tool that can be used to generate and verify internal and external dependency information.</summary>
-    <description>This package provides utilities for implementing the repository produces/consumes API.  You should not need to reference this package from your project.  This tool requires .NET Core 1.0 or later.</description>
+    <summary>A collection of tools that can be used to generate and verify internal and external dependency information.</summary>
+    <description>This package provides utilities for implementing the repository produces/consumes API.  You should not need to reference this package from your project.</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags></tags>
     <dependencies>


### PR DESCRIPTION
This package will likely end up containing multiple utilities for repo
dependency management so changing the name as there are no dependencies on
this package at present.