### PR TITLE
Keep old packages in file when updating Latest_Packages

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubApiModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubApiModel.cs
@@ -43,6 +43,12 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
         public int Number { get; set; }
     }
 
+    public class GitHubContents
+    {
+        public string Sha { get; set; }
+        public string Content { get; set; }
+    }
+
     public class GitCommit
     {
         public string Sha { get; set; }
@@ -65,5 +71,23 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
     public class GitReferenceObject
     {
         public string Sha { get; set; }
+    }
+
+    public class GitTree
+    {
+        public string Sha { get; set; }
+    }
+
+    public class GitObject
+    {
+        public const string TypeBlob = "blob";
+
+        public const string ModeFile = "100644";
+
+        public string Path { get; set; }
+        public string Mode { get; set; }
+        public string Type { get; set; }
+        public string Sha { get; set; }
+        public string Content { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -44,6 +44,28 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             _httpClient.DefaultRequestHeaders.Add("User-Agent", auth.User);
         }
 
+        public async Task<GitHubContents> GetGitHubFileAsync(
+            string path,
+            GitHubBranch branch)
+        {
+            string url = $"https://api.github.com/repos/{branch.Project.Segments}/contents/{path}?ref=heads/{branch.Name}";
+
+            Trace.TraceInformation($"Getting contents of '{path}' using '{url}'");
+
+            using (HttpResponseMessage response = await _httpClient.GetAsync(url))
+            {
+                return await DeserializeSuccessfulAsync<GitHubContents>(response);
+            }
+        }
+
+        public async Task<string> GetGitHubFileContentsAsync(
+            string path,
+            GitHubBranch branch)
+        {
+            GitHubContents file = await GetGitHubFileAsync(path, branch);
+            return FromBase64(file.Content);
+        }
+
         public async Task PutGitHubFileAsync(
             string fileUrl,
             string commitMessage,
@@ -179,11 +201,7 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
 
             using (HttpResponseMessage response = await _httpClient.GetAsync(pullRequestUrl))
             {
-                await EnsureSuccessfulAsync(response);
-
-                return JsonConvert.DeserializeObject<GitHubPullRequest>(
-                    await response.Content.ReadAsStringAsync(),
-                    s_jsonSettings);
+                return await DeserializeSuccessfulAsync<GitHubPullRequest>(response);
             }
         }
 
@@ -209,12 +227,8 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
 
             using (HttpResponseMessage response = await _httpClient.GetAsync(url))
             {
-                await EnsureSuccessfulAsync(response);
-                Trace.TraceInformation($"Got info about commit {sha} in {project.Segments}");
-
-                return JsonConvert.DeserializeObject<GitCommit>(
-                    await response.Content.ReadAsStringAsync(),
-                    s_jsonSettings);
+                Trace.TraceInformation($"Getting info about commit {sha} in {project.Segments}");
+                return await DeserializeSuccessfulAsync<GitCommit>(response);
             }
         }
 
@@ -224,18 +238,86 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
 
             using (HttpResponseMessage response = await _httpClient.GetAsync(url))
             {
-                await EnsureSuccessfulAsync(response);
-                Trace.TraceInformation($"Got info about ref {@ref} in {project.Segments}");
+                Trace.TraceInformation($"Getting info about ref {@ref} in {project.Segments}");
+                return await DeserializeSuccessfulAsync<GitReference>(response);
+            }
+        }
 
-                return JsonConvert.DeserializeObject<GitReference>(
-                    await response.Content.ReadAsStringAsync(),
-                    s_jsonSettings);
+        public async Task<GitTree> PostTreeAsync(GitHubProject project, string baseTree, GitObject[] tree)
+        {
+            string body = JsonConvert.SerializeObject(new
+            {
+                base_tree = baseTree,
+                tree
+            }, Formatting.Indented, s_jsonSettings);
+
+            string url = $"https://api.github.com/repos/{project.Segments}/git/trees";
+
+            var bodyContent = new StringContent(body);
+            using (HttpResponseMessage response = await _httpClient.PostAsync(url, bodyContent))
+            {
+                Trace.TraceInformation($"Posting new tree to {project.Segments}");
+                return await DeserializeSuccessfulAsync<GitTree>(response);
+            }
+        }
+
+        public async Task<GitCommit> PostCommitAsync(
+            GitHubProject project,
+            string message,
+            string tree,
+            string[] parents)
+        {
+            string body = JsonConvert.SerializeObject(new
+            {
+                message,
+                tree,
+                parents
+            }, Formatting.Indented);
+
+            string url = $"https://api.github.com/repos/{project.Segments}/git/commits";
+
+            var bodyContent = new StringContent(body);
+            using (HttpResponseMessage response = await _httpClient.PostAsync(url, bodyContent))
+            {
+                Trace.TraceInformation($"Posting new commit for tree '{tree}' with parents '{string.Join(", ", parents)}' to {project.Segments}");
+                return await DeserializeSuccessfulAsync<GitCommit>(response);
+            }
+        }
+
+        public async Task<GitReference> PatchReferenceAsync(GitHubProject project, string @ref, string sha, bool force)
+        {
+            string body = JsonConvert.SerializeObject(new
+            {
+                sha,
+                force
+            }, Formatting.Indented);
+
+            string url = $"https://api.github.com/repos/{project.Segments}/git/refs/{@ref}";
+
+            var bodyContent = new StringContent(body);
+            HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), url)
+            {
+                Content = bodyContent
+            };
+            using (HttpResponseMessage response = await _httpClient.SendAsync(request))
+            {
+                Trace.TraceInformation($"Patching reference '{@ref}' to '{sha}' with force={force} in {project.Segments}");
+                return await DeserializeSuccessfulAsync<GitReference>(response);
             }
         }
 
         public void Dispose()
         {
             _httpClient.Dispose();
+        }
+
+        private static async Task<T> DeserializeSuccessfulAsync<T>(HttpResponseMessage response)
+        {
+            await EnsureSuccessfulAsync(response);
+
+            return JsonConvert.DeserializeObject<T>(
+                await response.Content.ReadAsStringAsync(),
+                s_jsonSettings);
         }
 
         private static async Task EnsureSuccessfulAsync(HttpResponseMessage response)
@@ -268,5 +350,6 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
         }
 
         private static string ToBase64(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+        private static string FromBase64(string value) => Encoding.UTF8.GetString(Convert.FromBase64String(value));
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -106,13 +106,13 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
                         if (updateLatestPackageList)
                         {
-                            string path = $"{versionsRepoPath}/Latest_Packages.txt";
+                            string latestPackagesPath = $"{versionsRepoPath}/Latest_Packages.txt";
 
                             var allPackages = new Dictionary<string, string>(packageDictionary);
 
                             if (updateLastBuildPackageList)
                             {
-                                Dictionary<string, string> existingPackages = await GetPackagesAsync(client, path);
+                                Dictionary<string, string> existingPackages = await GetPackagesAsync(client, latestPackagesPath);
 
                                 // Add each existing package if there isn't a new package with the same id.
                                 foreach (var package in existingPackages)
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
                             objects.Add(new GitObject
                             {
-                                Path = path,
+                                Path = latestPackagesPath,
                                 Type = GitObject.TypeBlob,
                                 Mode = GitObject.ModeFile,
                                 Content = CreatePackageListFile(allPackages)

--- a/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.VersionTools
             return $"{rawRepoUrl}/{gitRef}/{buildInfoPath}";
         }
 
-        private static async Task<Dictionary<string, string>> ReadPackageListAsync(TextReader reader)
+        public static async Task<Dictionary<string, string>> ReadPackageListAsync(TextReader reader)
         {
             var packages = new Dictionary<string, string>();
             string currentLine;


### PR DESCRIPTION
Adds a new build-info file `Last_Build_Packages.txt` that stores only the new packages. When creating `Last_Build_Packages` is enabled, the update to `Latest_Packages` carries the existing `Latest_Packages` entries over into the new version.

Also includes changes to publish all build-info files in a single commit.

Fixes (once uptaken) https://github.com/dotnet/buildtools/issues/1117.

Example commit, using some odd packages I had lying around: https://github.com/dagood/versions/commit/e34d05821c5c713ce8fa1a4f0d95bc7428fc893a.

@chcosta @weshaggard @karajas
/cc @eerhardt 