### PR TITLE
Fix Condition on pkgproj references build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -258,7 +258,7 @@
     <!-- Only rebuild project references when specified -->
     <MSBuild Targets="Build"
              BuildInParallel="$(BuildInParallel)"
-             Condition="'$(BuildPackageLibraryReferences)' == 'true' AND '$(DesignTimeBuild)' == 'false'"
+             Condition="'$(BuildPackageLibraryReferences)' == 'true' AND '$(DesignTimeBuild)' != 'true'"
              Projects="@(_NonPkgProjProjectReference)"
              Properties="$(ProjectProperties)"
              ContinueOnError="WarnAndContinue"/>


### PR DESCRIPTION
The DesignTimeBuild property is not defined during a commandline build
causing this condition to evaluate to false and skip building the project
references.  This broke CoreFx build when trying to pick up buildtools.

/cc @hughbe 