### PR TITLE
GenAPI: Ignore obsolete-as-error ctors when generating base call

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
@@ -630,5 +630,33 @@ namespace Microsoft.Cci.Extensions
 
             return true;
         }
+
+        public static bool IsObsoleteWithUsageTreatedAsCompilationError(this ICustomAttribute attribute)
+        {
+            if (attribute.Type.FullName() != typeof(ObsoleteAttribute).FullName)
+            {
+                return false;
+            }
+
+            if (attribute.Arguments == null || attribute.Arguments.Count() != 2)
+            {
+                return false;
+            }
+
+            IMetadataConstant messageArgument = attribute.Arguments.ElementAt(0) as IMetadataConstant;
+            IMetadataConstant errorArgument = attribute.Arguments.ElementAt(1) as IMetadataConstant;
+
+            if (messageArgument == null || errorArgument == null)
+            {
+                return false;
+            }
+
+            if (!(messageArgument.Value is string && errorArgument.Value is bool))
+            {
+                return false;
+            }
+
+            return (bool)errorArgument.Value;
+        }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Cci.Writers.CSharp
             if (baseType == null)
                 return;
 
-            var ctors = baseType.Methods.Where(m => m.IsConstructor && _filter.Include(m));
+            var ctors = baseType.Methods.Where(m => m.IsConstructor && _filter.Include(m) && !m.Attributes.Any(a => a.IsObsoleteWithUsageTreatedAsCompilationError()));
 
             var defaultCtor = ctors.Where(c => c.ParameterCount == 0);
 


### PR DESCRIPTION
The first constructor in the base class is sometimes one that is marked as [Obsolete("message", true)] meaning any usage of that ctor results in a compilation error. Example: System.ComponentModel.AsyncCompletedEventArgs

We now skip those constructors when generating the base call so classes that inherit from those types compile out of the box.