### PR TITLE
Bump buildtools package versions for rel/1.1.0

### DIFF
--- a/src/nuget/Microsoft.DotNet.BuildTools.GenAPI.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.GenAPI.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.GenAPI</id>
-    <version>1.0.0-beta2</version>
+    <version>1.0.0-beta3</version>
     <title>Reference Assembly Source Generator (GenAPI)</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.RepoUtils</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>Repository Produces/Consumes Utilities</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.Run.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.Run.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.Run</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>Microsoft DotNet Run Tool</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.TestSuite</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>xUnit suite of .NET Core test projects</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.VstsBuildsApi</id>
-    <version>1.0.26-prerelease</version>
+    <version>1.0.27-prerelease</version>
     <title>Microsoft DotNet VSTS Builds REST APIs</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools</id>
-    <version>1.0.26-prerelease</version>
+    <version>1.0.27-prerelease</version>
     <title>Microsoft DotNet BuildTools</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.VersionTools.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.VersionTools</id>
-    <version>1.0.26-prerelease</version>
+    <version>1.0.27-prerelease</version>
     <title>Microsoft DotNet VersionTools</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
+++ b/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.5">
     <id>Microsoft.xunit.extensibility.execution.netcore</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>Redist of xunit.execution.execution to target netstandard1.0</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
+++ b/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.xunit.netcore.extensions</id>
-    <version>1.0.0-prerelease</version>
+    <version>1.0.1-prerelease</version>
     <title>xUnit extensions of .NET Core test projects</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>xunit.console.netcore</id>
-    <version>1.0.3-prerelease</version>
+    <version>1.0.4-prerelease</version>
     <title>xUnit.net [Runners - .NET Core]</title>
     <authors>James Newkirk, Brad Wilson (.NET Core package by Matt Cohn)</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/xunit.runner.uwp.nuspec
+++ b/src/nuget/xunit.runner.uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>microsoft.xunit.runner.uwp</id>
-    <version>1.0.3-prerelease</version>
+    <version>1.0.4-prerelease</version>
     <title>xUnit UWP Runner</title>
     <authors>Chris Rummel</authors>
     <owners>Microsoft</owners>


### PR DESCRIPTION
I'm creating a branch for 1.1.0 to allow for buildtools changes.

As such we need to move the current versions out of the way.

I did the same for 1.0.0.

/cc @MattGal @dagood @karajas @chcosta @weshaggard 
since you all commonly update buildtools.  Take note of the version bumps so you pick up the correct builds when merging changes.