### PR TITLE
Prevent run.ps1 from parsing arguments.

### DIFF
--- a/run.cmd
+++ b/run.cmd
@@ -12,5 +12,5 @@ if not defined VisualStudioVersion (
 )
 
 :Run
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "%~dp0run.ps1 %*"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "%~dp0run.ps1 -- %*"
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
The arguments passed to run.ps1 are intended for the run.exe tool, so
prefix the args to run.ps1 with a double dash so that powershell doesn't
attempt to parse them (without this it will "eat" any double dashes passed
to run.ps1).