### PR TITLE
Make sure to import MicroBuild.core.props

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -40,4 +40,9 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Roslyn.Common.props" />
+
+  <!--
+    import the MicroBuild boot-strapper props (only relevant for shipping binaries)
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.props" Condition="'$(IsTestProject)'!='true'" />
 </Project>


### PR DESCRIPTION
Some plugins require both props and targets.  Make sure we import both.

Fixes #1186

/cc @markwilkie @chcosta @dagood @weshaggard 