### PR TITLE
[release/1.1.0] Ensure we're comparing 3-part versions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     Log.LogMessage($"Could not parse version {versionString} for LatestPackage {packageId}, will use latest stable.");
                 }
 
-                latestPackages[packageId] = nuGetVersion?.Version;
+                latestPackages[packageId] = VersionUtility.As3PartVersion(nuGetVersion?.Version);
                 originalItems[packageId] = latestPackage;
             }
 
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     Log.LogMessage($"Could not parse version {versionString} for LatestPackage {packageId}, will use latest stable.");
                 }
 
-                var latestVersion = nuGetVersion?.Version;
+                var latestVersion = VersionUtility.As3PartVersion(nuGetVersion?.Version);
 
                 PackageInfo info;
                 if (PackageIndex.Current.Packages.TryGetValue(packageId, out info))

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -52,6 +52,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static Version As3PartVersion(Version version)
         {
+            if (version == null)
+            {
+                return null;
+            }
+
             int build = version.Build;
 
             if (build == -1)
@@ -70,6 +75,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public static Version As4PartVersion(Version version)
         {
+            if (version == null)
+            {
+                return null;
+            }
+
             int build = version.Build, revision = version.Revision;
 
             if (build == -1)


### PR DESCRIPTION
NuGetVersion was returning a 4-part version even though the version
string it was constructed with only had 3 parts.  As a result, when we
compared it to the 3 part version in the stable version list it came out
as greater even though it was the same.  This caused us to stop 
harvesting from stable packages and resulted in numerous package
validation errors.

Fix this by ensuring we are comparing 3-part versions.

/cc @weshaggard @chcosta 