### PR TITLE
Handle multiple runtime deps from same project

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -1026,7 +1026,7 @@
       <!-- map back to the project references -->
       <RuntimeDependencyProjectFullPath Include="@(RuntimeDependencyProject->'%(FullPath)')"/>
       <ProjectReferenceFullPath Include="@(ProjectReference->'%(FullPath)')"/>
-      <RuntimeProjectReference Include="@(ProjectReferenceFullPath)" Condition="'@(ProjectReferenceFullPath)' == '@(RuntimeDependencyProjectFullPath)' AND '%(Identity)' != ''"/>
+      <RuntimeProjectReference Include="@(ProjectReferenceFullPath)" Condition="'@(ProjectReferenceFullPath->Distinct())' == '@(RuntimeDependencyProjectFullPath)' AND '%(Identity)' != ''"/>
     </ItemGroup>
 
 


### PR DESCRIPTION
Previously we were failing to intersect here.  ProjectReferenceFullPath
had multiple entries for the same project which caused the equal
comparison to fail and we'd miss including these items.

/cc @weshaggard @chcosta 