### PR TITLE
Add AttributeUsage to __BlockReflectionAttribute

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BlockReflectionAttribute.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BlockReflectionAttribute.cs
@@ -9,5 +9,6 @@ using System;
 
 namespace System.Runtime.CompilerServices
 {
+    [AttributeUsage(AttributeTargets.All)]
     internal class __BlockReflectionAttribute : Attribute { }
 }


### PR DESCRIPTION
This cleans up FxCop analyzer warnings.