### PR TITLE
Add PreReleaseGroup support

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 if (!IsStable(packageId, packageVersion))
                 {
                     // pre-release, set with suffix
-                    updatedPackage.SetMetadata("Version", packageVersion.ToString() + PreReleaseSuffix);
+                    updatedPackage.SetMetadata("Version", packageVersion.ToString() + GetSuffix(packageId));
                 }
                 else
                 {
@@ -140,6 +140,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             return isStable;
+        }
+
+        private string GetSuffix(string packageId)
+        {
+            return PackageIndex.Current.GetPreRelease(packageId) ?? PreReleaseSuffix;
         }
 
         private static Version ParseAs3PartVersion(string versionString)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
@@ -59,6 +59,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// </summary>
         public ITaskItem[] PackageFolders { get; set; }
 
+        /// <summary>
+        /// Pre-release version to use for all pre-release packages covered by this index.
+        /// </summary>
+        public string PreRelease { get; set; }
+
         public override bool Execute()
         {
             string indexFilePath = PackageIndexFile.GetMetadata("FullPath");
@@ -132,6 +137,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     var package = moduleToPackage.GetMetadata("Package");
                     index.ModulesToPackages[moduleToPackage.ItemSpec] = package;
                 }
+            }
+
+            if (!String.IsNullOrEmpty(PreRelease))
+            {
+                index.PreRelease = PreRelease;
             }
 
             index.Save(indexFilePath);


### PR DESCRIPTION
This allows for PackageIndexes to specify a PreReleaseGroup.  This can
be specified at the index level or package level in the package index
file.

If PreReleaseGroups are used in the index then the PreReleaseGroup item
should be defined to provide a mapping from group name to the version
suffix to be used for that group.

For example, for the WCF repo:
```xml
<ItemGroup>
  <PreReleaseGroup Include="CoreFx">
    <PreRelease>$(CoreFxExpectedPrerelease)</PreRelease>
  </PreReleaseGroup>
  <PreReleaseGroup Include="WCF">
    <PreRelease>$(VersionSuffix)</PreRelease>
  </PreReleaseGroup>
<ItemGroup>
```

Fixes https://github.com/dotnet/buildtools/issues/1013
/cc @StephenBonikowsky @weshaggard 

