### PR TITLE
DiscoverTestInputs should depend on ResolveReferences

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -135,7 +135,7 @@
     <StartArguments Condition="'$(StartArguments)'==''">$(TestArguments) -wait -parallel none</StartArguments>
   </PropertyGroup>
 
-  <Target Name="DiscoverTestInputs" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences;GetCopyToOutputDirectoryItems">
+  <Target Name="DiscoverTestInputs" DependsOnTargets="ResolveReferences;GetCopyToOutputDirectoryItems">
     <ItemGroup>
       <RunTestsForProjectInputs Include="@(ReferenceCopyLocalPaths)" />
       <RunTestsForProjectInputs Include="@(Content)" />


### PR DESCRIPTION
Our official build does some work that filtered ProjectReferences
to replace them with package references instead. The filtering
of the ProjectReferences currently happens as part of BeforeResolveReferences https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets#L64
(we might consider changing that to hook ResolveProjectReferences).

However in our DiscoverTestInputs target we do ResolveProjectReferences
first which means the filtering does happen before that. To eliminate
the need for us to know about the ordering of references we should just
depend on ResolveReferences instead.

@ericstj @chcosta can you please take a look. 