### PR TITLE
Handle packages with placeholders only in ref

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
@@ -159,19 +159,14 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 return;
             }
 
-            string refFolder = Path.Combine(path, "ref");
+            var refFiles = Directory.EnumerateFiles(Path.Combine(path, "ref"), "*.dll", SearchOption.AllDirectories);
 
-            if (!Directory.Exists(refFolder))
+            if (!refFiles.Any())
             {
-                refFolder = Path.Combine(path, "lib");
+                refFiles = Directory.EnumerateFiles(Path.Combine(path, "lib"), "*.dll", SearchOption.AllDirectories);
             }
 
-            IEnumerable<Version> assemblyVersions = null;
-            if (Directory.Exists(refFolder))
-            {
-                assemblyVersions = Directory.EnumerateFiles(refFolder, "*.dll", SearchOption.AllDirectories)
-                    .Select(f => VersionUtility.GetAssemblyVersion(f));
-            }
+            var assemblyVersions = refFiles.Select(f => VersionUtility.GetAssemblyVersion(f));
 
             UpdateFromValues(index, id, version, assemblyVersions);
         }
@@ -193,7 +188,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     return;
                 }
 
-                var refFiles = reader.GetFiles("ref");
+                var refFiles = reader.GetFiles("ref").Where(r => !NuGetAssetResolver.IsPlaceholder(r));
 
                 if (!refFiles.Any())
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -456,7 +456,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             var thisPackageFiles = _validateFiles[PackageId];
-            var refFiles = thisPackageFiles.Where(f => f.TargetPath.StartsWith("ref/", StringComparison.OrdinalIgnoreCase));
+            var refFiles = thisPackageFiles.Where(f => f.TargetPath.StartsWith("ref/", StringComparison.OrdinalIgnoreCase)).Where(r => !NuGetAssetResolver.IsPlaceholder(r.TargetPath));
 
             if (!refFiles.Any())
             {


### PR DESCRIPTION
Some packages have placeholders in ref but no reference assembly
(eg: System.Private assemblies)

Make sure we index these to get the correct assembly version.

I noticed this issue when reviewing the dev-api merge.

/cc @weshaggard @joperezr 