### PR TITLE
Fix debugging from VS

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -190,6 +190,12 @@
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
   </Target>
+  
+  <!-- Outside VS this is only run during the "Test" target, 
+       but for debugging in VS we need to deploy the test during build for the default TestTFM. -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
+    <PrepareForRunDependsOn>$(PrepareForRunDependsOn);CopyTestToTestDirectory</PrepareForRunDependsOn>
+  </PropertyGroup>
 
   <!-- Workaround for VS execution:  This will form the same list and copy the same files as
        copied via RunTests script so VS can work when the test dir is initially clean.


### PR DESCRIPTION
VS will only run the build target, so we need to make sure the test is
deployed as part of build.

/cc @weshaggard 