### PR TITLE
Use INamedTypeReference instead in order to also copy the nested class type forwards from the contract assembly

### DIFF
--- a/src/GenFacades/Program.cs
+++ b/src/GenFacades/Program.cs
@@ -311,8 +311,8 @@ namespace GenFacades
 
         private static IEnumerable<string> EnumerateDocIdsToForward(IAssembly contractAssembly)
         {
-            // Make note that all type forwards (including nested) implement INamespaceAliasForType, so do
-            // not be tempted to filter using it, instead, we look at the aliased type to them.
+            // Use INamedTypeReference instead of INamespaceTypeReference in order to also include nested
+            // class type-forwards.
             var typeForwardsToForward = contractAssembly.ExportedTypes.Select(alias => alias.AliasedType)
                                                                       .OfType<INamedTypeReference>();
 

--- a/src/GenFacades/Program.cs
+++ b/src/GenFacades/Program.cs
@@ -314,7 +314,7 @@ namespace GenFacades
             // Make note that all type forwards (including nested) implement INamespaceAliasForType, so do
             // not be tempted to filter using it, instead, we look at the aliased type to them.
             var typeForwardsToForward = contractAssembly.ExportedTypes.Select(alias => alias.AliasedType)
-                                                                      .OfType<INamespaceTypeReference>();
+                                                                      .OfType<INamedTypeReference>();
 
             var typesToForward = contractAssembly.GetAllTypes().Where(t => TypeHelper.IsVisibleOutsideAssembly(t))
                                                                .OfType<INamespaceTypeDefinition>();


### PR DESCRIPTION
cc: @weshaggard 

When a contract contains nested class type-forwards they are getting filtered out by GenFacades because their type is `NonGenericNestedType` which doesn't implement `INamespaceTypeReference`. With this change, I'm using `INamedTypeReference` which they do  implement and is actually also implemented by `INamespaceTypeReference` so they will be includded.