### PR TITLE
updating copyandcheck: The initial condition to skip over the copying…

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
@@ -32,7 +32,7 @@ EXIT /B %ERRORLEVEL%
 :: ======== CopyAndCheck subroutine ====
 :copyandcheck
 IF EXIST %2 (
-exit /b 0
+  del %2
 )
 mklink /H %2 %1 > NUL 2>&1
 IF %ERRORLEVEL% == 1 (


### PR DESCRIPTION
… when the destination file exists causes invalid test configuarion. copyAndCheck should not assume that the existing file is the right one. Instead it should always overwrite the existing file