### PR TITLE
Don't write generate project.json if contents match

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -391,9 +391,13 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private static void WriteProject(JObject projectRoot, string projectJsonPath)
         {
-            string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
-            Directory.CreateDirectory(Path.GetDirectoryName(projectJsonPath));
-            File.WriteAllText(projectJsonPath, projectJson + Environment.NewLine); 
+            string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented) + Environment.NewLine;
+
+            if (!File.Exists(projectJsonPath) || !projectJson.Equals(File.ReadAllText(projectJsonPath)))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(projectJsonPath));
+                File.WriteAllText(projectJsonPath, projectJson);
+            }
         }
 
         /* JProperties are encapsulated with "['" and "']" to assist with matching Paths which


### PR DESCRIPTION
This change doesn't write a new generated project.json for test projects if the contents match the exisiting project.json.  Doing this allows us to make use of the "IsRestoreRequired" task in CoreFx and improves perf for restoring generated test packages when no changes have been made.  On my machine, restore time goes from ~11 minutes to ~10 seconds.

/cc @weshaggard 