### PR TITLE
During auto-update, update CurrentBranch property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -16,6 +16,16 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
     public abstract class BaseDependenciesTask : Task
     {
+        internal const string RawUrlMetadataName = "RawUrl";
+        internal const string RawVersionsBaseUrlMetadataName = "RawVersionsBaseUrl";
+        internal const string BuildInfoPathMetadataName = "BuildInfoPath";
+        internal const string CurrentRefMetadataName = "CurrentRef";
+        internal const string CurrentBranchMetadataName = "CurrentBranch";
+        internal const string PackageIdMetadataName = "PackageId";
+        internal const string VersionMetadataName = "Version";
+
+        internal const string AutoUpgradeBranchMetadataName = "Version";
+
         [Required]
         public ITaskItem[] DependencyBuildInfo { get; set; }
 
@@ -104,21 +114,28 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
 
         private static BuildInfo CreateBuildInfo(ITaskItem item, string cacheDir)
         {
-            string rawUrl = item.GetMetadata("RawUrl");
+            string rawUrl = item.GetMetadata(RawUrlMetadataName);
 
             if (!string.IsNullOrEmpty(rawUrl))
             {
                 return BuildInfo.Get(item.ItemSpec, rawUrl);
             }
 
-            string rawVersionsBaseUrl = item.GetMetadata("RawVersionsBaseUrl");
-            string buildInfoPath = item.GetMetadata("BuildInfoPath");
-            string currentRef = item.GetMetadata("CurrentRef");
+            string rawVersionsBaseUrl = item.GetMetadata(RawVersionsBaseUrlMetadataName);
+            string buildInfoPath = item.GetMetadata(BuildInfoPathMetadataName);
+            string currentRef = item.GetMetadata(CurrentRefMetadataName);
+            // Optional
+            string currentBranch = item.GetMetadata(CurrentBranchMetadataName);
 
             if (!string.IsNullOrEmpty(rawVersionsBaseUrl) &&
                 !string.IsNullOrEmpty(buildInfoPath) &&
                 !string.IsNullOrEmpty(currentRef))
             {
+                if (!string.IsNullOrEmpty(currentBranch))
+                {
+                    buildInfoPath = $"{buildInfoPath}/{currentBranch}";
+                }
+
                 return BuildInfo.CachedGet(
                     item.ItemSpec,
                     rawVersionsBaseUrl,
@@ -127,8 +144,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                     cacheDir);
             }
 
-            string packageId = item.GetMetadata("PackageId");
-            string version = item.GetMetadata("Version");
+            string packageId = item.GetMetadata(PackageIdMetadataName);
+            string version = item.GetMetadata(VersionMetadataName);
 
             if (!string.IsNullOrEmpty(packageId) &&
                 !string.IsNullOrEmpty(version))

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
             {
                 string originalValue = null;
 
-                Action replace = FileUtils.ReplaceFileContents(
+                Action update = FileUtils.GetUpdateFileContentsTask(
                     Path,
                     contents => ReplaceGroupValue(
                         Regex,
@@ -39,14 +39,14 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
                         newValue,
                         out originalValue));
 
-                if (replace != null)
+                if (update != null)
                 {
                     var messageLines = new[]
                     {
                         $"In '{Path}', '{originalValue}' must be '{newValue}' based on build info " +
                             $"'{string.Join(", ", usedBuildInfos.Select(info => info.Name))}'"
                     };
-                    yield return new DependencyUpdateTask(replace, usedBuildInfos, messageLines);
+                    yield return new DependencyUpdateTask(update, usedBuildInfos, messageLines);
                 }
             }
         }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/ProjectJsonUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/ProjectJsonUpdater.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
                 {
                     IEnumerable<DependencyChange> dependencyChanges = null;
 
-                    Action replace = FileUtils.ReplaceFileContents(
+                    Action update = FileUtils.GetUpdateFileContentsTask(
                         projectJsonFile,
                         contents => ReplaceAllDependencyVersions(
                             contents,
@@ -41,10 +41,10 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
                             out dependencyChanges));
 
                     // The output json may be different even if there weren't any changes made.
-                    if (replace != null && dependencyChanges.Any())
+                    if (update != null && dependencyChanges.Any())
                     {
                         tasks.Add(new DependencyUpdateTask(
-                            replace,
+                            update,
                             dependencyChanges.Select(change => change.BuildInfo),
                             dependencyChanges.Select(change => $"In '{projectJsonFile}', {change.ToString()}")));
                     }

--- a/src/Microsoft.DotNet.VersionTools/Util/FileUtils.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/FileUtils.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.VersionTools.Util
         /// </summary>
         /// <param name="path">Path of the file to change.</param>
         /// <param name="replacement">A function that takes file contents as input and returns the desired replacement.</param>
-        public static Action ReplaceFileContents(string path, Func<string, string> replacement)
+        public static Action GetUpdateFileContentsTask(string path, Func<string, string> replacement)
         {
             string contents;
             Encoding encoding;


### PR DESCRIPTION
Implements the buildtools side of this idea: https://github.com/dotnet/corefx/pull/10970#discussion_r75404356. The CoreFX-side config: https://github.com/dotnet/corefx/commit/1392eaf5b71e893e8cd61089de4949348239d932

An example auto-PR, simulating the point where dev/api has just split off from master, and this is the first auto-PR with dev/api packages available: https://github.com/dagood/corefx/pull/22

It works the same way as the CurrentRef update, but writes the name of the `AutoUpgradeBranch`, which in this case is passed in as `BranchBeingUpgraded`.

@weshaggard @joperezr 