### PR TITLE
Enable reading versions file from URI

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -26,6 +26,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -197,13 +197,11 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private static async System.Threading.Tasks.Task<string> GetFileAsync(string uri)
         {
-            string contents = string.Empty;
             using (var stream = (File.Exists(uri)) ? File.OpenRead(uri) : await new HttpClient().GetStreamAsync(uri))
             using (StreamReader reader = new StreamReader(stream))
             {
-                contents = await reader.ReadToEndAsync();
+                return await reader.ReadToEndAsync();
             }
-            return contents;
         }
 
         // A versions file is of the form https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/master/Latest_Packages.txt

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -11,6 +11,7 @@
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Linq.Parallel": "4.0.1",
+    "System.Net.Http": "4.1.0",
     "System.Reflection.Metadata": "1.3.0",
     "System.Xml.XPath.XmlDocument": "4.0.0"
   },


### PR DESCRIPTION
This change is necessary for our release branches where we want to be able to point to the latest versions of the release branch packages.

This change is in conjunction with https://github.com/dotnet/buildtools/pull/1105 to address servicing requirements.

@weshaggard @dagood 
