### PR TITLE
Fix help for command without alias

### DIFF
--- a/src/Run/CommandLine.cs
+++ b/src/Run/CommandLine.cs
@@ -762,8 +762,7 @@ class CommandLine
                     }
                 }
             }
-
-            if (hasQualifiers)
+            else if (hasQualifiers)
             {
                 sb.AppendLine().Append("  Actions:").AppendLine();
 
@@ -779,6 +778,11 @@ class CommandLine
                         Wrap(sb, commandSettingsHelp, QualifierSyntaxWidth + 7, new string(' ', QualifierSyntaxWidth + 7), maxLineWidth, false);
                     }
                 }
+            }
+            else
+            {
+                string commandSettingsHelp = _setupContent.GetHelpCommand(parameterSetParameter.Name);
+                Wrap(sb, commandSettingsHelp, QualifierSyntaxWidth + 7, new string(' ', QualifierSyntaxWidth + 7), maxLineWidth, false);
             }
 
             string globalQualifiers = null;

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -410,20 +410,13 @@ namespace Microsoft.DotNet.Execute
         private string GetProject(Command commandToExecute, List<string> parametersSelectedByUser)
         {
             string project = string.Empty;
-            bool moreThanOneProject = false;
+            
             if(parametersSelectedByUser != null)
             {
-                foreach (string param in parametersSelectedByUser)
+                if (parametersSelectedByUser.Count(p => commandToExecute.Alias[p].Settings.TryGetValue("Project", out project)) > 1)
                 {
-                    if (commandToExecute.Alias[param].Settings.TryGetValue("Project", out project))
-                    {
-                        if (moreThanOneProject)
-                        {
-                            Console.Error.WriteLine("Error: There can only be one project execution per command.");
-                            return string.Empty;
-                        }
-                        moreThanOneProject = true;
-                    }
+                    Console.Error.WriteLine("Error: There can only be one project execution per command.");
+                    return string.Empty;
                 }
             }
             

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -208,11 +208,11 @@ namespace Microsoft.DotNet.Execute
                 {
                     if (result == 0)
                     {
-                        PrintColorMessage(ConsoleColor.Green, "Build Succeeded.");
+                        PrintColorMessage(ConsoleColor.Green, "Command execution succeeded.");
                     }
                     else
                     {
-                        PrintColorMessage(ConsoleColor.Red, "Build Failed.");
+                        PrintColorMessage(ConsoleColor.Red, "Command execution failed with exit code {0}.", result);
                     }
                 }
 
@@ -411,19 +411,22 @@ namespace Microsoft.DotNet.Execute
         {
             string project = string.Empty;
             bool moreThanOneProject = false;
-            foreach (string param in parametersSelectedByUser)
+            if(parametersSelectedByUser != null)
             {
-                if (commandToExecute.Alias[param].Settings.TryGetValue("Project", out project))
+                foreach (string param in parametersSelectedByUser)
                 {
-                    if (moreThanOneProject)
+                    if (commandToExecute.Alias[param].Settings.TryGetValue("Project", out project))
                     {
-                        Console.Error.WriteLine("Error: There can only be one project execution per command.");
-                        return string.Empty;
+                        if (moreThanOneProject)
+                        {
+                            Console.Error.WriteLine("Error: There can only be one project execution per command.");
+                            return string.Empty;
+                        }
+                        moreThanOneProject = true;
                     }
-                    moreThanOneProject = true;
                 }
             }
-
+            
             if (string.IsNullOrEmpty(project))
             {
                 project = commandToExecute.DefaultValues.Project;
@@ -466,15 +469,19 @@ namespace Microsoft.DotNet.Execute
             {
                 StringBuilder sb = new StringBuilder();
                 Dictionary<string, string> commandParametersToPrint = new Dictionary<string, string>();
+                List<string> aliasList = null;
 
                 sb.AppendLine().Append("Settings: ").AppendLine();
-                sb.Append(GetHelpAlias(commandToPrint.Alias[alias].Settings, commandParametersToPrint));
 
-                //sb.AppendLine().Append("Default Settings for action (values can be overwritten): ").AppendLine();
+                if (!string.IsNullOrEmpty(alias))
+                {
+                    sb.Append(GetHelpAlias(commandToPrint.Alias[alias].Settings, commandParametersToPrint));
+                    aliasList = new List<string>(alias.Split(' '));
+                }
+
                 sb.Append(GetHelpAlias(commandToPrint.DefaultValues.Settings, commandParametersToPrint));
-
-                CompleteCommand completeCommand = BuildCommand(commandName, new List<string>(alias.Split(' ')), commandParametersToPrint);
-
+                CompleteCommand completeCommand = BuildCommand(commandName, aliasList, commandParametersToPrint);
+                
                 sb.AppendLine().Append("It will run: ").AppendLine();
                 sb.Append(string.Format("{0} {1}", completeCommand.ToolCommand, completeCommand.ParametersCommand));
                 return sb.ToString();


### PR DESCRIPTION
- Changes output message after running the command

- Fix #969 

cc: @chcosta @weshaggard 

As an example, for the [produces](https://github.com/dotnet/corefx/blob/master/config.json#L404) command in CoreFx it will print:
```
produces

Usage: run produces [Action] (global settings)

                                        Settings:
                                        Project = src/packages.builds
                                        ProducesTarget =

                                        It will run:
                                        D:\mariariCoreFx\Tools\msbuild.cmd /nologo /verbosity:minimal /clp:Summary
                                        /maxcpucount /nodeReuse:false
                                        /l:BinClashLogger,Tools\net45\Microsoft.DotNet.Build.Tasks.dll;LogFile=binclash.log
                                        src/packages.builds /t:ProducesTarget
```