### PR TITLE
Use Version Metadata in buildagainstpackages if specified and remove AssemblyVersion

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -374,21 +374,22 @@ namespace Microsoft.DotNet.Build.Tasks
                 // Don't add a new dependency if one already exists.
                 if (!returnDependenciesList.ContainsKey(name))
                 {
-                    NuGetVersion nuGetVersion = NuGetVersion.Parse(dependency.GetMetadata("Version"));
-                    PackageItem packageItem = new PackageItem(name, nuGetVersion);
-                    bool? forceVersion = dependency.GetMetadata("ForceVersion")?.Equals("true", StringComparison.OrdinalIgnoreCase);
-                    string version = packageItem.GetVersionString();
+                    string versionFromMetadata = dependency.GetMetadata("Version");
+                    NuGetVersion nuGetVersion = null;
+                    if (versionFromMetadata != string.Empty)
+                    {
+                        nuGetVersion = NuGetVersion.Parse(dependency.GetMetadata("Version"));
+                    }
 
                     // a package version was provided, use its version information.
-                    if (packageInformation.ContainsKey(name) && (bool) !forceVersion)
+                    if (packageInformation.ContainsKey(name))
                     {
-                        version = packageInformation[name].Version.ToString();
+                        nuGetVersion = packageInformation[name].Version;
                     }
+                    PackageItem packageItem = new PackageItem(name, nuGetVersion);
+                    string version = packageItem.GetVersionString();
+
                     JProperty property = new JProperty(name, version);
-                    if (forceVersion == true && framework != null)
-                    {
-                        continue;
-                    }
                     returnDependenciesList.Add(name, property);
                 }
                 else

--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -376,14 +376,19 @@ namespace Microsoft.DotNet.Build.Tasks
                 {
                     NuGetVersion nuGetVersion = NuGetVersion.Parse(dependency.GetMetadata("Version"));
                     PackageItem packageItem = new PackageItem(name, nuGetVersion);
+                    bool? forceVersion = dependency.GetMetadata("ForceVersion")?.Equals("true", StringComparison.OrdinalIgnoreCase);
                     string version = packageItem.GetVersionString();
 
                     // a package version was provided, use its version information.
-                    if (packageInformation.ContainsKey(name))
+                    if (packageInformation.ContainsKey(name) && forceVersion!=true)
                     {
                         version = packageInformation[name].Version.ToString();
                     }
                     JProperty property = new JProperty(name, version);
+                    if (forceVersion == true && framework != null)
+                    {
+                        continue;
+                    }
                     returnDependenciesList.Add(name, property);
                 }
                 else
@@ -476,7 +481,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public string GetVersionString()
         {
-            return string.Join(".", _version.Major, _version.Minor, _version.Patch);
+            return _version.ToString();
         }
 
         public TaskItem ToTaskItem()

--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -380,7 +380,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     string version = packageItem.GetVersionString();
 
                     // a package version was provided, use its version information.
-                    if (packageInformation.ContainsKey(name) && forceVersion!=true)
+                    if (packageInformation.ContainsKey(name) && (bool) !forceVersion)
                     {
                         version = packageInformation[name].Version.ToString();
                     }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -104,25 +104,6 @@
       <_InjectProjectReference>%(_PackageProjectReference.FileName)</_InjectProjectReference>
     </PropertyGroup>
 
-    <ItemGroup>
-      <_AdditionalProperties Condition="'$(AssemblyVersionTransition)' != ''" Include="AssemblyVersionTransition=$(AssemblyVersionTransition);" />
-    </ItemGroup>
-
-    <!-- Evaluate the project references to determine the assembly version for the package dependency.
-         Only evaluate the project reference if we were not able to find an assembly version in "PackageDrops" -->
-    <MSBuild Condition="'%(_PackageProjectReference.Identity)' != ''"
-             Projects="%(_PackageProjectReference.Identity)"
-             Targets="GetAssemblyVersion"
-             Properties="@(_AdditionalProperties)">
-      <Output TaskParameter="TargetOutputs"
-              PropertyName="_EvaluatedAssemblyVersion" />
-    </MSBuild>
-    <PropertyGroup>
-      <_AssemblyVersion Condition="'$(_AssemblyVersion)' == ''">$(_EvaluatedAssemblyVersion)</_AssemblyVersion>
-    </PropertyGroup>
-
-    <Error Condition="'$(_AssemblyVersion)' == ''" Text="Unable to determine assembly version for project reference '%(_PackageProjectReference.Identity)'" />
-
     <PropertyGroup>
       <!-- Use the alternative PackageReferenceName metadata if available -->
       <_InjectProjectReferenceDependencyName Condition="'$(_PackageReferenceName)' == ''">%(_PackageProjectReference.FileName)</_InjectProjectReferenceDependencyName>
@@ -133,7 +114,6 @@
       <_InjectProjectReferenceDependency  Include="$(_InjectProjectReferenceDependencyName)">
         <Name>$(_InjectProjectReferenceDependencyName)</Name>
         <OriginalName>$(_InjectProjectReference)</OriginalName>
-        <Version>$(_AssemblyVersion)</Version>
         <FilePath>%(_PackageProjectReference.Identity)</FilePath>
         <TargetGroup>%(_PackageProjectReference.TargetGroup)</TargetGroup>
         </_InjectProjectReferenceDependency>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -3,7 +3,11 @@
   <UsingTask TaskName="AddDependenciesToProjectJson" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="GetPackageNumberFromPackageDrop" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="DumpItem" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-
+  
+  <PropertyGroup>
+    <!-- PackageDrops is set to the bin folder where packages are built to generate the new test project.json for these -->
+    <PackagesDrops Condition="'$(PackagesDrops)' == ''">$(PackageOutputPath)</PackagesDrops>
+  </PropertyGroup>
   <ItemGroup>
     <_PackagesDrops Include="$(PackagesDrops)" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -86,8 +86,7 @@
     <ItemGroup Condition="'$(KeepAllProjectReferences)' != 'true'">
       <!-- Don't alter the ProjectReference's from the project during the extraction phase -->
       <_ClonedProjectReference Include="@(ProjectReference)" />
-      <_RemovePackageProjectReference Condition="'%(_ClonedProjectReference.KeepProjectReference)' == 'true' or $([System.Text.RegularExpressions.Regex]::IsMatch('%(_ClonedProjectReference.FullPath)', '\\tests\\', System.Text.RegularExpressions.RegexOptions.IgnoreCase)) or $([System.Text.RegularExpressions.Regex]::IsMatch('%(_ClonedProjectReference.FullPath)', '//tests//', System.Text.RegularExpressions.RegexOptions.IgnoreCase))"
-                                Include="%(_ClonedProjectReference.Identity)" />
+      <_RemovePackageProjectReference Condition="'%(_ClonedProjectReference.KeepProjectReference)' != 'true' and !$([System.Text.RegularExpressions.Regex]::IsMatch('%(_ClonedProjectReference.FullPath)', ''[\\/]tests[\\/]', System.Text.RegularExpressions.RegexOptions.IgnoreCase))" Include="%(_ClonedProjectReference.Identity)" />
       <!-- Populate items first with the project references so that we can trim them but keep the item metadata -->
       <_PackageProjectReference Include="@(_ClonedProjectReference)" />
       <_ClonedProjectReference Remove="@(_RemovePackageProjectReference)" />


### PR DESCRIPTION
Ensure version returned contains prerelease label.