### PR TITLE
Allow for ContractProject to be specified as item

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
@@ -19,22 +19,27 @@
 
   <!-- ApiCompat for Implementation Assemblies  -->
   <Target Name="ValidateApiCompatForSrc"
-          Condition="'$(RunApiCompatForSrc)' == 'true' AND '$(RunApiCompat)' == 'true' AND Exists('$(ContractProject)')" >
+          Condition="'$(RunApiCompatForSrc)' == 'true' AND '$(RunApiCompat)' == 'true' AND Exists('@(ContractProject)')" >
 
     <PropertyGroup>
       <ReferenceAssembly>@(ResolvedMatchingContract)</ReferenceAssembly>
-      <RefProjectForDependencies>$(ContractProject)</RefProjectForDependencies>
       <!--
         For depproj's we should approximate the dependencies based on the current contract which
         should be a superset of the older contract dependencies.
       -->
-      <RefProjectForDependencies Condition="$(ContractProject.EndsWith('depproj'))">$(SourceDir)/$(AssemblyName)/ref/$(AssemblyName).csproj</RefProjectForDependencies>
+      <UseCSProjForDependencies Condition="'%(ContractProject.Extension)' == '.depproj'">true</UseCSProjForDependencies>
     </PropertyGroup>
 
-    <MSBuild Projects="$(RefProjectForDependencies)"
+    <ItemGroup>
+      <RefProjectForDependencies Condition="'$(UseCSProjForDependencies)' != 'true'" Include="@(ContractProject)" />
+      <RefProjectForDependencies Condition="'$(UseCSProjForDependencies)' == 'true'" Include="$(SourceDir)/$(AssemblyName)/ref/$(AssemblyName).csproj">
+        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
+      </RefProjectForDependencies>
+    </ItemGroup>
+
+    <MSBuild Projects="@(RefProjectForDependencies)"
              Targets="ResolveProjectReferences;ResolveAssemblyReferences"
-             RemoveProperties="OSGroup;TargetGroup"
-             Condition="Exists('$(RefProjectForDependencies)')">
+             Condition="Exists('@(RefProjectForDependencies)')">
       <Output TaskParameter="TargetOutputs" ItemName="ReferenceAssemblyReferencePath" />
     </MSBuild>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resolveContract.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resolveContract.targets
@@ -13,18 +13,34 @@
   </PropertyGroup>
   
   <Target Name="ResolveMatchingContract">
-    <PropertyGroup Condition="'$(ContractProject)' == ''">
+    <PropertyGroup Condition="'$(ContractProject)' == '' AND '@(ContractProject)' == ''">
       <ContractProject>$(SourceDir)/$(AssemblyName)/ref/$(APIVersion)/$(AssemblyName).csproj</ContractProject>
       <!-- fall back to 'current' version if specific version does not exist -->
       <ContractProject Condition="!(Exists('$(ContractProject)'))">$(SourceDir)/$(AssemblyName)/ref/$(AssemblyName).csproj</ContractProject>
       <!-- don't add a project if one can't be found-->
       <ContractProject Condition="!(Exists('$(ContractProject)'))"></ContractProject>
     </PropertyGroup>
-    <ItemGroup>
-      <ProjectReference Include="$(ContractProject)" Condition="'$(ContractProject)' != ''">
+
+    <ItemGroup Condition="'@(ContractProject)' == ''">
+      <ContractProject Include="$(ContractProject)" />
+    </ItemGroup>
+
+    <Error Condition="'@(ContractProject->Count())' &gt; '1'" Text="Only one value may be specified for ContractProject item but '@(ContractProject)' is '@(ContractProject->Count())' items." />
+
+    <ItemGroup Condition="'@(ContractProject)' != ''">
+      <!-- Don't flow the values for OSGroup/TargetGroup unless explicitly defined -->
+      <ContractProject>
+        <UndefineProperties Condition="'%(ContractProject.OSGroup)'==''">OSGroup;%(ContractProject.UndefineProperties)</UndefineProperties>
+        <AdditionalProperties Condition="'%(ContractProject.OSGroup)'!=''">OSGroup=%(ContractProject.OSGroup);%(ContractProject.AdditionalProperties)</AdditionalProperties>
+      </ContractProject>
+      <ContractProject>
+        <UndefineProperties Condition="'%(ContractProject.TargetGroup)'==''">TargetGroup;%(ContractProject.UndefineProperties)</UndefineProperties>
+        <AdditionalProperties Condition="'%(ContractProject.TargetGroup)'!=''">TargetGroup=%(ContractProject.TargetGroup);%(ContractProject.AdditionalProperties)</AdditionalProperties>
+      </ContractProject>
+
+      <ProjectReference Include="@(ContractProject)">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <OutputItemType>ResolvedMatchingContract</OutputItemType>
-        <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
       </ProjectReference>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This allows folks to define metadata on that item like TargetGroup.

Fixes #1041 

I needed to fix this in order to make all the projects contributing to NETCoreApp as TargetGroup='' (/cc @ellismg @chcosta)

/cc @weshaggard @JeremyKuhne