### PR TITLE
Make package harvesting replace refs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -420,9 +420,6 @@
           Condition="'$(HarvestStablePackage)' != 'false'"
           DependsOnTargets="EnsureOOBFramework;GetPkgProjPackageDependencies">
     <ItemGroup>
-      <!-- Exclude any paths already included by the pkgproj -->
-      <HarvestExcludePaths Include="%(File.TargetPath)" KeepDuplicates="false" />
-
       <_latestPackage Include="$(Id)">
         <Version>$(PackageVersion)</Version>
       </_latestPackage>
@@ -464,7 +461,8 @@
     <HarvestPackage PackageId="$(Id)"
                     PackageVersion="$(HarvestVersion)"
                     PackagesFolder="$(PackagesDir)"
-                    RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
+                    Files="@(File)"
+                    RuntimeFile="$(RuntimeIdGraphDefinitionFile)" 
                     RuntimePackages="@(HarvestRuntimePackages);@(HarvestAdditionalPackages)"
                     HarvestAssets="$(HarvestFiles)"
                     PathsToExclude="@(HarvestExcludePaths)"
@@ -472,19 +470,26 @@
                     Frameworks="@(DefaultValidateFramework)"
                     Condition="'$(HarvestVersion)' != ''">
       <Output TaskParameter="SupportedFrameworks" ItemName="_HarvestedSupportedFramework"/>
-      <Output TaskParameter="Files" ItemName="File"/>
+      <Output TaskParameter="HarvestedFiles" ItemName="_harvestedFiles"/>
+      <Output TaskParameter="UpdatedFiles" ItemName="_updatedFiles" />
     </HarvestPackage>
+
+    <ItemGroup Condition="'@(_harvestedFiles)' != ''">
+      <File Remove="@(File)"/>
+      <File Include="@(_updatedFiles);@(_harvestedFiles)"/>
+    </ItemGroup>
 
     <!-- Harvest files from HarvestAdditionalPackages, but don't calculate support-->
     <HarvestPackage PackageId="%(HarvestAdditionalPackages.Identity)"
                     PackageVersion="%(HarvestAdditionalPackages.Version)"
                     PackagesFolder="$(PackagesDir)"
+                    Files="@(File)"
                     RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
                     HarvestAssets="$(HarvestFiles)"
                     PathsToExclude="@(HarvestExcludePaths);%(HarvestAdditionalPackages.ExcludePaths)"
                     PathsToSuppress="@(HarvestSuppressPaths);%(HarvestAdditionalPackages.SuppressPaths)"
                     Condition="'@(HarvestAdditionalPackages)' != ''" >
-      <Output TaskParameter="Files" ItemName="File"/>
+      <Output TaskParameter="HarvestedFiles" ItemName="File"/>
     </HarvestPackage>
     
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageItem.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageItem.cs
@@ -26,6 +26,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             TargetPath = item.GetMetadata("TargetPath");
             Package = item.GetMetadata("PackageId");
             PackageVersion = item.GetMetadata("PackageVersion");
+            IsDll = Path.GetExtension(SourcePath).Equals(".dll", StringComparison.OrdinalIgnoreCase);
+            IsRef = TargetPath.StartsWith("ref/", StringComparison.OrdinalIgnoreCase);
 
             // determine if we need to append filename to TargetPath
             // see https://docs.nuget.org/create/nuspec-reference#specifying-files-to-include-in-the-package
@@ -68,7 +70,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                         Version.TryParse(versionString, out _version);
                     }
 
-                    if (_version == null && File.Exists(SourcePath))
+                    if (_version == null && IsDll && File.Exists(SourcePath))
                     {
                         _version = VersionUtility.GetAssemblyVersion(SourcePath);
                     }
@@ -78,6 +80,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
         }
 
+        public bool IsDll { get; }
+        public bool IsRef { get; }
         public ITaskItem OriginalItem { get; }
         public string SourcePath { get; }
         public string SourceProject { get; }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteReferenceDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteReferenceDependencies.cs
@@ -62,6 +62,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                         // This should never happen and indicates a bug in the package.  If a package contains references,
                         // all implementations should have an applicable reference assembly.
                         Log.LogError($"Could not find applicable reference assembly for implementation framework {implementationFx} from reference frameworks {string.Join(", ", referenceSets.Keys)}");
+                        continue;
                     }
 
                     foreach (var reference in referenceSets[nearestReferenceFx])

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/HarvestPackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/HarvestPackageTests.cs
@@ -99,9 +99,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
 
             Assert.Equal(0, _log.ErrorsLogged);
             Assert.Equal(0, _log.WarningsLogged);
-            Assert.Equal(4, task.Files.Length);
-            Assert.Equal("netstandard1.0", task.Files[0].GetMetadata("TargetFramework"));
-            Assert.Equal("1.2.0.0", task.Files[0].GetMetadata("AssemblyVersion"));
+            Assert.Equal(4, task.HarvestedFiles.Length);
+            Assert.Equal("netstandard1.0", task.HarvestedFiles[0].GetMetadata("TargetFramework"));
+            Assert.Equal("1.2.0.0", task.HarvestedFiles[0].GetMetadata("AssemblyVersion"));
             Assert.Equal(_frameworks.Length, task.SupportedFrameworks.Length);
         }
 
@@ -125,8 +125,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
 
             Assert.Equal(0, _log.ErrorsLogged);
             Assert.Equal(0, _log.WarningsLogged);
-            Assert.Equal(17, task.Files.Length);
-            Assert.Equal("4.0.0.0", task.Files[0].GetMetadata("AssemblyVersion"));
+            Assert.Equal(17, task.HarvestedFiles.Length);
+            Assert.Equal("4.0.0.0", task.HarvestedFiles[0].GetMetadata("AssemblyVersion"));
             Assert.Equal(6, task.SupportedFrameworks.Length);
         }
 
@@ -155,8 +155,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
 
             Assert.Equal(0, _log.ErrorsLogged);
             Assert.Equal(0, _log.WarningsLogged);
-            Assert.Equal(79, task.Files.Length);
-            Assert.True(task.Files.Any(f => f.GetMetadata("AssemblyVersion") == "4.1.0.0"));
+            Assert.Equal(79, task.HarvestedFiles.Length);
+            Assert.True(task.HarvestedFiles.Any(f => f.GetMetadata("AssemblyVersion") == "4.1.0.0"));
             Assert.Equal(_frameworks.Length, task.SupportedFrameworks.Length);
             Assert.All(task.SupportedFrameworks, f => Assert.NotEqual("unknown", f.GetMetadata("Version")));
         }


### PR DESCRIPTION
Previously we'd always prefer live assets over harvested assets from the
previous shipped package.  That put the burden on the developer to
know when to include references.

This change lets us keep references in the package and only use them
when they are significant.  This should help reduce the concept count
required by folks working in corefx.

/cc @weshaggard @joperezr @stephentoub