### PR TITLE
Move test publishing from post-build to pre-test-run

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PrepareForRunDependsOn Condition="'$(IsTestProject)'=='true'">$(PrepareForRunDependsOn);CopyTestToTestDirectory;CreateTestNuGetPackage;ArchiveTestBuild</PrepareForRunDependsOn>
     <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
     <TestNugetRuntimeId Condition="'$(TestNugetRuntimeId)' == ''">win7-$(TestArchitecture)</TestNugetRuntimeId>
   </PropertyGroup>
@@ -55,7 +54,7 @@
                                TargetMonikers="@(TestNugetTargetMoniker)">
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </PrereleaseResolveNuGetPackageAssets>
-    
+
     <ItemGroup Condition="'$(TestWithCore)' != 'true'">
       <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.exe" />
       <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.1.0\tools\*.dll" />
@@ -65,7 +64,7 @@
         <Private>false</Private>
       </TestCopyLocal>
     </ItemGroup>
-    
+
     <ItemGroup Condition="'$(TestAppX)' == 'true'">
       <_TestCopyLocalAppXRunner Include="$(PackagesDir)microsoft.xunit.runner.uwp\$(AppXRunnerVersion)\**\*.*"/>
       <TestCopyLocal Include="@(_TestCopyLocalAppXRunner)">
@@ -217,11 +216,11 @@
   </Target>
 
   <!-- Workaround for VS execution:  This will form the same list and copy the same files as
-       copied via RunTests script so VS can work when the test dir is initially clean. 
+       copied via RunTests script so VS can work when the test dir is initially clean.
        -->
   <Target Name="CopyRunnerScriptFiles" Condition="'$(BuildingInsideVisualStudio)'=='true'"
         AfterTargets="CopySupplementalTestData">
-     <!-- This was copied from RunTestsForProject in tests.targets 
+     <!-- This was copied from RunTestsForProject in tests.targets
           The RunTestsForProject target does not execute in VS context and would be confused by the script based runner.
           _TestCopyLocalByFileNameWithoutDuplicates are the precise items that are fed to the runner script generation code.
      -->
@@ -235,7 +234,7 @@
       </_IncludedFileForTestsInVS>
       <_DestinationsForTestsInVS Include="@(_IncludedFileForTestsInVS->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)')" />
     </ItemGroup>
-    
+
     <Copy
       SourceFiles="@(_IncludedFileForTestsInVS  -> '%(SourcePath)')"
       DestinationFiles="@(_DestinationsForTestsInVS)"
@@ -245,7 +244,7 @@
       RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
       UseHardlinksIfPossible="true">
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
-    </Copy>    
+    </Copy>
   </Target>
 
     <!-- archive the test binaries along with some supporting files -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -106,7 +106,7 @@
     <XunitOptions Condition="'$(Performance)'!='true'">$(XunitOptions) -notrait Benchmark=true</XunitOptions>
 
     <XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(XunitOptions) -redirectoutput</XunitOptions>
-    
+
     <XunitOptions Condition="'$(TestTFM)'!=''">$(XunitOptions) -notrait category=non$(TestTFM)tests</XunitOptions>
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
     <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
@@ -151,7 +151,7 @@
   -->
   <Target Name="RunTestsForProject"
           DependsOnTargets="DiscoverTestInputs;CheckTestCategories"
-          AfterTargets="CheckTestCategories"
+          Condition="'$(TestDisabled)' != 'true'"
           Inputs="@(RunTestsForProjectInputs)"
           Outputs="$(TestsSuccessfulSemaphore);$(TestPath)%(TestNugetTargetMoniker.Folder)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
           >
@@ -258,8 +258,7 @@
       ScriptOutputPath ="$(OutputPathForScriptGenerator)"
     />
 
-    <Exec Condition="'$(TestDisabled)'!='true'"
-          Command="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(RunnerScriptName) $(PackagesDir)"
+    <Exec Command="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(RunnerScriptName) $(PackagesDir)"
           WorkingDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)"
           CustomErrorRegularExpression="Failed: [^0]"
           ContinueOnError="true"
@@ -274,8 +273,7 @@
   </Target>
 
   <!-- Needs to run before RunTestsForProject target as it computes categories and set TestDisabled -->
-  <Target Name="CheckTestCategories"
-          AfterTargets="CheckTestPlatforms">
+  <Target Name="CheckTestCategories">
 
     <!-- Default behavior is to disable OuterLoop and failing tests if not specified in WithCategories. -->
     <ItemGroup>
@@ -300,8 +298,7 @@
             Files="$(TestsSuccessfulSemaphore)" />
   </Target>
 
-  <Target Name="CheckTestPlatforms"
-          BeforeTargets="Test">
+  <Target Name="CheckTestPlatforms">
     <GetTargetMachineInfo Condition="'$(TargetOS)' == ''">
       <Output TaskParameter="TargetOS" PropertyName="TargetOS" />
     </GetTargetMachineInfo>
@@ -311,4 +308,22 @@
     <Message Condition="'%(UnsupportedPlatformsItems.Identity)' == '$(TargetOS)'"
       Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
   </Target>
+
+  <Target Name="SetupTestProperties" DependsOnTargets="CheckTestPlatforms;CheckTestCategories" />
+
+  <PropertyGroup>
+    <TestDependsOn>
+      $(TestDependsOn);
+      DiscoverTestInputs;
+      SetupTestProperties;
+      CopyTestToTestDirectory;
+      RunTestsForProject;
+      ArchiveTestBuild
+    </TestDependsOn>
+  </PropertyGroup>
+
+  <Target Name="Test"
+          DependsOnTargets="$(TestDependsOn)">
+  </Target>
+
 </Project>


### PR DESCRIPTION
Currently test publishing happens during PrepareForRun which is a
post step of build. However we need TestTFM as a parameter in test
publishing which we don't know until test runtime because a given
test build can have a set of TestTFM's that apply to it. To address
this we are moving test publishing as a pre-step for test running.
To do this we are overriding the Test target and adding a set of
DependsOnTargets to allow for ordering them correctly.

cc @joperezr @tarekgh 

fyi @stephentoub this should fix the issue we saw with CodeDom tests.