### PR TITLE
Fix default config file path for run tool.

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -22,7 +22,7 @@ set _toolRuntime=%~dp0Tools
 set _dotnet=%_toolRuntime%\dotnetcli\dotnet.exe
 
 echo Running: %_dotnet% %_toolRuntime%\run.exe %*
-call %_dotnet% %_toolRuntime%\run.exe %*
+call %_dotnet% %_toolRuntime%\run.exe %~dp0config.json %*
 if NOT [%ERRORLEVEL%]==[0] (
   exit /b 1
 )


### PR DESCRIPTION
Remove a hard-coded assumption on the location of the run tool, using the
current working directory instead.  Removed some duplicate code.