### PR TITLE
Update TestSuite runtime.json with 3 new test RIDs

### DIFF
--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -75,9 +75,12 @@
                 "rhel.7-x64",
                 "ubuntu.14.04-x64",
                 "ubuntu.16.04-x64",
+                "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
-                "opensuse.13.2-x64"
+                "opensuse.13.2-x64",
+                "opensuse.42.1-x64"
             ],
             "netcoreapp1.1": [
                 "win7-x86",
@@ -89,9 +92,12 @@
                 "rhel.7-x64",
                 "ubuntu.14.04-x64",
                 "ubuntu.16.04-x64",
+                "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
-                "opensuse.13.2-x64"
+                "opensuse.13.2-x64",
+                "opensuse.42.1-x64"
             ]
         },
         "coreFx.Test.netcoreapp1.1": {
@@ -105,9 +111,12 @@
                 "rhel.7-x64",
                 "ubuntu.14.04-x64",
                 "ubuntu.16.04-x64",
+                "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
-                "opensuse.13.2-x64"
+                "opensuse.13.2-x64",
+                "opensuse.42.1-x64"
             ]
         },
         "coreFx.Test.wp8": {


### PR DESCRIPTION
Ubuntu 16.10, openSUSE 42.1, and Fedora 24 are new supported RIDs.

@karajas 