### PR TITLE
Call non-prerelease builds "stable", not ""

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
             string prereleaseVersion = packages
                 .Select(t => t.Prerelease)
                 .FirstOrDefault(prerelease => !string.IsNullOrEmpty(prerelease))
-                ?? "";
+                ?? "stable";
 
             Dictionary<string, string> packageDictionary = packages.ToDictionary(
                     t => t.Id,


### PR DESCRIPTION
This avoids adding empty files to the versions repo when releasing stable builds. This flows to auto-update PR titles looking nicer and avoids a GitHub bug where accessing an empty file through the raw API for the first time causes a 503 response.

I don't think this is useful enough to take for the current release, but it will make prerelease => stable auto-PRs smoother in the future.

/cc @gkhanna79 @weshaggard 
