### PR TITLE
Allow BuildAgainstPackages to work with global test project.json 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -323,7 +323,7 @@ namespace Microsoft.DotNet.Build.Tasks
                                     if (jo["version"] != null)
                                     {
                                         jo.Remove("version");
-                                        jo.Add("version", nuGetVersion.ToString());
+                                        jo["version"] = nuGetVersion.ToString();
                                     }
                                     else
                                     {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -39,12 +39,12 @@
   </PropertyGroup>
   
   <PropertyGroup>
-      <GenerateTestProjectJsonDependsOn Condition="'$(SkipGenerateTestProjectJson)'=='false'">
-        ExtractProjectReferences;
-        GatherProjectReferenceForProjectJson;
-        DetermineProjectJsonPath;
-        AddDependenciesToProjectJson
-      </GenerateTestProjectJsonDependsOn>
+    <GenerateTestProjectJsonDependsOn Condition="'$(SkipGenerateTestProjectJson)'=='false'">
+      ExtractProjectReferences;
+      GatherProjectReferenceForProjectJson;
+      DetermineProjectJsonPath;
+      AddDependenciesToProjectJson
+    </GenerateTestProjectJsonDependsOn>
   </PropertyGroup>
  
   <Target Name="GenerateTestProjectJson" DependsOnTargets="$(GenerateTestProjectJsonDependsOn)" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -38,14 +38,14 @@
     </ResolveNuGetPackagesDependsOn>
   </PropertyGroup>
   
-    <PropertyGroup>
+  <PropertyGroup>
       <GenerateTestProjectJsonDependsOn Condition="'$(SkipGenerateTestProjectJson)'=='false'">
         ExtractProjectReferences;
         GatherProjectReferenceForProjectJson;
         DetermineProjectJsonPath;
         AddDependenciesToProjectJson
       </GenerateTestProjectJsonDependsOn>
-    </PropertyGroup>
+  </PropertyGroup>
  
   <Target Name="GenerateTestProjectJson" DependsOnTargets="$(GenerateTestProjectJsonDependsOn)" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -37,8 +37,21 @@
       DetermineProjectJsonPath;
     </ResolveNuGetPackagesDependsOn>
   </PropertyGroup>
-
-  <Target Name="GenerateTestProjectJson" DependsOnTargets="ExtractProjectReferences;GatherProjectReferenceForProjectJson;DetermineProjectJsonPath;AddDependenciesToProjectJson" />
+  
+  <!--This target is required to evaluate this property uniquely in the context of each project -->
+  <Target Name="EvaluateGenerateTestProjectJsonDependsOn" >
+    <PropertyGroup>
+      <GenerateTestProjectJsonDependsOn Condition="'$(SkipGenerateTestProjectJson)'=='false'">
+        ExtractProjectReferences;
+        GatherProjectReferenceForProjectJson;
+        DetermineProjectJsonPath;
+        AddDependenciesToProjectJson
+      </GenerateTestProjectJsonDependsOn>
+    </PropertyGroup>
+    <CallTarget Targets="$(GenerateTestProjectJsonDependsOn)"/>
+  </Target>
+ 
+  <Target Name="GenerateTestProjectJson" DependsOnTargets="EvaluateGenerateTestProjectJsonDependsOn" />
 
   <Target Name="GenerateAllTestProjectJsons" DependsOnTargets="GenerateTestProjectJson" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -38,8 +38,6 @@
     </ResolveNuGetPackagesDependsOn>
   </PropertyGroup>
   
-  <!--This target is required to evaluate this property uniquely in the context of each project -->
-  <Target Name="EvaluateGenerateTestProjectJsonDependsOn" >
     <PropertyGroup>
       <GenerateTestProjectJsonDependsOn Condition="'$(SkipGenerateTestProjectJson)'=='false'">
         ExtractProjectReferences;
@@ -48,10 +46,8 @@
         AddDependenciesToProjectJson
       </GenerateTestProjectJsonDependsOn>
     </PropertyGroup>
-    <CallTarget Targets="$(GenerateTestProjectJsonDependsOn)"/>
-  </Target>
  
-  <Target Name="GenerateTestProjectJson" DependsOnTargets="EvaluateGenerateTestProjectJsonDependsOn" />
+  <Target Name="GenerateTestProjectJson" DependsOnTargets="$(GenerateTestProjectJsonDependsOn)" />
 
   <Target Name="GenerateAllTestProjectJsons" DependsOnTargets="GenerateTestProjectJson" />
 


### PR DESCRIPTION
Check for use of common test project.json

Change AddDependenciesToProjectJson to allow for compile only assets in framework specific dependencies of common project.json