### PR TITLE
Permit the use of TargetGroup in refs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
@@ -14,9 +14,9 @@
 
   <PropertyGroup Condition="'$(IsReferenceAssembly)'=='true'">
     <AssemblyName Condition="'$(AssemblyName)' == ''">$(MSBuildProjectName)</AssemblyName>
-    <OutputPathSubfolder Condition="'$(IsCompatAssembly)'=='true'">/Compat</OutputPathSubfolder>
-    <OutputPath>$(ReferenceAssemblyOutputPath)$(AssemblyName)/$(AssemblyVersion)$(OutputPathSubFolder)</OutputPath>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)ref/$(AssemblyName)/$(AssemblyVersion)$(OutputPathSubfolder)</IntermediateOutputPath>
+    <TargetOutputRelPath Condition="'$(IsCompatAssembly)'=='true'">$(TargetOutputRelPath)Compat/</TargetOutputRelPath>
+    <OutputPath>$(ReferenceAssemblyOutputPath)$(AssemblyName)/$(AssemblyVersion)/$(TargetOutputRelPath)</OutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)ref/$(AssemblyName)/$(AssemblyVersion)/$(TargetOutputRelPath)</IntermediateOutputPath>
 
     <OmitTransitiveCompileReferences>true</OmitTransitiveCompileReferences>
     <!-- if this is a reference assembly deployment project use compile assets 


### PR DESCRIPTION
We weren't honoring TargetGroup for subdirectories in reference assembly projects.
/cc @weshaggard