### PR TITLE
Add package index

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class GetPackageFromModule : PackagingTask
+    {
+        /// <summary>
+        /// Modules referenced that need to be mapped to packages
+        /// </summary>
+        [Required]
+        public ITaskItem[] ModulesReferenced { get; set; }
+
+        /// <summary>
+        /// Permitted package baseline versions.
+        ///   Identity: module name
+        ///   Package: package which contains the module
+        /// </summary>
+        public ITaskItem[] ModulePackages { get; set; }
+
+        /// <summary>
+        /// Package index files used to define module to package mapping.
+        /// </summary>
+        public ITaskItem[] PackageIndexes { get; set; }
+
+        /// <summary>
+        /// Packages containing the referenced modules
+        /// </summary>
+        [Output]
+        public ITaskItem[] PackagesReferenced { get; set; }
+
+        public override bool Execute()
+        {
+            Dictionary<string, string> modulesToPackages;
+
+            if (PackageIndexes != null && PackageIndexes.Length > 0)
+            {
+                PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+
+                modulesToPackages = PackageIndex.Current.ModulesToPackages;
+            }
+            else
+            {
+                modulesToPackages = new Dictionary<string, string>();
+
+                foreach(var modulePackage in ModulePackages.NullAsEmpty())
+                {
+                    modulesToPackages.Add(modulePackage.ItemSpec, modulePackage.GetMetadata("Package"));
+                }
+            }
+
+            List<ITaskItem> packagesReferenced = new List<ITaskItem>();
+
+            foreach(var moduleReferenced in ModulesReferenced)
+            {
+                string moduleName = moduleReferenced.ItemSpec;
+                string packageId;
+
+                if (modulesToPackages.TryGetValue(moduleName, out packageId))
+                {
+                    var packageReferenced = new TaskItem(packageId);
+                    packageReferenced.SetMetadata("NativeLibrary", moduleName);
+                    moduleReferenced.CopyMetadataTo(packageReferenced);
+                    packagesReferenced.Add(packageReferenced);
+                }
+            }
+
+            PackagesReferenced = packagesReferenced.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -22,12 +22,14 @@
   <ItemGroup>
     <Compile Include="GetApplicableAssetsFromPackageReports.cs" />
     <Compile Include="GetLastStablePackage.cs" />
+    <Compile Include="UpdatePackageIndex.cs" />
     <Compile Include="HarvestPackage.cs" />
     <Compile Include="GetApplicableAssetsFromPackages.cs" />
     <Compile Include="GetMinimumNETStandard.cs" />
     <Compile Include="NugetPropertyStringProvider.cs" />
     <Compile Include="GetRuntimeJsonValues.cs" />
     <Compile Include="GetRuntimeTargets.cs" />
+    <Compile Include="PackageIndex.cs" />
     <Compile Include="SplitDependenciesBySupport.cs" />
     <Compile Include="GenerateNetStandardSupportTable.cs" />
     <Compile Include="PromoteReferenceDependencies.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="GetApplicableAssetsFromPackageReports.cs" />
     <Compile Include="GetLastStablePackage.cs" />
+    <Compile Include="GetPackageFromModule.cs" />
     <Compile Include="UpdatePackageIndex.cs" />
     <Compile Include="HarvestPackage.cs" />
     <Compile Include="GetApplicableAssetsFromPackages.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -7,6 +7,7 @@
   -->
 
   <PropertyGroup>
+    <PackageVersion Condition="'$(StableVersion)' != ''">$(StableVersion)</PackageVersion>
     <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != ''">$(Version)</PackageVersion>
     <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">rc2</PreReleaseLabel>
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
@@ -806,14 +807,15 @@
       </_thisPackage>
     </ItemGroup>
 
-    <ApplyPreReleaseSuffix OriginalPackages="@(_thisPackage)" 
+    <ApplyPreReleaseSuffix Condition="'$(StableVersion)' == ''"
+                           OriginalPackages="@(_thisPackage)" 
                            StablePackages="@(StablePackage)"
                            PackageIndexes="@(PackageIndex)"
                            PreReleaseSuffix="$(VersionSuffix)" >
       <Output TaskParameter="UpdatedPackages" ItemName="_thisPackageFinal"/>
     </ApplyPreReleaseSuffix>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(StableVersion)' == ''">
       <PackageVersion>%(_thisPackageFinal.Version)</PackageVersion>
     </PropertyGroup>
   </Target>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -429,6 +429,7 @@
     <!-- Calculate the package version to harvest -->
     <GetLastStablePackage Condition="'$(HarvestVersion)' == ''" 
                           LatestPackages="@(_latestPackage)" 
+                          StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)">
       <Output  TaskParameter="LastStablePackages" ItemName="_lastStablePackage"/>
     </GetLastStablePackage>
@@ -440,6 +441,7 @@
     <!-- Calculate the runtime package versions to use for applicability evaluation -->
     <GetLastStablePackage Condition="'@(HarvestRuntimePackages)' == ''" 
                           LatestPackages="@(_latestRuntimePackages)" 
+                          StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestRuntimePackages"/>
     </GetLastStablePackage>
@@ -710,19 +712,21 @@
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
     </PromoteReferenceDependencies>
 
-    <Error Condition="'@(PackageIndex)' == '' AND '@(FilePackageDependency)' != ''"
-           Text="The PackageIndex item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
-    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" 
+    <Error Condition="'@(PackageIndex)' == '' AND '@(BaseLinePackage)' == '' AND '@(FilePackageDependency)' != '' AND '$(BaseLinePackageDependencies)' != 'false'"
+           Text="Neither PackageIndex nor BaseLinePackage items are defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
+    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)"
+                   BaseLinePackages="@(BaseLinePackage)"
                    PackageIndexes="@(PackageIndex)"
                    Apply="$(BaseLinePackageDependencies)">
       <Output TaskParameter="BaseLinedDependencies" ItemName="_BaseLinedDependencies" />
     </ApplyBaseLine>
 
 
-    <Error Condition="'@(_BaseLinedDependencies)' != '' AND '@(PackageIndex)' == ''" 
-           Text="The PackageIndex item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
+    <Error Condition="'@(_BaseLinedDependencies)' != '' AND '@(PackageIndex)' == '' AND '@(StablePackage)' == ''" 
+           Text="Neither PackageIndex nor StablePackage items are defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
     <ApplyPreReleaseSuffix Condition="'@(_BaseLinedDependencies)' != ''" 
                            OriginalPackages="@(_BaseLinedDependencies)" 
+                           StablePackages="@(StablePackage)"
                            PackageIndexes="@(PackageIndex)"
                            PreReleaseSuffix="$(VersionSuffix)">
       <Output TaskParameter="UpdatedPackages" ItemName="Dependency"/>
@@ -806,6 +810,7 @@
     </ItemGroup>
 
     <ApplyPreReleaseSuffix OriginalPackages="@(_thisPackage)" 
+                           StablePackages="@(StablePackage)"
                            PackageIndexes="@(PackageIndex)"
                            PreReleaseSuffix="$(VersionSuffix)" >
       <Output TaskParameter="UpdatedPackages" ItemName="_thisPackageFinal"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -7,8 +7,6 @@
   -->
 
   <PropertyGroup>
-    <Version Condition="'$(StableVersion)' != ''">$(StableVersion)</Version>
-
     <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">rc2</PreReleaseLabel>
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
 
@@ -21,8 +19,7 @@
     -->
     <ProjectProperties></ProjectProperties>
 
-    <PackageRevStableToPrerelease Condition="'$(PackageRevStableToPrerelease)' == ''">false</PackageRevStableToPrerelease>
-    <DependencyRevStableToPrerelease Condition="'$(PackageRevStableToPrerelease)' == ''">false</DependencyRevStableToPrerelease>
+    <BaseLinePackageDependencies Condition="'$(BaseLinePackageDependencies)' == ''">true</BaseLinePackageDependencies>
 
     <!-- By default we'll build libraries referenced by packages -->
     <BuildPackageLibraryReferences Condition="'$(BuildPackageLibraryReferences)' == ''">true</BuildPackageLibraryReferences>
@@ -88,13 +85,6 @@
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.1</PlatformPackageVersion>
   </PropertyGroup>
 
-  <!-- If this package explicitly sets the StableVersion then add it to the stable list -->
-  <ItemGroup Condition="'$(StableVersion)' != ''">
-    <StablePackage Include="$(Id)">
-      <Version>$(StableVersion)</Version>
-    </StablePackage>
-  </ItemGroup>
-
   <UsingTask TaskName="ApplyPreReleaseSuffix" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetAssemblyReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="SplitReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
@@ -113,6 +103,7 @@
   <UsingTask TaskName="SplitDependenciesBySupport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetLastStablePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="HarvestPackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms
@@ -133,6 +124,7 @@
     <ShouldCreatePackage Condition="'$(ShouldCreatePackage)' == ''">$(ShouldGenerateNuSpec)</ShouldCreatePackage>
     <BuildDependsOn Condition="'$(ShouldGenerateNuSpec)' == 'true'">GenerateNuSpec</BuildDependsOn>
     <BuildDependsOn Condition="'$(ShouldCreatePackage)' == 'true'">$(BuildDependsOn);CreatePackage</BuildDependsOn>
+    <BuildDependsOn>$(BuildDependsOn);ValidatePackage</BuildDependsOn>
   </PropertyGroup>
 
   <!-- Redefine build to just create the NuSpec only, we'll create the package during ArcProjects phase -->
@@ -434,7 +426,9 @@
     </ItemGroup>
 
     <!-- Calculate the package version to harvest -->
-    <GetLastStablePackage Condition="'$(HarvestVersion)' == ''" LatestPackages="@(_latestPackage)" StablePackages="@(StablePackage)">
+    <GetLastStablePackage Condition="'$(HarvestVersion)' == ''" 
+                          LatestPackages="@(_latestPackage)" 
+                          PackageIndexes="@(PackageIndex)">
       <Output  TaskParameter="LastStablePackages" ItemName="_lastStablePackage"/>
     </GetLastStablePackage>
 
@@ -443,7 +437,9 @@
     </PropertyGroup>
 
     <!-- Calculate the runtime package versions to use for applicability evaluation -->
-    <GetLastStablePackage Condition="'@(HarvestRuntimePackages)' == ''" LatestPackages="@(_latestRuntimePackages)" StablePackages="@(StablePackage)">
+    <GetLastStablePackage Condition="'@(HarvestRuntimePackages)' == ''" 
+                          LatestPackages="@(_latestRuntimePackages)" 
+                          PackageIndexes="@(PackageIndex)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestRuntimePackages"/>
     </GetLastStablePackage>
 
@@ -713,19 +709,21 @@
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
     </PromoteReferenceDependencies>
 
-    <Error Condition="'@(BaseLinePackage)' == '' AND '@(FilePackageDependency)' != '' AND '$(BaseLinePackageDependencies)' != 'false'"
-           Text="The BaseLinePackage item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
-    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" BaseLinePackages="@(BaseLinePackage)" Condition="'$(BaseLinePackageDependencies)' != 'false'">
+    <Error Condition="'@(PackageIndex)' == '' AND '@(FilePackageDependency)' != ''"
+           Text="The PackageIndex item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
+    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)" 
+                   PackageIndexes="@(PackageIndex)"
+                   Apply="$(BaseLinePackageDependencies)">
       <Output TaskParameter="BaseLinedDependencies" ItemName="_BaseLinedDependencies" />
     </ApplyBaseLine>
 
-    <!-- if not baselining, flow the dependencies unmodified -->
-    <ItemGroup Condition="'$(BaseLinePackageDependencies)' == 'false'">
-      <_BaseLinedDependencies Include="@(FilePackageDependency)" />
-    </ItemGroup>
 
-    <Error Condition="'@(_BaseLinedDependencies)' != '' AND '@(StablePackage)' == ''" Text="The StablePackage item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
-    <ApplyPreReleaseSuffix Condition="'@(_BaseLinedDependencies)' != ''" StablePackages="@(StablePackage)" OriginalPackages="@(_BaseLinedDependencies)" PreReleaseSuffix="$(VersionSuffix)" RevStableToPrerelease="$(DependencyRevStableToPrerelease)">
+    <Error Condition="'@(_BaseLinedDependencies)' != '' AND '@(PackageIndex)' == ''" 
+           Text="The PackageIndex item is not defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
+    <ApplyPreReleaseSuffix Condition="'@(_BaseLinedDependencies)' != ''" 
+                           OriginalPackages="@(_BaseLinedDependencies)" 
+                           PackageIndexes="@(PackageIndex)"
+                           PreReleaseSuffix="$(VersionSuffix)">
       <Output TaskParameter="UpdatedPackages" ItemName="Dependency"/>
     </ApplyPreReleaseSuffix>
   </Target>
@@ -806,7 +804,9 @@
       </_thisPackage>
     </ItemGroup>
 
-    <ApplyPreReleaseSuffix StablePackages="@(StablePackage)" OriginalPackages="@(_thisPackage)" PreReleaseSuffix="$(VersionSuffix)" RevStableToPrerelease="$(PackageRevStableToPrerelease)">
+    <ApplyPreReleaseSuffix OriginalPackages="@(_thisPackage)" 
+                           PackageIndexes="@(PackageIndex)"
+                           PreReleaseSuffix="$(VersionSuffix)" >
       <Output TaskParameter="UpdatedPackages" ItemName="_thisPackageFinal"/>
     </ApplyPreReleaseSuffix>
 
@@ -1043,32 +1043,22 @@
     </ItemGroup>
 
     <ValidatePackage ContractName="$(BaseId)"
-                     PackageId="$(Id)"
-                     PackageVersion="$(Version)"
                      Files="@(PackageAsset)"
-                     SupportedFrameworks="@(SupportedFramework)"
-                     Frameworks="@(ValidateFramework)"
-                     RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
                      FrameworkListsPath="$(FrameworkListsPath)"
+                     Frameworks="@(ValidateFramework)"
+                     PackageId="$(Id)"
+                     PackageIndexes="@(PackageIndex)"
+                     PackageVersion="$(Version)"
+                     RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
                      SkipGenerationCheck="$(SkipGenerationCheck)"
+                     SkipIndexCheck="$(SkipIndexCheck)"
                      SkipSupportCheck="$(SkipSupportCheck)"
+                     SupportedFrameworks="@(SupportedFramework)"
                      Suppressions="@(ValidatePackageSuppression)"
                      SuppressionFile="$(ValidationSuppressionFile)"
                      UseNetPlatform="$(UseNetPlatform)"
                      ValidationReport="$(PackageReportPath)" />
 
-    <!-- Validate that this package version is part of the baseline -->
-    <ItemGroup>
-      <_thisPackageBaseLine Include="@(BaseLinePackage)" Condition="'$(Id)' == '%(Identity)'" />
-    </ItemGroup>
-    <PropertyGroup>
-      <_VersionWithoutPreRelease>$(Version)</_VersionWithoutPreRelease>
-      <_VersionWithoutPreRelease Condition="$(Version.Contains('-'))">$(Version.SubString(0, $(Version.IndexOf('-'))))</_VersionWithoutPreRelease>
-      <BaseLinePropsUpdateMessage Condition="'$(BaseLinePropsFile)' != ''">  Please update '$(BaseLinePropsFile)'.</BaseLinePropsUpdateMessage>
-    </PropertyGroup>
-
-    <Error Condition="'$(SkipBaseLineCheck)' != 'true' AND '@(_thisPackageBaseLine)' != '' AND '@(_thisPackageBaseLine->WithMetadataValue('Version', '$(_VersionWithoutPreRelease)'))' == ''"
-           Text="This package's version '$(_VersionWithoutPreRelease)' is not part of any BaseLine '@(_thisPackageBaseLine->'%(Version)')'.$(BaseLinePropsUpdateMessage)" />
   </Target>
 
   <Target Name="GetValidationReport" DependsOnTargets="ValidatePackage" Returns="$(PackageReportPath)" />
@@ -1094,7 +1084,7 @@
   <Target Name="GetPackagingOutputs" />
 
   <Target Name="GenerateNuSpec"
-          DependsOnTargets="GetPackageDependencies;GetPackageFiles;GetPackageMetadata;GenerateRuntimeDependencies;EnsureEmptyPackage;ValidatePackage">
+          DependsOnTargets="GetPackageDependencies;GetPackageFiles;GetPackageMetadata;GenerateRuntimeDependencies;EnsureEmptyPackage">
     <!-- Please Note:
          In order to avoid incremental build issues this target will always run.
          However, the task will make sure that it doesn't touch the file if the
@@ -1153,5 +1143,38 @@
                       File="$(NuSpecPath).pkgpath"
                       Overwrite="true"
                       Condition="'$(_SkipCreatePackage)' != 'true'"/>
+  </Target>
+
+
+  <!-- Updates the packageIndex with information from the built package for this project -->
+  <!-- Intentionally not sequenced, invoked directly through /t:UpdatePackageIndex -->
+  <Target Name="UpdatePackageIndex"
+          DependsOnTargets="CalculatePackageVersion">
+
+    <Error Condition="'$(PackageIndexFile)' == ''"
+           Text="The PackageIndexFile property is not set.  Please set this property to point to the path of the packageIndex.json file for your repo." />
+
+    <UpdatePackageIndex PackageIndexFile="$(PackageIndexFile)"
+                        Packages="$(PackageOutputPath)$(Id).$(Version).nupkg" />
+  </Target>
+
+  <!-- Updates the packageIndex with information from the multiple sources for the entire repo -->
+  <!-- Intentionally not sequenced, invoked directly through /t:UpdateRepoPackageIndex -->
+  <Target Name="UpdateRepoPackageIndex">
+    <Error Condition="'$(PackageIndexFile)' == ''"
+           Text="The PackageIndexFile property is not set.  Please set this property to point to the path of the packageIndex.json file for your repo." />
+
+    <!-- Set PackageFolders to point to the directories to index, this directories may contain nupkgs or expanded nupkgs -->
+    <!-- Set PackageIds to the list of package Ids to consider from PackageFolders -->
+    <!-- Set BaseLinePackage to packageId identity with 'Version' metadata to define the set of packages which should set their baseline to a particular version -->
+    <!-- Set StablePackage to packageId identity with 'Version' metadata to define the set of packages which should be set as stable -->
+    <!-- Set ModuleToPackage to module name identity with 'Package' metadata to define mappings from native modules to package IDs which contain those -->
+
+    <UpdatePackageIndex PackageIndexFile="$(PackageIndexFile)"
+                        PackageIds="@(PackageIds)"
+                        PackageFolders="@(PackageFolders)"
+                        BaselinePackages="@(BaselinePackage)"
+                        StablePackages="@(StablePackage)"
+                        ModuleToPackages="@(ModuleToPackage)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -105,7 +105,8 @@
   <UsingTask TaskName="GetLastStablePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="HarvestPackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-
+  <UsingTask TaskName="GetPackageFromModule" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms
        property as a semi-colon delimited list.
@@ -625,16 +626,12 @@
       </_FilePackageReference>
     </ItemGroup>
 
-    <ItemGroup Condition="'@(_FileReferencedNativeLibraries)' != ''">
-      <!-- intersect with NativeLibrary and add Package metadata from NativeLibrary, preserving native lib file name in metadata -->
-      <_FileReferencedNativeLibrariesWithPackage Include="@(_FileReferencedNativeLibraries)"
-                                                 Condition="'@(_FileReferencedNativeLibraries)' == '@(NativeLibrary)' AND '%(Identity)' != ''">
-        <Package>@(NativeLibrary->'%(Package)')</Package>
-        <NativeLibrary>%(Identity)</NativeLibrary>
-      </_FileReferencedNativeLibrariesWithPackage>
-
-      <_FilePackageReference Include="@(_FileReferencedNativeLibrariesWithPackage->'%(Package)')" />
-    </ItemGroup>
+    <GetPackageFromModule Condition="'@(_FileReferencedNativeLibraries)' != ''"
+                          ModulesReferenced="@(_FileReferencedNativeLibraries)"
+                          ModulePackages="@(NativeLibrary)"
+                          PackageIndexes="@(PackageIndex)">
+      <Output TaskParameter="PackagesReferenced" ItemName="_FilePackageReference" />
+    </GetPackageFromModule>
 
     <ItemGroup>
       <FilePackageDependency Include="@(_FilePackageReference)" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -7,6 +7,7 @@
   -->
 
   <PropertyGroup>
+    <PackageVersion Condition="'$(PackageVersion)' == '' AND '$(Version)' != ''">$(Version)</PackageVersion>
     <PreReleaseLabel Condition="'$(PreReleaseLabel)' == ''">rc2</PreReleaseLabel>
     <IncludeBuildNumberInPackageVersion Condition="'$(IncludeBuildNumberInPackageVersion)' == ''">true</IncludeBuildNumberInPackageVersion>
 
@@ -272,7 +273,7 @@
       <_FilesToPackage Remove="@(_FilesToPackage)" Condition="'$(ExcludeReferenceAssets)' == 'true' AND '%(_FilesToPackage.IsReferenceAsset)' == 'true'" />
       <File Include="@(_FilesToPackage)">
         <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(Version)</PackageVersion>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
         <!-- Some packages support legacy portable profiles where dependencies are provided by targeting pack -->
         <HarvestDependencies Condition="!$([System.String]::new('%(_FilesToPackage.TargetFramework)').StartsWith('portable-'))">true</HarvestDependencies>
       </File>
@@ -297,7 +298,7 @@
     <ItemGroup Condition="'$(PreventImplementationReference)' == 'true'">
       <File Include="$(PlaceholderFile)">
         <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(Version)</PackageVersion>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
         <TargetPath Condition="'$(UseNetPlatform)' != 'true'">ref/netstandard</TargetPath>
         <TargetPath Condition="'$(UseNetPlatform)' == 'true'">ref/dotnet</TargetPath>
       </File>
@@ -330,13 +331,13 @@
     <ItemGroup>
       <File Include="$(PlaceholderFile)">
         <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(Version)</PackageVersion>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
         <TargetPath Condition="'$(_targetRuntime)' != ''">runtimes/$(_targetRuntime)/lib/$(_target)</TargetPath>
         <TargetPath Condition="'$(_targetRuntime)' == ''">lib/$(_target)</TargetPath>
       </File>
       <File Include="$(PlaceholderFile)" Condition="'$(_targetRef)' == 'true'">
         <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(Version)</PackageVersion>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
         <TargetPath>ref/$(_target)</TargetPath>
       </File>
       <FrameworkReference Condition="'%(InboxOnTargetFramework.AsFrameworkReference)' == 'true'" Include="$(Id)">
@@ -420,7 +421,7 @@
       <HarvestExcludePaths Include="%(File.TargetPath)" KeepDuplicates="false" />
 
       <_latestPackage Include="$(Id)">
-        <Version>$(Version)</Version>
+        <Version>$(PackageVersion)</Version>
       </_latestPackage>
       <_latestRuntimePackages Include="@(PkgProjDependency)" Condition="'%(PkgProjDependency.TargetRuntime)' != ''" KeepDuplicates="false" />
     </ItemGroup>
@@ -481,7 +482,7 @@
       <PackageFile Include="@(File)" Condition="'%(File.IsSourceCodeFile)'!='true'" />
       <PackageFile Condition="'%(PackageFile.PackageId)' == ''">
         <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(Version)</PackageVersion>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
       </PackageFile>
 
       <!-- Include Sources. Deduplicate so the nuspec doesn't contain multiple entries for each source file. -->
@@ -570,7 +571,7 @@
       <PackageFile Condition="'$(RuntimeFileSource)' != ''" Remove="$(RuntimeFileSource)"/>
       <PackageFile Include="$(RuntimeFilePath)">
         <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(Version)</PackageVersion>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
         <IsLibrary>false</IsLibrary>
       </PackageFile>
     </ItemGroup>
@@ -767,7 +768,7 @@
     <ItemGroup Condition="'@(PackageFile)' == ''">
       <PackageFile Include="$(PlaceholderFile)">
         <PackageId>$(Id)</PackageId>
-        <PackageVersion>$(Version)</PackageVersion>
+        <PackageVersion>$(PackageVersion)</PackageVersion>
         <IsLibrary>false</IsLibrary>
       </PackageFile>
     </ItemGroup>
@@ -779,7 +780,7 @@
   <!-- Walks every project gathering its AssemblyVersion, choosing the highest -->
   <!-- Skipped if the package explicitly defines a version -->
   <Target Name="GetAssemblyVersionFromProjects"
-          Condition="$(Version) == ''"
+          Condition="$(PackageVersion) == ''"
           DependsOnTargets="GetFiles">
 
     <GetPackageVersion Files="@(File)">
@@ -795,12 +796,12 @@
         DependsOnTargets="CreateVersionFileDuringBuild;GetAssemblyVersionFromProjects">
 
     <Error Text="No version could be detected.  Either specify the Version property or provide at least one managed assembly."
-           Condition="'$(Version)' == '' AND '$(_AssemblyVersion)' == ''" />
+           Condition="'$(PackageVersion)' == '' AND '$(_AssemblyVersion)' == ''" />
 
     <ItemGroup>
       <_thisPackage Include="$(Id)">
-        <Version Condition="'$(Version)' != ''">$(Version)</Version>
-        <Version Condition="'$(Version)' == ''">$(_AssemblyVersion)</Version>
+        <Version Condition="'$(PackageVersion)' != ''">$(PackageVersion)</Version>
+        <Version Condition="'$(PackageVersion)' == ''">$(_AssemblyVersion)</Version>
       </_thisPackage>
     </ItemGroup>
 
@@ -811,7 +812,7 @@
     </ApplyPreReleaseSuffix>
 
     <PropertyGroup>
-      <Version>%(_thisPackageFinal.Version)</Version>
+      <PackageVersion>%(_thisPackageFinal.Version)</PackageVersion>
     </PropertyGroup>
   </Target>
 
@@ -831,7 +832,7 @@
 
     <ItemGroup>
       <_PackageIdentity Include="$(Id)">
-        <Version>$(Version)</Version>
+        <Version>$(PackageVersion)</Version>
         <TargetFramework Condition="'$(PackageTargetFramework)' != ''">$(PackageTargetFramework)</TargetFramework>
         <TargetRuntime Condition="'$(PackageTargetRuntime)' != ''">$(PackageTargetRuntime)</TargetRuntime>
         <MinimumNETStandard Condition="'$(MinimumNETStandard)' != ''">$(MinimumNETStandard)</MinimumNETStandard>
@@ -1048,7 +1049,7 @@
                      Frameworks="@(ValidateFramework)"
                      PackageId="$(Id)"
                      PackageIndexes="@(PackageIndex)"
-                     PackageVersion="$(Version)"
+                     PackageVersion="$(PackageVersion)"
                      RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
                      SkipGenerationCheck="$(SkipGenerationCheck)"
                      SkipIndexCheck="$(SkipIndexCheck)"
@@ -1094,7 +1095,7 @@
                     OutputFileName="$(NuSpecPath)"
                     MinClientVersion="$(MinClientVersion)"
                     Id="$(Id)"
-                    Version="$(Version)"
+                    Version="$(PackageVersion)"
                     Title="$(Title)"
                     Authors="$(Authors)"
                     Owners="$(Owners)"
@@ -1118,7 +1119,7 @@
 
   <Target Name="CreatePackage"
           Inputs="$(NuSpecPath)"
-          Outputs="$(PackageOutputPath)$(Id).$(Version).nupkg">
+          Outputs="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg">
 
     <ItemGroup>
       <_missingFiles Include="@(PackageFile)" Condition="!Exists(%(FullPath))"/>
@@ -1139,7 +1140,7 @@
                AdditionalSymbolPackageExcludes="@(AdditionalSymbolPackageExcludes)"
                Condition="'$(_SkipCreatePackage)' != 'true'"/>
     <!-- Create a marker that records the path to the generated package -->
-    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(Version).nupkg;$(SymbolPackageOutputPath)$(Id).$(Version).symbols.nupkg"
+    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg;$(SymbolPackageOutputPath)$(Id).$(PackageVersion).symbols.nupkg"
                       File="$(NuSpecPath).pkgpath"
                       Overwrite="true"
                       Condition="'$(_SkipCreatePackage)' != 'true'"/>
@@ -1155,7 +1156,7 @@
            Text="The PackageIndexFile property is not set.  Please set this property to point to the path of the packageIndex.json file for your repo." />
 
     <UpdatePackageIndex PackageIndexFile="$(PackageIndexFile)"
-                        Packages="$(PackageOutputPath)$(Id).$(Version).nupkg" />
+                        Packages="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg" />
   </Target>
 
   <!-- Updates the packageIndex with information from the multiple sources for the entire repo -->

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
@@ -1,0 +1,234 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class PackageIndex
+    {
+        public static PackageIndex Current { get; } = new PackageIndex();
+
+        public Dictionary<string, PackageInfo> Packages { get; set; } = new Dictionary<string, PackageInfo>();
+
+        public Dictionary<string, string> ModulesToPackages { get; set; } = new Dictionary<string, string>();
+
+        [JsonIgnore]
+        public HashSet<string> IndexSources { get; set; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        public static PackageIndex Load(string packageIndexFile)
+        {
+            using (var file = File.OpenText(packageIndexFile))
+            using (var jsonTextReader = new JsonTextReader(file))
+            {
+                var serializer = new JsonSerializer();
+                serializer.Converters.Add(new VersionConverter());
+                var result = serializer.Deserialize<PackageIndex>(jsonTextReader);
+                result.IndexSources.Add(Path.GetFullPath(packageIndexFile));
+                return result;
+            }
+        }
+
+        public void Save(string path)
+        {
+            string directory = Path.GetDirectoryName(path);
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            using (var file = File.CreateText(path))
+            {
+                var serializer = new JsonSerializer();
+                serializer.StringEscapeHandling = StringEscapeHandling.EscapeNonAscii;
+                serializer.Formatting = Formatting.Indented;
+                serializer.NullValueHandling = NullValueHandling.Ignore;
+                serializer.DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate;
+                serializer.Converters.Add(new VersionConverter());
+                serializer.Serialize(file, this);
+            }
+        }
+
+        /// <summary>
+        /// Merges an index into the currently loaded index if not already merged.
+        /// </summary>
+        /// <param name="otherIndexFile"></param>
+        public void Merge(string otherIndexFile)
+        {
+            if (!IndexSources.Contains(otherIndexFile))
+            {
+                Merge(Load(otherIndexFile));
+            }
+        }
+
+        /// <summary>
+        /// Merges a list of indexes into the currently loaded index if not already merged.
+        /// </summary>
+        /// <param name="otherIndexFiles"></param>
+        public void Merge(IEnumerable<string> otherIndexFiles)
+        {
+            foreach(var otherIndexFile in otherIndexFiles)
+            {
+                Merge(otherIndexFile);
+            }
+        }
+
+        /// <summary>
+        /// Merges another packageIndex into this package index.  For any overlapping
+        /// data 'other' has precedence.
+        /// </summary>
+        /// <param name="other"></param>
+        public void Merge(PackageIndex other)
+        {
+            if (other.IndexSources.IsSubsetOf(IndexSources))
+            {
+                return;
+            }
+
+            foreach(var otherPackage in other.Packages)
+            {
+                var otherInfo = otherPackage.Value;
+                PackageInfo existingInfo;
+
+                if (Packages.TryGetValue(otherPackage.Key, out existingInfo))
+                {
+                    existingInfo.Merge(otherInfo);
+                }
+                else
+                {
+                    Packages[otherPackage.Key] = otherInfo;
+                }
+            }
+
+            foreach(var otherModuleToPackage in other.ModulesToPackages)
+            {
+                ModulesToPackages[otherModuleToPackage.Key] = otherModuleToPackage.Value;
+            }
+
+            foreach(var otherIndexSource in other.IndexSources)
+            {
+                IndexSources.Add(otherIndexSource);
+            }
+        }
+
+        // helper functions
+        public bool TryGetBaseLineVersion(string packageId, out Version baseLineVersion)
+        {
+            PackageInfo info;
+            baseLineVersion = null;
+
+            if (Packages.TryGetValue(packageId, out info))
+            {
+                baseLineVersion = info.BaselineVersion;
+            }
+
+            return baseLineVersion != null;
+        }
+
+        public bool IsStable(string packageId, Version packageVersion)
+        {
+            PackageInfo info;
+            bool isStable = false;
+
+            if (Packages.TryGetValue(packageId, out info))
+            {
+                isStable = info.StableVersions.Contains(packageVersion);
+            }
+
+            return isStable;
+        }
+
+        public Version GetPackageVersionForAssemblyVersion(string packageId, Version assemblyVersion)
+        {
+            PackageInfo info;
+            Version packageVersion = null;
+
+            if (assemblyVersion != null)
+            {
+                if (Packages.TryGetValue(packageId, out info))
+                {
+                    packageVersion = info.GetPackageVersionForAssemblyVersion(assemblyVersion);
+                }
+                else
+                {
+                    // if not found assume 1:1 with assembly version
+                    packageVersion = VersionUtility.As3PartVersion(assemblyVersion);
+                }
+            }
+
+            return packageVersion;
+        }
+    }
+
+    public class PackageInfo
+    {
+        public HashSet<Version> StableVersions { get; set; } = new HashSet<Version>();
+
+        public bool ShouldSerializeStableVersions() { return StableVersions.Count > 0; }
+
+        public Version BaselineVersion { get; set; }
+
+        public Dictionary<Version, Version> AssemblyVersionInPackageVersion { get; set; } = new Dictionary<Version, Version>();
+
+        public bool ShouldSerializeAssemblyVersionInPackageVersion() { return AssemblyVersionInPackageVersion.Count > 0; }
+
+        public void Merge(PackageInfo other)
+        {
+            StableVersions.UnionWith(other.StableVersions);
+
+            if (other.BaselineVersion != null)
+            {
+                // prefer other over existing
+                BaselineVersion = other.BaselineVersion;
+            }
+
+            foreach (var assemblyVersionInPackage in other.AssemblyVersionInPackageVersion)
+            {
+                Version otherAssemblyVersion = assemblyVersionInPackage.Key;
+                Version otherPackageVersion = assemblyVersionInPackage.Value;
+
+                AddAssemblyVersionInPackage(otherAssemblyVersion, otherPackageVersion);
+            }
+        }
+
+        public void AddAssemblyVersionInPackage(Version assemblyVersion, Version packageVersion)
+        {
+            Version existingPackageVersion;
+            if (AssemblyVersionInPackageVersion.TryGetValue(assemblyVersion, out existingPackageVersion))
+            {
+                // prefer the lowest versioned package which first exposed this API version
+                if (existingPackageVersion > packageVersion)
+                {
+                    AssemblyVersionInPackageVersion[assemblyVersion] = packageVersion;
+                }
+            }
+            else
+            {
+                AssemblyVersionInPackageVersion[assemblyVersion] = packageVersion;
+            }
+        }
+
+        public Version GetPackageVersionForAssemblyVersion(Version assemblyVersion)
+        {
+            Version packageVersion = null;
+
+            if (assemblyVersion != null)
+            {
+                // prefer an explicit mapping
+                if (!AssemblyVersionInPackageVersion.TryGetValue(assemblyVersion, out packageVersion))
+                {
+                    // if not found assume 1:1 with assembly version
+                    packageVersion = VersionUtility.As3PartVersion(assemblyVersion);
+                }
+            }
+
+            return packageVersion;
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
@@ -1,0 +1,245 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using NuGet.Packaging;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class UpdatePackageIndex : PackagingTask
+    {
+        private HashSet<string> _packageIdsToInclude;
+
+        /// <summary>
+        /// File to update or create
+        /// </summary>
+        [Required]
+        public ITaskItem PackageIndexFile { get; set; }
+
+        /// <summary>
+        /// Specific packages to index
+        /// </summary>
+        public ITaskItem[] Packages { get; set; }
+
+        /// <summary>
+        /// Baseline packages to add
+        ///   Identity: Package ID
+        ///   Version: Package version
+        /// </summary>
+        public ITaskItem[] BaselinePackages { get; set; }
+
+        /// <summary>
+        /// Stable packages to add
+        ///   Identity: Package ID
+        ///   Version: Package version
+        /// </summary>
+        public ITaskItem[] StablePackages { get; set; }
+
+        /// <summary>
+        /// Module to package mappings to add
+        ///   Identity: Module name without extension
+        ///   Package: Package id which provides module
+        /// </summary>
+        public ITaskItem[] ModuleToPackages { get; set; }
+
+        /// <summary>
+        /// When used with PackageFolders restricts the set of packages indexed.
+        /// </summary>
+        public ITaskItem[] PackageIds { get; set; }
+
+        /// <summary>
+        /// Folders to index, can contain flat set of packages or expanded package format.
+        /// </summary>
+        public ITaskItem[] PackageFolders { get; set; }
+
+        public override bool Execute()
+        {
+            string indexFilePath = PackageIndexFile.GetMetadata("FullPath");
+
+            PackageIndex index = File.Exists(indexFilePath) ?
+                index = PackageIndex.Load(indexFilePath) :
+                new PackageIndex();
+
+            if (PackageIds != null && PackageIds.Any())
+            {
+                _packageIdsToInclude = new HashSet<string>(PackageIds.Select(i => i.ItemSpec), StringComparer.OrdinalIgnoreCase);
+            }
+
+            foreach(var package in Packages.NullAsEmpty().Select(f => f.GetMetadata("FullPath")))
+            {
+                Log.LogMessage($"Updating from {package}.");
+                UpdateFromPackage(index, package);
+            }
+
+            foreach(var packageFolder in PackageFolders.NullAsEmpty().Select(f => f.GetMetadata("FullPath")))
+            {
+                var nupkgs = Directory.EnumerateFiles(packageFolder, "*.nupkg", SearchOption.TopDirectoryOnly);
+
+                if (nupkgs.Any())
+                {
+                    foreach(var nupkg in nupkgs)
+                    {
+                        Log.LogMessage($"Updating from {nupkg}.");
+                        UpdateFromPackage(index, nupkg, true);
+                    }
+                }
+                else
+                {
+                    var nuspecFolders = Directory.EnumerateFiles(packageFolder, "*.nuspec", SearchOption.AllDirectories)
+                        .Select(nuspec => Path.GetDirectoryName(nuspec));
+
+                    foreach (var nuspecFolder in nuspecFolders)
+                    {
+                        Log.LogMessage($"Updating from {nuspecFolder}.");
+                        UpdateFromFolderLayout(index, nuspecFolder, true);
+                    }
+                }
+            }
+
+            if (BaselinePackages != null)
+            {
+                foreach (var baselinePackage in BaselinePackages)
+                {
+                    var info = GetOrCreatePackageInfo(index, baselinePackage.ItemSpec);
+                    var version = baselinePackage.GetMetadata("Version");
+
+                    info.BaselineVersion = Version.Parse(version);
+                }
+            }
+
+            if (StablePackages != null)
+            {
+                foreach (var stablePackage in StablePackages)
+                {
+                    var info = GetOrCreatePackageInfo(index, stablePackage.ItemSpec);
+                    var version = stablePackage.GetMetadata("Version");
+
+                    info.StableVersions.Add(Version.Parse(version));
+                }
+            }
+
+            if (ModuleToPackages != null)
+            {
+                foreach (var moduleToPackage in ModuleToPackages)
+                {
+                    var package = moduleToPackage.GetMetadata("Package");
+                    index.ModulesToPackages[moduleToPackage.ItemSpec] = package;
+                }
+            }
+
+            index.Save(indexFilePath);
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void UpdateFromFolderLayout(PackageIndex index, string path, bool filter = false)
+        {
+            var version = NuGetVersion.Parse(Path.GetFileName(path));
+            var id = Path.GetFileName(Path.GetDirectoryName(path));
+
+            if (filter && !ShouldInclude(id))
+            {
+                return;
+            }
+
+            string refFolder = Path.Combine(path, "ref");
+
+            if (!Directory.Exists(refFolder))
+            {
+                refFolder = Path.Combine(path, "lib");
+            }
+
+            IEnumerable<Version> assemblyVersions = null;
+            if (Directory.Exists(refFolder))
+            {
+                assemblyVersions = Directory.EnumerateFiles(refFolder, "*.dll", SearchOption.AllDirectories)
+                    .Select(f => VersionUtility.GetAssemblyVersion(f));
+            }
+
+            UpdateFromValues(index, id, version, assemblyVersions);
+        }
+
+        private void UpdateFromPackage(PackageIndex index, string packagePath, bool filter = false)
+        {
+            string id;
+            NuGetVersion version;
+            IEnumerable<Version> assemblyVersions;
+
+            using (var reader = new PackageArchiveReader(packagePath))
+            {
+                var identity = reader.GetIdentity();
+                id = identity.Id;
+                version = identity.Version;
+
+                if (filter && !ShouldInclude(id))
+                {
+                    return;
+                }
+
+                var refFiles = reader.GetFiles("ref");
+
+                if (!refFiles.Any())
+                {
+                    refFiles = reader.GetFiles("lib");
+                }
+
+                assemblyVersions = refFiles.Select(refFile =>
+                {
+                    using (var refStream = reader.GetStream(refFile))
+                    using (var memStream = new MemoryStream())
+                    {
+                        refStream.CopyTo(memStream);
+                        memStream.Seek(0, SeekOrigin.Begin);
+                        return VersionUtility.GetAssemblyVersion(memStream);
+                    }
+                }).ToArray();
+            }
+
+            UpdateFromValues(index, id, version, assemblyVersions);
+        }
+
+        private void UpdateFromValues(PackageIndex index, string id, NuGetVersion version, IEnumerable<Version> assemblyVersions)
+        {
+            PackageInfo info = GetOrCreatePackageInfo(index, id);
+
+            var packageVersion = VersionUtility.As3PartVersion(version.Version);
+            // if we have a stable version, add it to the stable versions list
+            if (!version.IsPrerelease)
+            {
+                info.StableVersions.Add(packageVersion);
+            }
+
+            if (assemblyVersions != null)
+            {
+                foreach(var assemblyVersion in assemblyVersions.Where(v => v != null))
+                {
+                    info.AddAssemblyVersionInPackage(assemblyVersion, packageVersion);
+                }
+            }
+        }
+
+        private PackageInfo GetOrCreatePackageInfo(PackageIndex index, string id)
+        {
+            PackageInfo info;
+
+            if (!index.Packages.TryGetValue(id, out info))
+            {
+                index.Packages[id] = info = new PackageInfo();
+            }
+
+            return info;
+        }
+
+        private bool ShouldInclude(string packageId)
+        {
+            return (_packageIdsToInclude != null) ? _packageIdsToInclude.Contains(packageId) : true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -442,7 +442,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (PackageIndexes == null || PackageIndexes.Length == 0)
             {
-                Log.LogError($"{nameof(PackageIndexes)} must be specified");
                 return;
             }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -125,6 +125,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             get;
             set;
         }
+        public bool SkipIndexCheck
+        {
+            get;
+            set;
+        }
 
         public bool SkipSupportCheck
         {
@@ -162,6 +167,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         }
 
         /// <summary>
+        /// Package index files used to define package version mapping.
+        /// </summary>
+        [Required]
+        public ITaskItem[] PackageIndexes { get; set; }
+
+        /// <summary>
         /// property bag of error suppressions
         /// </summary>
         private Dictionary<Suppression, HashSet<string>> _suppressions;
@@ -191,6 +202,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 ValidateSupport();
             }
 
+            ValidateIndex();
 
             return !Log.HasLoggedErrors;
         }
@@ -418,6 +430,45 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             if (!String.IsNullOrEmpty(ValidationReport))
             {
                 report.Save(ValidationReport);
+            }
+        }
+
+        private void ValidateIndex()
+        {
+            if (SkipIndexCheck)
+            {
+                return;
+            }
+
+            if (PackageIndexes == null || PackageIndexes.Length == 0)
+            {
+                Log.LogError($"{nameof(PackageIndexes)} must be specified");
+                return;
+            }
+
+            PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+
+            PackageInfo info;
+            if (!PackageIndex.Current.Packages.TryGetValue(PackageId, out info))
+            {
+                Log.LogError($"PackageIndex from {String.Join(", ", PackageIndexes.Select(i => i.ItemSpec))} is missing an entry for package {PackageId}.  Please run /t:UpdatePackageIndex on this project to commit an update.");
+                return;
+            }
+
+            var thisPackageFiles = _validateFiles[PackageId];
+            var refFiles = thisPackageFiles.Where(f => f.TargetPath.StartsWith("ref/", StringComparison.OrdinalIgnoreCase));
+
+            if (!refFiles.Any())
+            {
+                refFiles = thisPackageFiles.Where(f => f.TargetPath.StartsWith("lib/", StringComparison.OrdinalIgnoreCase));
+            }
+
+            foreach (var refFileVersion in refFiles.Where(r => r.Version != null).Select(r => VersionUtility.As4PartVersion(r.Version)).Distinct())
+            {
+                if (!info.AssemblyVersionInPackageVersion.ContainsKey(refFileVersion))
+                {
+                    Log.LogError($"PackageIndex from {String.Join(", ", PackageIndexes.Select(i => i.ItemSpec))} is missing an assembly version entry for {refFileVersion} for package {PackageId}.  Please run /t:UpdatePackageIndex on this project to commit an update.");
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -22,10 +22,18 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static Version GetAssemblyVersion(string assemblyPath)
         {
+            using (var fileStream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read))
+            {
+                return GetAssemblyVersion(fileStream);
+            }
+        }
+
+        public static Version GetAssemblyVersion(Stream assemblyStream)
+        {
             Version result = null;
             try
             {
-                using (PEReader peReader = new PEReader(new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Delete | FileShare.Read)))
+                using (PEReader peReader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
                 {
                     if (peReader.HasMetadata)
                     {
@@ -40,6 +48,48 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             return result;
+        }
+
+        public static Version As3PartVersion(Version version)
+        {
+            int build = version.Build;
+
+            if (build == -1)
+            {
+                // we have a 2-part version
+                build = 0;
+            }
+            else if (version.Revision == -1)
+            {
+                // we already have a 3-part version
+                return version;
+            }
+
+            return new Version(version.Major, version.Minor, build);
+        }
+
+        public static Version As4PartVersion(Version version)
+        {
+            int build = version.Build, revision = version.Revision;
+
+            if (build == -1)
+            {
+                // we have a 2-part version
+                build = 0;
+                revision = 0;
+            }
+            else if (revision == -1)
+            {
+                // we have a 3-part version
+                revision = 0;
+            }
+            else
+            {
+                // we already have a 4-part version
+                return version;
+            }
+
+            return new Version(version.Major, version.Minor, build, revision);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/ApplyBaseLineTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/ApplyBaseLineTests.cs
@@ -13,21 +13,18 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
     {
         private Log _log;
         private TestBuildEngine _engine;
+        private ITaskItem[] _packageIndexes;
 
         public ApplyBaseLineTests(ITestOutputHelper output)
         {
             _log = new Log(output);
             _engine = new TestBuildEngine(_log);
+            _packageIndexes = new[] { new TaskItem("packageIndex.json") };
         }
 
         [Fact]
         public void ApplyBaseLineLiftToBaseLine()
         {
-            ITaskItem[] baseLine = new[]
-            {
-                CreateItem("System.Runtime", "4.0.21")
-            };
-
             ITaskItem[] dependencies = new[]
             {
                 CreateItem("System.Runtime", "4.0.0")
@@ -36,36 +33,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             ApplyBaseLine task = new ApplyBaseLine()
             {
                 BuildEngine = _engine,
-                BaseLinePackages = baseLine,
-                OriginalDependencies = dependencies
-            };
-
-            _log.Reset();
-            task.Execute();
-            Assert.Equal(0, _log.ErrorsLogged);
-            Assert.Equal(0, _log.WarningsLogged);
-            Assert.Equal(task.OriginalDependencies.Length, task.BaseLinedDependencies.Length);
-            Assert.Equal("System.Runtime", task.BaseLinedDependencies[0].ItemSpec);
-            Assert.Equal("4.0.21", task.BaseLinedDependencies[0].GetMetadata("Version"));
-        }
-        [Fact]
-        public void ApplyBaseLineLiftToMinimumBaseLine()
-        {
-            ITaskItem[] baseLine = new[]
-            {
-                CreateItem("System.Runtime", "4.0.21"),
-                CreateItem("System.Runtime", "4.1.0")
-            };
-
-            ITaskItem[] dependencies = new[]
-            {
-                CreateItem("System.Runtime", "4.0.0")
-            };
-
-            ApplyBaseLine task = new ApplyBaseLine()
-            {
-                BuildEngine = _engine,
-                BaseLinePackages = baseLine,
+                Apply = true,
+                PackageIndexes = _packageIndexes,
                 OriginalDependencies = dependencies
             };
 
@@ -81,10 +50,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         [Fact]
         public void DontApplyBaseLineIfGreater()
         {
-            ITaskItem[] baseLine = new[]
-            {
-                CreateItem("System.Runtime", "4.0.21")
-            };
 
             ITaskItem[] dependencies = new[]
             {
@@ -94,7 +59,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             ApplyBaseLine task = new ApplyBaseLine()
             {
                 BuildEngine = _engine,
-                BaseLinePackages = baseLine,
+                Apply = true,
+                PackageIndexes = _packageIndexes,
                 OriginalDependencies = dependencies
             };
 
@@ -110,11 +76,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         [Fact]
         public void ApplyBaselineToUnversionedDependency()
         {
-            ITaskItem[] baseLine = new[]
-            {
-                CreateItem("System.Runtime", "4.0.21")
-            };
-
             ITaskItem[] dependencies = new[]
             {
                 CreateItem("System.Runtime", null)
@@ -123,7 +84,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             ApplyBaseLine task = new ApplyBaseLine()
             {
                 BuildEngine = _engine,
-                BaseLinePackages = baseLine,
+                Apply = true,
+                PackageIndexes = _packageIndexes,
                 OriginalDependencies = dependencies
             };
 
@@ -137,42 +99,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
         }
 
         [Fact]
-        public void ApplyHighestBaselineToUnversionedDependency()
-        {
-            ITaskItem[] baseLine = new[]
-            {
-                CreateItem("System.Runtime", "4.0.21"),
-                CreateItem("System.Runtime", "4.1.0")
-            };
-
-            ITaskItem[] dependencies = new[]
-            {
-                CreateItem("System.Runtime", null)
-            };
-
-            ApplyBaseLine task = new ApplyBaseLine()
-            {
-                BuildEngine = _engine,
-                BaseLinePackages = baseLine,
-                OriginalDependencies = dependencies
-            };
-
-            _log.Reset();
-            task.Execute();
-            Assert.Equal(0, _log.ErrorsLogged);
-            Assert.Equal(0, _log.WarningsLogged);
-            Assert.Equal(task.OriginalDependencies.Length, task.BaseLinedDependencies.Length);
-            Assert.Equal("System.Runtime", task.BaseLinedDependencies[0].ItemSpec);
-            Assert.Equal("4.1.0", task.BaseLinedDependencies[0].GetMetadata("Version"));
-        }
-
-        [Fact]
         public void ApplyBaselineToUntrackedDependency()
         {
-            ITaskItem[] baseLine = new[]
-            {
-                CreateItem("System.Runtime", "4.0.21")
-            };
 
             ITaskItem[] dependencies = new[]
             {
@@ -182,7 +110,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
             ApplyBaseLine task = new ApplyBaseLine()
             {
                 BuildEngine = _engine,
-                BaseLinePackages = baseLine,
+                Apply = true,
+                PackageIndexes = _packageIndexes,
                 OriginalDependencies = dependencies
             };
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
@@ -30,6 +30,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="packageIndex.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="project.json" />
     <None Include="$(PackagesDir)Microsoft.NETCore.Platforms\1.0.1\runtime.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/packageIndex.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/packageIndex.json
@@ -1,0 +1,7 @@
+﻿{
+  "Packages": {
+    "System.Runtime": {
+      "BaselineVersion": "4.0.21"
+    }
+  }
+}


### PR DESCRIPTION
Now that package versions are divorced from assembly version we need a
data file to track the mapping.

In addition to tracking assembly version to package version, this data
file will track stable packages, baseline packages, and module-to-
package mappings.  This will help speed up our builds by caching the
data rather than parsing giant item lists in every msbuild project.

To keep the data file up to date I added validation with an error
message that tells folks to run a command to update the data file.  I
don't update the file automatically because I can't be certain that
packages with stale data have already been created.

CoreFx change which supports this: https://github.com/dotnet/corefx/pull/10971/commits/254ce644dc75132f787053b67177decf9651a86e

/cc @weshaggard @joperezr
