### PR TITLE
Add Fedora 24 support to release/1.1.0 branch

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -1,14 +1,14 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
-    <CoreFxCurrentRef>6c43ba94713264be37d01321af15505e9229e508</CoreFxCurrentRef>
+    <CoreFxCurrentRef>12abd697857d39b1a07dfae9e01d31f875500ebf</CoreFxCurrentRef>
     <CoreClrCurrentRef>a8be270baa206a3d87112b7912869661b0c46f0a</CoreClrCurrentRef>
     <ProjectKTfsCurrentRef>b6fe7bf0d879e7a750b15e90743d5191e3b478de</ProjectKTfsCurrentRef>
   </PropertyGroup>
 
   <!-- Auto-upgraded properties for each build info dependency. -->
   <PropertyGroup>
-    <MicrosoftNETCorePlatformsVersion>1.0.2-beta-24506-02</MicrosoftNETCorePlatformsVersion>
+    <MicrosoftNETCorePlatformsVersion>1.1.0</MicrosoftNETCorePlatformsVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <RemoteDependencyBuildInfo Include="CoreFx">
-      <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/$(DependencyBranch)</BuildInfoPath>
+      <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/release/1.1.0</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="CoreClr">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -19,7 +19,7 @@
         "System.Runtime.Serialization.Primitives": "4.1.1",
         "Newtonsoft.Json": "9.0.1",
         "NETStandard.Library": {
-          "version": "1.6.1-beta-24506-02",
+          "version": "1.6.1",
           "exclude": "runtime"
         }
       },
@@ -38,6 +38,7 @@
     "centos.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {},
     "osx.10.10-x64": {},

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/runtime.json
@@ -77,6 +77,7 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"
@@ -93,6 +94,7 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"
@@ -111,6 +113,7 @@
                 "ubuntu.16.04-x64",
                 "ubuntu.16.10-x64",
                 "fedora.23-x64",
+                "fedora.24-x64",
                 "linux-x64",
                 "opensuse.13.2-x64",
                 "opensuse.42.1-x64"


### PR DESCRIPTION
~~This is a direct port of my master PR: #1177 . It will allow us to run tests against Fedora 24 in the release/1.1.0 branch.~~

I've made a small modification to the TestSuite's runtime.json over what is in master, so that we can run tests in the release/1.1.0 branch without retargeting all of the test projects to netcoreapp1.1.