### PR TITLE
Replace Xunit.PlatformID with Xunit.TestPlatforms

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -14,7 +14,11 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class ActiveIssueAttribute : Attribute, ITraitAttribute
     {
-        public ActiveIssueAttribute(int issueNumber, PlatformID platforms = PlatformID.Any) { }
-        public ActiveIssueAttribute(string issue, PlatformID platforms = PlatformID.Any) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any) { }
+
+        // TODO #999: Remove PlatformID when all uses have transitioned to TestPlatforms.
+        public ActiveIssueAttribute(int issueNumber, PlatformID platforms) { }
+        public ActiveIssueAttribute(string issue, PlatformID platforms) { }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/PlatformSpecificAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/PlatformSpecificAttribute.cs
@@ -14,6 +14,9 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
     public class PlatformSpecificAttribute : Attribute, ITraitAttribute
     {
+        public PlatformSpecificAttribute(TestPlatforms platforms) { }
+
+        // TODO #999: Remove PlatformID when all uses have transitioned to TestPlatforms.
         public PlatformSpecificAttribute(PlatformID platform) { }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -28,12 +28,12 @@ namespace Xunit.NetCore.Extensions
             Debug.Assert(ctorArgs.Count() >= 2);
 
             string issue = ctorArgs.First().ToString();
-            PlatformID platforms = (PlatformID)ctorArgs.Last();
-            if ((platforms.HasFlag(PlatformID.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
-                (platforms.HasFlag(PlatformID.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
-                (platforms.HasFlag(PlatformID.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
-                (platforms.HasFlag(PlatformID.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
-                (platforms.HasFlag(PlatformID.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+            TestPlatforms platforms = (TestPlatforms)ctorArgs.Last();
+            if ((platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
+                (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+                (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
+                (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
+                (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
             {
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
                 yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);

--- a/src/xunit.netcore.extensions/Discoverers/PlatformSpecificDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/PlatformSpecificDiscoverer.cs
@@ -22,16 +22,16 @@ namespace Xunit.NetCore.Extensions
         /// <returns>The trait values.</returns>
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            PlatformID platform = (PlatformID)traitAttribute.GetConstructorArguments().First();
-            if (!platform.HasFlag(PlatformID.Windows))
+            TestPlatforms platforms = (TestPlatforms)traitAttribute.GetConstructorArguments().First();
+            if (!platforms.HasFlag(TestPlatforms.Windows))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonWindowsTest);
-            if (!platform.HasFlag(PlatformID.Linux))
+            if (!platforms.HasFlag(TestPlatforms.Linux))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonLinuxTest);
-            if (!platform.HasFlag(PlatformID.OSX))
+            if (!platforms.HasFlag(TestPlatforms.OSX))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonOSXTest);
-            if (!platform.HasFlag(PlatformID.FreeBSD))
+            if (!platforms.HasFlag(TestPlatforms.FreeBSD))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonFreeBSDTest);
-            if (!platform.HasFlag(PlatformID.NetBSD))
+            if (!platforms.HasFlag(TestPlatforms.NetBSD))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetBSDTest);
         }
     }

--- a/src/xunit.netcore.extensions/TestPlatforms.cs
+++ b/src/xunit.netcore.extensions/TestPlatforms.cs
@@ -3,13 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Xunit.Sdk;
 
 namespace Xunit
 {
-    // TODO #999: Remove PlatformID when all uses have transitioned to TestPlatforms.
     [Flags]
-    public enum PlatformID
+    public enum TestPlatforms
     {
         Windows = 1,
         Linux = 2,

--- a/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
+++ b/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
@@ -31,6 +31,7 @@
     <Compile Include="PlatformID.cs" />
     <Compile Include="SkippedTestCase.cs" />
     <Compile Include="TargetFrameworkMonikers.cs" />
+    <Compile Include="TestPlatforms.cs" />
     <Compile Include="XunitConstants.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`Xunit.PlatformID` conflicts with `System.PlatformID` and should be plural according to the naming guidelines for flags enums.

This commit adds a new `Xunit.TestPlatforms` enum as a replacement for `Xunit.PlatformID`. `Xunit.PlatformID` remains for now, until all uses have transitioned to the new enum.

Part of: #999