### PR TITLE
Condition the use of locally built shims on a new property instead of TestWithLocalLibraries

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -80,8 +80,11 @@
       <Output Condition="'$(TargetOS)'==''" TaskParameter="TargetOS" PropertyName="TargetOS" />
     </GetTargetMachineInfo>
 
+    <PropertyGroup>
+      <TestWithLocalNativeLibraries Condition="'$(TestWithLocalLibraries)'=='true'">true</TestWithLocalNativeLibraries>
+    </PropertyGroup>
     <!-- Test using locally built shim libraries. -->
-    <ItemGroup Condition="'$(TestWithLocalLibraries)'=='true'">
+    <ItemGroup Condition="'$(TestWithLocalNativeLibraries)'=='true'">
       <TestCopyLocal Include="$(BaseOutputPath)$(TargetOS).$(TargetArch).$(ConfigurationGroup)/Native/*.*" />
     </ItemGroup>
 


### PR DESCRIPTION
cc: @ericstj @weshaggard 

This is required in order to remove the use of TestWithLocalLibraries in corefx CI.

related comment: https://github.com/dotnet/corefx/issues/11203#issuecomment-243207773