### PR TITLE
Generate layout from package reports

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackageReports.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackageReports.cs
@@ -36,6 +36,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         public ITaskItem[] RuntimeAssets { get; set; }
 
         [Output]
+        public ITaskItem[] NativeAssets { get; set; }
+
+        [Output]
         public ITaskItem[] BuildProjects { get; set; }
 
         /// <summary>
@@ -63,6 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             var compileAssets = new List<ITaskItem>();
             var runtimeAssets = new List<ITaskItem>();
+            var nativeAssets = new List<ITaskItem>();
             var buildProjects = new List<BuildProject>();
 
             foreach (var reportPath in PackageReports)
@@ -76,6 +80,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     buildProjects.AddRange(target.CompileAssets.Select(c => c.SourceProject).Where(bp => bp != null));
                     runtimeAssets.AddRange(target.RuntimeAssets.Select(r => ItemFromApplicableAsset(r, report.Id, report.Version)));
                     buildProjects.AddRange(target.RuntimeAssets.Select(r => r.SourceProject).Where(bp => bp != null));
+                    nativeAssets.AddRange(target.NativeAssets.Select(r => ItemFromApplicableAsset(r, report.Id, report.Version)));
+                    buildProjects.AddRange(target.NativeAssets.Select(r => r.SourceProject).Where(bp => bp != null));
                 }
                 else
                 {
@@ -85,6 +91,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             CompileAssets = compileAssets.ToArray();
             RuntimeAssets = runtimeAssets.ToArray();
+            NativeAssets = nativeAssets.ToArray();
             BuildProjects = buildProjects.Distinct().Select(bp => bp.ToItem()).ToArray();
 
             return !Log.HasLoggedErrors;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLayoutFiles.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLayoutFiles.cs
@@ -1,0 +1,139 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class GetLayoutFiles : PackagingTask
+    {
+        /// <summary>
+        /// Package report files
+        /// </summary>
+        [Required]
+        public string[] PackageReports { get; set; }
+
+        /// <summary>
+        /// Destination directory for layout
+        /// </summary>
+        [Required]
+        public string DestinationDirectory { get; set; }
+
+        /// <summary>
+        /// Optional set of frameworks to restrict the layout
+        ///   Identity: Framework
+        ///   RuntimeIDs: Semi-colon seperated list of runtime IDs
+        /// </summary>
+        public ITaskItem[] Frameworks { get; set; }
+
+        /// <summary>
+        /// Files to be copied to layout
+        ///   Identity : source path
+        ///   Destination : destination path
+        /// </summary>
+        [Output]
+        public ITaskItem[] LayoutFiles { get; set; }
+        
+        public override bool Execute()
+        {
+            var frameworks = Frameworks.NullAsEmpty().ToDictionary(
+                i => NuGetFramework.Parse(i.ItemSpec),
+                i => 
+                {
+                    var rids = i.GetMetadata("RuntimeIds");
+                    return String.IsNullOrEmpty(rids) ? new HashSet<string>() : new HashSet<string>(rids.Split(';'));
+                },
+                NuGetFramework.Comparer);
+
+            var layoutFiles = new List<ITaskItem>();
+
+            foreach(var packageReportFile in PackageReports)
+            {
+                var packageReport = PackageReport.Load(packageReportFile);
+
+                foreach(var targetInfo in packageReport.Targets)
+                {
+                    var targetName = targetInfo.Key;
+                    var target = targetInfo.Value;
+
+                    var targetParts = targetName.Split('/');
+
+                    var fx = NuGetFramework.Parse(targetParts[0]);
+                    string rid = null;
+
+                    if (targetParts.Length > 1)
+                    {
+                        rid = targetParts[1];
+                    }
+                    
+                    if (frameworks.Count != 0)
+                    {
+                        HashSet<string> rids = null;
+
+                        if (!frameworks.TryGetValue(fx, out rids))
+                        {
+                            Log.LogMessage(LogImportance.Low, $"Skipping {fx} since it is not in {nameof(Frameworks)}");
+                            continue;
+                        }
+
+                        if (rid != null && rids.Count > 0 && !rids.Contains(rid))
+                        {
+                            Log.LogMessage(LogImportance.Low, $"Skipping {fx}/{rid} since it is not in {nameof(Frameworks)}");
+                            continue;
+                        }
+                    }
+
+                    if (!packageReport.SupportedFrameworks.ContainsKey(fx.ToString()))
+                    {
+                        Log.LogMessage(LogImportance.Low, $"Skipping {fx} since it is not supported");
+                        continue;
+                    }
+
+                    if (rid == null)
+                    {
+                        // only consider compile assets for RID-less target
+                        foreach (var compileAsset in target.CompileAssets.Where(pa => !NuGetAssetResolver.IsPlaceholder(pa.LocalPath)))
+                        {
+                            layoutFiles.Add(CreateLayoutFile(compileAsset.LocalPath, "ref", fx));
+                        }
+                    }
+
+                    var runtimeAssets = target.RuntimeAssets.Concat(target.NativeAssets);
+                    foreach (var runtimeAsset in runtimeAssets.Where(pa => !NuGetAssetResolver.IsPlaceholder(pa.LocalPath)))
+                    {
+                        layoutFiles.Add(CreateLayoutFile(runtimeAsset.LocalPath, "runtime", fx, rid));
+                    }
+                }
+            }
+
+            LayoutFiles = layoutFiles.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private ITaskItem CreateLayoutFile(string source, string subfolder, NuGetFramework framework, string rid = null)
+        {
+            var item = new TaskItem(source);
+
+            var destination = Path.Combine(DestinationDirectory, subfolder, framework.GetShortFolderName());
+
+            if (rid != null)
+            {
+                destination = Path.Combine(destination, rid);
+            }
+
+            destination = Path.Combine(destination, Path.GetFileName(source));
+
+            item.SetMetadata("Destination", destination);
+
+            return item;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -20,6 +20,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="GetLayoutFiles.cs" />
     <Compile Include="FilterUnknownPackages.cs" />
     <Compile Include="GetPackageDestination.cs" />
     <Compile Include="GetApplicableAssetsFromPackageReports.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -62,6 +62,7 @@
     <Compile Include="SplitReferences.cs" />
     <Compile Include="ValidatePackage.cs" />
     <Compile Include="PackageReport.cs" />
+    <Compile Include="VerifyClosure.cs" />
     <Compile Include="VersionUtility.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -71,6 +71,7 @@
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(PackageOutputPath)reports/</PackageReportDir>
+    <PackageLayoutDir Condition="'$(PackageLayoutDir)' == ''">$(PackageOutputPath)layout/</PackageLayoutDir>
     <PackageReportPath>$(PackageReportDir)$(Id)$(NuspecSuffix).json</PackageReportPath>
     <TargetPath>$(NuSpecPath)</TargetPath>
     <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)/runtime.json</RuntimeFilePath>
@@ -110,6 +111,8 @@
   <UsingTask TaskName="FilterUnknownPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GeneratePackageReport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="InstallPackageFromFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GetLayoutFiles" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+
   
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms
@@ -1251,4 +1254,28 @@
                         ModuleToPackages="@(ModuleToPackage)" />
   </Target>
 
+  <Target Name="CreateLayout"
+          Condition="'$(IsRuntimePackage)' != 'true'"
+          DependsOnTargets="GetPackageReport">
+
+    <GetLayoutFiles PackageReports="$(PackageReportPath)"
+                    DestinationDirectory="$(PackageLayoutDir)">
+      <Output TaskParameter="LayoutFiles" ItemName="LayoutFiles"/>
+    </GetLayoutFiles>
+
+    <ItemGroup>
+      <_missingLayoutFiles Include="@(LayoutFiles)" Condition="!Exists('%(FullPath)')" />
+      <LayoutFiles Remove="@(_missingLayoutFiles)" />
+    </ItemGroup>
+
+    <Message Text="Skipping '%(_missingLayoutFiles.FullPath) because it does not exist." Condition="'@(_missingLayoutFiles)' != ''" />
+
+    <Copy SourceFiles="@(LayoutFiles)"
+          DestinationFiles="@(LayoutFiles->'%(Destination)')"
+          SkipUnchangedFiles="true"
+          OverwriteReadOnlyFiles="true"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="true" />
+  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -933,7 +933,7 @@
       <RuntimeIDs>win7-x86;win7-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;linuxmint.17-x64;opensuse.13.2-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="netcoreapp1.1">
-      <RuntimeIDs>win7-x86;win7-x64;win10-arm64;osx.10.11-x64;centos.7-x64;debian.8-x64;linuxmint.17-x64;opensuse.13.2-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64</RuntimeIDs>
+      <RuntimeIDs>win7-x86;win7-x64;win10-arm64;alpine.3.4.3-x64;osx.10.10-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;linuxmint.17-x64;opensuse.13.2-x64;opensuse.42.1-x64;rhel.7-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64</RuntimeIDs>
     </DefaultValidateFramework>
 
     <DefaultValidateFramework Include="netcore50">

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -112,6 +112,7 @@
   <UsingTask TaskName="GeneratePackageReport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="InstallPackageFromFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
   <UsingTask TaskName="GetLayoutFiles" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="VerifyClosure" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
   
   <!-- Determine if we actually need to build for this architecture -->

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -129,9 +129,11 @@
     <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND $(PackageTargetRuntime.Contains('-$(PackagePlatform)'))">true</ShouldGenerateNuSpec>
     <!-- build if PackagePlatforms is not specified and arch is x86 or AnyCPU -->
     <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND ('$(PackagePlatform)' == 'x86' OR '$(PackagePlatform)' == 'AnyCPU')">true</ShouldGenerateNuSpec>
-    <!-- if we built a nuspec, also pack unless explicitly set -->
+    <!-- if we built a nuspec, also create layout and pack unless explicitly set -->
+    <ShouldCreateLayout Condition="'$(ShouldCreateLayout)' == ''">$(ShouldGenerateNuSpec)</ShouldCreateLayout>
     <ShouldCreatePackage Condition="'$(ShouldCreatePackage)' == ''">$(ShouldGenerateNuSpec)</ShouldCreatePackage>
     <BuildDependsOn Condition="'$(ShouldGenerateNuSpec)' == 'true'">GenerateNuSpec</BuildDependsOn>
+    <BuildDependsOn Condition="'$(ShouldCreateLayout)' == 'true'">$(BuildDependsOn);CreateLayout</BuildDependsOn>
     <BuildDependsOn Condition="'$(ShouldCreatePackage)' == 'true'">$(BuildDependsOn);CreatePackage</BuildDependsOn>
     <BuildDependsOn Condition="'$(ShouldCreatePackage)' == 'true' OR '$(ShouldGenerateNuSpec)' == 'true'">$(BuildDependsOn);GetPackageReport;ValidatePackage</BuildDependsOn>
   </PropertyGroup>
@@ -1258,7 +1260,12 @@
           Condition="'$(IsRuntimePackage)' != 'true'"
           DependsOnTargets="GetPackageReport">
 
+    <ItemGroup>
+      <LayoutFrameworks Condition="'@(LayoutFrameworks)' == ''" Include="NETCoreApp,Version=v1.1" />
+    </ItemGroup>
+
     <GetLayoutFiles PackageReports="$(PackageReportPath)"
+                    Frameworks="@(LayoutFrameworks)"
                     DestinationDirectory="$(PackageLayoutDir)">
       <Output TaskParameter="LayoutFiles" ItemName="LayoutFiles"/>
     </GetLayoutFiles>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
@@ -1,0 +1,417 @@
+﻿using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    /// <summary>
+    /// Verifies the closure of a set of DLLs, making sure all files are present and no cycles exist
+    /// </summary>
+    public class VerifyClosure : PackagingTask
+    {
+
+        /// <summary>
+        /// Sources to scan.  Items can be directories or files.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+        
+        /// <summary>
+        /// Dependencies to ignore.
+        ///     Identity: FileName
+        ///     Version: Maximum version to ignore, if not specified all versions will be ignored.
+        /// </summary>
+        public ITaskItem[] IgnoredReferences { get; set; }
+
+
+        public bool CheckModuleReferences { get; set; }
+
+
+        private Dictionary<string, AssemblyInfo> assemblies = new Dictionary<string, AssemblyInfo>();
+        private HashSet<string> otherFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, Version> ignoredReferences = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
+        
+        public override bool Execute()
+        {
+            if (Sources == null || Sources.Length == 0)
+            {
+                Log.LogError("No sources to scan.");
+                return false;
+            }
+
+            LoadSources();
+            LoadIgnoredReferences();
+
+            foreach(var assembly in assemblies.Values)
+            {
+                CheckDependencies(assembly);
+            }
+
+            foreach(var assembly in assemblies.Values)
+            {
+                DumpCycles(assembly);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private void LoadSources()
+        {
+            foreach (var source in Sources)
+            {
+                var path = source.GetMetadata("FullPath");
+
+                if (Directory.Exists(path))
+                {
+                    foreach (var file in Directory.EnumerateFiles(path))
+                    {
+                        AddSourceFile(file);
+                    }
+                }
+                else
+                {
+                    AddSourceFile(path);
+                }
+            }
+        }
+
+        private void AddSourceFile(string file)
+        {
+            var assemblyInfo = AssemblyInfo.GetAssemblyInfo(file);
+
+            if (assemblyInfo == null)
+            {
+                otherFiles.Add(Path.GetFileName(file));
+            }
+            else
+            {
+                AssemblyInfo existingInfo;
+                if (assemblies.TryGetValue(assemblyInfo.Name, out existingInfo))
+                {
+                    Log.LogError($"Duplicate entries for {assemblyInfo.Name} : {assemblyInfo.Path} & {existingInfo.Path}");
+                }
+                else
+                {
+                    assemblies[assemblyInfo.Name] = assemblyInfo;
+                }
+            }
+        }
+
+        private void LoadIgnoredReferences()
+        {
+            foreach (var ignoredReference in IgnoredReferences.NullAsEmpty())
+            {
+                var name = ignoredReference.ItemSpec;
+                var versionString = ignoredReference.GetMetadata("Version");
+                Version version = null;
+
+                if (!string.IsNullOrEmpty(versionString))
+                {
+                    version = Version.Parse(versionString);
+                }
+
+                Version existingVersion;
+
+                if (!ignoredReferences.TryGetValue(name, out existingVersion) ||
+                    (existingVersion != null && (version == null || version > existingVersion)))
+                {
+                    ignoredReferences[name] = version;
+                }
+            }
+        }
+
+        private bool ShouldIgnore(string moduleReference)
+        {
+            return ignoredReferences.ContainsKey(moduleReference);
+        }
+
+        private bool ShouldIgnore(AssemblyReference reference)
+        {
+            Version toIgnore;
+            return ignoredReferences.TryGetValue(reference.Name, out toIgnore) && (toIgnore == null || toIgnore >= reference.Version);
+        }
+
+        void CheckDependencies(AssemblyInfo assembly)
+        {
+            if (assembly.State == CheckState.Unchecked)
+            {
+                var depStack = new Stack<AssemblyInfo>();
+                depStack.Push(assembly);
+
+                CheckDependencies(depStack);
+            }
+        }
+
+        void CheckDependencies(Stack<AssemblyInfo> depStack)
+        {
+            AssemblyInfo assm = depStack.Peek();
+
+            // check module references
+            if (assm.State == CheckState.Unchecked && CheckModuleReferences)
+            {
+                foreach(var moduleReference in assm.ModuleReferences.NullAsEmpty())
+                {
+                    if (ShouldIgnore(moduleReference))
+                    {
+                        continue;
+                    }
+
+                    if (!otherFiles.Contains(moduleReference))
+                    {
+                        Log.LogError($"Assembly '{assm.Name}' is missing module dependency '{moduleReference}'");
+                    }
+                }
+            }
+            
+            // walk dependencies
+            foreach (var dep in assm.References)
+            {
+                if (ShouldIgnore(dep))
+                {
+                    continue;
+                }
+
+                AssemblyInfo depAssm;
+
+                assemblies.TryGetValue(dep.Name, out depAssm);
+
+                if (assm.State == CheckState.Unchecked)
+                {
+                    // first time we've seen this assembly, validate that its dependencies are satisfied
+                    if (depAssm == null)
+                    {
+                        Log.LogError($"Assembly '{assm.Name}' is missing dependency '{dep.Name}'");
+                    }
+                    else if (depAssm.Version < dep.Version)
+                    {
+                        Log.LogError($"Assembly '{assm.Name}' has insufficient version for dependency '{dep.Name}' : {depAssm.Version} < {dep.Version}.");
+                    }
+                }
+
+                // missing dependency
+                if (depAssm == null)
+                {
+                    continue;
+                }
+
+                if (depAssm.State == CheckState.HasCycle)
+                {
+                    // Don't bother finding multiple cycles for the same assembly.
+                    // We'll do a second pass to dump all cycles.
+                    continue;
+                }
+
+                if (depStack.Contains(depAssm))
+                {
+                    depAssm.State = CheckState.HasCycle;
+
+                }
+                else
+                {
+                    depStack.Push(depAssm);
+                    CheckDependencies(depStack);
+                }
+            }
+
+            if (assm.State == CheckState.Unchecked)
+            {
+                Log.LogMessage(LogImportance.Low, $"Checked {assm.Path}");
+                assm.State = CheckState.Checked;
+            }
+
+            depStack.Pop();
+        }
+
+        void DumpCycles(AssemblyInfo assembly)
+        {
+            if (assembly.State == CheckState.HasCycle)
+            {
+                var depStack = new Stack<AssemblyInfo>();
+                depStack.Push(assembly);
+
+                var suspectCycles = new Dictionary<AssemblyInfo, AssemblyInfo[]>();
+                
+                DumpCycles(depStack, assembly, suspectCycles);
+                
+                StringBuilder cycleError = new StringBuilder();
+                Log.LogError($"Cycle detected for {assembly.Path}.");
+
+                foreach(var suspectCycle in suspectCycles)
+                {
+                    Log.LogError(PrintCycle(suspectCycle.Value));
+                }
+            }
+        }
+
+        void DumpCycles(Stack<AssemblyInfo> depStack, AssemblyInfo root, Dictionary<AssemblyInfo, AssemblyInfo[]> suspectCycles)
+        {
+            AssemblyInfo assm = depStack.Peek();
+
+            foreach (var dep in assm.References)
+            {
+                if (ShouldIgnore(dep))
+                {
+                    continue;
+                }
+
+                AssemblyInfo depAssm;
+
+                if (!assemblies.TryGetValue(dep.Name, out depAssm))
+                {
+                    continue;
+                }
+
+                if (depAssm != root && depStack.Contains(depAssm))
+                {
+                    // ignore other cycles but halt traversal
+                    continue;
+                }
+
+                depStack.Push(depAssm);
+
+                if (depAssm == root)
+                {
+                    // we found a cycle for the specified root
+                    var cycle = depStack.Reverse().ToArray();
+                    Log.LogMessage($"Cycle detected for {depAssm.Path} : {PrintCycle(cycle)}.");
+
+                    var suspectAssembly = cycle.First(a => a != root);
+
+                    AssemblyInfo[] existingCycle;
+                    if (!suspectCycles.TryGetValue(suspectAssembly, out existingCycle) ||
+                        existingCycle.Length > cycle.Length)
+                    {
+                        // keep the shortest cycle for a unique dependency from the root.
+                        suspectCycles[suspectAssembly] = cycle;
+                    }
+                }
+                else
+                {
+                    // not a cycle, continue traversal
+                    DumpCycles(depStack, root, suspectCycles);
+                }
+                depStack.Pop();
+            }
+        }
+
+        private string PrintCycle(AssemblyInfo[] cycleStack)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            foreach (var assmebly in cycleStack)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(" > ");
+                }
+                builder.Append(assmebly.Name);
+            }
+
+            return builder.ToString();
+        }
+
+        class AssemblyInfo
+        {
+            public AssemblyInfo(string path, string name, Version version, AssemblyReference[] references, string[] moduleReferences)
+            {
+                Path = path;
+                Name = name;
+                Version = version;
+                References = references;
+                ModuleReferences = moduleReferences;
+                State = CheckState.Unchecked;
+            }
+
+            public string Path { get; }
+            public string Name { get; }
+            public Version Version { get; }
+            public AssemblyReference[] References { get; }
+            public string[] ModuleReferences { get; }
+            public CheckState State { get; set; }
+
+            public static AssemblyInfo GetAssemblyInfo(string path)
+            {
+                try
+                {
+                    using (PEReader peReader = new PEReader(new FileStream(path, FileMode.Open, FileAccess.Read)))
+                    {
+                        if (peReader.HasMetadata)
+                        {
+                            MetadataReader contractReader = peReader.GetMetadataReader();
+                            AssemblyDefinition assembly = contractReader.GetAssemblyDefinition();
+
+                            var name = contractReader.GetString(assembly.Name);
+                            var version = assembly.Version;
+                            var references = GetAssemblyReferences(contractReader);
+                            var moduleReferences = GetModuleReferences(contractReader);
+
+                            return new AssemblyInfo(path, name, version, references, moduleReferences);
+                        }
+                    }
+                }
+                catch(BadImageFormatException)
+                {
+                    //not a PE
+                }
+
+                return null;
+            }
+
+            private static AssemblyReference[] GetAssemblyReferences(MetadataReader reader)
+            {
+                var count = reader.GetTableRowCount(TableIndex.AssemblyRef);
+                var references = new AssemblyReference[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    var reference = reader.GetAssemblyReference(MetadataTokens.AssemblyReferenceHandle(i + 1));
+                    references[i] = new AssemblyReference(reader.GetString(reference.Name), reference.Version);
+                }
+
+                return references.ToArray();
+            }
+
+            private static string[] GetModuleReferences(MetadataReader reader)
+            {
+                var count = reader.GetTableRowCount(TableIndex.ModuleRef);
+                var references = new string[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    var moduleRef = reader.GetModuleReference(MetadataTokens.ModuleReferenceHandle(i + 1));
+                    var moduleName = reader.GetString(moduleRef.Name);
+
+                    references[i] = moduleName;
+                }
+
+                return references;
+            }
+        }
+
+        class AssemblyReference
+        {
+            public AssemblyReference(string name, Version version)
+            {
+                Name = name;
+                Version = version;
+            }
+
+            public string Name { get; }
+            public Version Version { get; }
+        }
+        
+        enum CheckState
+        {
+            Unchecked,
+            HasCycle,
+            Checked
+        }
+    }
+}


### PR DESCRIPTION
This produces flat-file layout directories from corefx.

These look like
ref{tfm}\file.dll
runtime{tfm}{rid}\file.dll

/cc @weshaggard @Petermarcu @ellismg
