### PR TITLE
Update NETCore platform versions and add support for fedora 24

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,14 +1,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
-    <CoreFxCurrentRef>6c43ba94713264be37d01321af15505e9229e508</CoreFxCurrentRef>
+    <CoreFxCurrentRef>47ad30e523399c0e256af419bceedae239acb398</CoreFxCurrentRef>
     <CoreClrCurrentRef>a8be270baa206a3d87112b7912869661b0c46f0a</CoreClrCurrentRef>
     <ProjectKTfsCurrentRef>b6fe7bf0d879e7a750b15e90743d5191e3b478de</ProjectKTfsCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsVersion>1.0.2-beta-24506-02</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCorePlatformsVersion>1.2.0-beta-24625-02</MicrosoftNETCorePlatformsVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -18,7 +18,7 @@
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "Newtonsoft.Json": "9.0.1",
         "NETStandard.Library": {
-          "version": "1.6.1-beta-24506-02",
+          "version": "1.6.2-beta-24625-02",
           "exclude": "runtime"
         }
       },
@@ -37,6 +37,7 @@
     "centos.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {},
     "osx.10.10-x64": {},

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -93,6 +93,7 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"
@@ -111,6 +112,7 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"


### PR DESCRIPTION
I'd like to enable testing on Fedora 24 in corefx. To do that, we need to add the RID into our TestSuite `runtime.json`. I've also added support for "regular" building on Fedora 24 by making the tool-runtime project.json compatible with the fedora.24-x64 rid. Previously, you needed to set your __PUBLISH_RID to fedora.23-x64 to successfully restore the tools.

@dagood 