### PR TITLE
Add TargetGroup to the dependency list file to avoid clashes

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -206,6 +206,8 @@
     <MakeDir Directories="$(OutputFolderForTestDependencies)" />
     <PropertyGroup>
       <_TestDependencyListRoot>$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
+      <_TestDependencyListRoot Condition="'$(TargetGroup)' != ''">$(_TestDependencyListRoot).$(TargetGroup)</_TestDependencyListRoot>
+      <_TestDependencyListRoot Condition="'$(TargetGroup)' == ''">$(_TestDependencyListRoot).default</_TestDependencyListRoot>
       <_TestDependencyListRoot Condition="'$(TestTFM)' != ''">$(_TestDependencyListRoot).$(TestTFM)</_TestDependencyListRoot>
       <_TestDependencyListFileName>$(_TestDependencyListRoot).dependencylist.txt</_TestDependencyListFileName>
       <TestDependencyListFilePath>$(OutputFolderForTestDependencies)/$(_TestDependencyListFileName)</TestDependencyListFilePath>


### PR DESCRIPTION
cc: @weshaggard @MattGal 
FYI: @karajas @tarekgh 

Adding `TargetGroup` to the dependency list file name, which will help avoid race conditions of two builds trying to write to the same file, which has caused some intermittent build brakes.