### PR TITLE
Ignore "draft" definitions

### DIFF
--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildClient.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements. 
+// Licensed to the .NET Foundation under one or more agreements. 
 // The .NET Foundation licenses this file to you under the MIT license. 
 // See the LICENSE file in the project root for more information. 
 
@@ -174,7 +174,8 @@ namespace VstsBuildsApi
                 foreach(var childDefinition in children)
                 {
                     JObject childObject = (JObject)childDefinition;
-                    if (definition["path"].ToString() == childObject["path"].ToString())
+                    if (definition["quality"].ToString() == "definition" &&
+                        definition["path"].ToString() == childObject["path"].ToString())
                     {
                         definitions.Add(childObject);
                     }


### PR DESCRIPTION
https://github.com/dotnet/buildtools/issues/1181

Only iterate "definition" quality build definitions, ignore "drafts".  

/cc @weshaggard 