### PR TITLE
Fix typo in PackageInstallPath property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -66,7 +66,7 @@
   <PropertyGroup>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(BaseOutputPath)symbolpkg/</SymbolPackageOutputPath>
-    <PackageInstallPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)localpkg/</PackageInstallPath>
+    <PackageInstallPath Condition="'$(PackageInstallPath)' == ''">$(BaseOutputPath)localpkg/</PackageInstallPath>
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
@@ -1205,7 +1205,7 @@
   <!-- Installs locally built package into a packageinstalldir for consuming -->
   <!-- Overwrites previous installs, supports only one version installed -->
   <Target Name="InstallLocallyBuiltPackages"
-          Condition="$(SkipInstallLocallyBuiltPackages)!='true'"
+          Condition="'$(SkipInstallLocallyBuiltPackages)' != 'true'"
           AfterTargets="CreatePackage">
     
     <Error Text="Package not installed as it was not found at $(PackageOutputPath)$(Id).$(PackageVersion).nupkg" 


### PR DESCRIPTION
Looks like this was meant to have a default value, but there was a
copy/paste error in the property definition.

I also fixed the condition on InstallLocallyBuiltPackages.

This will let folks pick up buildtools in CoreFx/elsewhere without making changes to the repo settings.

/cc @alexperovich @karajas @weshaggard 