### PR TITLE
Update to signed version of analyzers

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis.net45/project.json
+++ b/src/Microsoft.DotNet.CodeAnalysis.net45/project.json
@@ -5,6 +5,8 @@
     "Microsoft.CodeAnalysis.CSharp":"1.3.0",
     "System.Collections.Immutable": "1.2.0",
     "System.Reflection.Metadata": "1.3.0",
+    "System.Runtime.Analyzers": "1.1.0",
+    "System.Runtime.InteropServices.Analyzers": "1.1.0",
     "Microsoft.CodeAnalysis.FxCopAnalyzers": "1.1.0"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.CodeAnalysis/project.json
+++ b/src/Microsoft.DotNet.CodeAnalysis/project.json
@@ -7,6 +7,8 @@
       "type": "platform",
       "version": "1.0.0"
     },
+    "System.Runtime.Analyzers": "1.1.0",
+    "System.Runtime.InteropServices.Analyzers": "1.1.0",
     "System.Reflection.Metadata": "1.3.0",
     "System.Runtime.Extensions": "4.1.0",
     "Microsoft.CodeAnalysis.FxCopAnalyzers": "1.1.0"


### PR DESCRIPTION
The System.Runtime.Analyzers & System.Runtime.InteropServices.Analyzers
packages referenced by Microsoft.CodeAnalysis.FxCopAnalyzers are
unsigned.  Update the package references to pull down signed versions.

/cc @alexperovich @safern 