### PR TITLE
Use environment INIT_TOOLS_RESTORE_ARGS variable when bootstrapping

### DIFF
--- a/bootstrap/bootstrap.ps1
+++ b/bootstrap/bootstrap.ps1
@@ -90,7 +90,7 @@ if ($env:buildtools_source -ne $null)
 }
 $packagesPath = Join-Path $RepositoryRoot "packages"
 $dotNetExe = Join-Path $cliLocalPath "dotnet.exe"
-$restoreArgs = "restore $projectJson --packages $packagesPath --source $buildToolsSource --source $nugetOrgSource"
+$restoreArgs = "restore $projectJson --packages $packagesPath --source $buildToolsSource --source $nugetOrgSource $($env:init_tools_restore_args)"
 $process = Start-Process -Wait -NoNewWindow -FilePath $dotNetExe -ArgumentList $restoreArgs -PassThru
 if ($process.ExitCode -ne 0)
 {

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -216,7 +216,7 @@ nugetOrgSource="https://api.nuget.org/v3/index.json"
 
 packagesPath="$repoRoot/packages"
 dotNetExe="$cliInstallPath/dotnet"
-restoreArgs="restore $projectJson --packages $packagesPath --source $buildToolsSource --source $nugetOrgSource"
+restoreArgs="restore $projectJson --packages $packagesPath --source $buildToolsSource --source $nugetOrgSource ${__INIT_TOOLS_RESTORE_ARGS:-}"
 say_verbose "Running $dotNetExe $restoreArgs"
 $dotNetExe $restoreArgs
 if [ $? != 0 ]; then


### PR DESCRIPTION
Like [init-tools.cmd](https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd) and [init-tools.sh](https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh), makes `bootstrap.sh/cmd` pick up on the `INIT_TOOLS_RESTORE_ARGS` variable to pass as extra arguments to `dotnet restore`.

For example, the variable can be set to `--disable-parallel` or `--verbosity debug`.

Since bootstrap.sh only downloads a few packages, this PR shouldn't actually matter much for the overall `--disable-parallel` fix. I was thinking a bootstrap PR was necessary to pass along the value to the buildtools init-tools script, but that isn't the case since it's an environment variable. I'm submitting this anyway for consistency, but this PR shouldn't block fixing the CLI build.

@crummel @chcosta
/cc @weshaggard
