### PR TITLE
Fix UWPTestRunner ObjectDisposedException when writing logs

### DIFF
--- a/src/xunit.runner.uwp/App.xaml.cs
+++ b/src/xunit.runner.uwp/App.xaml.cs
@@ -139,7 +139,6 @@ namespace XunitUwpRunner
                 {
                     await sw.WriteAsync(data);
                 }
-                stream.Flush();
             }
         }
 


### PR DESCRIPTION
I was getting crashes in the UWPTestRunner every time I tried to run the 'netcore50' tests for any library:
```
msbuild /t:rebuildandtest /p:TestTFM=netcore50  /p:TestNugetRuntimeId=win10-x64
```

The exception in the UWPTestRunner just after running the tests and writing out the logs:

```
0:023> !pe
Exception object: 0000011cc11f1df8
Exception type:   System.ObjectDisposedException
Message:          Cannot access a closed Stream.
InnerException:   <none>
StackTrace (generated):
    SP               IP               Function
    00000014DBC3EE30 00007FFD6DFB833B mscorlib_ni!System.IO.__Error.StreamIsClosed()+0x3b
    00000014DBC3EE60 00007FFD6D7995E4 mscorlib_ni!System.IO.BufferedStream.Flush()+0x14
    00000014DBC3EE90 00007FFD10F0AC9A XunitUwpRunner!XunitUwpRunner.App+<WriteLogs>d__4.MoveNext()+0x33a
    00000014DBC3F000 00007FFD6E50B460 mscorlib_ni!System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(System.Threading.Tasks.Task)+0xd7bef0
    00000014DBC3F040 00007FFD6D78F4BE mscorlib_ni!System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)+0x3e
    00000014DBC3F070 00007FFD10D94496 XunitUwpRunner!XunitUwpRunner.App+<RunTests>d__2.MoveNext()+0xbb6
```

This was being caused because the `Flush` method was called after the underlying stream was disposed. This was happening because the default constructor of StreamWriter() will dispose of the underlying stream when the Streamwriter is disposed.

The code has been like this for a while and I don't quite understand why this bug was not discovered earlier. Perhaps there was a different bug in CoreFx StreamWriter that was masking this problem.