### PR TITLE
Fix test script generation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -151,7 +151,6 @@
   -->
   <Target Name="RunTestsForProject"
           DependsOnTargets="DiscoverTestInputs;CheckTestCategories"
-          Condition="'$(TestDisabled)' != 'true'"
           Inputs="@(RunTestsForProjectInputs)"
           Outputs="$(TestsSuccessfulSemaphore);$(TestPath)%(TestNugetTargetMoniker.Folder)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
           >
@@ -259,6 +258,7 @@
     />
 
     <Exec Command="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(RunnerScriptName) $(PackagesDir)"
+          Condition="'$(TestDisabled)' != 'true'"
           WorkingDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)"
           CustomErrorRegularExpression="Failed: [^0]"
           ContinueOnError="true"


### PR DESCRIPTION
RunTestsForProject not only runs the tests but also generates the
test runner script. As part of a recent clean-up that aspect was missed
with change https://github.com/dotnet/buildtools/commit/499458e3889a68b633be1bccc31eae6fe4f30191.

To get our official test runs working again we need to move the condition
to of TestDisabled!=true to the actual execution of thests instead of the
RunTestsForProject target.

In the future we need to split this logic into mutliple targets if we need the
logic for different purposes.

@MattGal PTAL - This should get us unblocked for the time being until we can spend some time refactoring these targets.