### PR TITLE
Changing TestNugetTargetMoniker to be a Property instead of an Item

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -33,7 +33,7 @@
   <Target Name="ResolvePkgProjReferences" Condition="'@(PkgProjAsset)' != ''" DependsOnTargets="$(ResolvePkgProjReferencesDependsOn)">
     <GetApplicableAssetsFromPackages PackageAssets="@(PkgProjAsset)" 
                                      TargetMonikers="$(NuGetTargetMoniker)"
-                                     RuntimeTargetMonikers="@(TestNuGetTargetMoniker)"
+                                     RuntimeTargetMonikers="$(TestNuGetTargetMoniker)"
                                      TargetRuntime="$(TestNugetRuntimeId)"
                                      RuntimeFile="$(RuntimeIdGraphDefinitionFile)">
       <Output TaskParameter="CompileAssets" ItemName="Reference" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -111,7 +111,7 @@
           AfterTargets="RunTestsForProject"
           Condition="'$(AnalyzePerfResults)' == 'true' and Exists('$(PerfRunOutputFile)')">
     <Exec Command="$(PerfAnalysisReportCommand)"
-          WorkingDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)"
+          WorkingDirectory="$(TestPath)"
           ContinueOnError="false">
       <Output PropertyName="PerfTestRunExitCode" TaskParameter="ExitCode" />
     </Exec>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -27,7 +27,7 @@
                                RuntimeIdentifier="$(TestNugetRuntimeId)"
                                ProjectLanguage="$(Language)"
                                ProjectLockFile="$(ProjectLockJson)"
-                               TargetMonikers="@(TestNugetTargetMoniker)">
+                               TargetMonikers="$(TestNugetTargetMoniker)">
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="TestCopyLocal" />
     </PrereleaseResolveNuGetPackageAssets>
 
@@ -111,19 +111,15 @@
       <CreateHardLinksForCopyTestToTestDirectoryIfPossible Condition="'$(CreateHardLinksForCopyTestToTestDirectoryIfPossible)'==''">$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)</CreateHardLinksForCopyTestToTestDirectoryIfPossible>
     </PropertyGroup>
 
-    <PropertyGroup>
-      <TestNugetTargetMonikerFolder>%(TestNugetTargetMoniker.Folder)</TestNugetTargetMonikerFolder>
-    </PropertyGroup>
-
     <ItemGroup>
       <SourcesToCopyToTestDir Include="@(RunTestsForProjectInputs)" />
-      <DestinationsForTestDir Include="@(RunTestsForProjectInputs->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)')" />
+      <DestinationsForTestDir Include="@(RunTestsForProjectInputs->'$(TestPath)\%(Filename)%(Extension)')" />
 
       <SourcesToCopyToTestDir Include="@(ContentWithTargetPath)" />
-      <DestinationsForTestDir Include="@(ContentWithTargetPath->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(TargetPath)')" />
+      <DestinationsForTestDir Include="@(ContentWithTargetPath->'$(TestPath)\%(TargetPath)')" />
 
       <SourcesToCopyToTestDir Include="@(OverridenRuntimeContent)" />
-      <DestinationsForTestDir Include="@(OverridenRuntimeContent->'$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)')" />
+      <DestinationsForTestDir Include="@(OverridenRuntimeContent->'$(TestPath)\%(Filename)%(Extension)')" />
     </ItemGroup>
 
     <Copy
@@ -138,8 +134,8 @@
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
     </Copy>
 
-    <Exec Condition="'$(OS)'=='Unix' and Exists('$(TestPath)%(TestNugetTargetMoniker.Folder)/corerun')"
-          Command="chmod a+x &quot;$(TestPath)%(TestNugetTargetMoniker.Folder)/corerun&quot;" />
+    <Exec Condition="'$(OS)'=='Unix' and Exists('$(TestPath)/corerun')"
+          Command="chmod a+x &quot;$(TestPath)/corerun&quot;" />
 
   </Target>
 
@@ -148,12 +144,7 @@
     Copies supplemental test data to the build output and test directories.
   -->
   <Target Name="CopySupplementalTestData"
-          AfterTargets="CopyTestToTestDirectory"
-          Inputs="@(SupplementalTestData)"
-          Outputs="%(TestNugetTargetMoniker.Folder)">
-    <PropertyGroup>
-      <TestNugetTargetMonikerFolder>%(TestNugetTargetMoniker.Folder)</TestNugetTargetMonikerFolder>
-    </PropertyGroup>
+          AfterTargets="CopyTestToTestDirectory">
     <!-- coalesce supplemental test data items with and without DestinationDir metadata -->
     <ItemGroup>
       <_SupplementalTestData Include="@(SupplementalTestData)" Condition="'%(DestinationDir)' != ''">
@@ -164,7 +155,7 @@
       </_SupplementalTestData>
     </ItemGroup>
     <ItemGroup>
-      <SupplementalTestDataTestDir Include="@(_SupplementalTestData->'$(TestPath)$(TestNugetTargetMonikerFolder)/%(DestinationDir)%(Filename)%(Extension)')" />
+      <SupplementalTestDataTestDir Include="@(_SupplementalTestData->'$(TestPath)/%(DestinationDir)%(Filename)%(Extension)')" />
       <SupplementalTestDataOutDir Include="@(_SupplementalTestData->'$(OutDir)%(DestinationDir)%(Filename)%(Extension)')" />
     </ItemGroup>
     <Copy
@@ -209,7 +200,7 @@
                                  Condition="'$(TestWithoutNativeImages)' != 'true' Or !$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').EndsWith('.ni.dll'))" >
         <PackageRelativePath Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.NugetPackageId)' != ''">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').Replace('$(PackagesDir)',''))</PackageRelativePath>
         <UseAbsolutePath Condition="'$(TestWithLocalLibraries)'=='true'">$([System.String]::Copy('%(_TestCopyLocalByFileNameWithoutDuplicates.SourcePath)').StartsWith('$(BinDir)'))</UseAbsolutePath>
-        <DestinationPath>$(TestPath)$(TestNugetTargetMonikerFolder)\%(Filename)%(Extension)</DestinationPath>
+        <DestinationPath>$(TestPath)\%(Filename)%(Extension)</DestinationPath>
       </_IncludedFileForTestsInVS>
       <_IncludedFileForTestsInVs Remove="@(_IncludedFileForTestsInVS)" Condition="Exists('%(DestinationPath)')" />
     </ItemGroup>
@@ -238,9 +229,9 @@
     </PropertyGroup>
 
     <!-- the project json and runner script files need to be included in the archive -->
-    <Copy SourceFiles="$(ProjectJson);$(ProjectLockJson)" DestinationFolder="$(TestPath)%(TestNugetTargetMoniker.Folder)" />
+    <Copy SourceFiles="$(ProjectJson);$(ProjectLockJson)" DestinationFolder="$(TestPath)" />
     <MakeDir Directories="$(TestArchiveDir)" />
-    <ZipFileCreateFromDirectory SourceDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)" DestinationArchive="$(TestArchiveDir)$(TestProjectName).zip" OverwriteDestination="true" />
+    <ZipFileCreateFromDirectory SourceDirectory="$(TestPath)" DestinationArchive="$(TestArchiveDir)$(TestProjectName).zip" OverwriteDestination="true" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -12,6 +12,13 @@
     <TestsSuccessfulSemaphore>tests.passed</TestsSuccessfulSemaphore>
   </PropertyGroup>
 
+  <!-- In case that TestPath is not yet set, default it here -->
+  <PropertyGroup>
+    <TestTargetOutputRelPath Condition="'$(TestTargetOutputRelPath)'=='' And '$(TargetGroup)'!='' And '$(TestTFM)'!=''">$(TargetGroup).$(TestTFM)/</TestTargetOutputRelPath>
+    <TestTargetOutputRelPath Condition="'$(TestTargetOutputRelPath)'=='' And '$(TargetGroup)'=='' And '$(TestTFM)'!=''">default.$(TestTFM)/</TestTargetOutputRelPath>
+    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)/$(MSBuildProjectName)/$(TestTargetOutputRelPath)</TestPath>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Split semicolon separated lists -->
     <WithCategoriesItems Include="$(WithCategories)" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -58,43 +58,20 @@
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.uwp.exe</XunitExecutable>
   </PropertyGroup>
 
-  <ItemGroup>
+  <PropertyGroup>
     <!-- Table to track mapping between TestNugetTargetMoniker and the corresponding TestTFM -->
-    <TestNugetTargetMoniker Include=".NETCoreApp,Version=v1.0" Condition="'$(TestTFM)' == 'netcoreapp1.0'">
-      <Folder>netcoreapp1.0</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETCoreApp,Version=v1.1" Condition="'$(TestTFM)' == 'netcoreapp1.1'">
-      <Folder>netcoreapp1.1</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.3" Condition="'$(TestTFM)' == 'net463'">
-      <Folder>net463</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.2" Condition="'$(TestTFM)' == 'net462'">
-      <Folder>net462</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6.1" Condition="'$(TestTFM)' == 'net461'">
-      <Folder>net461</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.6" Condition="'$(TestTFM)' == 'net46'">
-      <Folder>net46</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5" Condition="'$(TestTFM)' == 'net45'">
-      <Folder>net45</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5.1" Condition="'$(TestTFM)' == 'net451'">
-      <Folder>net451</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include=".NETFramework,Version=v4.5.2" Condition="'$(TestTFM)' == 'net452'">
-      <Folder>net452</Folder>
-    </TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcoreapp1.0'">.NETCoreApp,Version=v1.0</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcoreapp1.1'">.NETCoreApp,Version=v1.1</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net463'">.NETFramework,Version=v4.6.3</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net462'">.NETFramework,Version=v4.6.2</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net461'">.NETFramework,Version=v4.6.1</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net46'">.NETFramework,Version=v4.6</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net45'">.NETFramework,Version=v4.5</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net451'">.NETFramework,Version=v4.5.1</TestNugetTargetMoniker>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'net452'">.NETFramework,Version=v4.5.2</TestNugetTargetMoniker>
     <!-- Project template for UWP Apps uses uap10.0, this mapping allows support for the Debug and Release scenarios -->
-    <TestNugetTargetMoniker Include="UAP,Version=v10.0" Condition="'$(TestTFM)' == 'netcore50aot'">
-      <Folder>netcore50aot</Folder>
-    </TestNugetTargetMoniker>
-    <TestNugetTargetMoniker Include="UAP,Version=v10.0" Condition="'$(TestTFM)' == 'netcore50'">
-      <Folder>netcore50</Folder>
-    </TestNugetTargetMoniker>
-  </ItemGroup>
+    <TestNugetTargetMoniker Condition="'$(TestTFM)' == 'netcore50aot' Or '$(TestTFM)' == 'netcore50'">UAP,Version=v10.0</TestNugetTargetMoniker>
+  </PropertyGroup>
 
   <!-- General xunit options -->
   <PropertyGroup>
@@ -152,7 +129,7 @@
   <Target Name="RunTestsForProject"
           DependsOnTargets="DiscoverTestInputs;CheckTestCategories"
           Inputs="@(RunTestsForProjectInputs)"
-          Outputs="$(TestsSuccessfulSemaphore);$(TestPath)%(TestNugetTargetMoniker.Folder)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
+          Outputs="$(TestsSuccessfulSemaphore);$(TestPath)/$(XunitResultsFileName);$(CoverageOutputFilePath)"
           >
 
     <ItemGroup>
@@ -186,7 +163,7 @@
     <PropertyGroup>
       <TestCommandLine Condition="'$(TargetOS)'!='Windows_NT'" >$(TestCommandLine.Replace('$(TestHostExecutable)', './corerun'))</TestCommandLine>
       <TestCommandLine>$(TestCommandLine.Replace('{XunitTraitOptions}', '$(XunitTraitOptions)'))</TestCommandLine>
-      <OutputFolderForScriptGenerator>$(TestPath)%(TestNugetTargetMoniker.Folder)</OutputFolderForScriptGenerator>
+      <OutputFolderForScriptGenerator>$(TestPath)</OutputFolderForScriptGenerator>
       <OutputPathForScriptGenerator>$(OutputFolderForScriptGenerator)/$(RunnerScriptName)</OutputPathForScriptGenerator>
       <OutputFolderForTestDependencies>$(BinDir)/TestDependencies</OutputFolderForTestDependencies>
     </PropertyGroup>
@@ -257,9 +234,9 @@
       ScriptOutputPath ="$(OutputPathForScriptGenerator)"
     />
 
-    <Exec Command="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(RunnerScriptName) $(PackagesDir)"
+    <Exec Command="$(TestPath)/$(RunnerScriptName) $(PackagesDir)"
           Condition="'$(TestDisabled)' != 'true'"
-          WorkingDirectory="$(TestPath)%(TestNugetTargetMoniker.Folder)"
+          WorkingDirectory="$(TestPath)"
           CustomErrorRegularExpression="Failed: [^0]"
           ContinueOnError="true"
           IgnoreStandardErrorWarningFormat="true"
@@ -267,7 +244,7 @@
       <Output PropertyName="TestRunExitCode" TaskParameter="ExitCode" />
     </Exec>
 
-    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)%(TestNugetTargetMoniker.Folder)/$(EventTracerDataFile)" />
+    <Delete Condition="'$(DeletePerfDataFile)' == 'true'" Files="$(TestPath)/$(EventTracerDataFile)" />
     <Error Condition="'$(TestDisabled)'!='true' And '$(TestRunExitCode)' != '0'" Text="One or more tests failed while running tests from '$(MSBuildProjectName)' please check log for details!" />
     <Touch Condition="'$(TestRunExitCode)' == '0'" Files="$(TestsSuccessfulSemaphore)" AlwaysCreate="true" />
   </Target>
@@ -291,7 +268,7 @@
     <PropertyGroup>
       <TestsSuccessfulSemaphore Condition="'@(RunWithTraits)' != ''">$(TestsSuccessfulSemaphore).with.@(RunWithTraits, '.')</TestsSuccessfulSemaphore>
       <TestsSuccessfulSemaphore Condition="'@(RunWithoutTraits)' != ''">$(TestsSuccessfulSemaphore).without.@(RunWithoutTraits, '.')</TestsSuccessfulSemaphore>
-      <TestsSuccessfulSemaphore>$(TestPath)%(TestNugetTargetMoniker.Folder)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
+      <TestsSuccessfulSemaphore>$(TestPath)/$(TestsSuccessfulSemaphore)</TestsSuccessfulSemaphore>
     </PropertyGroup>
 
     <Delete Condition="'$(ForceRunTests)'=='true' And Exists($(TestsSuccessfulSemaphore))"


### PR DESCRIPTION
cc: @weshaggard @ericstj @karajas 

Now that each TestPath is unique to a build (since TargetGroup and TestTFM are part of it) we can get rid of the need of having TestNugetTargetMoniker being an item, since we don't need its metadata anymore.