### PR TITLE
Only import props if they exist

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -44,5 +44,5 @@
   <!--
     import the MicroBuild boot-strapper props (only relevant for shipping binaries)
   -->
-  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.props" Condition="'$(IsTestProject)'!='true'" />
+  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.props" Condition="'$(IsTestProject)'!='true' AND Exists('$(MSBuildThisFileDirectory)MicroBuild.Core.props')" />
 </Project>


### PR DESCRIPTION
This change exposed a bug introduced with https://github.com/dotnet/buildtools/commit/2d3d95068daf1b3edb6f7eb7001c6030bc23f4f3

That commit added a dependency on find which isn't working on
fedora or alpine.

Builds were still succeeding despite this regression because there was
no hard dependency on the packages pulled down (MS.Portable.Targets
or MicroBuild.Core) during the fedora/alpine builds.  My change to import
MicroBuild.Core props made this break, so I'm just sofenting the dependency
until init-tools can be fixed.

/cc @dagood @weshaggard 