### PR TITLE
Add tasks to support installing package from nupkg file and reading package folder locations out of the lock file

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -62,7 +62,7 @@
     <NuGetDependency Include="NuGet.ProjectModel"/>
     <NuGetDependency Include="NuGet.Versioning"/>
     <StaticDependency Include="@(NuGetDependency)">
-      <Version>3.5.0-rc1-final</Version>
+      <Version>3.6.0-rc-1987</Version>
     </StaticDependency>
 
     <NETCoreDependency Include="Microsoft.NETCore.App"/>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks.net45/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Versioning": "3.5.0-rc1-final",
+    "NuGet.Versioning": "3.6.0-rc-1987",
     "System.Reflection.Metadata": "1.1.0"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Client": "3.5.0-rc1-final",
-    "NuGet.ProjectModel": "3.5.0-rc1-final",
+    "NuGet.Client": "3.6.0-rc-1987",
+    "NuGet.ProjectModel": "3.6.0-rc-1987",
     "System.Reflection.Metadata": "1.0.22",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -66,6 +66,7 @@
   <PropertyGroup>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(BaseOutputPath)symbolpkg/</SymbolPackageOutputPath>
+    <PackageInstallPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)localpkg/</PackageInstallPath>
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
@@ -108,6 +109,7 @@
   <UsingTask TaskName="GetPackageFromModule" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="FilterUnknownPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GeneratePackageReport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="InstallPackageFromFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
   
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms
@@ -1192,13 +1194,30 @@
                AdditionalLibPackageExcludes="@(AdditionalLibPackageExcludes)"
                AdditionalSymbolPackageExcludes="@(AdditionalSymbolPackageExcludes)"
                Condition="'$(_SkipCreatePackage)' != 'true'"/>
+        
     <!-- Create a marker that records the path to the generated package -->
-    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg;$(SymbolPackageOutputPath)$(Id).$(PackageVersion).symbols.nupkg"
+    <WriteLinesToFile Lines="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg;$(SymbolPackageOutputPath)$(Id).$(PackageVersion).nupkg"
                       File="$(NuSpecPath).pkgpath"
                       Overwrite="true"
                       Condition="'$(_SkipCreatePackage)' != 'true'"/>
   </Target>
+  
+  <!-- Installs locally built package into a packageinstalldir for consuming -->
+  <!-- Overwrites previous installs, supports only one version installed -->
+  <Target Name="InstallLocallyBuiltPackages"
+          Condition="$(SkipInstallLocallyBuiltPackages)!='true'"
+          AfterTargets="CreatePackage">
+    
+    <Error Text="Package not installed as it was not found at $(PackageOutputPath)$(Id).$(PackageVersion).nupkg" 
+           Condition="!Exists('$(PackageOutputPath)$(Id).$(PackageVersion).nupkg')" />
+    
+    <!-- Force overwrite install directory of package to allow only one version installed -->
+    <RemoveDir Directories="$(PackageInstallPath)\$(Id)" />
 
+    <InstallPackageFromFile PackageFile="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg"
+                            PackagesFolder="$(PackageInstallPath)" />
+      
+  </Target>
 
   <!-- Updates the packageIndex with information from the built package for this project -->
   <!-- Intentionally not sequenced, invoked directly through /t:UpdatePackageIndex -->
@@ -1231,4 +1250,5 @@
                         StablePackages="@(StablePackage)"
                         ModuleToPackages="@(ModuleToPackage)" />
   </Target>
+
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
@@ -4,8 +4,8 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Client": "3.5.0-rc1-final",
-    "NuGet.ProjectModel": "3.5.0-rc1-final",
+    "NuGet.Client": "3.6.0-rc-1987",
+    "NuGet.ProjectModel": "3.6.0-rc-1987",
     "NETStandard.Library": "1.6.0"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test.Desktop/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Client": "3.5.0-rc1-final",
+    "NuGet.Client": "3.6.0-rc-1987",
     "System.Reflection.Metadata": "1.3.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
@@ -4,7 +4,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Client": "3.5.0-rc1-final",
+    "NuGet.Client": "3.6.0-rc-1987",
     "NETStandard.Library": "1.6.0",
     "Microsoft.NETCore.Targets": "1.0.2",
     "xunit": "2.1.0",

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -2,9 +2,9 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Packaging": "3.5.0-rc1-final",
-    "NuGet.ProjectModel": "3.5.0-rc1-final",
-    "NuGet.Versioning": "3.5.0-rc1-final",
+    "NuGet.Packaging": "3.6.0-rc-1987",
+    "NuGet.ProjectModel": "3.6.0-rc-1987",
+    "NuGet.Versioning": "3.6.0-rc-1987",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.1.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"

--- a/src/Microsoft.DotNet.Build.Tasks/BinClashLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/BinClashLogger.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 case "logfile":
                     _logFile = value;
                     break;
-                case "excptiononerror":
+                case "exceptiononerror":
                     _exceptionOnError = Boolean.Parse(value);
                     break;
                 case "outputtostderr":

--- a/src/Microsoft.DotNet.Build.Tasks/InstallPackageFromFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/InstallPackageFromFile.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using Task = Microsoft.Build.Utilities.Task;
+using ThreadingTask = System.Threading.Tasks.Task;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class InstallPackageFromFile : Task, ICancelableTask
+    {
+        [Required]
+        public string PackageFile { get; set; }
+
+        [Required]
+        public string PackagesFolder { get; set; }
+
+        private static readonly CancellationTokenSource TokenSource = new CancellationTokenSource();
+        private static readonly CancellationToken CancellationToken = TokenSource.Token;
+        internal const int DefaultBufferSize = 81920;
+
+        public override bool Execute()
+        {
+            return ExecuteAsync(CancellationToken).Result;
+        }
+
+        public void Cancel()
+        {
+            TokenSource.Cancel();
+        }
+
+        private async Task<bool> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            using (Stream stream = File.OpenRead(PackageFile))
+            {
+                var reader = new PackageArchiveReader(stream, leaveStreamOpen: true);
+                var packageIdentity = reader.GetIdentity();
+                reader.Dispose();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                await
+                    InstallFromStream(ThreadingTask.FromResult(stream), packageIdentity, PackagesFolder,
+                        cancellationToken);
+            }
+            return true;
+        }
+
+        private async ThreadingTask InstallFromStream(Task<Stream> getStream, PackageIdentity package,
+            string packagesFolder, CancellationToken token)
+        {
+            bool isValid = true;
+            if (OfflineFeedUtility.PackageExists(package, packagesFolder, out isValid))
+            {
+                return;
+            }
+
+            var logger = new NugetMsBuildLogger(new TaskLoggingHelper(this));
+
+            var versionFolderPathContext = new VersionFolderPathContext(
+                package,
+                packagesFolder,
+                isLowercasePackagesDirectory: false,
+                logger: logger,
+                packageSaveMode: PackageSaveMode.Defaultv3,
+                xmlDocFileSaveMode: XmlDocFileSaveMode.None);
+
+            await PackageExtractor.InstallFromSourceAsync(
+                async dest =>
+                {
+                    var source = await getStream;
+                    await source.CopyToAsync(dest, bufferSize: DefaultBufferSize, cancellationToken: token);
+                },
+                versionFolderPathContext,
+                token);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -32,9 +32,11 @@
     <Compile Include="GetPackageDependencies.cs" />
     <Compile Include="GetNextRevisionNumber.cs" />
     <Compile Include="GetTargetMachineInfo.cs" />
+    <Compile Include="InstallPackageFromFile.cs" />
     <Compile Include="LocatePreviousContract.cs" />
     <Compile Include="NormalizePaths.cs" />
     <Compile Include="GetDoItemsIntersect.cs" />
+    <Compile Include="NugetMsBuildLogger.cs" />
     <Compile Include="NuGetPackageObject.cs" />
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/NugetMsBuildLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/NugetMsBuildLogger.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using ILogger = NuGet.Common.ILogger;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Logging helper for Nuget tasks
+    /// </summary>
+    internal class NugetMsBuildLogger : ILogger
+    {
+        private readonly TaskLoggingHelper _taskLogging;
+
+        public NugetMsBuildLogger(TaskLoggingHelper taskLogging)
+        {
+            _taskLogging = taskLogging;
+        }
+
+        public void LogDebug(string data)
+        {
+            _taskLogging.LogMessage(MessageImportance.Low, data);
+        }
+
+        public void LogError(string data)
+        {
+            _taskLogging.LogError(data);
+        }
+
+        public void LogErrorSummary(string data)
+        {
+            _taskLogging.LogMessage(MessageImportance.High, data);
+        }
+
+        public void LogInformation(string data)
+        {
+            _taskLogging.LogMessage(MessageImportance.Normal, data);
+        }
+
+        public void LogInformationSummary(string data)
+        {
+            LogInformation(data);
+        }
+
+        public void LogMinimal(string data)
+        {
+            _taskLogging.LogMessage(MessageImportance.High, data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            _taskLogging.LogMessage(MessageImportance.Low, data);
+        }
+
+        public void LogWarning(string data)
+        {
+            _taskLogging.LogWarning(data);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -106,7 +106,7 @@
        the targets necessary to build tests with project references converted to package dependencies.
   -->
   <PropertyGroup>
-    <_BuildAgainstPackages Condition="'$(KeepAllProjectReferences)' != 'true' and '$(IsTestProject)' == 'true' and '$(MSBuildProjectExtension)' != '.builds'">$(BuildTestsAgainstPackages)</_BuildAgainstPackages>
+    <_BuildAgainstPackages Condition="'$(KeepAllProjectReferences)' != 'true' and '$(IsTestProject)' == 'true' and '$(MSBuildProjectExtension)' != '.builds' and '$(SkipBuildAgainstPackages)'!='true'">true</_BuildAgainstPackages>
   </PropertyGroup>
   <!-- 
     Import the default package restore and resolve targets 

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -1,13 +1,13 @@
-{
+﻿{
   "dependencies": {
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "NETStandard.Library": "1.6.0",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Packaging": "3.5.0-rc1-final",
-    "NuGet.ProjectModel": "3.5.0-rc1-final",
-    "NuGet.Versioning": "3.5.0-rc1-final",
+    "NuGet.Packaging": "3.6.0-rc-1987",
+    "NuGet.ProjectModel": "3.6.0-rc-1987",
+    "NuGet.Versioning": "3.6.0-rc-1987",
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Linq.Parallel": "4.0.1",

--- a/src/Microsoft.DotNet.VersionTools.net45/project.json
+++ b/src/Microsoft.DotNet.VersionTools.net45/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Packaging": "3.5.0-rc1-final",
-    "NuGet.Versioning": "3.5.0-rc1-final",
+    "NuGet.Packaging": "3.6.0-rc-1987",
+    "NuGet.Versioning": "3.6.0-rc-1987",
     "Microsoft.NETCore.Platforms": "1.0.1",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },

--- a/src/Microsoft.DotNet.VersionTools/project.json
+++ b/src/Microsoft.DotNet.VersionTools/project.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Packaging": "3.5.0-rc1-final",
-    "NuGet.Versioning": "3.5.0-rc1-final",
+    "NuGet.Packaging": "3.6.0-rc-1987",
+    "NuGet.Versioning": "3.6.0-rc-1987",
     "System.Diagnostics.Process": "4.1.0",
     "System.Diagnostics.TraceSource": "4.0.0"
   },


### PR DESCRIPTION
This change will allow 

- Install from nupkg to local path for installing locally built packages
- Reading from a lockfile that restored from a local path as a fallback source

These changes are required to enable the buildagainstpackages scenario by default. Associated corefx changes: https://github.com/dotnet/corefx/compare/master...karajas:defaultBAP?expand=1

/cc @weshaggard @chcosta 