### PR TITLE
Redirect git rev-parse HEAD error output

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -205,7 +205,7 @@
   </Target>
 
   <Target Name="GetLatestCommitHash" Condition="'$(LatestCommit)'==''">
-    <Exec Command="git rev-parse HEAD" StandardOutputImportance="Low" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true">
+    <Exec Command="git rev-parse HEAD 2>&amp;1" StandardOutputImportance="Low" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit" />
       <Output TaskParameter="ExitCode" PropertyName="LatestCommitExitCode" />
     </Exec>


### PR DESCRIPTION
Redirect git rev-parse HEAD error output to avoid bogus messages about missing git tool when building inside VS and not having git on the path. Any errors are ignored anyway.