### PR TITLE
Add support for commands to have a "default alias"

### DIFF
--- a/src/Run/Executor.cs
+++ b/src/Run/Executor.cs
@@ -17,10 +17,10 @@ namespace Microsoft.DotNet.Execute
         public string configFilePath;
         public string configFileName = "config.json";
         public string CommandSelectedByUser { get; set; }
-        
+
         public Dictionary<string, string> SettingParameters { get; set; }
         public Dictionary<string, Dictionary<string, string>> CommandParameters { get; set; }
-        
+
         public Executor()
         {
             SettingParameters = new Dictionary<string, string>();
@@ -90,14 +90,14 @@ namespace Microsoft.DotNet.Execute
                     {
                         parser.DefineParameterSet(comm.Key, ref userCommand, comm.Key, string.Format("Help for {0}", comm.Key));
                         Dictionary<string, string> param = new Dictionary<string, string>();
-                        foreach(KeyValuePair<string, AliasPerCommand> aliasInfo in comm.Value.Alias)
+                        foreach (KeyValuePair<string, AliasPerCommand> aliasInfo in comm.Value.Alias)
                         {
                             string temp = "";
                             parser.DefineOptionalQualifier(aliasInfo.Key, ref temp, aliasInfo.Value.Description, null, null);
-                            if(!string.IsNullOrEmpty(temp) && !temp.Equals("true"))
+                            if (!string.IsNullOrEmpty(temp) && !temp.Equals("true"))
                             {
                                 List<string> keys = new List<string>(aliasInfo.Value.Settings.Keys);
-                                if(keys.Count < 2)
+                                if (keys.Count < 2)
                                 {
                                     foreach (string key in keys)
                                     {
@@ -121,14 +121,14 @@ namespace Microsoft.DotNet.Execute
                 Console.Error.WriteLine("Error: {0} {1}", e.Message, e.StackTrace);
                 return false;
             }
-            
+
         }
 
         public static int Main(string[] args)
         {
             string[] parseArgs;
             Executor executor;
-            if(args.Length > 0 && args[0].EndsWith(".json"))
+            if (args.Length > 0 && args[0].EndsWith(".json"))
             {
                 executor = new Executor(args[0]);
                 parseArgs = new string[args.Length - 1];
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Execute
                 Console.Error.WriteLine("Error: Could not load Json configuration file.");
                 return 1;
             }
-            string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows": "unix";
+            string os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "windows" : "unix";
 
             if (jsonSetup.PrepareValues(os, executor.SettingParameters, executor.configFilePath) == 0)
             {
@@ -166,6 +166,22 @@ namespace Microsoft.DotNet.Execute
                             paramSelected.Add(param.Key);
                         }
                     }
+
+                    // If aliases exist, and the user's parameters have no match, we'll end up in this state. 
+                    // If a default alias is provided, we can add that; otherwise we should error out as the 
+                    // behavior at this point may be unexpected.
+                    if (paramSelected.Count == 0 && executor.CommandParameters[executor.CommandSelectedByUser].Count > 0)
+                    {
+                        string defaultAlias = jsonSetup.Commands[executor.CommandSelectedByUser].DefaultAlias;
+                        if (!string.IsNullOrEmpty(defaultAlias))
+                        {
+                            Console.WriteLine($"No parameter selected, using default alias '{defaultAlias}'");
+                            paramSelected.Add(defaultAlias);
+                        }
+                        // May want to error out here in the future;  Need to find out if there's ever a reason
+                        // to allow aliases, but specify none.
+                    }
+
                     return jsonSetup.ExecuteCommand(executor.CommandSelectedByUser, paramSelected);
                 }
             }

--- a/src/Run/Executor.cs
+++ b/src/Run/Executor.cs
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.Execute
                     // behavior at this point may be unexpected.
                     if (paramSelected.Count == 0 && executor.CommandParameters[executor.CommandSelectedByUser].Count > 0)
                     {
-                        string defaultAlias = jsonSetup.Commands[executor.CommandSelectedByUser].DefaultAlias;
+                        string defaultAlias = jsonSetup.Commands[executor.CommandSelectedByUser].DefaultValues.DefaultAlias;
                         if (!string.IsNullOrEmpty(defaultAlias))
                         {
                             Console.WriteLine($"No parameter selected, using default alias '{defaultAlias}'");

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -528,6 +528,7 @@ namespace Microsoft.DotNet.Execute
     {
         public Dictionary<string, AliasPerCommand> Alias { get; set; }
         public DefaultValuesPerCommand DefaultValues { get; set; }
+        public string DefaultAlias { get; set; }
     }
 
     public class Tool

--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -521,6 +521,7 @@ namespace Microsoft.DotNet.Execute
     {
         public string Project { get; set; }
         public string ToolName { get; set; }
+        public string DefaultAlias { get; set; }
         public Dictionary<string, string> Settings { get; set; }
     }
 
@@ -528,7 +529,6 @@ namespace Microsoft.DotNet.Execute
     {
         public Dictionary<string, AliasPerCommand> Alias { get; set; }
         public DefaultValuesPerCommand DefaultValues { get; set; }
-        public string DefaultAlias { get; set; }
     }
 
     public class Tool


### PR DESCRIPTION
- Create a new property on Command that allows specifying a "DefaultAlias" value where Aliases are listed.  This value is only used if no other flags are provided.  

In this incarnation still allows things to continue if the user fails to specify an alias because there might be a scenario where that makes some kind of sense  (I haven't found that yet).   This was inspired by what happened when a user called "clean.cmd --all.   Since Clean.cmd was explicitly matching on "-all", this ended up passing "clean --all" to Run.exe, which failed to match the letters to the actual aliases allowed (b, p, c), and since these aliases were needed to pick a build target, no  build target gets specified, and thus "Build" is invoked.  

Once this change is in CoreFX / other repos, we simply need to tweak their config.json files like:

  "clean": {
      "alias": {
        "b": { ...        },
        "p": {...        },
        "c": {... }
        }
      },
      "defaultAlias" : "b",
      ...
Allowing us to specify the same default behavior as clean.cmd was going to use on a case-by-case basis.