### PR TITLE
Support ubuntu.16.10 and opensuse.42.1 in tool-runtime project.json

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,20 +1,20 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
-    <CoreFxCurrentRef>b6fe7bf0d879e7a750b15e90743d5191e3b478de</CoreFxCurrentRef>
+    <CoreFxCurrentRef>6c43ba94713264be37d01321af15505e9229e508</CoreFxCurrentRef>
     <CoreClrCurrentRef>a8be270baa206a3d87112b7912869661b0c46f0a</CoreClrCurrentRef>
     <ProjectKTfsCurrentRef>b6fe7bf0d879e7a750b15e90743d5191e3b478de</ProjectKTfsCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsVersion>1.0.1</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCorePlatformsVersion>1.0.2-beta-24506-02</MicrosoftNETCorePlatformsVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
-    <DependencyBranch>release/1.0.0</DependencyBranch>
+    <DependencyBranch>master</DependencyBranch>
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 

--- a/src/ApiCompat/project.json
+++ b/src/ApiCompat/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc3-24214-00",
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
     "Microsoft.Composition": "1.0.30",
     "Microsoft.NETCore.App": {
       "type": "platform",

--- a/src/BinaryRewriting/BclRewriter/project.json
+++ b/src/BinaryRewriting/BclRewriter/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc3-24214-00",
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.0"

--- a/src/GenAPI.Desktop/project.json
+++ b/src/GenAPI.Desktop/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc3-24214-00",
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
     "System.Console": "4.0.0",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0",
     "System.Diagnostics.TraceSource": "4.0.0",

--- a/src/GenAPI/project.json
+++ b/src/GenAPI/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc3-24214-00",
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.0"

--- a/src/GenFacades.Desktop/project.json
+++ b/src/GenFacades.Desktop/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc3-24214-00",
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/GenFacades/project.json
+++ b/src/GenFacades/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc3-24214-00",
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0",
     "System.Diagnostics.FileVersionInfo": "4.0.0",
     "Microsoft.NETCore.App": {

--- a/src/Microsoft.Cci.Extensions/project.json
+++ b/src/Microsoft.Cci.Extensions/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.Cci": "4.0.0-rc3-24214-00",
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
     "Microsoft.Composition": "1.0.30",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.TraceSource": "4.0.0",

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -11,7 +11,7 @@
         "Microsoft.Build": "0.1.0-preview-00024-160610",
         "Microsoft.Net.Compilers.netcore": "2.0.0-beta3",
         "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
-        "Microsoft.Cci": "4.0.0-rc3-24214-00",
+        "Microsoft.Cci": "4.0.0-rc4-24217-00",
         "Microsoft.Composition": "1.0.30",
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0",
@@ -20,7 +20,7 @@
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "Newtonsoft.Json": "9.0.1",
         "NETStandard.Library": {
-          "version": "1.6.0",
+          "version": "1.6.1-beta-24506-02",
           "exclude": "runtime"
         }
       },
@@ -40,10 +40,12 @@
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {},
     "osx.10.10-x64": {},
     "rhel.7-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "win7-x64": {},
     "win7-x86": {}
   }


### PR DESCRIPTION
This allows openSUSE 42.1 and ubuntu 16.10 to publish buildtools without an alternate `__PUBLISH_RID`. The NETStandard.Library version referenced here is a recent build, from after [this](https://github.com/dotnet/corefx/pull/11356) was merged in last week.

@ericstj , @dagood