### PR TITLE
Allow overriding the AssemblyOriginatorKeyFile property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -11,7 +11,7 @@
   
   <PropertyGroup Condition="'$(SkipSigning)'!='true'">
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(ToolsDir)MSFT.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile Condition="'$(AssemblyOriginatorKeyFile)' == ''">$(ToolsDir)MSFT.snk</AssemblyOriginatorKeyFile>
     <AssemblyOriginatorKeyFile Condition="'$(UseECMAKey)' == 'true'">$(ToolsDir)ECMA.snk</AssemblyOriginatorKeyFile>
     <AssemblyOriginatorKeyFile Condition="'$(UseOpenKey)' == 'true'">$(ToolsDir)Open.snk</AssemblyOriginatorKeyFile>
 


### PR DESCRIPTION
This is useful if a project wants to specify a key other than the MSFT.snk, ECMA.snk or Open.snk.