### PR TITLE
Move version.txt to obj directory

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -217,7 +217,6 @@
 
   <PropertyGroup>
     <GetNuGetPackageVersionsDependsOn>$(GetNuGetPackageVersionsDependsOn);CreateVersionInfoFile</GetNuGetPackageVersionsDependsOn>
-    <BeforeTraversalBuildDependsOn>CreateVersionInfoFile;$(BeforeTraversalBuildDependsOn)</BeforeTraversalBuildDependsOn>
   </PropertyGroup>
     
   <PropertyGroup>
@@ -227,6 +226,7 @@
   
   <Target Name="CreateVersionInfoFile"
           DependsOnTargets="GetLatestCommitHash"
+          BeforeTargets="BuildAllProjects"
           Inputs="$(LatestCommit)"
           Outputs="$(SyncInfoFile)">
     <MakeDir Condition="!Exists('$(SyncInfoDirectory)')"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -217,12 +217,12 @@
 
   <PropertyGroup>
     <GetNuGetPackageVersionsDependsOn>$(GetNuGetPackageVersionsDependsOn);CreateVersionInfoFile</GetNuGetPackageVersionsDependsOn>
-    <TraversalBuildDependsOn>CreateVersionInfoFile;$(TraversalBuildDependsOn)</TraversalBuildDependsOn>
+    <BeforeTraversalBuildDependsOn>CreateVersionInfoFile;$(BeforeTraversalBuildDependsOn)</BeforeTraversalBuildDependsOn>
   </PropertyGroup>
     
   <PropertyGroup>
-    <SyncInfoDirectory>$(ObjDir)</SyncInfoDirectory>
-    <SyncInfoFile>$(SyncInfoDirectory)version.txt</SyncInfoFile>
+    <SyncInfoDirectory Condition="'$(SyncInfoDirectory)' == ''">$(ObjDir)</SyncInfoDirectory>
+    <SyncInfoFile Condition="'$(SyncInfoFile)' == ''">$(SyncInfoDirectory)version.txt</SyncInfoFile>
   </PropertyGroup>
   
   <Target Name="CreateVersionInfoFile"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -217,13 +217,20 @@
 
   <PropertyGroup>
     <GetNuGetPackageVersionsDependsOn>$(GetNuGetPackageVersionsDependsOn);CreateVersionInfoFile</GetNuGetPackageVersionsDependsOn>
+    <TraversalBuildDependsOn>CreateVersionInfoFile;$(TraversalBuildDependsOn)</TraversalBuildDependsOn>
+  </PropertyGroup>
+    
+  <PropertyGroup>
+    <SyncInfoDirectory>$(ObjDir)</SyncInfoDirectory>
+    <SyncInfoFile>$(SyncInfoDirectory)version.txt</SyncInfoFile>
   </PropertyGroup>
   
   <Target Name="CreateVersionInfoFile"
-          DependsOnTargets="GetLatestCommitHash">
-    <PropertyGroup>
-      <SyncInfoFile>$(PackagesBasePath)\version.txt</SyncInfoFile>
-    </PropertyGroup>
+          DependsOnTargets="GetLatestCommitHash"
+          Inputs="$(LatestCommit)"
+          Outputs="$(SyncInfoFile)">
+    <MakeDir Condition="!Exists('$(SyncInfoDirectory)')"
+             Directories="$(SyncInfoDirectory)" />
     <WriteLinesToFile
       Condition="'$(LatestCommit)' != ''"
       File="$(SyncInfoFile)"


### PR DESCRIPTION
Creating a version.txt file in the PackagesBasePath folder was not optimal because PackageBasePath contains the $(OSGroup) which gets filtered for a build.  The result is that you could have multiple PackageBasePaths, which meant generating redundant version.txt files.  We really just want to generate one version.txt file and use that for all of the produced packages.  In some repo's, like buildtools, this doesn't matter as much as in other repo's, like CoreFx, where there are multiple OSGroups for a build.  

This change moves the version.txt file to get generated in the obj directory, and creates a traversal build dependency so that the target gets called once before a traversal build.

@joperezr @weshaggard 