### PR TITLE
Register ValidPinvokeMappings for netstandard TargetGroups

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
@@ -17,9 +17,7 @@
        2. For all other windows configuration we use OneCoreAPIs.txt file.
     -->
 
-    <ValidPinvokeMappings Condition="'$(TargetGroup)'==''">$(MSBuildThisFileDirectory)PinvokeAnalyzer_OneCoreApis.txt</ValidPinvokeMappings>
-    <ValidPinvokeMappings Condition="'$(TargetGroup)'=='netstandard13aot'">$(MSBuildThisFileDirectory)PinvokeAnalyzer_OneCoreApis.txt</ValidPinvokeMappings>
-    <ValidPinvokeMappings Condition="'$(TargetGroup)'=='netstandard15aot'">$(MSBuildThisFileDirectory)PinvokeAnalyzer_OneCoreApis.txt</ValidPinvokeMappings>
+    <ValidPinvokeMappings>$(MSBuildThisFileDirectory)PinvokeAnalyzer_OneCoreApis.txt</ValidPinvokeMappings>
     <ValidPinvokeMappings Condition="'$(TargetGroup)'=='netcore50' or '$(TargetGroup)'=='netcore50aot' or '$(SupportsUWP)'=='true'">$(MSBuildThisFileDirectory)PinvokeAnalyzer_UWPApis.txt</ValidPinvokeMappings>
   </PropertyGroup>
 


### PR DESCRIPTION
The description of the assignment of ValidPinvokeMappings says that it is
OneCoreUwp for UWP and OneCore otherwise; but the implementation is
a much more complicated setup.

Projects may need to build for two different netstandard versions, and the
easiest way for them to do so in corefx is with the TargetGroup property
(e.g. TargetGroup=netstandard1.3); but assigning TargetGroup to anything
which is not a special value in this file makes the ValidPinvokeMappings
variable be unset, which means all p/invokes fail.

This change makes all Windows_NT builds use the OneCore list, unless
the stronger OneCoreUWP list should be chosen instead.

cc: @ericstj @weshaggard @AlexGhiondea 