### PR TITLE
Remove fedora.24 from TestSuite runtime.json

### DIFF
--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -77,7 +77,6 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
-                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"
@@ -94,7 +93,6 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
-                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"
@@ -113,7 +111,6 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
-                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"


### PR DESCRIPTION
Official builds for this rid have connection issues, so packages have never been published. We can add these back later when the official builds are working.