### PR TITLE
Add properties to the tools section for run.exe

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,12 +30,6 @@
       "values": [],
       "defaultValue": "/flp:v=normal"
     },
-    "MsBuildParameters": {
-      "description": "MsBuild building options.",
-      "valueType": "passThrough",
-      "values": [],
-      "defaultValue": "/nologo /maxcpucount /verbosity:minimal /nodeReuse:false"
-    },
     "Project": {
       "description": "Project where the commands are going to be applied.",
       "valueType": "passThrough",
@@ -86,15 +80,14 @@
         "verbose":{
           "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
           "settings":{
-            "MsBuildLogging": "/flp:v=diag"
+            "MsBuildLogging": "/flp:v=diag;LogFile=sync.log"
           }
         }
       },
       "defaultValues":{
         "toolName": "msbuild",
         "settings": {
-          "MsBuildParameters":"default",
-          "MsBuildLogging":"default"
+          "MsBuildLogging":"/flp:v=normal;LogFile=sync.log"
         }
       }
     },
@@ -140,7 +133,7 @@
       "defaultValues":{
         "toolName": "msbuild",
         "settings": {
-          "MsBuildParameters":"default"
+          "MsBuildLogging":"default"
         }
       }
     },
@@ -168,17 +161,24 @@
       "defaultValues":{
         "toolName": "msbuild",
         "settings": {
-          "MsBuildParameters":"default",
-          "MsBuildLogging":"default"
+          "MsBuildLogging":"/flp:v=normal;LogFile=clean.log"
         }
       }
     }
   },
   "tools": {
     "msbuild": {
-      "run": {
-        "windows": "Tools/msbuild.cmd",
-        "unix": "Tools/msbuild.sh"
+      "osSpecific":{
+        "windows": {
+          "defaultParameters": "/nologo /verbosity:minimal /clp:Summary /maxcpucount /nodeReuse:false /l:BinClashLogger,Tools\\net45\\Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log",
+          "path": "Tools/msbuild.cmd",
+          "filesExtension": ""
+        },
+        "unix":{
+          "defaultParameters": "/nologo /verbosity:minimal /clp:Summary /maxcpucount /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log",
+          "path": "Tools/msbuild.sh",
+          "filesExtension": ""
+        }
       },
       "valueTypes": {
         "property": "/p:{name}={value}",
@@ -186,10 +186,18 @@
         "internal": "/{name}"
       }
     },
-    "terminal": {
-      "run": {
-        "windows": "cmd",
-        "unix": "sh"
+    "script": {
+      "osSpecific":{
+        "windows": {
+          "defaultParameters": "",
+          "path": "",
+          "filesExtension": "cmd"
+        },
+        "unix":{
+          "defaultParameters": "",
+          "path": "",
+          "filesExtension": "sh"
+        }
       },
       "valueTypes": {}
     }

--- a/config.json
+++ b/config.json
@@ -171,13 +171,11 @@
       "osSpecific":{
         "windows": {
           "defaultParameters": "/nologo /verbosity:minimal /clp:Summary /maxcpucount /nodeReuse:false /l:BinClashLogger,Tools\\net45\\Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log",
-          "path": "Tools/msbuild.cmd",
-          "filesExtension": ""
+          "path": "Tools/msbuild.cmd"
         },
         "unix":{
           "defaultParameters": "/nologo /verbosity:minimal /clp:Summary /maxcpucount /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log",
-          "path": "Tools/msbuild.sh",
-          "filesExtension": ""
+          "path": "Tools/msbuild.sh"
         }
       },
       "valueTypes": {
@@ -189,13 +187,9 @@
     "script": {
       "osSpecific":{
         "windows": {
-          "defaultParameters": "",
-          "path": "",
           "filesExtension": "cmd"
         },
         "unix":{
-          "defaultParameters": "",
-          "path": "",
           "filesExtension": "sh"
         }
       },

--- a/config.json
+++ b/config.json
@@ -30,6 +30,12 @@
       "values": [],
       "defaultValue": "/flp:v=normal"
     },
+    "MsBuildParameters": {
+      "description": "MsBuild building options.",
+      "valueType": "passThrough",
+      "values": [],
+      "defaultValue": "/nologo /maxcpucount /verbosity:minimal /nodeReuse:false"
+    },
     "Project": {
       "description": "Project where the commands are going to be applied.",
       "valueType": "passThrough",
@@ -80,14 +86,15 @@
         "verbose":{
           "description": "Passes /flp:v=diag to the msbuild command or the value passed by the user.",
           "settings":{
-            "MsBuildLogging": "/flp:v=diag;LogFile=sync.log"
+            "MsBuildLogging": "/flp:v=diag"
           }
         }
       },
       "defaultValues":{
         "toolName": "msbuild",
         "settings": {
-          "MsBuildLogging":"/flp:v=normal;LogFile=sync.log"
+          "MsBuildParameters":"default",
+          "MsBuildLogging":"default"
         }
       }
     },
@@ -133,7 +140,7 @@
       "defaultValues":{
         "toolName": "msbuild",
         "settings": {
-          "MsBuildLogging":"default"
+          "MsBuildParameters":"default"
         }
       }
     },
@@ -161,22 +168,17 @@
       "defaultValues":{
         "toolName": "msbuild",
         "settings": {
-          "MsBuildLogging":"/flp:v=normal;LogFile=clean.log"
+          "MsBuildParameters":"default",
+          "MsBuildLogging":"default"
         }
       }
     }
   },
   "tools": {
     "msbuild": {
-      "osSpecific":{
-        "windows": {
-          "defaultParameters": "/nologo /verbosity:minimal /clp:Summary /maxcpucount /nodeReuse:false /l:BinClashLogger,Tools\\net45\\Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log",
-          "path": "Tools/msbuild.cmd"
-        },
-        "unix":{
-          "defaultParameters": "/nologo /verbosity:minimal /clp:Summary /maxcpucount /l:BinClashLogger,Tools/Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log",
-          "path": "Tools/msbuild.sh"
-        }
+      "run": {
+        "windows": "Tools/msbuild.cmd",
+        "unix": "Tools/msbuild.sh"
       },
       "valueTypes": {
         "property": "/p:{name}={value}",
@@ -184,14 +186,10 @@
         "internal": "/{name}"
       }
     },
-    "script": {
-      "osSpecific":{
-        "windows": {
-          "filesExtension": "cmd"
-        },
-        "unix":{
-          "filesExtension": "sh"
-        }
+    "terminal": {
+      "run": {
+        "windows": "cmd",
+        "unix": "sh"
       },
       "valueTypes": {}
     }

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -150,10 +150,7 @@ namespace Microsoft.DotNet.Execute
         {
             string commandSetting = string.Empty;
 
-            if (Tools.ContainsKey(toolName))
-            {
-                commandSetting = Tools[toolName].osSpecific[Os]["defaultParameters"];
-            }
+            Tools[toolName].osSpecific[Os].TryGetValue("defaultParameters", out commandSetting);            
 
             foreach (KeyValuePair<string, string> parameters in commandParameters)
             {
@@ -271,14 +268,14 @@ namespace Microsoft.DotNet.Execute
             if (Tools.ContainsKey(toolname))
             {
                 SettingParameters["toolName"] = toolname;
-
-                if(!string.IsNullOrEmpty(Tools[toolname].osSpecific[os]["path"]))
+                string value = string.Empty;
+                if(Tools[toolname].osSpecific[os].TryGetValue("path", out value) && !string.IsNullOrEmpty(value))
                 {
-                    return Path.GetFullPath(Path.Combine(configPath, Tools[toolname].osSpecific[os]["path"]));
+                    return Path.GetFullPath(Path.Combine(configPath, value));
                 }
-                else if (!string.IsNullOrEmpty(Tools[toolname].osSpecific[os]["filesExtension"]))
+                else if (Tools[toolname].osSpecific[os].TryGetValue("filesExtension", out value) && !string.IsNullOrEmpty(value))
                 {
-                    string extension = Tools[toolname].osSpecific[os]["filesExtension"];
+                    string extension = value;
                     return Path.GetFullPath(Path.Combine(configPath, string.Format("{0}.{1}", project, extension)));
                 }
                 else

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -262,18 +262,19 @@ namespace Microsoft.DotNet.Execute
         private string GetTool(Command commandToExecute, string os, string configPath, List<string> parametersSelectedByUser)
         {
             string toolname = commandToExecute.DefaultValues.ToolName;
-
             string project = GetProject(commandToExecute, parametersSelectedByUser);
 
-            if (Tools.ContainsKey(toolname))
+            Tool toolProperties = null;
+
+            if(Tools.TryGetValue(toolname, out toolProperties))
             {
                 SettingParameters["toolName"] = toolname;
                 string value = string.Empty;
-                if(Tools[toolname].osSpecific[os].TryGetValue("path", out value) && !string.IsNullOrEmpty(value))
+                if (toolProperties.osSpecific[os].TryGetValue("path", out value) && !string.IsNullOrEmpty(value))
                 {
                     return Path.GetFullPath(Path.Combine(configPath, value));
                 }
-                else if (Tools[toolname].osSpecific[os].TryGetValue("filesExtension", out value) && !string.IsNullOrEmpty(value))
+                else if (toolProperties.osSpecific[os].TryGetValue("filesExtension", out value) && !string.IsNullOrEmpty(value))
                 {
                     string extension = value;
                     return Path.GetFullPath(Path.Combine(configPath, string.Format("{0}.{1}", project, extension)));
@@ -284,6 +285,7 @@ namespace Microsoft.DotNet.Execute
                     return string.Empty;
                 }
             }
+
             Console.Error.WriteLine("Error: The process {0} is not specified in the Json file.", toolname);
             return string.Empty;
         }


### PR DESCRIPTION
With this change we could add specific tools parameters to pass to all the commands. For example, MsBuildParameters like: /nologo /verbosity:minimal /clp:Summary /maxcpucount are always going to be pass when a command uses the tool MsBuild,
That way we could customize them per OS and we only have to declare the parameters in one place.

I don't intend to merge this PR with the config.json file as it woul break the build. It is here for information purposes. Once the PR is approved I'll create a different PR updating the version of BT and adding the changes to config.json

Related to dotnet/corefx#10864.
Also, fix #890 

cc: @weshaggard @TyOverby 