### PR TITLE
Calling target `Test` with BeforeTargets in tests.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -298,7 +298,7 @@
   </Target>
 
   <Target Name="CheckTestPlatforms"
-          AfterTargets="Test">
+          BeforeTargets="Test">
     <GetTargetMachineInfo Condition="'$(TargetOS)' == ''">
       <Output TaskParameter="TargetOS" PropertyName="TargetOS" />
     </GetTargetMachineInfo>


### PR DESCRIPTION
In CoreFx we started hitting the problem that the result of the build was `Build Succeeded` even when we had test failures. It was not obvious until run.exe got implemented.

The problem relies on how the value of the MsBuild property `MSBuildLastTaskResult` was being propagated.
With the AfterTargets property, the result of the subsequent targets, like [RunTestsForProject](https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets#L151) was not being returned to the target `Test` as this one had already finished before the execution of the tests happened.

With this change, the target `CheckTestPlatforms` and all its dependencies are executed and they return the exit code value before `Test` is executed, so the propagation of the value of `MSBuildLastTaskResult` happens correctly.

I tested the change in CoreFx (windows, ubuntu) and Build Tools.

Fix: dotnet/corefx#10430

cc: @weshaggard  @joperezr 