### PR TITLE
Fix issue with removing orphaned versions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/UpdatePackageIndex.cs
@@ -250,7 +250,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 orphanedAssemblyVersions = orphanedAssemblyVersions.Except(runtimeAssemblyVersions);
             }
 
-            foreach (var orphanedAssemblyVersion in orphanedAssemblyVersions)
+            foreach (var orphanedAssemblyVersion in orphanedAssemblyVersions.ToArray())
             {
                 info.AssemblyVersionInPackageVersion.Remove(orphanedAssemblyVersion);
             }


### PR DESCRIPTION
I had removed a call to ToArray which caused the removal to happen while
enumerating over the collection.  Add it back.