### PR TITLE
Don't generate a project.json file if 'RestoreDuringBuild' is 'false'.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -131,7 +131,7 @@
 
   <Target Name="AddDependenciesToProjectJson"
           DependsOnTargets="GatherProjectReferenceForProjectJson;DetermineProjectJsonPath"
-          Condition="'@(_InjectProjectReferenceDependency)' != ''">
+          Condition="'@(_InjectProjectReferenceDependency)' != '' and '$(RestoreDuringBuild)' != 'false'">
 
     <!-- If VersionsFiles were passed on the command-line, convert them to an item group -->
     <ItemGroup>


### PR DESCRIPTION
This prevents us from generating project.json's in the build step after we
have already generated them in the sync step.

/cc @weshaggard 