### PR TITLE
Repo API buildtools implementation proposal doc

### DIFF
--- a/Documentation/RepoCompose.md
+++ b/Documentation/RepoCompose.md
@@ -56,7 +56,7 @@ The data in the output is further grouped by operating system.  Builds of the sa
 
 In the case the `consumes` output doesn't want to take advantage of OS specific dependencies it can specify `"os-all"` as a catch all. 
 
-In addition to artifacts the consume feed can also optionally list any machine prerequitsites needed to build or test the repo:
+In addition to artifacts the consume feed can also optionally list any machine prerequisites needed to build or test the repo:
 
 ``` json
 "prereq": { 
@@ -93,21 +93,21 @@ Like `consumes` the `produces` output is also grouped by the operating system:
 }
 ```
 
-A ful sample output for `produces` is available in the Samples section.
+A full sample output for `produces` is available in the Samples section.
 
 ### change
 
 The `change` command is used to alter the floating build dependencies section.  It can establish new versions of NuGet packages, new locations to find file artifacts, different NuGet feeds, etc ...  
 
-This is the command which allow us to use the build output of one repo as the input of a dependent repo.  The first repo can build using a new output version (say beta5) and dependent repos can be changed to accept this new version.  
+This is the command which allow us to use the build output of one repo as the input of a dependent repo.  The first repo can build using a new output version (say beta5) and dependent repos can be changed to accept this new version.
 
-This command operates by providing json whose format is a subset of the output of `consumes`.  In particular it will provide the `"dependencies.floating"` section.  
+This command is operated by providing it json whose format is a subset of the output of `consumes`.  In particular it takes the `"dependencies.floating"` section.
 
 ``` json
 "dependencies" {
     "floating": { 
         "nuget": {
-            "packages" {
+            "packages": {
                 "MicroBuild.Core": "0.2.0",
                 "Microsoft.NETCore.Platforms": "1.0.1"
             }
@@ -118,14 +118,14 @@ This command operates by providing json whose format is a subset of the output o
 
 A tool responsible for composing repos would ideally:
 
-1. Execute `run.cmd consumes` and capture the output.
-2. Alter the NuGet package versions in the json to have the correct build identifier: beta5, RTM, etc ..
-3. Execute `run.cmd change` and pass in the altered output.
+1. Execute `consumes` and capture the output.
+2. Alter the NuGet package versions in the captured json to have the desired values: beta5, RTM, etc
+3. Execute `change` and pass in the altered json.
 
 
 ### publish
 
-The `publish` command takes a json input that describes the locations artifacts should be published to.  The input to this command is the output of `produces` that is augmented with location information.  
+The `publish` command takes a json input that describes the locations artifacts should be published to: the output of `produces` augmented with location information.
 
 ## Artifact Specification
 
@@ -159,12 +159,12 @@ Example:
 }
 ```
 
-### File 
+### Files
 
 Any file which is not a NuGet package should be listed as a file artifact.  These can be downloaded from the web or copied from local places on the hard drive.  Each type of file entry will have a name uniquely identifying the artifact and a kind property specifying the remainder of the properties:
 
-    - uri: a property named `"uri"` will contain an absolute Uri for the artifact.
-    - filesystem: a property named `"location"` will contain an OS specific file path for the artifact.
+- uri: a property named `"uri"` will contain an absolute Uri for the artifact.
+- filesystem: a property named `"location"` will contain an OS specific file path for the artifact.
 
 Example: 
 
@@ -177,6 +177,10 @@ Example:
     "run.exe": { 
         "kind": "filesystem",
         "location": "c:\\tools\\run.exe"
+    },
+    "bootstrap.ps1": {
+        "kind": "uri",
+        "uri": "https://raw.githubusercontent.com/dotnet/buildtools/master/bootstrap/bootstrap.ps1"
     }
 }
 ```
@@ -201,7 +205,7 @@ Example:
                             "value": "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
                         }
                     ],
-                    "packages" {
+                    "packages": {
                         "MicroBuild.Core": "0.2.0",
                         "Microsoft.NETCore.Platforms": "1.0.1"
                     }
@@ -232,7 +236,7 @@ Example:
 {
     "os-all": {
         "nuget": {
-            "packages" {
+            "packages": {
                 "MicroBuild.Core": "0.2.0",
                 "Microsoft.NETCore.Platforms": "1.0.1"
             }

--- a/Documentation/buildtools-repo-compose.md
+++ b/Documentation/buildtools-repo-compose.md
@@ -1,0 +1,83 @@
+# Implementing [Repo API](RepoCompose.md) compose commands in buildtools
+
+## Why not RepoUtil?
+
+[RepoUtil][RepoUtil] derives `consumes` and `change` behavior from the contents of project.json files in a project, considering them the *source of truth* for dependency information. In some repositories, dependency information is solely stored in project.json files. When adding Repo API support in those repositories, it makes sense to use RepoUtil as-is.
+
+However, repositories that currently use buildtools tend to store some dependency information in other files, for example package versions used in MSBuild project files. There is already a *source of truth* independent of project.jsons in these repositories: [dependencies.props](https://github.com/dotnet/corefx/blob/713e104c72538f5b42c75882a337178ad8e4229b/dependencies.props). This doc assumes that buildtools-using repositories will want to continue using a non-project.json source of truth. Repositories that use buildtools are corefx, coreclr, wcf, and buildtools. (The current plan is to also convert core-setup to use buildtools, but that project doesn't have a dependencies.props source of truth as of writing. See [core-setup #283](https://github.com/dotnet/core-setup/issues/283).)
+
+This doc proposes the way that Repo API Compose commands will be implemented in BuildTools, with a non-project.json source of truth.
+
+
+## Overview
+
+The way `consumes`, `change`, and `verify` interact make it so they can be simplified by checking the `consumes` output into the repo as "consumes.json" and using it as the source of truth.
+
+ * `consumes` reads the contents of consumes.json and writes it out verbatim.
+
+ * `change` takes a modified consumes.json and overwrites the checked-in consumes.json file. Then, it changes the project contents so they match the new source of truth.
+
+ * `verify` reads consumes.json and ensures its contents are self-consistent and match the repository contents. This allows devs to check if their project.json or other modifications are valid.
+   * This is not a documented Repo API Compose command, but [RepoUtil][RepoUtil] offers it and the existing buildtools target `/t:VerifyDependencies` is an analogue.
+
+The `produces` command scans artifacts of a completed build for files that the repository produced and intends to publish. More detailed documentation will be available in BuildToolsRepoApiProducesImplementation.md [~~link~~](BuildToolsRepoApiProducesImplementation.md).
+
+The Repo API Compose command document [describes the workflow to update a version](RepoCompose.md#change), but to go into more detail, the corresponding flow in the Buildtools implementation is:
+
+ 1. `run consumes > temp.json`
+ 2. Open the temp file in an editor, change the versions as desired.
+ 3. `run change < temp.json`
+
+That flow leaves the temporary file for manual cleanup. If that isn't desired:
+
+ 1. Edit "consumes.json".
+ 2. `run change -InPlace`
+
+The Repo API spec doesn't require a file that represents `consumes` output, so the stdin/stdout flow is standard.
+
+
+## Mechanics of a `change`
+
+A `change` scenario typically has three steps. This is what a dev (or automation process) would do to change dependencies in a project:
+
+ 1. Execute `consumes` and capture the output json.
+ 2. Change the versions in the output json to the desired dependency state.
+ 3. Execute `change` and pass in the altered output json.
+
+In the last step, the `change` implementation makes any source file changes needed to ensure:
+
+ * The next time `consumes` is called, it will output the same json that was passed to `change`.
+ * The dependencies specified by `consumes` are the exact ones being consumed by the repository.
+
+The proposed way that a buildtools-using repository would ensure these properties is:
+
+ * Replace the checked-in "consumes.json" file with the provided "consumes.json". This changes the `consumes` output to be correct.
+ * Using a set of repository-specific rules, enforce the dependencies and versions defined in the provided consumes data.
+   * To reuse the most possible code, this uses the msbuild configuration and targets already created to do this using rules defined in "dependencies.props". The targets need to be modified to allow "consumes.json" as the source of truth.
+
+
+## Edge cases of `change`
+
+### Upgrading from a stable dependency
+In CoreFX, some projects depend on other projects within the repository. When possible, these dependencies are set to the lowest-possible stable version, and should never auto-update. However, when one project needs to consume a breaking change from another, the dependency is set to a prerelease version and auto-updated from then on.
+
+So far, this has been dealt with by the rule "if a dependency is stable, don't auto-update it; if it's a prerelease dependency, auto-update it."
+
+This causes problems after a release. When building release candidate packages that have stable versions, *all* dependencies in the release branch source are auto-updated to stable versions and no longer auto-update. This means that when a servicing change or similar is building after a stable version has been released from that git branch, all applicable dependency versions must be updated manually. It's unclear how to distinguish between stable dependencies not to upgrade vs. stable dependencies to upgrade.
+
+This situation is something to address in the future if we can think of a reliable update strategy.
+
+### Adding/removing a dependency
+With the set of Repo API Compose commands above, when a dev adds or removes a dependency, they need to make the change to the entire source tree at the same time, including the checked-in "consumes.json". `verify` can be used to check if the add/remove was done correctly, but that's only partially helpful.
+
+If this is worthwhile to solve, we could add a new command (or an option for `change`) that finds discrepancies in the source tree and tries to modify "consumes.json" to match. This could work for simple removes and adds. The new mode would be a reversal of the usual `change` flow of *source of truth* to project, flowing from the project state to the source of truth instead.
+
+
+## Using RepoUtil to seed `consumes` output.
+
+When adding the Repo API Compose commands to a buildtools-using repository, the repository needs an initial accurate consumes.json file. To get the initial list of everything a repository consumes, we can use [RepoUtil][RepoUtil] to generate an initial source of truth from project.json files with the full set of dependencies.
+
+Most of this information can be derived from a "dependencies.props" file, but it isn't complete because in that system, unregulated dependencies are allowed.
+
+
+[RepoUtil]: ../src/RepoUtil/README.md

--- a/Documentation/dependency-auto-update.md
+++ b/Documentation/dependency-auto-update.md
@@ -1,0 +1,26 @@
+# Dependency auto-update
+
+**TODO**: How auto-update happens without the repo API.
+
+# Auto-update using the Repo API
+
+The Repo API Compose commands (see [the proposed buildtools implementation](buildtools-repo-compose.md)) are used by the auto-update flow in the same way that a dev could use them. A full cycle, from the end of an official build to update PRs being posted to dependent repositories, is:
+
+1. The build publishes its output (packages, installers, etc.).
+2. `produces` and `consumes` are run and their output captured.
+3. The `produces` and `consumes` outputs are published on the dotnet/versions repository, representing the state of the latest official build. (See [#986](https://github.com/dotnet/buildtools/issues/986))
+4. [Maestro][Maestro] notices the change and triggers the auto-update pull request generation VSTS build for each dependent repository:
+   1. `consumes` is run.
+   2. The `consumes` output is compared against the `produces` output found on dotnet/versions. Dependencies that have a new version available are changed in the `consumes` output.
+      * Some per-repository metadata is necessary for any unusual upgrade behaviors we need to follow. See [Configuring Repo API auto-update](#configuring-repo-api-auto-update)
+   3. The modified `consumes` output is passed to `change`.
+   4. The changes that `change` makes to the dependent repository are committed and pushed.
+   5. A new PR is opened for the pushed branch, but if there was an existing auto-upgrade PR, that is updated to include the new change.
+
+
+## Configuring Repo API auto-update
+
+An additional file maps `produces` outputs from dotnet/versions to update locations in the `consumes` data. For example, the coreclr build-info is mapped to update floating dependencies in corefx.
+
+
+[Maestro]: https://github.com/dotnet/versions/tree/master/Maestro


### PR DESCRIPTION
An initial proposal for implementing the Repo API Compose commands in buildtools, at a high level.

We don't need solutions for some of the finer points in the doc yet: the first implementation goal is to make the auto-PR system produce updates on par with what we have now, but using the Repo API.

@chcosta @weshaggard @ellismg @jaredpar 
/cc @markwilkie @dleeapho
