### PR TITLE
Support repos that don't define package lists

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyBaseLine.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyBaseLine.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         public void GetBaseLinedDependenciesFromBaseLinePackages()
         {
             Dictionary<string, SortedSet<Version>> baseLineVersions = new Dictionary<string, SortedSet<Version>>();
-            foreach (var baseLinePackage in BaseLinePackages)
+            foreach (var baseLinePackage in BaseLinePackages.NullAsEmpty())
             {
                 SortedSet<Version> versions = null;
                 if (!baseLineVersions.TryGetValue(baseLinePackage.ItemSpec, out versions))

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
@@ -33,7 +33,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// <summary>
         /// Package index files used to define stable package list.
         /// </summary>
-        [Required]
         public ITaskItem[] PackageIndexes { get; set; }
 
         /// <summary>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
             else
             {
-                var baseLinePackageIds = new HashSet<string>(BaseLinePackages.Select(b => b.ItemSpec));
+                var baseLinePackageIds = new HashSet<string>(BaseLinePackages.NullAsEmpty().Select(b => b.ItemSpec));
                 isKnownPackage = packageId => baseLinePackageIds.Contains(packageId);
             }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
@@ -30,7 +30,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// <summary>
         /// Package index files used to define stable packages.
         /// </summary>
-        [Required]
         public ITaskItem[] PackageIndexes { get; set; }
         
         /// <summary>
@@ -78,7 +77,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 latestPackages[packageId] = nuGetVersion?.Version;
             }
 
-            foreach (var stablePackage in StablePackages)
+            foreach (var stablePackage in StablePackages.NullAsEmpty())
             {
                 var packageId = stablePackage.ItemSpec;
 


### PR DESCRIPTION
Allow for packaging to work in the absense of a package index, stable
package list, baseline package list, and native module to package list.

@dagood this should fix the issue you were seeing with coreclr.

/cc @weshaggard 