### PR TITLE
Add "DisabledPackages" buildinfo metadata that ignores a package by id

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -95,7 +95,11 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                 .GetMetadata("UpdateStableVersions")
                 .Equals("true", StringComparison.OrdinalIgnoreCase);
 
-            return new DependencyBuildInfo(info, updateStaticDependencies);
+            string[] disabledPackages = item
+                .GetMetadata("DisabledPackages")
+                .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            return new DependencyBuildInfo(info, updateStaticDependencies, disabledPackages);
         }
 
         private static BuildInfo CreateBuildInfo(ITaskItem item, string cacheDir)

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexPackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexPackageUpdater.cs
@@ -17,8 +17,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
             out IEnumerable<BuildInfo> usedBuildInfos)
         {
             var matchingBuildInfo = dependencyBuildInfos
-                .Select(d => d.BuildInfo)
-                .FirstOrDefault(d => d.LatestPackages.ContainsKey(PackageId));
+                .FirstOrDefault(d => d.RawPackages.ContainsKey(PackageId));
 
             if (matchingBuildInfo == null)
             {
@@ -28,9 +27,9 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
                 return $"DEPENDENCY '{PackageId}' NOT FOUND";
             }
 
-            usedBuildInfos = new[] { matchingBuildInfo };
+            usedBuildInfos = new[] { matchingBuildInfo.BuildInfo };
 
-            return matchingBuildInfo.LatestPackages[PackageId];
+            return matchingBuildInfo.RawPackages[PackageId];
         }
     }
 }


### PR DESCRIPTION
This will normally not be used ([it is needed in the dev/api branch](https://github.com/dotnet/corefx/pull/10970#issuecomment-241046344)), but it allows a package to be ignored from a buildinfo and not used for verification and auto-upgrade. Example usage: https://github.com/dotnet/corefx/commit/f61cbf732569f5b3a7c8a5d7dee24abc53c32ac1 (I added the package to a different `DependencyBuildInfo` to ensure it stays at a given version, even though it won't be auto-upgraded.)

/cc @weshaggard @joperezr 