### PR TITLE
Workaround netcore roslyn assembly loading issue

### DIFF
--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -36,6 +36,12 @@
     <file src="Microsoft.DotNet.CodeAnalysis.net45\Microsoft.DotNet.CodeAnalysis.dll" target="lib\net45\analyzers" />
     <file src="Microsoft.DotNet.CodeAnalysis\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.CodeAnalysis\Analyzers\*.*" target="lib\analyzers" />
+
+    <!-- workaround bug where Roslyn is failing to load analyzer dependencies that aren't in app-base,
+         copy these two dlls, which are dependencies of other analyzers, to app-base.  -->
+    <file src="Microsoft.DotNet.CodeAnalysis\Analyzers\Desktop.Analyzers.dll" target="lib" />
+    <file src="Microsoft.DotNet.CodeAnalysis\Analyzers\System.Security.Cryptography.Hashing.Algorithms.Analyzers.dll" target="lib" />
+
     <file src="Microsoft.DotNet.CodeAnalysis.net45\Analyzers\*.*" target="lib\net45\analyzers" />
     <file src="Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib" />


### PR DESCRIPTION
Roslyn on .NETCore wasn't finding dependencies of analyzers if those
dependencies were not in the same directory as CSC itself.  It should be
looking next to the analyzer but is not.

On desktop this happens automatically but on Core I suspect roslyn's AssemblyLoadContext needs to handle it.

Workaround that by copying these dependencies to lib temporarily.  

/cc @alexperovich @tmat @tmeschter @mavasani