### PR TITLE
Fix default test runs from VS

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -209,13 +209,14 @@
                                  Condition="'$(TestWithoutNativeImages)' != 'true' Or !$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').EndsWith('.ni.dll'))" >
         <PackageRelativePath Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.NugetPackageId)' != ''">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').Replace('$(PackagesDir)',''))</PackageRelativePath>
         <UseAbsolutePath Condition="'$(TestWithLocalLibraries)'=='true'">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').StartsWith('$(BinDir)'))</UseAbsolutePath>
+        <DestinationPath>$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)</DestinationPath>
       </_IncludedFileForTestsInVS>
-      <_DestinationsForTestsInVS Include="@(_IncludedFileForTestsInVS->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)')" />
+      <_IncludedFileForTestsInVs Remove="@(_IncludedFileForTestsInVS)" Condition="Exists('%(DestinationPath)')" />
     </ItemGroup>
 
     <Copy
       SourceFiles="@(_IncludedFileForTestsInVS  -> '%(SourcePath)')"
-      DestinationFiles="@(_DestinationsForTestsInVS)"
+      DestinationFiles="@(_IncludedFileForTestsInVS->'%(DestinationPath)')"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -194,8 +194,10 @@
   <!-- Workaround for VS execution:  This will form the same list and copy the same files as
        copied via RunTests script so VS can work when the test dir is initially clean.
        -->
-  <Target Name="CopyRunnerScriptFiles" Condition="'$(BuildingInsideVisualStudio)'=='true'"
-        AfterTargets="CopySupplementalTestData">
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);CopyDefaultTestAssetsForVS</PrepareForRunDependsOn>
+  </PropertyGroup>
+  <Target Name="CopyDefaultTestAssetsForVS" DependsOnTargets="CopyTestToTestDirectory;CopySupplementalTestData">
      <!-- This was copied from RunTestsForProject in tests.targets
           The RunTestsForProject target does not execute in VS context and would be confused by the script based runner.
           _TestCopyLocalByFileNameWithoutDuplicates are the precise items that are fed to the runner script generation code.


### PR DESCRIPTION
Change
https://github.com/dotnet/buildtools/commit/499458e3889a68b633be1bccc31eae6fe4f30191
broken running tests in VS when you didn't actually build from the command line first.

This change hooks the test publishing step, not the running, to the PrepareForRun
so that the default test configuration can be F5'ed and work in VS.

Note this isn't full-proof because it does rely on the default configuration to
exist and be .NET Core based but it will enable most of our test projects to just work.

cc @ericstj 