### PR TITLE
Update package indexing and Validation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
@@ -244,6 +244,14 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
         }
 
+        public void AddAssemblyVersionsInPackage(IEnumerable<Version> assemblyVersions, Version packageVersion)
+        {
+            foreach (var assemblyVersion in assemblyVersions)
+            {
+                AddAssemblyVersionInPackage(assemblyVersion, packageVersion);
+            }
+        }
+
         public void AddAssemblyVersionInPackage(Version assemblyVersion, Version packageVersion)
         {
             Version existingPackageVersion;


### PR DESCRIPTION
This improves the indexing to also index implementation versions,
potentially from runtime-specific packages.  Previously we only indexed
references which missed cases where impl assemblies compiled against
other impl assemblies and the ref didn't change.  Such is the case for
partial facades.

I've also added some validation to catch cases where we add new shim
packages.

This change requires CoreFx change: https://github.com/ericstj/corefx/commit/6965cf0b5a0ce9073f79b8bbeaa8a488f41b4202

/cc @weshaggard 