### PR TITLE
Fix package downgrade in tool-runtime project.json

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -16,7 +16,6 @@
         "System.Diagnostics.Process": "4.1.0",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0",
         "System.Diagnostics.TraceSource": "4.0.0",
-        "System.Net.Http": "4.1.0",
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "Newtonsoft.Json": "9.0.1",
         "NETStandard.Library": {


### PR DESCRIPTION
@ericstj , @dagood 

I still get hundreds of downgrade warnings, but that seems to be due to bad dependencies in the MSBuild packages (we have the same versions of all those), which were pre-existing.