### PR TITLE
Add required networking capabilities for Http UWP tests

### DIFF
--- a/src/xunit.runner.uwp/Package.appxmanifest
+++ b/src/xunit.runner.uwp/Package.appxmanifest
@@ -45,5 +45,8 @@
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <Capability Name="internetClientServer" />
+    <Capability Name="privateNetworkClientServer" />
+    <uap:Capability Name="enterpriseAuthentication" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
The System.Net.Http tests use a loopback server as well as possibly
other intranet servers. So, these additional capabilities are required
in order to run the tests in a UWP app container.