### PR TITLE
Add support for HarvestAdditionalPackageIds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/HarvestPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/HarvestPackage.cs
@@ -67,7 +67,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         ///   Identity: Framework
         ///   RuntimeIDs: Semi-colon seperated list of runtime IDs
         /// </summary>
-        [Required]
         public ITaskItem[] Frameworks { get; set; }
 
 
@@ -109,7 +108,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     HarvestFilesFromPackage();
                 }
 
-                HarvestSupportedFrameworks();
+                if (Frameworks != null && Frameworks.Length > 0)
+                {
+                    HarvestSupportedFrameworks();
+                }
             }
 
             return !Log.HasLoggedErrors;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -449,15 +449,23 @@
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestRuntimePackages"/>
     </GetLastStablePackage>
 
+    <GetLastStablePackage Condition="'@(HarvestAdditionalPackageIds)' != ''" 
+                          LatestPackages="@(HarvestAdditionalPackageIds)" 
+                          StablePackages="@(StablePackage)"
+                          PackageIndexes="@(PackageIndex)">
+      <Output  TaskParameter="LastStablePackages" ItemName="HarvestAdditionalPackages"/>
+    </GetLastStablePackage>
+    
     <PropertyGroup>
       <HarvestFiles Condition="'$(HarvestFiles)' == ''">true</HarvestFiles>
     </PropertyGroup>
 
+    <!-- Harvest files from old package and determine support using both runtime and additional packages -->
     <HarvestPackage PackageId="$(Id)"
                     PackageVersion="$(HarvestVersion)"
                     PackagesFolder="$(PackagesDir)"
                     RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
-                    RuntimePackages="@(HarvestRuntimePackages)"
+                    RuntimePackages="@(HarvestRuntimePackages);@(HarvestAdditionalPackages)"
                     HarvestAssets="$(HarvestFiles)"
                     PathsToExclude="@(HarvestExcludePaths)"
                     PathsToSuppress="@(HarvestSuppressPaths)"
@@ -467,6 +475,18 @@
       <Output TaskParameter="Files" ItemName="File"/>
     </HarvestPackage>
 
+    <!-- Harvest files from HarvestAdditionalPackages, but don't calculate support-->
+    <HarvestPackage PackageId="%(HarvestAdditionalPackages.Identity)"
+                    PackageVersion="%(HarvestAdditionalPackages.Version)"
+                    PackagesFolder="$(PackagesDir)"
+                    RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
+                    HarvestAssets="$(HarvestFiles)"
+                    PathsToExclude="@(HarvestExcludePaths);%(HarvestAdditionalPackages.ExcludePaths)"
+                    PathsToSuppress="@(HarvestSuppressPaths);%(HarvestAdditionalPackages.SuppressPaths)"
+                    Condition="'@(HarvestAdditionalPackages)' != ''" >
+      <Output TaskParameter="Files" ItemName="File"/>
+    </HarvestPackage>
+    
     <ItemGroup>
       <SupportedFramework Include="@(_HarvestedSupportedFramework)" Exclude="@(NotSupportedOnTargetFramework)" />
     </ItemGroup>


### PR DESCRIPTION
HarvestAdditionalPackageIds can be specified to tell packaging to
harvest additional packages other than the current package and its
runtime packages.

This is needed when transitioning from a split package to a fat package.

Fixes #1039

/cc @weshaggard @SedarG 