### PR TITLE
Fix symbol package generation on Unix

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -144,6 +144,13 @@
     <!-- fail if not specified by the project  -->
     <Error Condition="'@(PackageDestination)' == ''" Text="Error could not determine packaging destination.  Please set either PackageTargetFramework property, PackageTargetFramework item, NuGetTargetMoniker property or PackageDestination item." />
 
+    <!-- Be explicit about path seperators for the target path for source files. When building packages on *nix, the use of the DOS seperator
+         was causing us to include source files in our packages in a folder called src\src, instead of them being stripped. -->
+    <PropertyGroup>
+      <SourceFileTargetPathPrefix Condition="'$(OSEnvironment)' == 'Windows_NT'">src\</SourceFileTargetPathPrefix>
+      <SourceFileTargetPathPrefix Condition="'$(OSEnvironment)' != 'Windows_NT'">src/</SourceFileTargetPathPrefix>
+    </PropertyGroup>
+
     <!-- *** include assets *** -->
     <ItemGroup>
       <!-- Include symbols output -->
@@ -179,7 +186,7 @@
       <!-- Include source files for symbol packages. -->
       <FilesToPackage Include="@(Compile->'%(FullPath)')">
         <TargetPath>src</TargetPath>
-        <TargetPath Condition="$([System.String]::new('%(FullPath)').StartsWith('$(ProjectRoot)'))">src\$([System.String]::new('%(FullPath)').Substring('$(ProjectRootLength)'))</TargetPath>
+        <TargetPath Condition="$([System.String]::new('%(FullPath)').StartsWith('$(ProjectRoot)'))">$(SourceFileTargetPathPrefix)$([System.String]::new('%(FullPath)').Substring('$(ProjectRootLength)'))</TargetPath>
         <IsSourceCodeFile>true</IsSourceCodeFile>
       </FilesToPackage>
     </ItemGroup>


### PR DESCRIPTION
We were using a windows path seperator when setting the TargetPath
metadata on source files we added to the ItemGroup of artifacts to pack.
This was causing the logic that splits the nuget package into a product
and symbols package to place the source assets in the product package in
an oddly named 'src\src" directory.

The NuGet logic around dealing with path seperators cross platform has
known issues (e.g. NuGet/Home#3584).

For now, we will use the correct path seperator when adding the metadata.
This seems to be the cleanest solution (I considered changing the path
seperators in the GenerateNuSpec target, but I worry about doing path
normalization there).

Contributes to dotnet/corefx#12758.  This actually fixes the issue, but of
course they will need to tae buildtools update.