### PR TITLE
Add IgnoreStandardErrorWarningFormat to tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -262,7 +262,9 @@
           Command="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(RunnerScriptName) $(PackagesDir)"
           WorkingDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)"
           CustomErrorRegularExpression="Failed: [^0]"
-          ContinueOnError="true">
+          ContinueOnError="true"
+          IgnoreStandardErrorWarningFormat="true"
+          >
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
     </Exec>
 


### PR DESCRIPTION
Setting IgnoreStandardErrorWarningFormat="true" can prevent the case where specific unusual output  (despite no other problems in execution) leads to the exit code of an msbuild task being changed from 0 to -1, thus "breaking" test build.

This fixes test execution on my local box despite this being the "default" value per: 
https://msdn.microsoft.com/en-us/library/microsoft.build.tasks.exec.ignorestandarderrorwarningformat.aspx?f=255&MSPPError=-2147217396 

@weshaggard @crummel 