### PR TITLE
Do not redirect std[out|err] when running command

### DIFF
--- a/src/Run/RunProcess.cs
+++ b/src/Run/RunProcess.cs
@@ -10,9 +10,6 @@ namespace Microsoft.DotNet.Execute
 {
     public static class RunProcess
     {
-        private static System.Diagnostics.Process _process;
-        private static bool _exited = false;
-
         public static int ExecuteProcess(string filename, string args = null)
         {
             try
@@ -21,31 +18,14 @@ namespace Microsoft.DotNet.Execute
                 {
                     FileName = filename,
                     Arguments = args,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
                     UseShellExecute = false
                 };
 
-                _process = new System.Diagnostics.Process();
-                _process.StartInfo = psi;
-                _process.EnableRaisingEvents = true;
-
-                // Set the event handler to asynchronously read the output.
-                _process.OutputDataReceived += new DataReceivedEventHandler(ReadOutputHandler);
-                
-                _process.Start();
-                _process.BeginOutputReadLine();
-                string errorOutput = _process.StandardError.ReadToEnd();
-
-                _process.WaitForExit();
-                Console.Error.WriteLine(errorOutput);
-
-                const int SLEEP_AMOUNT = 1000;
-                while (!_exited)
+                using (Process p = Process.Start(psi))
                 {
-                    Thread.Sleep(SLEEP_AMOUNT);
+                    p.WaitForExit();
+                    return p.ExitCode;
                 }
-                return _process.ExitCode;
             }
             catch (InvalidOperationException e)
             {
@@ -56,20 +36,6 @@ namespace Microsoft.DotNet.Execute
             {
                 Console.Error.WriteLine("Error in the command: {0}. => {1}", string.Format("{0} {1}", filename, args), e.Message);
                 return 1;
-            }
-        }
-
-        private static void ReadOutputHandler(object sendingProcess,
-            DataReceivedEventArgs outLine)
-        {
-            // Collect the command output.
-            if (outLine.Data != null)
-            {
-                Console.WriteLine(outLine.Data);
-            }
-            else
-            {
-                _exited = true;
             }
         }
     }


### PR DESCRIPTION
Previously, we would redirect both the standard output and error streams
when run.exe would run a child process. This allowed us to "batch up" all
the output to stderr and report it at the end of the command.

The redirection prevented colorized output from working (on Win32 the
console color commands are no-ops when the output streams are no going to
a console, and similar logic on Unix causes ANSI escape sequences for
colors to not be included when the output is redirected).

This was a significant regression for MSBuild which uses colors. The
buffering we do for standard output/error also prevented tools from
interleaving errors/warnings and regular output.

Stop doing this redirection. Child processes which spew output to stderr
and then doing "replay" it at the end of command execution will no longer
have their output at the end of a run invocation. However, we get back
colors and child command execution works the same way now as if you had
invoked the command directly.

Fixes #864