### PR TITLE
Fix System.Private package filtering

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class FilterUnknownPackages : PackagingTask
+    {
+        /// <summary>
+        /// Original dependencies
+        /// </summary>
+        [Required]
+        public ITaskItem[] OriginalDependencies { get; set; }
+
+        /// <summary>
+        /// Permitted package baseline versions.
+        ///   Identity: Package ID
+        ///   Version: Package version.
+        /// </summary>
+        public ITaskItem[] BaseLinePackages { get; set; }
+
+        /// <summary>
+        /// Package index files used to define known packages.
+        /// </summary>
+        public ITaskItem[] PackageIndexes { get; set; }
+
+
+        [Output]
+        public ITaskItem[] FilteredDependencies { get; set; }
+
+        public override bool Execute()
+        {
+            Func<string, bool> isKnownPackage;
+
+            if (PackageIndexes != null && PackageIndexes.Length > 0)
+            {
+                PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+                isKnownPackage = packageId => PackageIndex.Current.Packages.ContainsKey(packageId);
+            }
+            else
+            {
+                var baseLinePackageIds = new HashSet<string>(BaseLinePackages.Select(b => b.ItemSpec));
+                isKnownPackage = packageId => baseLinePackageIds.Contains(packageId);
+            }
+
+            FilteredDependencies = OriginalDependencies.Where(
+                dependency =>
+                    !dependency.ItemSpec.StartsWith("System.Private") ||  // only apply filtering to System.Private dependencies
+                    isKnownPackage(dependency.ItemSpec)
+                ).ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -20,6 +20,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="FilterUnknownPackages.cs" />
     <Compile Include="GetApplicableAssetsFromPackageReports.cs" />
     <Compile Include="GetLastStablePackage.cs" />
     <Compile Include="GetPackageFromModule.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -107,6 +107,7 @@
   <UsingTask TaskName="HarvestPackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetPackageFromModule" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="FilterUnknownPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms
@@ -605,18 +606,19 @@
                      TargetFramework="$(_TargetFramework)"
                      FrameworkListsPath="$(FrameworkListsPath)">
       <Output TaskParameter="FrameworkReferences" ItemName="_FileFrameworkReference"/>
-      <Output TaskParameter="PackageReferences" ItemName="_FilePackageReference"/>
+      <Output TaskParameter="PackageReferences" ItemName="_FilePackageReferenceUnfiltered"/>
     </SplitReferences>
+    
+    <FilterUnknownPackages Condition="'@(_FilePackageReferenceUnfiltered)' != ''"
+                           OriginalDependencies="@(_FilePackageReferenceUnfiltered)"
+                           BaseLinePackages="@(BaseLinePackage)"
+                           PackageIndexes="@(PackageIndex)">
+      <Output TaskParameter="FilteredDependencies" ItemName="_FilePackageReference" />
+    </FilterUnknownPackages>
+                           
 
     <ItemGroup Condition="'@(_FilePackageReference)' != ''">
       <_FilePackageReference Remove="corefx;mscorlib;System;System.Core;System.Xml;Windows" />
-
-      <_FilePackageReferencePrivate Include="@(_FilePackageReference)"
-                                    Condition="$([System.String]::new('%(Identity)').StartsWith('System.Private.'))"/>
-
-      <!-- exclude any System.Private dependencies that aren't known packages, where known packages are in BaseLinePackage -->
-      <PackageDependencyExclude Include="@(_FilePackageReferencePrivate)" Exclude="@(BaseLinePackage)" />
-      <_FilePackageReference Remove="@(PackageDependencyExclude)"/>
 
       <!-- Projects may specify additional references by assembly name & identity that we'll process
            applying pre-release logic -->


### PR DESCRIPTION
I broke this filtering when switching to package index.  Previously we'd
only trim System.Private package references if they were "unknown"
packages.  We did this to handle the netcore50 cases where we have
assemblies that don't ship as packages.

Previously we determined "unkown" by checking if the package was in the
BaselinePackage item.  Now we need to check both that item and the index.

This is a targeted fix to restore the thing I broke.
I'd like to refactor the entire dependency harvesting into a smaller
number of tasks but I'll do that in a future commit.

/cc @weshaggard @roncain 