### PR TITLE
Change test-archiving command's source over to TFM-aware folder path 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -260,10 +260,9 @@
     </PropertyGroup>
 
     <!-- the project json and runner script files need to be included in the archive -->
-    <Copy SourceFiles="$(ProjectJson);$(ProjectLockJson)" DestinationFolder="$(OutDir)" />
-    <Copy SourceFiles="$(OutputPathForScriptGenerator)" DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="$(ProjectJson);$(ProjectLockJson)" DestinationFolder="$(TestPath)%(TestNugetTargetMoniker.Folder)" />
     <MakeDir Directories="$(TestArchiveDir)" />
-    <ZipFileCreateFromDirectory SourceDirectory="$(OutDir)" DestinationArchive="$(TestArchiveDir)$(TestProjectName).zip" OverwriteDestination="true" />
+    <ZipFileCreateFromDirectory SourceDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)" DestinationArchive="$(TestArchiveDir)$(TestProjectName).zip" OverwriteDestination="true" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -67,7 +67,7 @@
       <Folder>netcoreapp1.1</Folder>
     </TestNugetTargetMoniker>
     <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.3" Condition="'$(TestTFM)' == 'net463'">
-      <Folder>net462</Folder>
+      <Folder>net463</Folder>
     </TestNugetTargetMoniker>
     <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.2" Condition="'$(TestTFM)' == 'net462'">
       <Folder>net462</Folder>
@@ -85,7 +85,7 @@
       <Folder>net451</Folder>
     </TestNugetTargetMoniker>
     <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5.2" Condition="'$(TestTFM)' == 'net452'">
-      <Folder>net451</Folder>
+      <Folder>net452</Folder>
     </TestNugetTargetMoniker>
     <!-- Project template for UWP Apps uses uap10.0, this mapping allows support for the Debug and Release scenarios -->
     <TestNugetTargetMoniker Include="UAP,Version=v10.0" Condition="'$(TestTFM)' == 'netcore50aot'">


### PR DESCRIPTION
To prevent collisions seen when archiving a build with > 1 TFM included. 

I'm still testing this but it definitely produces valid test archives that look the same as before, now coming from paths like "\bin\tests\Windows_NT.AnyCPU.Release\System.IO.FileSystem.DriveInfo.Tests\netcoreapp1.0" instead of "\bin\Windows_NT.AnyCPU.Release\System.IO.FileSystem.DriveInfo.Tests"

@chcosta , @weshaggard 