### PR TITLE
Enable run quiet mode for run tool (suppress run tool output, only display exec output)

### DIFF
--- a/src/Run/Executor.cs
+++ b/src/Run/Executor.cs
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Execute
             }
             string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows": "unix";
 
-            jsonSetup.prepareValues(os, executor.SettingParameters, executor.configFilePath);
+            jsonSetup.PrepareValues(os, executor.SettingParameters, executor.configFilePath);
             if (executor.DefineParameters(parseArgs, jsonSetup))
             {
                 if(string.IsNullOrEmpty(executor.CommandSelectedByUser))

--- a/src/Run/Executor.cs
+++ b/src/Run/Executor.cs
@@ -146,24 +146,26 @@ namespace Microsoft.DotNet.Execute
             }
             string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows": "unix";
 
-            jsonSetup.PrepareValues(os, executor.SettingParameters, executor.configFilePath);
-            if (executor.DefineParameters(parseArgs, jsonSetup))
+            if (jsonSetup.PrepareValues(os, executor.SettingParameters, executor.configFilePath) == 0)
             {
-                if(string.IsNullOrEmpty(executor.CommandSelectedByUser))
+                if (executor.DefineParameters(parseArgs, jsonSetup))
                 {
-                    Console.Error.WriteLine("Error: No command was passed. Use -? for help.");
-                    return 1;
-                }
-
-                List<string> paramSelected = new List<string>();
-                foreach (KeyValuePair<string, string> param in executor.CommandParameters[executor.CommandSelectedByUser])
-                {
-                    if (!string.IsNullOrEmpty(param.Value))
+                    if (string.IsNullOrEmpty(executor.CommandSelectedByUser))
                     {
-                        paramSelected.Add(param.Key);
+                        Console.Error.WriteLine("Error: No command was passed. Use -? for help.");
+                        return 1;
                     }
+
+                    List<string> paramSelected = new List<string>();
+                    foreach (KeyValuePair<string, string> param in executor.CommandParameters[executor.CommandSelectedByUser])
+                    {
+                        if (!string.IsNullOrEmpty(param.Value))
+                        {
+                            paramSelected.Add(param.Key);
+                        }
+                    }
+                    return jsonSetup.ExecuteCommand(executor.CommandSelectedByUser, paramSelected);
                 }
-                return jsonSetup.ExecuteCommand(executor.CommandSelectedByUser, paramSelected);
             }
             //There was an error when parsing the user input, Define Parameters is in charge of printing an error message.
             return 1;

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -12,8 +12,8 @@ namespace Microsoft.DotNet.Execute
 {
     public class Setup
     {
-        private const string runQuietReservedKeyword = "RunQuiet";
-        private const string runToolSettingValueTypeReservedKeyword = "runToolSetting";
+        private const string RunQuietReservedKeyword = "RunQuiet";
+        private const string RunToolSettingValueTypeReservedKeyword = "runToolSetting";
 
         public Dictionary<string, string> ToolSettings { get; set; }
         public Dictionary<string, Setting> Settings { get; set; }
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Execute
 
         private bool IsReservedKeyword(string keyword)
         {
-            if(keyword.Equals(runQuietReservedKeyword))
+            if(keyword.Equals(RunQuietReservedKeyword))
             {
                 return true;
             }
@@ -154,12 +154,12 @@ namespace Microsoft.DotNet.Execute
             int returnCode = ValidateSettings();
 
             ToolSettings = Settings.Where(s => s.Value.ValueType == null  ||
-                                               s.Value.ValueType.Equals(runToolSettingValueTypeReservedKeyword)
+                                               s.Value.ValueType.Equals(RunToolSettingValueTypeReservedKeyword)
                                                ).ToDictionary(s => s.Key, s => string.Empty) ?? new Dictionary<string, string>();
             // A dev may have overriden the default values for a tool setting, but not specified the ValueType
             foreach(var key in ToolSettings.Keys)
             {
-                Settings[key].ValueType = runToolSettingValueTypeReservedKeyword;
+                Settings[key].ValueType = RunToolSettingValueTypeReservedKeyword;
             }
 
             // Parse run tool settings for any settings which do not apply to a Command, this allows us to have run tool settings
@@ -171,17 +171,17 @@ namespace Microsoft.DotNet.Execute
         private void SetRunToolSettingsDefaults()
         {
             // If RunQuiet is already defined in config.json, don't override it
-            if (!Settings.ContainsKey(runQuietReservedKeyword))
+            if (!Settings.ContainsKey(RunQuietReservedKeyword))
             {
                 Setting runQuietSetting = new Setting()
                 {
                     Values = new List<string>() { "True", "False" },
-                    ValueType = runToolSettingValueTypeReservedKeyword,
+                    ValueType = RunToolSettingValueTypeReservedKeyword,
                     Description = "Run tool specific setting.  Set to True to only display output from the executing command.  Default, False",
                     DefaultValue = "false"
                 };
 
-                Settings.Add(runQuietReservedKeyword, runQuietSetting);
+                Settings.Add(RunQuietReservedKeyword, runQuietSetting);
             }
 
         }
@@ -191,7 +191,7 @@ namespace Microsoft.DotNet.Execute
             ParseRunToolSettings(commandSelectedByUser);
             string runQuietValue;
             bool runQuiet = false;
-            if (ToolSettings.TryGetValue(runQuietReservedKeyword, out runQuietValue))
+            if (ToolSettings.TryGetValue(RunQuietReservedKeyword, out runQuietValue))
             {
                 runQuiet = runQuietValue.Equals("true", StringComparison.OrdinalIgnoreCase);
             }
@@ -439,7 +439,7 @@ namespace Microsoft.DotNet.Execute
             {
                 commandOption = string.Format(" {0}", toolName.Equals("console") ? "" : value);
             }
-            else if(type.Equals(runToolSettingValueTypeReservedKeyword)) { /* do nothing */ }
+            else if(type.Equals(RunToolSettingValueTypeReservedKeyword)) { /* do nothing */ }
             else
             {
                 Tool toolFormat;

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.Execute
                 {
                     Values = new List<string>() { "True", "False" },
                     ValueType = RunToolSettingValueTypeReservedKeyword,
-                    Description = "Run tool specific setting.  Set to True to only display output from the executing command.  Default, False",
+                    Description = "Run tool specific setting.  Set to True to only display output from the executing command.",
                     DefaultValue = "false"
                 };
 


### PR DESCRIPTION
https://github.com/dotnet/buildtools/issues/973

Adds a "RunQuiet" option (default false), which, if true, suppresses extra output from the run tool itself.  The default values for RunQuiet are part of the run tool, but a repo may override these values by either adding a setting with a default value in that repo's config.json, adding a "RunQuiet" property to a Command, or specifying the value on the command-line.

/cc @maririos , @weshaggard 