### PR TITLE
Xunit issue 659

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
@@ -13,8 +13,6 @@ from helix_test_execution import HelixTestExecution
 
 log = helix.logs.get_logger()
 
-WORKITEM_PASSED = 0
-WORKITEM_FAILED = 1
 
 def main(args=None):
     def _main(settings, optlist, args):
@@ -83,9 +81,8 @@ def main(args=None):
         else:
             log.error("Error: No exception thrown, but XUnit results not created")
             test_executor.report_error(settings, failure_type="XUnitTestFailure")
-            return WORKITEM_FAILED
 
-        return WORKITEM_PASSED
+        return return_code
 
     return command_main(_main, ['script='], args)
 

--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -34,7 +34,7 @@ namespace Xunit.ConsoleClient
                 if (args.Length == 0 || args[0] == "-?")
                 {
                     PrintUsage();
-                    return 1;
+                    return 2;
                 }
 
 #if !NETCORE
@@ -95,17 +95,17 @@ namespace Xunit.ConsoleClient
                     Console.WriteLine();
                 }
 
-                return failCount;
+                return failCount > 0 ? 1 : 0;
             }
             catch (ArgumentException ex)
             {
                 Console.WriteLine("error: {0}", ex.Message);
-                return 1;
+                return 3;
             }
             catch (BadImageFormatException ex)
             {
                 Console.WriteLine("{0}", ex.Message);
-                return 1;
+                return 4;
             }
             finally
             {


### PR DESCRIPTION
Port of https://github.com/xunit/xunit/issues/659 and matching change to scriptrunner.py (since we can now trust exit codes)