### PR TITLE
Add source index supporting targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -108,8 +108,20 @@
       <_ReferenceCopyLocalPathsFromPackage Remove="@(_ReferenceCopyLocalPathsFileNamesToRemove)" />
 
       <!-- add the filtered resolved package output -->
-      <Reference Include="@(_ReferenceFromPackage)" />
+      <Reference Condition="'$(SourceIndex)' != 'true'" Include="@(_ReferenceFromPackage)" />
       <ReferenceCopyLocalPaths Include="@(_ReferenceCopyLocalPathsFromPackage)" />
+
+      <_ReferenceProjectToHarvest Condition="'$(SourceIndex)' == 'true'" Include="@(_ReferenceFromPackage -> '$(MSBuildThisFileDirectory)../src/%(Filename)/src/%(FileName).builds')" />
+    </ItemGroup>
+    <MSBuild Condition="'$(SourceIndex)' == 'true' AND Exists('%(Identity)')"
+             Projects="%(_ReferenceProjectToHarvest.Identity)"
+             Targets="GetTargetPath">
+      <Output TaskParameter="TargetOutputs" ItemName="_PackageLibReferencePath"/>
+    </MSBuild>
+    <ItemGroup Condition=" '$(SourceIndex)' == 'true' ">
+      <ReferencePath Include="%(_PackageLibReferencePath.Identity)" Condition="Exists('%(Identity)')"/>
+      <ReferencePath Include="$(MSBuildThisFileDirectory)..\packages\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.2.0-$(CoreClrExpectedPrerelease)\runtimes\win7-x64\lib\netstandard1.0\mscorlib.dll"/>
+      <ReferencePath Include="$(MSBuildThisFileDirectory)..\packages\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.2.0-$(CoreClrExpectedPrerelease)\runtimes\win7-x64\lib\netstandard1.0\System.Private.CoreLib.dll"/>
     </ItemGroup>
 
     <Message Text="Excluding @(_ReferenceFileNamesToRemove);@(_ReferenceCopyLocalPathsFileNamesToRemove) from package references since the same file is provided by a project reference."


### PR DESCRIPTION
This change adds support for building a source index by using all the implementation assemblies as references passed to the compiler. This enables the source indexer to connect references between source projects correctly. Specifically this allows references to things that are type forwarded to reference the actual source where the implementation lives.