### PR TITLE
Add reason message to OuterLoopAttribute

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/OuterLoopAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/OuterLoopAttribute.cs
@@ -15,5 +15,6 @@ namespace Xunit
     public class OuterLoopAttribute : Attribute, ITraitAttribute
     {
         public OuterLoopAttribute() { }
+        public OuterLoopAttribute(string reason) { }
     }
 }


### PR DESCRIPTION
We're often using comments to indicate why a test is being marked as OuterLoop.  This lets us do that as a string.  Then once all use has been updated to specify a message, we can remove the ctor without the message, and devs will be forced to specify a reason for why a test is marked as OuterLoop.

cc: @weshaggard, @bartonjs, @ianhays 