### PR TITLE
Move project-nuget-dependencies.md from corefx

### DIFF
--- a/Documentation/annotated-dependency-props.md
+++ b/Documentation/annotated-dependency-props.md
@@ -1,6 +1,6 @@
 # Annotated dependencies.props
 
-This file is used in CoreFX, CoreCLR, WCF, and BuildTools, and it isn't immediately clear how it's used for auto-updates, and how it's updated by auto-update. Below is a breakdown of [corefx's master dependencies.props](https://github.com/dotnet/corefx/blob/b57a43bb40fc2099e91d641a8b4f8c76a46afe6a/dependencies.props):
+This file is used in CoreFX, CoreCLR, WCF, and BuildTools, located in the repository root. Below is a breakdown of [corefx's master dependencies.props](https://github.com/dotnet/corefx/blob/b57a43bb40fc2099e91d641a8b4f8c76a46afe6a/dependencies.props). It is used for dependency auto-upgrade and dependency verification.
 
 ``` xml
 <PropertyGroup>

--- a/Documentation/project-nuget-dependencies.md
+++ b/Documentation/project-nuget-dependencies.md
@@ -1,0 +1,38 @@
+# Project NuGet Dependencies
+
+## Dependency version verification
+
+The dependencies in each project.json file are validated by a few rules in `dependencies.props` to ensure package versions across the repository stay in sync. Dependencies are normally verified before the NUuGet restore step, but to manually verify run the `VerifyDependencies` MSBuild target.
+
+Errors from failed dependency version validation are like the following:
+
+    C:\git\corefx\Tools\VersionTools.targets(47,5): error : Dependency verification errors detected. To automatically fix based on dependency rules, run the msbuild target 'UpdateDependencies' [C:\git\corefx\build.proj]
+    C:\git\corefx\Tools\VersionTools.targets(47,5): error : Dependencies invalid: In 'C:\git\corefx\src\Common\test-runtime\project.json', 'Microsoft.DotNet.BuildTools.TestSuite 1.0.0-prerelease-00704-04' must be '1.0.0-prerelease-00704-05' (Microsoft.DotNet.BuildTools.TestSuite) [C:\git\corefx\build.proj]
+    C:\git\corefx\Tools\VersionTools.targets(47,5): error : Dependencies invalid: In 'C:\git\corefx\src\Common\tests\project.json', 'Microsoft.xunit.netcore.extensions 1.0.0-prerelease-00704-04' must be '1.0.0-prerelease-00704-05' (Microsoft.xunit.netcore.extensions) [C:\git\corefx\build.proj]
+
+To automatically fix these by setting the versions to expected values, use the `UpdateDependencies` target. `UpdateDependencies` can also be used to automatically update package versions, described in the next section.
+
+If an expected value looks wrong, edit `dependencies.props` to change it. See [annotated-dependency-props.md](annotated-dependency-props.md) for an explanation of `dependencies.props`.
+
+
+## Upgrading a package dependency
+
+To update a package that isn't validated by a rule, simply change the project.json file.
+
+Otherwise, follow these steps:
+
+ 1. Edit `dependencies.props` to match the new expectations. See [annotated-dependency-props.md](annotated-dependency-props.md).
+ 2. Run the dependency update target in the repository root. In corefx, use this command:
+
+        build-managed.cmd -- /t:UpdateDependencies
+
+    Other repositories have slightly different ways to run targets.
+
+ 3. Commit the automated updates in an independent commit, isolating them from other changes. This makes pull requests easier to review because updates can change many files.
+
+The `UpdateDependencies` target looks through all dependencies, using the validation rules to update any invalid versions. On `/verbosity:Normal` or higher, it logs which files were changed.
+
+
+## Dependency auto-update
+
+Dependency auto-update uses the dependency update/verify system to submit automated pull requests for package updates. See [dependency-auto-update.md](dependency-auto-update.md) for details.


### PR DESCRIPTION
Brings over https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/project-nuget-dependencies.md with some edits to make it more general. Slight edit to annotated-dependency-props.md for more generality.

This doc is for the non-auto-update side of the dependency tooling.

I changed https://github.com/dotnet/corefx/pull/12554 to point to this new buildtools doc instead of adding another link for auto-update.

@weshaggard @markwilkie 