### PR TITLE
Document dependency auto-update PR process

### DIFF
--- a/Documentation/annotated-dependency-props.md
+++ b/Documentation/annotated-dependency-props.md
@@ -1,0 +1,156 @@
+# Annotated dependencies.props
+
+This file is used in CoreFX, CoreCLR, WCF, and BuildTools, and it isn't immediately clear how it's used for auto-updates, and how it's updated by auto-update. Below is a breakdown of [corefx's master dependencies.props](https://github.com/dotnet/corefx/blob/b57a43bb40fc2099e91d641a8b4f8c76a46afe6a/dependencies.props):
+
+``` xml
+<PropertyGroup>
+	<CoreFxCurrentRef>450606241ffd24c3c9671cd002955a68e98008a7</CoreFxCurrentRef>
+	<CoreClrCurrentRef>450606241ffd24c3c9671cd002955a68e98008a7</CoreClrCurrentRef>
+	<ExternalCurrentRef>0db1f9d8996a6a05960f79712299652a4b04147f</ExternalCurrentRef>
+	<ProjectNTfsCurrentRef>450606241ffd24c3c9671cd002955a68e98008a7</ProjectNTfsCurrentRef>
+</PropertyGroup>
+```
+
+Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. These are used with the GitHub raw api to download build-infos.
+
+In `/t:UpdateDependenciesAndSubmitPullRequest`, the task first finds the latest CurrentRef of the dotnet/versions repository, which when used with the raw API will return the latest version of *every* build info. The update proceeds, using that latest build-info data. After updating, the task determines which build-infos were used and updates only the used build-info `*CurrentRef`s in the above part of dependencies.props.
+
+When doing a manual update with `/t:UpdateDependencies`, you need to change these `CurrentRef`s yourself to whatever dotnet/versions commit you want to update to before executing the target.
+
+During dependency verification (`/t:VerifyDependencies` or automatically during `sync`) the targeted build-infos are downloaded and project files are checked for consistency with the build-infos.
+
+``` xml
+<!-- Auto-upgraded properties for each build info dependency. -->
+<PropertyGroup>
+	<CoreFxExpectedPrerelease>beta-24601-02</CoreFxExpectedPrerelease>
+	<CoreClrExpectedPrerelease>beta-24603-02</CoreClrExpectedPrerelease>
+	<ExternalExpectedPrerelease>beta-24523-00</ExternalExpectedPrerelease>
+	<ProjectNTfsExpectedPrerelease>beta-24603-00</ProjectNTfsExpectedPrerelease>
+</PropertyGroup>
+```
+
+These are auto-updated by `UpdateDependenciesAndSubmitPullRequest` and `UpdateDependencies`, with values taken from `Latest.txt`. They are only used to flow this info into MSBuild, *not* by project.json validation (as they were in older types of dependency auto-update).
+
+These properties are verified to match the downloaded build-info during `VerifyDependencies`.
+
+``` xml
+<!-- Full package version strings that are used in other parts of the build. -->
+<PropertyGroup>
+	<AppXRunnerVersion>1.0.3-prerelease-00826-05</AppXRunnerVersion>
+	<XunitPerfAnalysisPackageVersion>1.0.0-alpha-build0040</XunitPerfAnalysisPackageVersion>
+</PropertyGroup>
+```
+
+Similar to the `*ExpectedPrerelease` properties, but these are for specific named packages. They are used in MSBuild targets during builds. These versions in particular aren't auto-updated because they are tools that don't regularly change.
+
+``` xml
+<!-- Package dependency verification/auto-upgrade configuration. -->
+<PropertyGroup>
+	<BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
+	<DependencyBranch>master</DependencyBranch>
+	<CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
+</PropertyGroup>
+```
+
+The first two properties assemble the path to the build-info files that CoreFX master depends on.
+
+`CurrentRefXmlPath` is used by the auto-update targets to determine where `dependencies.props` is.
+
+``` xml
+<ItemGroup>
+	<RemoteDependencyBuildInfo Include="CoreFx">
+		<BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>
+		<CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
+	</RemoteDependencyBuildInfo>
+	<RemoteDependencyBuildInfo Include="CoreClr">
+		<BuildInfoPath>$(BaseDotNetBuildInfo)coreclr/$(DependencyBranch)</BuildInfoPath>
+		<CurrentRef>$(CoreClrCurrentRef)</CurrentRef>
+	</RemoteDependencyBuildInfo>
+	<RemoteDependencyBuildInfo Include="External">
+		<BuildInfoPath>$(BaseDotNetBuildInfo)projectk-tfs/$(DependencyBranch)</BuildInfoPath>
+		<CurrentRef>$(ExternalCurrentRef)</CurrentRef>
+	</RemoteDependencyBuildInfo>
+	<RemoteDependencyBuildInfo Include="ProjectNTfs">
+		<BuildInfoPath>$(BaseDotNetBuildInfo)projectn-tfs/$(DependencyBranch)</BuildInfoPath>
+		<CurrentRef>$(ProjectNTfsCurrentRef)</CurrentRef>
+	</RemoteDependencyBuildInfo>
+
+	<DependencyBuildInfo Include="@(RemoteDependencyBuildInfo)">
+		<RawVersionsBaseUrl>https://raw.githubusercontent.com/dotnet/versions</RawVersionsBaseUrl>
+	</DependencyBuildInfo>
+	
+	<XmlUpdateStep Include="CoreFx">
+		<Path>$(MSBuildThisFileFullPath)</Path>
+		<ElementName>CoreFxExpectedPrerelease</ElementName>
+		<BuildInfoName>CoreFx</BuildInfoName>
+	</XmlUpdateStep>
+	<XmlUpdateStep Include="CoreClr">
+		<Path>$(MSBuildThisFileFullPath)</Path>
+		<ElementName>CoreClrExpectedPrerelease</ElementName>
+		<BuildInfoName>CoreClr</BuildInfoName>
+	</XmlUpdateStep>
+	<XmlUpdateStep Include="External">
+		<Path>$(MSBuildThisFileFullPath)</Path>
+		<ElementName>ExternalExpectedPrerelease</ElementName>
+		<BuildInfoName>External</BuildInfoName>
+	</XmlUpdateStep>
+	<XmlUpdateStep Include="ProjectNTfs">
+		<Path>$(MSBuildThisFileFullPath)</Path>
+		<ElementName>ProjectNTfsExpectedPrerelease</ElementName>
+		<BuildInfoName>ProjectNTfs</BuildInfoName>
+	</XmlUpdateStep>
+</ItemGroup>
+```
+
+Each `RemoteDependencyBuildInfo` indicates a build-info to download, which consists of the `Latest.txt` and `Latest_Packages.txt` at a certain path. `CurrentRef` is flowed from the property into the item metadata rather than hard-coded in the metadata for enhanced visibility in auto-update diffs.
+
+The `XmlUpdateStep`s are rules that match the `*ExpectedPrerelease` properties earlier in this file and link them to the build infos.
+
+``` xml
+<!-- Set up dependencies on packages that aren't found in a BuildInfo. -->
+<ItemGroup>
+	<TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5" />
+	<TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5.1" />
+	<TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.5.2" />
+	<TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6" />
+	<TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6.1" />
+	<TargetingPackDependency Include="Microsoft.TargetingPack.NETFramework.v4.6.2" />
+	<TargetingPackDependency Include="Microsoft.TargetingPack.Private.WinRT" />
+	<StaticDependency Include="@(TargetingPackDependency)">
+		<Version>1.0.1</Version>
+	</StaticDependency>
+
+	<XUnitDependency Include="xunit"/>
+	<XUnitDependency Include="xunit.runner.utility"/>
+	<XUnitDependency Include="xunit.runner.console"/>
+	<StaticDependency Include="@(XUnitDependency)">
+		<Version>2.1.0</Version>
+	</StaticDependency>
+
+	<StaticDependency Include="Microsoft.xunit.netcore.extensions;Microsoft.DotNet.BuildTools.TestSuite">
+		<Version>1.0.0-prerelease-00830-02</Version>
+	</StaticDependency>
+
+	<PerformancePackDependency Include="Microsoft.DotNet.xunit.performance" />
+	<PerformancePackDependency Include="Microsoft.DotNet.xunit.performance.analysis" />
+	<PerformancePackDependency Include="Microsoft.DotNet.xunit.performance.analysis.cli" />
+	<PerformancePackDependency Include="Microsoft.DotNet.xunit.performance.runner.cli" />
+	<PerformancePackDependency Include="Microsoft.DotNet.xunit.performance.runner.Windows" />
+	<StaticDependency Include="@(PerformancePackDependency)">
+		<Version>$(XunitPerfAnalysisPackageVersion)</Version>
+	</StaticDependency>
+
+	<DependencyBuildInfo Include="@(StaticDependency)">
+		<PackageId>%(Identity)</PackageId>
+		<UpdateStableVersions>true</UpdateStableVersions>
+	</DependencyBuildInfo>
+
+	<DependencyBuildInfo Include="uwpRunnerVersion">
+		<PackageId>microsoft.xunit.runner.uwp</PackageId>
+		<Version>$(AppXRunnerVersion)</Version>
+	</DependencyBuildInfo>
+
+</ItemGroup>
+```
+
+These are "local" `DependencyBuildInfo`s created to cover packages that aren't in downloaded build-infos because they are external, not published to dotnet/versions, or don't normally change. Specifically, these allow the package versions to be validated in `project.json` files.

--- a/Documentation/dependency-auto-update.md
+++ b/Documentation/dependency-auto-update.md
@@ -11,7 +11,7 @@ The [versions repo (dotnet/versions)][dotnet/versions] stores information about 
 
 [Maestro][Maestro] detects changes to files in GitHub and kicks off tasks depending on the file that changed, according to [subscriptions.json][subscriptions]. For dependency auto-update, the relevent files are the build-info files in dotnet/versions.
 
-VSTS builds are used to execute the auto-update pull request generation task. The naming scheme for these build definitions for CoreFX, CoreCLR, and WCF is Maestro-<Project>GeneralExecutor.
+VSTS builds are used to execute the auto-update pull request generation task. The naming scheme for these build definitions for CoreFX, CoreCLR, and WCF is `Maestro-<Project>GeneralExecutor`.
 
 [VersionTools][VersionTools] is a library that can update and verify dependencies, commit and push changes, and make pull requests. The main BuildTools package includes "wrapper" targets/tasks that run this library, and the library's DLL.
 

--- a/Documentation/dependency-auto-update.md
+++ b/Documentation/dependency-auto-update.md
@@ -1,0 +1,115 @@
+# Dependency auto-update
+
+Buildtools provides tooling for automatically updating a repository's dependencies (project.json, msbuild .props, and arbitrary versions in files). Combined with [Maestro][Maestro], this allows a flow where one repository finishes an official build, and all repositories that depend on that repository get an automatically generated pull request from a bot GitHub account.
+
+As of writing, the Repo API Compose commands are not implemented yet. This document describes auto-update in a pre-Repo-API world.
+
+
+## Parts of auto-update flow
+
+The [versions repo (dotnet/versions)][dotnet/versions] stores information about the last official build of each orchestrated repository in text files.
+
+[Maestro][Maestro] detects changes to files in GitHub and kicks off tasks depending on the file that changed, according to [subscriptions.json][subscriptions]. For dependency auto-update, the relevent files are the build-info files in dotnet/versions.
+
+VSTS builds are used to execute the auto-update pull request generation task. The naming scheme for these build definitions for CoreFX, CoreCLR, and WCF is Maestro-<Project>GeneralExecutor.
+
+[VersionTools][VersionTools] is a library that can update and verify dependencies, commit and push changes, and make pull requests. The main BuildTools package includes "wrapper" targets/tasks that run this library, and the library's DLL.
+
+
+## Auto-update in action
+
+For example, the flow that updated upgrade PR [coreclr/pull/7472](https://github.com/dotnet/coreclr/pull/7472) with CoreFX master beta-24604-02:
+
+ 1. The official build writes its output data to the dotnet/versions [build-info/dotnet/corefx/master](https://github.com/dotnet/versions/tree/0e83ecde3e99f5c13b9532e3b06003b85b83f435/build-info/dotnet/corefx/master).
+   1. Latest.txt stores the prerelease specifier for all packages published.
+   2. Latest_Packages.txt stores the full id and version identifier for each package published.
+ 2. [Maestro][Maestro] detects the build-info commit and the subscription triggers [Maestro-CoreCLRGeneralExecutor #359499](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/index?buildId=359499).
+ 3. The VSTS build runs `/t:UpdateDependenciesAndSubmitPullRequest /p:GitHubUser=dotnet-bot /p:GitHubEmail=dotnet-bot@microsoft.com /p:GitHubAuthToken=******** /p:ProjectRepoOwner=dotnet /p:ProjectRepoName=coreclr /p:ProjectRepoBranch=master /p:NotifyGitHubUsers=dotnet/coreclr-contrib`.
+   1. The latest build-info Latest_Packages.txt is downloaded and used to update project.jsons and msbuild files.
+   2. The build searches for an auto-update PR that already exists for the branch and finds [coreclr/pull/7472](https://github.com/dotnet/coreclr/pull/7472).
+   3. Auto-update PRs are reused when possible, so changes are committed and pushed (`--force`) to the branch for PR 7472.
+   4. The build updates the title of PR 7472 to indicate the update that took place. If no auto-update PR had existed to update, it would create a fresh PR instead.
+ 4. CI runs, and when it's green, project maintainers can merge the auto-update PR when convenient.
+
+
+## Subscription
+
+A subscription is simply the path that [Maestro][Maestro] should listen to, and what build to run when it detects a change. These are defined in [subscriptions.json][subscriptions]. For example, a subscription to create auto-update PRs in WCF for the latest CoreFX build, (comments mine):
+
+```
+{
+	"path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
+	"handlers": [
+		{
+			// The build definition to run, a key to a dict elsewhere in subscriptions.json.
+			"maestroAction": "wcf-general", 
+			// A delay after the change is detected to allow published artifacts to propagate.
+			"maestroDelay": "00:10:00",
+			
+			// A queue-time variable sent to the build definition. No special Maestro handling.
+			// The definition runs the named script with the args given in the "Arguments" variable.
+			"ScriptFileName": "build-managed.cmd",
+			// Maestro concatenates the list of arguments and passes them at queue time as a string.
+			"Arguments": [
+				"--",
+				"/t:UpdateDependenciesAndSubmitPullRequest",
+				"/p:GitHubUser=dotnet-bot",
+				"/p:GitHubEmail=dotnet-bot@microsoft.com",
+				"/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+				"/p:ProjectRepoOwner=dotnet",
+				"/p:ProjectRepoName=wcf",
+				"/p:ProjectRepoBranch=master",
+				"/p:NotifyGitHubUsers=dotnet/wcf-contrib",
+				"/verbosity:Normal"
+			]
+		}
+	]
+}
+```
+
+([Link to subscription in context.](https://github.com/dotnet/versions/blob/0e83ecde3e99f5c13b9532e3b06003b85b83f435/Maestro/subscriptions.json#L146-L163))
+
+`wcf-general` is [defined as](https://github.com/dotnet/versions/blob/0e83ecde3e99f5c13b9532e3b06003b85b83f435/Maestro/subscriptions.json#L51-L56) this, pointing to the definition that should be queued:
+
+```
+"wcf-general": {
+	"vsoInstance": "devdiv.visualstudio.com",
+	"vsoProject": "DevDiv",
+	"buildDefinitionId": 4226
+}
+```
+
+### MSBuild arguments
+
+ * `/t:UpdateDependenciesAndSubmitPullRequest`: the target that invokes [VersionTools][VersionTools].
+ * `/p:GitHubUser=dotnet-bot`: the fork owner and committer name.
+ * `/p:GitHubEmail=dotnet-bot@microsoft.com`: committer email.
+ * `/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])`: fork owner token. The build definition has this as a secret variable, and the PowerShell in this string finds the secret's value and passes it to msbuild.
+ * `/p:ProjectRepoOwner=dotnet`: the owner of the repo to submit the PR to.
+ * `/p:ProjectRepoName=wcf`: the name of the repo to submit the PR to.
+ * `/p:ProjectRepoBranch=master`: the base branch to PR against.
+ * `/p:NotifyGitHubUsers=dotnet/wcf-contrib`: a user/group to `@`-mention in the PR description. In theory a semicolon-delimited list, but the layers of JSON and PowerShell escaping make it difficult so subscriptions have only specified a single user/group so far.
+
+
+## dependencies.props
+
+For an in-depth look at `dependencies.props`, which stores the current dependencies and configures auto-update's specific behavior for a repository, read [annotated-dependency-props.md](annotated-dependency-props.md).
+
+
+# Adding or removing a subscription
+
+In general, submit a PR for changes to [subscriptions.json][subscriptions].
+
+When adding a subscription to a new branch, if there isn't an existing "non-master" subscription to examine as an example, note that the `vsoSourceBranch` property (sibling of `maestroAction` and `maestroDelay`) tells Maestro which branch to run the GeneralExecutor on.
+
+When adding an entirely new project, a new build definition is also needed. Look at the `Maestro-*GeneralExecutor` definitions as examples and, if possible, clone an existing one and change the repository pointer in VSTS. Add a corresponding entry to the `actions` object in subscriptions.json.
+
+To remove a subscription, delete the entry in the `handlers` array.
+
+When changing subscriptions.json, match the existing comment style as best as possible, because it makes searching the file more consistent.
+
+
+[Maestro]: https://github.com/dotnet/versions/tree/master/Maestro
+[dotnet/versions]: https://github.com/dotnet/versions
+[subscriptions]: https://github.com/dotnet/versions/blob/master/Maestro/subscriptions.json
+[VersionTools]: https://github.com/dotnet/buildtools/tree/094e239b8c1e7f1495abf8c7dc96c71e56bf6c96/src/Microsoft.DotNet.VersionTools


### PR DESCRIPTION
Adds `dependency-auto-update.md`, an overview of auto-update PR flow, and `annotated-dependency-props.md`, a breakdown of dependencies.props.

This is the current state--the proposal using Repo API Compose commands is https://github.com/dotnet/buildtools/pull/1069. That proposal replaces some of this, but the Maestro and subscription parts will be mostly unchanged. Also, this info should be useful until the proposal has actually been implemented across all repos.

@chcosta @weshaggard @gkhanna79 
/cc @markwilkie @dleeapho