### PR TITLE
Add VSTS Api package for multiplexing checked in build definitions

### DIFF
--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.uwp", "xunit.r
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.VersionTools", "Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj", "{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.VstsBuildsApi", "Microsoft.DotNet.Build.VSTSBuildsApi\Microsoft.DotNet.Build.VstsBuildsApi.csproj", "{DD658734-88B2-48AD-8ADC-69D5C5798D9B}"  
+EndProject  
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -346,3 +348,4 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal
+

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi.net45/Microsoft.DotNet.Build.VstsBuildsApi.net45.csproj
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi.net45/Microsoft.DotNet.Build.VstsBuildsApi.net45.csproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
+    <ImportedProjectRelativePath>..\Microsoft.DotNet.Build.VstsBuildsApi\</ImportedProjectRelativePath>
+  </PropertyGroup>
+  <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.VstsBuildsApi.csproj" />
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi.net45/project.json
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi.net45/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "Newtonsoft.Json": "9.0.1",
+    "Microsoft.NETCore.Platforms": "1.0.1",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+  },
+  "frameworks": {
+    "net45": {}
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
+}

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/Microsoft.DotNet.Build.VstsBuildsApi.csproj
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/Microsoft.DotNet.Build.VstsBuildsApi.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DD658734-88B2-48AD-8ADC-69D5C5798D9B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.DotNet.Build.VstsBuildsApi</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.Build.VstsBuildsApi</AssemblyName>
+    <CLSCompliant>false</CLSCompliant>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="VstsBuildClient.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Reflection;
+
+[assembly : AssemblyTitle("Microsoft.DotNet.Build.VSTSBuildApi")]

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
@@ -122,7 +122,7 @@ namespace VstsBuildsApi
             string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions/{definition["id"].ToString()}?api-version=2.0";
 
             HttpContent content = new StringContent(JsonConvert.SerializeObject(definition), System.Text.Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await GetClient(definition["project"]["url"].ToString()).PutAsync(requestUri, content);
+            HttpResponseMessage response = await GetClient(GetVstsBuildsApiUrl(definition)).PutAsync(requestUri, content);
             ProcessResponseStatusCode(response);
             return JObject.Parse(await response.Content.ReadAsStringAsync());
         }
@@ -138,7 +138,7 @@ namespace VstsBuildsApi
             string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions?api-version=2.0";
 
             HttpContent content = new StringContent(JsonConvert.SerializeObject(definition), Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await GetClient(definition["project"]["url"].ToString()).PostAsync(requestUri, content);
+            HttpResponseMessage response = await GetClient(GetVstsBuildsApiUrl(definition)).PostAsync(requestUri, content);
             ProcessResponseStatusCode(response);
             return JObject.Parse(await response.Content.ReadAsStringAsync());
 
@@ -151,7 +151,7 @@ namespace VstsBuildsApi
         {
             string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions/{definition["id"].ToString()}?api-version=2.0";
 
-            HttpResponseMessage response = await GetClient(definition["project"]["url"].ToString()).GetAsync(requestUri);
+            HttpResponseMessage response = await GetClient(GetVstsBuildsApiUrl(definition)).GetAsync(requestUri);
             ProcessResponseStatusCode(response);
             return JObject.Parse(await response.Content.ReadAsStringAsync());
         }
@@ -163,7 +163,7 @@ namespace VstsBuildsApi
         {
             string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions?api-version=2.0&name={definition["name"].ToString()}";
 
-            HttpResponseMessage response = await GetClient(definition["project"]["url"].ToString()).GetAsync(requestUri);
+            HttpResponseMessage response = await GetClient(GetVstsBuildsApiUrl(definition)).GetAsync(requestUri);
             ProcessResponseStatusCode(response);
             string json = await response.Content.ReadAsStringAsync();
             JObject definitionsJObject = JObject.Parse(json);
@@ -186,6 +186,11 @@ namespace VstsBuildsApi
         private string VstsBuildsApiBase(JObject definition)
         {
             return definition["project"]["name"].ToString();
+        }
+
+        private string GetVstsBuildsApiUrl(JObject definition)
+        {
+            return definition["project"]["url"].ToString();
         }
 
         private HttpClient GetClient(string url)

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. 
+// The .NET Foundation licenses this file to you under the MIT license. 
+// See the LICENSE file in the project root for more information. 
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VstsBuildsApi
+{
+    public class VstsBuildClient
+    {
+        private string _collectionIdentifier;
+        private string _credentials;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="collectionIdentifier">collection identifer for build definitions</param>
+        /// <param name="credentials">credentials used for basic rest api authentication</param>
+        public VstsBuildClient(string collectionIdentifier, string credentials)
+        {
+            if(string.IsNullOrWhiteSpace(collectionIdentifier))
+            {
+                throw new Exception("Required parameter (collectionIdentifier) cannot be null or white space.");
+            }
+            if(!Uri.IsWellFormedUriString(collectionIdentifier, UriKind.Relative))
+            {
+                throw new Exception(string.Format("collectionIdentifier '{0}' contains invalid characters.  collectionIdentifier must contain only valid uri characters.", collectionIdentifier));
+            }
+
+            _collectionIdentifier = collectionIdentifier;
+            _credentials = credentials;
+        }
+
+        /// <summary>
+        /// Load a local build definition, combine the uniqueIdentifier with the definition name, 
+        /// check VSTS for a matching definition name, if present, update that definition with the
+        /// local build definition, otherwise create a new definition.
+        /// </summary>
+        /// <param name="stream">Stream to a VSTS build definition</param>
+        /// <returns>Created or updated build Id</returns>
+        public async Task<string> CreateOrUpdateDefinitionAsync(Stream stream)
+        {
+            JObject definition = GetDefinition(stream);
+            return await CreateOrUpdateDefinitionAsync(definition).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Load a local build definition, combine the uniqueIdentifier with the definition name, 
+        /// check VSTS for a matching definition name, if present, update that definition with the
+        /// local build definition, otherwise create a new definition.
+        /// </summary>
+        /// <param name="definition">VSTS build definition JSON object</param>
+        /// <returns>Created or updated build definition id</returns>
+        private async Task<string> CreateOrUpdateDefinitionAsync(JObject definition)
+        {
+            var key = string.Join("_", _collectionIdentifier, definition["name"].ToString());
+            definition["name"] = key;
+            var vstsDefinitions = await VstsRetrieveDefinitionsListByNameAndPathAsync(definition).ConfigureAwait(false);
+
+            if (vstsDefinitions.Count == 0)
+            {
+                /* Create */
+                var vstsDefinition = await VstsCreateDefinitionAsync(definition).ConfigureAwait(false);
+                return vstsDefinition["id"].ToString();
+            }
+            else if(vstsDefinitions.Count == 1)
+            {
+                var vstsDefinition = await VstsRetrieveDefinitionByIdAsync(vstsDefinitions[0]).ConfigureAwait(false);
+
+                /* Update */
+                if (!IsSameContents(definition, vstsDefinition))
+                {
+                    definition["revision"] = vstsDefinition["revision"];
+                    definition["id"] = vstsDefinition["id"];
+                    definition["uri"] = vstsDefinition["uri"];
+                    definition["path"] = vstsDefinition["path"];
+                    definition["createdDate"] = vstsDefinition["createdDate"];
+                    definition["url"] = vstsDefinition["url"];
+                    definition["comment"] = "Automated update";
+
+                    vstsDefinition = await VstsUpdateDefinitionAsync(definition).ConfigureAwait(false);
+                }
+                return vstsDefinition["id"].ToString();
+            }
+            else
+            {
+                throw new Exception(string.Format("Obtained multiple {0} definitions with the same 'name' ({1}) and 'path' ({2}) properties.  This should not be possible.", vstsDefinitions.Count, vstsDefinitions[0]["name"].ToString(), vstsDefinitions[0]["path"].ToString()));
+            }
+        }
+
+        private JObject GetDefinition(Stream stream)
+        {
+            using (StreamReader streamReader = new StreamReader(stream))
+            using (JsonTextReader jsonReader = new JsonTextReader(streamReader))
+            {
+               return (JObject)JToken.ReadFrom(jsonReader);
+            }
+        }
+
+        /// <summary>
+        /// Update VSTS Build Definition
+        /// </summary>
+        /// <returns>updated definitions id</returns>
+        private async Task<JObject> VstsUpdateDefinitionAsync(JObject definition)
+        {
+            string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions/{definition["id"].ToString()}?api-version=2.0";
+
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(definition), System.Text.Encoding.UTF8, "application/json");
+            HttpResponseMessage response = await GetClient(definition["url"].ToString()).PutAsync(requestUri, content);
+            ProcessResponseStatusCode(response);
+            return JObject.Parse(await response.Content.ReadAsStringAsync());
+        }
+
+        /// <summary>
+        /// Create VSTS Build Definition
+        /// </summary>
+        private async Task<JObject> VstsCreateDefinitionAsync(JObject definition)
+        {
+            /* Remove definition instance identifiable information */
+            RemoveJObjectToken("revison", definition);
+            RemoveJObjectToken("uri", definition);
+            RemoveJObjectToken("createdDate", definition);
+            RemoveJObjectToken("comment", definition);
+            RemoveJObjectToken("_links", definition);
+            RemoveJObjectToken("authoredBy", definition);
+            RemoveJObjectToken("id", definition);
+
+            string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions?api-version=2.0";
+
+            HttpContent content = new StringContent(JsonConvert.SerializeObject(definition), Encoding.UTF8, "application/json");
+            HttpResponseMessage response = await GetClient(definition["url"].ToString()).PostAsync(requestUri, content);
+            ProcessResponseStatusCode(response);
+            return JObject.Parse(await response.Content.ReadAsStringAsync());
+
+        }
+
+        /// <summary>
+        /// Retrieve a VSTS Build Definition by name and VSTS folder path
+        /// </summary>
+        private async Task<JObject> VstsRetrieveDefinitionByIdAsync(JObject definition)
+        {
+            string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions/{definition["id"].ToString()}?api-version=2.0";
+
+            HttpResponseMessage response = await GetClient(definition["url"].ToString()).GetAsync(requestUri);
+            ProcessResponseStatusCode(response);
+            return JObject.Parse(await response.Content.ReadAsStringAsync());
+        }
+
+        /// <summary>
+        /// Retrieve a VSTS Build Definition by name and VSTS folder path
+        /// </summary>
+        private async Task<IReadOnlyList<JObject>> VstsRetrieveDefinitionsListByNameAndPathAsync(JObject definition)
+        {
+            string requestUri = $"DefaultCollection/{VstsBuildsApiBase(definition)}/_apis/build/definitions?api-version=2.0&name={definition["name"].ToString()}";
+
+            HttpResponseMessage response = await GetClient(definition["url"].ToString()).GetAsync(requestUri);
+            ProcessResponseStatusCode(response);
+            string json = await response.Content.ReadAsStringAsync();
+            JObject definitionsJObject = JObject.Parse(json);
+            List<JObject> definitions = new List<JObject>();
+            if (int.Parse(definitionsJObject["count"].Value<string>()) > 0)
+            {
+                var children = definitionsJObject["value"].Children();
+                foreach(var childDefinition in children)
+                {
+                    JObject childObject = (JObject)childDefinition;
+                    if (definition["path"].ToString() == childObject["path"].ToString())
+                    {
+                        definitions.Add(childObject);
+                    }
+                }
+            }
+            return definitions;
+        }
+
+        private string VstsBuildsApiBase(JObject definition)
+        {
+            return definition["project"]["name"].ToString();
+        }
+
+        private HttpClient GetClient(string url)
+        {
+            HttpClient client = new HttpClient();
+            Uri uri = new Uri(url); 
+            client.BaseAddress = new Uri(string.Format("{0}://{1}/", uri.Scheme, uri.Authority));
+            client.DefaultRequestHeaders.Clear();
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", _credentials);
+            return client;
+        }
+
+        // This method performs similar functionality as HttpResponseMessage.EnsureSuccessStatusCode(), but is more strict about 
+        // what "success" is because we can not properly handle "non-authoratative" responses which are reported as "success".
+        private void ProcessResponseStatusCode(HttpResponseMessage response)
+        {
+            if(response.StatusCode == System.Net.HttpStatusCode.OK)
+            {
+                return;
+            }
+            throw new HttpRequestException(string.Format("Response code {0} received from {1} is not a valid response.", response.StatusCode, response.RequestMessage.RequestUri));
+        }
+
+        private static bool IsSameContents(JObject definition1, JObject definition2)
+        {
+            JObject _definition1 = (JObject)definition1.DeepClone();
+            JObject _definition2 = (JObject)definition2.DeepClone();
+
+            RemoveJObjectToken("_links", _definition1, _definition2);
+            RemoveJObjectToken("project", _definition1, _definition2);
+            RemoveJObjectToken("comment", _definition1, _definition2);
+            RemoveJObjectToken("revision", _definition1, _definition2);
+            RemoveJObjectToken("id", _definition1, _definition2);
+            RemoveJObjectToken("uri", _definition1, _definition2);
+            RemoveJObjectToken("path", _definition1, _definition2);
+            RemoveJObjectToken("createdDate", _definition1, _definition2);
+            RemoveJObjectToken("url", _definition1, _definition2);
+
+            return JToken.DeepEquals(_definition1, _definition2);
+        }
+
+        private static void RemoveJObjectToken(string tokenName, params JObject[] jObjects)
+        {
+            foreach(var jObject in jObjects)
+            {
+                jObject.Remove(tokenName);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
@@ -63,17 +63,17 @@ namespace VstsBuildsApi
         {
             var key = string.Join("_", _collectionIdentifier, definition["name"].ToString());
             definition["name"] = key;
-            var vstsDefinitions = await VstsRetrieveDefinitionsListByNameAndPathAsync(definition).ConfigureAwait(false);
+            IReadOnlyList<JObject> vstsDefinitions = await VstsRetrieveDefinitionsListByNameAndPathAsync(definition).ConfigureAwait(false);
 
             if (vstsDefinitions.Count == 0)
             {
                 /* Create */
-                var vstsDefinition = await VstsCreateDefinitionAsync(definition).ConfigureAwait(false);
+                JObject vstsDefinition = await VstsCreateDefinitionAsync(definition).ConfigureAwait(false);
                 return vstsDefinition["id"].ToString();
             }
             else if(vstsDefinitions.Count == 1)
             {
-                var vstsDefinition = await VstsRetrieveDefinitionByIdAsync(vstsDefinitions[0]).ConfigureAwait(false);
+                JObject vstsDefinition = await VstsRetrieveDefinitionByIdAsync(vstsDefinitions[0]).ConfigureAwait(false);
 
                 /* Update */
                 if (!IsSameContents(definition, vstsDefinition))

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/project.json
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/project.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "Newtonsoft.Json": "9.0.1",
+    "NETStandard.Library": "1.6.0"
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.BuildTools.VstsBuildsApi</id>
+    <version>1.0.26-prerelease</version>
+    <title>Microsoft DotNet VSTS Builds REST APIs</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>.NET Core Framework Build Tools</summary>
+    <description>This package provides VSTS REST API support.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+      <group targetFramework="netstandard1.5">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+      </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.DotNet.Build.VstsBuildsApi\*.dll" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.Build.VstsBuildsApi.net45\*.dll" target="lib\net45" />
+  </files>
+</package>


### PR DESCRIPTION
Implementation for API discussed in https://github.com/chcosta/buildtools/blob/vstsapi_proposal/Documentation/VSTSBuildManagement.md.

This allows us to multiplex build definitions based on a collection id which build orchestrators will utilize based on convention.  

@weshaggard @dagood @dleeapho @AlfredoMS @markwilkie 