### PR TITLE
Add Repo API Consumes, Change, Verify commands

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Compose/ConsumesHelpers.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Compose/ConsumesHelpers.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Compose.Model.Command;
+using Newtonsoft.Json;
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks.Compose
+{
+    internal static class ConsumesHelpers
+    {
+        private static JsonSerializerSettings s_settings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            Formatting = Formatting.Indented
+        };
+
+        public static ConsumesOutput ReadConsumesFile(string consumesJsonPath)
+        {
+            return Deserialize(File.ReadAllText(consumesJsonPath));
+        }
+
+        public static void WriteConsumesFile(string consumesJsonPath, ConsumesOutput output)
+        {
+            File.WriteAllText(consumesJsonPath, Serialize(output));
+        }
+
+        public static ConsumesOutput Deserialize(string consumesJsonContent)
+        {
+            return JsonConvert.DeserializeObject<ConsumesOutput>(consumesJsonContent, s_settings);
+        }
+
+        public static string Serialize(ConsumesOutput output)
+        {
+            return JsonConvert.SerializeObject(output, s_settings) + Environment.NewLine;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Compose/GatherStandardInput.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Compose/GatherStandardInput.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks.Compose
+{
+    public class GatherStandardInput : Task
+    {
+        public string WriteFilePath { get; set; }
+
+        [Output]
+        public string Contents { get; set; }
+
+        public override bool Execute()
+        {
+            Contents = ReadAllStandardInput();
+
+            if (!string.IsNullOrEmpty(WriteFilePath))
+            {
+                File.WriteAllText(WriteFilePath, Contents);
+            }
+            return true;
+        }
+
+        private static string ReadAllStandardInput()
+        {
+            using (var stdInReader = new StreamReader(Console.OpenStandardInput()))
+            {
+                return stdInReader.ReadToEnd();
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Compose/GenerateConsumesJsonBuildInfos.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Compose/GenerateConsumesJsonBuildInfos.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks.VersionTools;
+using Microsoft.DotNet.VersionTools.Compose.Model;
+using Microsoft.DotNet.VersionTools.Compose.Model.Command;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Compose
+{
+    /// <summary>
+    /// Generates DependencyBuildInfo items from a consumes.json file. These can be fed into
+    /// existing dependency verification/update tooling.
+    /// 
+    /// One DependencyBuildInfo is created per package because there is no reasonable way to put
+    /// multiple packages into one item. Downloading from the versions repo (the old method) was
+    /// able to store multiple by putting a single url in the item, not a list of packages.
+    /// </summary>
+    public class GenerateConsumesJsonBuildInfos : Task
+    {
+        [Required]
+        public string ConsumesJsonPath { get; set; }
+
+        [Required]
+        public string ConsumesRuntimeName { get; set; }
+
+        [Output]
+        public ITaskItem[] DependencyBuildInfo { get; set; }
+
+        public override bool Execute()
+        {
+            ConsumesOutput consumes = ConsumesHelpers.ReadConsumesFile(ConsumesJsonPath);
+
+            IEnumerable<NuGetArtifactSet> nugetSets = consumes[ConsumesRuntimeName]
+                .Dependencies.Values
+                .Select(set => set.NuGet)
+                .ToArray();
+
+            var dependencyBuildInfos = new List<ITaskItem>();
+
+            foreach (var set in nugetSets)
+            {
+                if (set.Packages != null)
+                {
+                    // For every package consumed, make a build info for each version consumed.
+                    dependencyBuildInfos.AddRange(set.Packages.SelectMany(CreateBuildInfoItems));
+                }
+                if (set.ReleaseLabels != null)
+                {
+                    // For each prerelease specifier, make a build info for upgraders to find.
+                    dependencyBuildInfos.AddRange(set.ReleaseLabels.Select(CreateReleaseSpecBuildInfoItem));
+                }
+            }
+
+            DependencyBuildInfo = dependencyBuildInfos.ToArray();
+
+            return true;
+        }
+
+        private static IEnumerable<ITaskItem> CreateBuildInfoItems(
+            KeyValuePair<string, PackageVersionList> dependency)
+        {
+            return dependency.Value.Select(version =>
+               new TaskItem(dependency.Key, new Dictionary<string, string>
+               {
+                   [BaseDependenciesTask.PackageIdMetadataName] = dependency.Key,
+                   [BaseDependenciesTask.VersionMetadataName] = version,
+                   [BaseDependenciesTask.UpdateStableVersionsMetadataName] = "true"
+               }));
+        }
+
+        private static ITaskItem CreateReleaseSpecBuildInfoItem(
+            KeyValuePair<string, string> releaseLabel)
+        {
+            return new TaskItem(releaseLabel.Key, new Dictionary<string, string>
+            {
+                [BaseDependenciesTask.LatestReleaseVersionMetadataName] = releaseLabel.Value
+            });
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Compose/GenerateUpdatedConsumesJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Compose/GenerateUpdatedConsumesJson.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks.VersionTools;
+using Microsoft.DotNet.VersionTools;
+using Microsoft.DotNet.VersionTools.Compose;
+using Microsoft.DotNet.VersionTools.Compose.Model;
+using Microsoft.DotNet.VersionTools.Compose.Model.Command;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Compose
+{
+    /// <summary>
+    /// Take a consumes output JSON string, change it to match build info items downloaded from the
+    /// versions repo, and output the changed JSON.
+    /// </summary>
+    public class GenerateUpdatedConsumesJson : Task
+    {
+        [Required]
+        public string ConsumesJsonPath { get; set; }
+
+        [Required]
+        public ITaskItem[] RemoteDependencyBuildInfo { get; set; }
+
+        /// <summary>
+        /// If set, uses the "auto-update" ref defined by the item rather than the CurrentRef. If
+        /// no auto-update ref is set, falls back to CurrentRef.
+        /// </summary>
+        public bool UseVersionsRepoAutoUpdateRef { get; set; }
+
+        [Output]
+        public string BuildInfoConsumesJsonContent { get; set; }
+
+        public override bool Execute()
+        {
+            ProducesOutput[] producesOutputs = RemoteDependencyBuildInfo
+                .Select(CreateBuildInfo)
+                .Select(CreateProducesOutput)
+                .ToArray();
+
+            ConsumesOutput consumes = ConsumesHelpers.ReadConsumesFile(ConsumesJsonPath);
+
+            var updater = new ConsumesUpdater
+            {
+                TargetDependencyGroupName = "build"
+            };
+            foreach (var produces in producesOutputs)
+            {
+                updater.Upgrade(consumes, produces);
+            }
+
+            BuildInfoConsumesJsonContent = ConsumesHelpers.Serialize(consumes);
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private BuildInfo CreateBuildInfo(ITaskItem item)
+        {
+            string currentRef = null;
+
+            if (UseVersionsRepoAutoUpdateRef)
+            {
+                currentRef = item.GetMetadata(BaseDependenciesTask.VersionsRepoAutoUpdateRefMetadataName);
+            }
+            if (string.IsNullOrEmpty(currentRef))
+            {
+                currentRef = item.GetMetadata(BaseDependenciesTask.CurrentRefMetadataName);
+            }
+
+            if (string.IsNullOrEmpty(currentRef))
+            {
+                Log.LogError($"Item has no {BaseDependenciesTask.CurrentRefMetadataName} metadata: {item}");
+            }
+
+            return BuildInfo.Get(
+                item.ItemSpec,
+                BuildInfo.RawBuildInfoBaseUrl(
+                    item.GetMetadata(BaseDependenciesTask.RawVersionsBaseUrlMetadataName),
+                    currentRef,
+                    item.GetMetadata(BaseDependenciesTask.BuildInfoPathMetadataName)));
+        }
+
+        /// <summary>
+        /// Create a fake Produces output from the published build-info.
+        /// </summary>
+        private ProducesOutput CreateProducesOutput(BuildInfo info)
+        {
+            return new ProducesOutput
+            {
+                OsAll = new ArtifactSet
+                {
+                    NuGet = new NuGetArtifactSet
+                    {
+                        Packages = new SortedDictionary<string, PackageVersionList>(
+                            info.LatestPackages.ToDictionary(
+                                p => p.Key,
+                                p => new PackageVersionList { p.Value })),
+
+                        ReleaseLabels = new SortedDictionary<string, string>
+                        {
+                            [info.Name] = info.LatestReleaseVersion
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Compose/UpdateConsumes.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Compose/UpdateConsumes.cs
@@ -1,0 +1,102 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Build.Tasks.VersionTools;
+using Microsoft.DotNet.VersionTools.Compose.Model;
+using Microsoft.DotNet.VersionTools.Compose.Model.Command;
+using Microsoft.DotNet.VersionTools.Dependencies;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Compose
+{
+    public class UpdateConsumes : Task
+    {
+        [Required]
+        public string ConsumesJsonPath { get; set; }
+
+        [Required]
+        public string ConsumesRuntimeName { get; set; }
+
+        [Required]
+        public string NewDependencyType { get; set; }
+
+        /// <summary>
+        /// Puts prerelease package dependencies in a different group. If not specified, all new
+        /// dependencies are put into NewDependencyType.
+        /// </summary>
+        public string NewPrereleaseDependencyType { get; set; }
+
+        [Required]
+        public ITaskItem[] ProjectJsonFiles { get; set; }
+
+        [Required]
+        public ITaskItem[] DependencyBuildInfo { get; set; }
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrEmpty(NewPrereleaseDependencyType))
+            {
+                NewPrereleaseDependencyType = NewDependencyType;
+            }
+
+            if (ProjectJsonFiles != null && ProjectJsonFiles.Any())
+            {
+                ConsumesOutput consumes = ConsumesHelpers.ReadConsumesFile(ConsumesJsonPath);
+
+                ProjectJsonUpdater jsonUpdater = new ProjectJsonUpdater(
+                    ProjectJsonFiles.Select(item => item.ItemSpec))
+                {
+                    AllowOnlySpecifiedPackages = true
+                };
+
+                DependencyBuildInfo[] dependencyBuildInfos = DependencyBuildInfo
+                    .Select(item => BaseDependenciesTask.CreateBuildInfoDependency(item, null))
+                    .ToArray();
+
+                IEnumerable<PackageDependencyUpdateTask> updateTasks = jsonUpdater
+                    .GetUpdateTasks(dependencyBuildInfos)
+                    .OfType<PackageDependencyUpdateTask>();
+
+                IDictionary<string, ArtifactSet> dependencies = consumes[ConsumesRuntimeName].Dependencies;
+
+                NuGetArtifactSet stableNuget = dependencies[NewDependencyType].NuGet;
+                NuGetArtifactSet prereleaseNuget = dependencies[NewPrereleaseDependencyType].NuGet;
+
+                foreach (PackageDependencyUpdateTask updateTask in updateTasks)
+                {
+                    foreach (PackageDependencyChange change in updateTask.Changes)
+                    {
+                        NuGetArtifactSet nuget = change.Before.IsPrerelease
+                            ? prereleaseNuget
+                            : stableNuget;
+
+                        PackageVersionList versions;
+                        if (!nuget.Packages.TryGetValue(change.PackageId, out versions))
+                        {
+                            versions = new PackageVersionList();
+                            nuget.Packages[change.PackageId] = versions;
+                        }
+
+                        string existingVersion = change.Before.ToNormalizedString();
+                        if (!versions.Contains(existingVersion))
+                        {
+                            Log.LogMessage($"Adding dependency '{change.PackageId} {existingVersion}'");
+                            versions.Add(existingVersion);
+                        }
+                    }
+                }
+
+                ConsumesHelpers.WriteConsumesFile(ConsumesJsonPath, consumes);
+            }
+            else
+            {
+                Log.LogWarning("No project.json files specified.");
+            }
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Compose/WriteFileToStandardOutput.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Compose/WriteFileToStandardOutput.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Build.Tasks.Compose
+{
+    public class WriteFileToStandardOutput : Task
+    {
+        [Required]
+        public string Path { get; set; }
+
+        public override bool Execute()
+        {
+            Console.Write(File.ReadAllText(Path));
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -18,6 +18,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinClashLogger.cs" />
+    <Compile Include="Compose\ConsumesHelpers.cs" />
+    <Compile Include="Compose\GenerateUpdatedConsumesJson.cs" />
+    <Compile Include="Compose\UpdateConsumes.cs" />
+    <Compile Include="Compose\WriteFileToStandardOutput.cs" />
+    <Compile Include="Compose\GatherStandardInput.cs" />
+    <Compile Include="Compose\GenerateConsumesJsonBuildInfos.cs" />
     <Compile Include="Delegates.cs" />
     <Compile Include="ExceptionFromResource.cs" />
     <Compile Include="ExecWithMutex.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Compose.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Compose.targets
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Repo API Compose commands -->
+
+  <Target Name="Consumes">
+    <WriteFileToStandardOutput Path="$(ConsumesJsonPath)" />
+  </Target>
+
+  <Target Name="Change"
+          DependsOnTargets="WriteConsumesJson;
+                            GenerateConsumesJsonBuildInfos;
+                            UpdateDependenciesFromChange" />
+
+  <Target Name="Verify"
+          DependsOnTargets="GenerateConsumesJsonBuildInfos;
+                            VerifyDependencies" />
+
+  <!--
+    Updates the Consumes output based on the state of the project. Useful to add many stable
+    dependencies at once, for example after a release.
+  -->
+  <Target Name="UpdateConsumes" DependsOnTargets="GenerateConsumesJsonBuildInfos">
+    <PropertyGroup>
+      <NewDependencyType Condition="'$(NewDependencyType)'==''">fixed</NewDependencyType>
+    </PropertyGroup>
+
+    <UpdateConsumes ConsumesJsonPath="$(ConsumesJsonPath)"
+                    ConsumesRuntimeName="$(ConsumesRuntimeName)"
+                    NewDependencyType="$(NewDependencyType)"
+                    NewPrereleaseDependencyType="$(NewPrereleaseDependencyType)"
+                    ProjectJsonFiles="@(ProjectJsonFiles)"
+                    DependencyBuildInfo="@(DependencyBuildInfo)" />
+  </Target>
+
+  <!--
+    Uses Change to update to versions in a build-info in the dotnet versions repository.
+  -->
+  <Target Name="ChangeToBuildInfo"
+          DependsOnTargets="GenerateUpdatedConsumesJson;
+                            Change" />
+
+  <Target Name="ChangeToBuildInfoAndSubmitPullRequest"
+          DependsOnTargets="EnableSubmitPullRequest;
+                            ChangeToBuildInfo" />
+
+  <!-- Utilities to reuse existing dependency tools. -->
+  <UsingTask TaskName="GatherStandardInput" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GenerateConsumesJsonBuildInfos" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="GenerateUpdatedConsumesJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdateConsumes" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="WriteFileToStandardOutput" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <Target Name="GenerateConsumesJsonBuildInfos">
+    <PropertyGroup>
+      <ConsumesRuntimeName Condition="'$(ConsumesRuntimeName)'==''">os-all</ConsumesRuntimeName>
+
+      <!-- Enable strict dependency checks. -->
+      <AllowOnlySpecifiedPackages>true</AllowOnlySpecifiedPackages>
+    </PropertyGroup>
+
+    <GenerateConsumesJsonBuildInfos ConsumesJsonPath="$(ConsumesJsonPath)"
+                                    ConsumesRuntimeName="$(ConsumesRuntimeName)">
+      <Output TaskParameter="DependencyBuildInfo" ItemName="ConsumesDependencyBuildInfo" />
+    </GenerateConsumesJsonBuildInfos>
+
+    <ItemGroup>
+      <DependencyBuildInfo Include="@(ConsumesDependencyBuildInfo)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Writes consumes.json using input from stdin or the value of BuildInfoConsumesJsonContent. -->
+  <Target Name="WriteConsumesJson">
+    <GatherStandardInput WriteFilePath="$(ConsumesJsonPath)"
+                         Condition="'$(BuildInfoConsumesJsonContent)'==''"/>
+
+    <WriteLinesToFile File="$(ConsumesJsonPath)"
+                      Lines="$(BuildInfoConsumesJsonContent)"
+                      Overwrite="true"
+                      Condition="'$(BuildInfoConsumesJsonContent)'!=''" />
+  </Target>
+
+  <Target Name="GenerateUpdatedConsumesJson">
+    <GenerateUpdatedConsumesJson ConsumesJsonPath="$(ConsumesJsonPath)"
+                                 RemoteDependencyBuildInfo="@(RemoteDependencyBuildInfo)"
+                                 UseVersionsRepoAutoUpdateRef="$(UseVersionsRepoAutoUpdateRef)">
+      <Output TaskParameter="BuildInfoConsumesJsonContent" PropertyName="BuildInfoConsumesJsonContent" />
+    </GenerateUpdatedConsumesJson>
+  </Target>
+
+  <!-- Targets to select between UpdateDependencies and UpdateDependenciesAndSubmitPullRequest. -->
+  <Target Name="EnableSubmitPullRequest">
+    <PropertyGroup>
+      <SubmitPullRequest>true</SubmitPullRequest>
+      <!-- When creating a pull request, get the version from master. -->
+      <UseVersionsRepoAutoUpdateRef Condition="'$(UseVersionsRepoAutoUpdateRef)'==''">true</UseVersionsRepoAutoUpdateRef>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="UpdateDependenciesFromChange"
+          DependsOnTargets="RunUpdateDependenciesFromChange;
+                            RunUpdateDependenciesAndSubmitPullRequestFromChange"/>
+  
+  <Target Name="RunUpdateDependenciesFromChange"
+          Condition="'$(SubmitPullRequest)'!='true'"
+          DependsOnTargets="UpdateDependencies"/>
+
+  <Target Name="RunUpdateDependenciesAndSubmitPullRequestFromChange"
+          Condition="'$(SubmitPullRequest)'=='true'"
+          DependsOnTargets="UpdateDependenciesAndSubmitPullRequest"/>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -34,6 +34,7 @@
     <UpdateDependencies DependencyBuildInfo="@(DependencyBuildInfo)"
                         ProjectJsonFiles="@(ProjectJsonFiles)"
                         XmlUpdateStep="@(XmlUpdateStep)"
+                        AllowOnlySpecifiedPackages="$(AllowOnlySpecifiedPackages)"
                         BuildInfoCacheDir="$(BuildInfoCacheDir)" />
   </Target>
 
@@ -47,6 +48,7 @@
     <VerifyDependencies DependencyBuildInfo="@(DependencyBuildInfo)"
                         ProjectJsonFiles="@(ProjectJsonFiles)"
                         XmlUpdateStep="@(XmlUpdateStep)"
+                        AllowOnlySpecifiedPackages="$(AllowOnlySpecifiedPackages)"
                         BuildInfoCacheDir="$(BuildInfoCacheDir)" />
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Verifying all auto-upgradeable dependencies... Done." />
@@ -59,6 +61,7 @@
     <UpdateDependenciesAndSubmitPullRequest DependencyBuildInfo="@(DependencyBuildInfo)"
                                             ProjectJsonFiles="@(ProjectJsonFiles)"
                                             XmlUpdateStep="@(XmlUpdateStep)"
+                                            AllowOnlySpecifiedPackages="$(AllowOnlySpecifiedPackages)"
                                             ProjectRepoName="$(ProjectRepoName)"
                                             ProjectRepoOwner="$(ProjectRepoOwner)"
                                             ProjectRepoBranch="$(ProjectRepoBranch)"

--- a/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdateResults.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdateResults.cs
@@ -21,7 +21,12 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
         public string GetSuggestedCommitMessage()
         {
-            var orderedInfos = UsedBuildInfos.OrderBy(info => info.Name).ToArray();
+            var orderedInfos = UsedBuildInfos
+                .Where(info =>
+                    !string.IsNullOrWhiteSpace(info.Name) &&
+                    !string.IsNullOrWhiteSpace(info.LatestReleaseVersion))
+                .OrderBy(info => info.Name)
+                .ToArray();
 
             string updatedDependencyNames = string.Join(", ", orderedInfos.Select(d => d.Name));
             string updatedDependencyVersions = string.Join(", ", orderedInfos.Select(d => d.LatestReleaseVersion));

--- a/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdateUtils.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdateUtils.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.DotNet.VersionTools.Dependencies;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -18,13 +19,41 @@ namespace Microsoft.DotNet.VersionTools.Automation
             IEnumerable<IDependencyUpdater> updaters,
             IEnumerable<DependencyBuildInfo> buildInfoDependencies)
         {
-            IEnumerable<BuildInfo> distinctUsedBuildInfos = GetUpdateTasks(updaters, buildInfoDependencies)
-                .Select(task =>
+            var results = new List<DependencyUpdateResults>();
+            var exceptions = new List<UpdateTargetNotFoundException>();
+
+            foreach (var task in GetUpdateTasks(updaters, buildInfoDependencies))
+            {
+                try
                 {
                     task.Start();
-                    return task.Result;
-                })
-                .SelectMany(results => results.UsedBuildInfos)
+                    results.Add(task.Result);
+                }
+                catch (AggregateException ex)
+                {
+                    // Gather all exceptions to avoid losing info about later ones.
+                    ex.Handle(inner =>
+                    {
+                        var targetNotFound = inner as UpdateTargetNotFoundException;
+                        if (targetNotFound != null)
+                        {
+                            exceptions.Add(targetNotFound);
+                            return true;
+                        }
+                        return false;
+                    });
+                }
+            }
+
+            if (exceptions.Any())
+            {
+                throw new UpdateTargetNotFoundException(
+                    $"Failed to find update targets for {exceptions.Count} updates.",
+                    new AggregateException(exceptions));
+            }
+
+            IEnumerable<BuildInfo> distinctUsedBuildInfos = results
+                .SelectMany(r => r.UsedBuildInfos)
                 .Distinct()
                 .ToArray();
 

--- a/src/Microsoft.DotNet.VersionTools/Compose/ConsumesUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Compose/ConsumesUpdater.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Compose.Model;
+using Microsoft.DotNet.VersionTools.Compose.Model.Command;
+using Microsoft.DotNet.VersionTools.Util;
+
+namespace Microsoft.DotNet.VersionTools.Compose
+{
+    public class ConsumesUpdater
+    {
+        public string TargetDependencyGroupName { get; set; } = "floating";
+
+        /// <summary>
+        /// Updates a Consumes command output to consume the build described by a Produces output.
+        /// </summary>
+        public void Upgrade(ConsumesOutput consumes, ProducesOutput produces)
+        {
+            NuGetArtifactSet targetSet = consumes.OsAll.Dependencies[TargetDependencyGroupName].NuGet;
+            NuGetArtifactSet sourceSet = produces.OsAll.NuGet;
+
+            foreach (var package in sourceSet.Packages.EmptyIfNull())
+            {
+                targetSet.Packages[package.Key] = package.Value;
+            }
+            foreach (var releaseLabel in sourceSet.ReleaseLabels.EmptyIfNull())
+            {
+                targetSet.ReleaseLabels[releaseLabel.Key] = releaseLabel.Value;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Compose/Model/ArtifactSet.cs
+++ b/src/Microsoft.DotNet.VersionTools/Compose/Model/ArtifactSet.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.DotNet.VersionTools.Compose.Model
+{
+    public class ArtifactSet
+    {
+        [JsonProperty("nuget")]
+        public NuGetArtifactSet NuGet { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Compose/Model/Command/ConsumesOutput.cs
+++ b/src/Microsoft.DotNet.VersionTools/Compose/Model/Command/ConsumesOutput.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.Compose.Model.Command
+{
+    public class ConsumesOutput : SortedDictionary<string, ConsumesPlatform>
+    {
+        public const string OsAllName = "os-all";
+
+        public ConsumesPlatform OsAll
+        {
+            get { return this[OsAllName]; }
+            set { this[OsAllName] = value; }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Compose/Model/Command/ProducesOutput.cs
+++ b/src/Microsoft.DotNet.VersionTools/Compose/Model/Command/ProducesOutput.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.Compose.Model.Command
+{
+    public class ProducesOutput : SortedDictionary<string, ArtifactSet>
+    {
+        public ArtifactSet OsAll
+        {
+            get { return this[ConsumesOutput.OsAllName]; }
+            set { this[ConsumesOutput.OsAllName] = value; }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Compose/Model/ConsumesPlatform.cs
+++ b/src/Microsoft.DotNet.VersionTools/Compose/Model/ConsumesPlatform.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.Compose.Model
+{
+    public class ConsumesPlatform
+    {
+        [JsonProperty("dependencies")]
+        public SortedDictionary<string, ArtifactSet> Dependencies { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Compose/Model/NuGetArtifactSet.cs
+++ b/src/Microsoft.DotNet.VersionTools/Compose/Model/NuGetArtifactSet.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.Compose.Model
+{
+    public class NuGetArtifactSet
+    {
+        [JsonProperty("packages")]
+        public SortedDictionary<string, PackageVersionList> Packages { get; set; }
+
+        [JsonProperty("release-labels")]
+        public SortedDictionary<string, string> ReleaseLabels { get; set; }
+
+        [JsonProperty("feeds")]
+        public SortedDictionary<string, string> Feeds { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Compose/Model/PackageVersionList.cs
+++ b/src/Microsoft.DotNet.VersionTools/Compose/Model/PackageVersionList.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Util;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.Compose.Model
+{
+    /// <summary>
+    /// A list of strings with special Json.NET serialization: when there is only one value, it is
+    /// treated as a value, not an array.
+    /// </summary>
+    [JsonConverter(typeof(ListOrSingleConverter))]
+    public class PackageVersionList : List<string>
+    {
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/PackageDependencyChange.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/PackageDependencyChange.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet.Versioning;
+using System;
+using System.Text;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public class PackageDependencyChange
+    {
+        public BuildInfo BuildInfo { get; }
+        public string PackageId { get; }
+        public NuGetVersion Before { get; }
+        public NuGetVersion After { get; }
+
+        public PackageDependencyChange(
+            BuildInfo buildInfo,
+            string packageId,
+            NuGetVersion before,
+            NuGetVersion after)
+        {
+            if (packageId == null)
+            {
+                throw new ArgumentNullException(nameof(packageId));
+            }
+
+            BuildInfo = buildInfo;
+            PackageId = packageId;
+            Before = before;
+            After = after;
+        }
+
+        public override string ToString()
+        {
+            var message = new StringBuilder("'");
+            message.Append(PackageId);
+
+            if (Before != null)
+            {
+                message.Append(" ");
+                message.Append(Before.ToNormalizedString());
+            }
+            message.Append("'");
+
+            if (After != null)
+            {
+                message.Append(" has upgrade '");
+                message.Append(After.ToNormalizedString());
+                message.Append("'");
+            }
+
+            if (BuildInfo != null)
+            {
+                message.Append(" (");
+                message.Append(BuildInfo.Name);
+                message.Append(")");
+            }
+            return message.ToString();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/PackageDependencyUpdateTask.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/PackageDependencyUpdateTask.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    /// <summary>
+    /// A dependency update task with additional information about the package update.
+    /// </summary>
+    public class PackageDependencyUpdateTask : DependencyUpdateTask
+    {
+        public IEnumerable<PackageDependencyChange> Changes { get; }
+
+        public PackageDependencyUpdateTask(
+            PackageDependencyChange[] changes,
+            string projectJsonFile,
+            Action updateAction)
+            : base(
+                () =>
+                {
+                    // Check for updates that are needed but can't be performed.
+                    bool errors = false;
+
+                    foreach (PackageDependencyChange change in changes.Where(change => change.After == null))
+                    {
+                        Trace.TraceError($"No update target found for {change} in '{projectJsonFile}'");
+                        errors = true;
+                    }
+
+                    if (errors)
+                    {
+                        throw new UpdateTargetNotFoundException(
+                            $"Could not find update target for package(s) in '{projectJsonFile}'");
+                    }
+
+                    updateAction?.Invoke();
+                },
+                changes.Select(change => change.BuildInfo),
+                changes.Select(change => $"In '{projectJsonFile}', {change.ToString()}"))
+        {
+            Changes = changes;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/UpdateTargetNotFoundException.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/UpdateTargetNotFoundException.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    /// <summary>
+    /// The exception that is thrown when an invalid dependency upgrade is attempted.
+    /// </summary>
+    public class UpdateTargetNotFoundException : Exception
+    {
+        public UpdateTargetNotFoundException()
+        {
+        }
+
+        public UpdateTargetNotFoundException(string message) : base(message)
+        {
+        }
+
+        public UpdateTargetNotFoundException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -21,6 +21,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Automation\DependencyUpdateResults.cs" />
+    <Compile Include="Compose\ConsumesUpdater.cs" />
+    <Compile Include="Compose\Model\ArtifactSet.cs" />
+    <Compile Include="Compose\Model\Command\ConsumesOutput.cs" />
+    <Compile Include="Compose\Model\ConsumesPlatform.cs" />
+    <Compile Include="Compose\Model\NuGetArtifactSet.cs" />
+    <Compile Include="Compose\Model\PackageVersionList.cs" />
+    <Compile Include="Compose\Model\Command\ProducesOutput.cs" />
     <Compile Include="Dependencies\DependencyBuildInfo.cs" />
     <Compile Include="Dependencies\DependencyUpdateTask.cs" />
     <Compile Include="Automation\GitHubApi\GitHubClient.cs" />
@@ -33,6 +40,9 @@
     <Compile Include="Dependencies\FileRegexReleaseUpdater.cs" />
     <Compile Include="Automation\IUpdateBranchNamingStrategy.cs" />
     <Compile Include="Automation\SingleBranchNamingStrategy.cs" />
+    <Compile Include="Dependencies\PackageDependencyChange.cs" />
+    <Compile Include="Dependencies\PackageDependencyUpdateTask.cs" />
+    <Compile Include="Dependencies\UpdateTargetNotFoundException.cs" />
     <Compile Include="Util\ArgumentEscaper.cs" />
     <Compile Include="Util\Command.cs" />
     <Compile Include="Util\CommandResult.cs" />
@@ -44,6 +54,8 @@
     <Compile Include="BuildInfo.cs" />
     <Compile Include="Dependencies\ProjectJsonUpdater.cs" />
     <Compile Include="Automation\VersionsRepoUpdater.cs" />
+    <Compile Include="Util\IEnumerableExtensions.cs" />
+    <Compile Include="Util\ListOrSingleConverter.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">

--- a/src/Microsoft.DotNet.VersionTools/Util/IEnumerableExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/IEnumerableExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Util
+{
+    internal static class IEnumerableExtensions
+    {
+        public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable ?? Enumerable.Empty<T>();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Util/ListOrSingleConverter.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/ListOrSingleConverter.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.DotNet.VersionTools.Util
+{
+    /// <summary>
+    /// Converts a class that inherits List`1 and has 1 T, many Ts, or null. 1 T is treated as a
+    /// value, many Ts is treated as an array, and null is null.
+    /// </summary>
+    internal class ListOrSingleConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            IList list = (IList)value;
+            object toWrite = list.Cast<object>().ToArray();
+            // If there is only one element, write it without wrapping in an array.
+            if (list.Count == 1)
+            {
+                toWrite = list[0];
+            }
+            serializer.Serialize(writer, toWrite);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            IList list = (IList)Activator.CreateInstance(objectType);
+
+            Type baseListType = FindListBaseType(objectType);
+            Type baseListArgType = baseListType.GetTypeInfo().GetGenericArguments()[0];
+
+            if (reader.TokenType == JsonToken.StartArray)
+            {
+                IList elements = (IList)serializer.Deserialize(reader, baseListType);
+                foreach (object element in elements)
+                {
+                    list.Add(element);
+                }
+            }
+            else
+            {
+                // Read the individual element into the list using IList.Add implementation.
+                list.Add(serializer.Deserialize(reader, baseListArgType));
+            }
+            return list;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            Type baseListType = FindListBaseType(objectType);
+
+            return baseListType != null &&
+                // Don't convert raw List<T> to avoid infinite recursion.
+                baseListType != objectType;
+        }
+
+        /// <summary>
+        /// Looks in "type"'s inheritance chain to find a List`1 type and returns it.
+        /// </summary>
+        private Type FindListBaseType(Type type)
+        {
+            if (type.IsConstructedGenericType)
+            {
+                Type genericType = type.GetGenericTypeDefinition();
+                if (genericType == typeof(List<>))
+                {
+                    return type;
+                }
+            }
+            Type baseType = type.GetTypeInfo().BaseType;
+            if (baseType != null)
+            {
+                return FindListBaseType(baseType);
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Adds implementations of the Repo API Compose commands described in https://github.com/dotnet/buildtools/pull/1069, where as much is reused from the existing dependency upgrade/verification system as manageable.
- `run consumes`
- `run change`
- `run verify`
- `/t:UpdateConsumes`
  - Adds new project.json dependencies into consumes.json. Useful for me when filling out consumes.json--it seemed like the one from RepoUtil didn’t see dependencies under frameworks. (This is the "backwards" flow I mentioned in the implementation proposal, but this only does adds.)
- `/t:ChangeToBuildInfo`
  - Uses the `change` flow to take versions from a build-info on dotnet/versions. (I'd initially planned on splitting this work out, but it seemed very difficult to split without breaking auto-PRs entirely so I implemented it now.)
- `/t:ChangeToBuildInfoAndSubmitPullRequest`

The changes reuse `/t:VerifyDependencies`, `/t:UpdateDependencies`, and `/t:UpdateDependenciesAndSubmitPullRequest` and don't break their behaviors on old configuration.

Changes to CoreFX to bring this in: https://github.com/dotnet/corefx/compare/master...dagood:compose (includes `consumes.json` initially copied from https://github.com/dotnet/corefx/pull/11350.) Note the init-tools change to `call %~dp0init-tools.cmd >&2`, where `>&2` allows usage of `consumes` like `run consumes > temp.json`.

Example auto-PR with new system: https://github.com/dagood/corefx/pull/27

@chcosta @weshaggard 
/cc @markwilkie @dleeapho 
