### PR TITLE
Fix VS Configuration workaround

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -126,7 +126,7 @@
     <!-- list each append as a seperate item to force re-evaluation of AdditionalProperties metadata -->
     <ItemGroup>
       <ProjectReference>
-        <UndefineProperties>%(ProjectReference.UndefineProperties);Configuration</UndefineProperties>
+        <UndefineProperties Condition="'$(ConfigurationGroup)' != ''">%(ProjectReference.UndefineProperties);Configuration</UndefineProperties>
       </ProjectReference>
 
       <!-- Set some basic configuration properties and pass them along to ProjectReference's -->
@@ -145,7 +145,7 @@
         <AdditionalProperties Condition="'%(ProjectReference.OSGroup)'!=''">OSGroup=%(ProjectReference.OSGroup);%(ProjectReference.AdditionalProperties)</AdditionalProperties>
       </ProjectReference>
       <ProjectReference>
-        <AdditionalProperties>ConfigurationGroup=$(ConfigurationGroup);%(ProjectReference.AdditionalProperties)</AdditionalProperties>
+        <AdditionalProperties Condition="'$(ConfigurationGroup)' != ''">ConfigurationGroup=$(ConfigurationGroup);%(ProjectReference.AdditionalProperties)</AdditionalProperties>
       </ProjectReference>
 
       <!-- Packaging property shortcuts -->


### PR DESCRIPTION
This change fixes builds for buildtools consumers that don't use ConfigurationGroup

Fixes #1143