### PR TITLE
Fix for CleanPackagesCache behavior on Windows

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/clean.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/clean.targets
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <UserLocalFolder Condition="'$(OsEnvironment)'=='Windows_NT'">$(LocalAppData)/</UserLocalFolder>
     <UserLocalFolder Condition="'$(OsEnvironment)'!='Windows_NT'">$(HOME)/.local/share/</UserLocalFolder>
+    <UserProfileFolder Condition="'$(OsEnvironment)'=='Windows_NT'">$(UserProfile)</UserProfileFolder>
+    <UserProfileFolder Condition="'$(OsEnvironment)'!='Windows_NT'">$(HOME)</UserProfileFolder>
   </PropertyGroup>
 
   <Target Name="CleanPackages">
@@ -12,8 +14,7 @@
 
   <Target Name="CleanPackagesCache">
     <RemoveDir Directories="$(UserLocalFolder)NuGet/Cache/;$(UserLocalFolder)NuGet/v3-cache/;$(UserLocalFolder)dnu/cache/" />
-    <!-- On Windows, there may also be a package cache under the user profile -->
-    <RemoveDir Condition="'$(OsEnvironment)'=='Windows_NT'" Directories="$(UserProfile)\.nuget\packages" />
+    <RemoveDir Directories="$(UserProfileFolder)/.nuget/packages" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/clean.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/clean.targets
@@ -2,8 +2,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <UserLocalFolder Condition="'$(OsEnvironment)'!='Unix'">$(LocalAppData)/</UserLocalFolder>
-    <UserLocalFolder Condition="'$(OsEnvironment)'=='Unix'">$(HOME)/.local/share/</UserLocalFolder>
+    <UserLocalFolder Condition="'$(OsEnvironment)'=='Windows_NT'">$(LocalAppData)/</UserLocalFolder>
+    <UserLocalFolder Condition="'$(OsEnvironment)'!='Windows_NT'">$(HOME)/.local/share/</UserLocalFolder>
   </PropertyGroup>
 
   <Target Name="CleanPackages">
@@ -12,6 +12,8 @@
 
   <Target Name="CleanPackagesCache">
     <RemoveDir Directories="$(UserLocalFolder)NuGet/Cache/;$(UserLocalFolder)NuGet/v3-cache/;$(UserLocalFolder)dnu/cache/" />
+    <!-- On Windows, there may also be a package cache under the user profile -->
+    <RemoveDir Condition="'$(OsEnvironment)'=='Windows_NT'" Directories="$(UserProfile)\.nuget\packages" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Update condition for folder choice to "Windows/not windows" since OSX and Linux use the same paths, and add a Windows-specific one for the C:\users\<user>\.nuget\packages folder.

@maririos ; @dagood 