### PR TITLE
Don't set prerelease on Unavailable

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -615,7 +615,7 @@
            this will prevent the package from installing on that platform. -->
       <FilePackageDependency Include="Unavailable" Condition="'$(AllowPartialPackages)' == 'true' AND '@(_missingHarvestFile)' != '' AND '$(_TargetFramework)' != ''">
         <TargetFramework>$(_TargetFramework)</TargetFramework>
-        <Version>0.0.0-unavailable</Version>
+        <Version>0.0.0</Version>
       </FilePackageDependency>
     </ItemGroup>
 


### PR DESCRIPTION
We weren't handling prerelease on FilePackageDependency items well.
I did this before just to ensure that we'd always have a prerelease
dependency, but that's unnecessary, this will always be pre-release
since its not in the index.