### PR TITLE
Update boostrapper scripts to allow selecting architecture.

### DIFF
--- a/bootstrap/bootstrap.ps1
+++ b/bootstrap/bootstrap.ps1
@@ -5,6 +5,7 @@ param
     [Parameter(Mandatory=$false)][string]$CliLocalPath = (Join-Path $ToolsLocalPath "dotnetcli"),
     [Parameter(Mandatory=$false)][string]$SharedFrameworkSymlinkPath = (Join-Path $ToolsLocalPath "dotnetcli\shared\Microsoft.NETCore.App\version"),
     [Parameter(Mandatory=$false)][string]$SharedFrameworkVersion = "<auto>",
+    [Parameter(Mandatory=$false)][string]$Architecture = "<auto>",
     [switch]$Force = $false
 )
 
@@ -24,7 +25,7 @@ if ((Test-Path $bootstrapComplete) -and !(Compare-Object (Get-Content $rootToolV
 }
 
 $initCliScript = "dotnet-install.ps1"
-$initCliLocalPath = Join-Path $ToolsLocalPath $initCliScript
+$dotnetInstallPath = Join-Path $ToolsLocalPath $initCliScript
 
 # blow away the tools directory so we can start from a known state
 if (Test-Path $ToolsLocalPath)
@@ -38,15 +39,15 @@ else
 }
 
 # download CLI boot-strapper script
-Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $initCliLocalPath
+Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $dotnetInstallPath
 
 # load the version of the CLI
 $rootCliVersion = Join-Path $RepositoryRoot ".cliversion"
 $dotNetCliVersion = Get-Content $rootCliVersion
 
 # now execute the script
-Write-Host "$initCliLocalPath -Version $dotNetCliVersion -InstallDir $CliLocalPath"
-Invoke-Expression "$initCliLocalPath -Version $dotNetCliVersion -InstallDir $CliLocalPath"
+Write-Host "$dotnetInstallPath -Version $dotNetCliVersion -InstallDir $CliLocalPath -Architecture ""$Architecture"""
+Invoke-Expression "$dotnetInstallPath -Version $dotNetCliVersion -InstallDir $CliLocalPath -Architecture ""$Architecture"""
 if ($LastExitCode -ne 0)
 {
     Write-Output "The .NET CLI installation failed with exit code $LastExitCode"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -79,6 +79,7 @@ symlinkPath="<auto>"
 sharedFxVersion="<auto>"
 force=false
 forcedCliLocalPath="<none>"
+architecture="<auto>"
 
 while [ $# -ne 0 ]
 do
@@ -99,6 +100,10 @@ do
         -u|--useLocalCli|-[Uu]seLocalCli)
             shift
             forcedCliLocalPath="$1"
+            ;;
+        -a|--architecture|-[Aa]rchitecture)
+            shift
+            architecture="$1"
             ;;
         --sharedFrameworkSymlinkPath|--symlink|-[Ss]haredFrameworkSymlinkPath)
             shift
@@ -147,7 +152,7 @@ if [[ $force && -f $bootstrapComplete ]]; then
 fi
 
 # if the semaphore file exists and is identical to the specified version then exit
-if [[ -f $bootstrapComplete && `cmp $bootstrapComplete $rootToolVersions` ]]; then
+if [[ -f $bootstrapComplete && ! `cmp $bootstrapComplete $rootToolVersions` ]]; then
     say "$bootstrapComplete appears to show that bootstrapping is complete.  Use --force if you want to re-bootstrap."
     exit 0
 fi
@@ -175,8 +180,8 @@ if [ $forcedCliLocalPath = "<none>" ]; then
     dotNetCliVersion=`cat $rootCliVersion`
 
     # now execute the script
-    say_verbose "installing CLI: $dotnetInstallPath --version $dotNetCliVersion --install-dir $cliInstallPath"
-    $dotnetInstallPath --version "$dotNetCliVersion" --install-dir $cliInstallPath
+    say_verbose "installing CLI: $dotnetInstallPath --version \"$dotNetCliVersion\" --install-dir $cliInstallPath --architecture \"$architecture\""
+    $dotnetInstallPath --version "$dotNetCliVersion" --install-dir $cliInstallPath --architecture "$architecture"
     if [ $? != 0 ]; then
         say_err "The .NET CLI installation failed with exit code $?"
         exit $?


### PR DESCRIPTION
Fixes #1165.
This is needed for CLI because their build script takes a architecture parameter that they need to respect.