### PR TITLE
Simplify case-insensitive target file copy in init-tools.sh

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -98,10 +98,10 @@ if [ "$?" != "0" ]; then
     echo "ERROR: An error ocurred when running: '$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECTJSON}\"'. Please check above for more details."
     exit 1
 fi
-find $__PACKAGES_DIR -type d \( \
-    -iwholename "${__PACKAGES_DIR}/Microsoft.Portable.Targets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any" -or \
-    -iwholename "${__PACKAGES_DIR}/MicroBuild.Core/${__MICROBUILD_VERSION}/build" \
-    \) -exec cp -R "{}/." "$__TOOLRUNTIME_DIR/." \;
+
+# Copy portable and MicroBuild targets from packages, allowing for lowercased package IDs.
+cp -R "${__PACKAGES_DIR}/[Mm]icrosoft.[Pp]ortable.[Tt]argets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
+cp -R "${__PACKAGES_DIR}/[Mm]icro[Bb]uild.[Cc]ore/${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
 
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages
 mv "$__TOOLRUNTIME_DIR/Microsoft.CSharp.targets" "$__TOOLRUNTIME_DIR/Microsoft.CSharp.Targets"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -100,8 +100,8 @@ if [ "$?" != "0" ]; then
 fi
 
 # Copy portable and MicroBuild targets from packages, allowing for lowercased package IDs.
-cp -R "${__PACKAGES_DIR}/[Mm]icrosoft.[Pp]ortable.[Tt]argets/${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
-cp -R "${__PACKAGES_DIR}/[Mm]icro[Bb]uild.[Cc]ore/${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
+cp -R "${__PACKAGES_DIR}"/[Mm]icrosoft.[Pp]ortable.[Tt]argets/"${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
+cp -R "${__PACKAGES_DIR}"/[Mm]icro[Bb]uild.[Cc]ore/"${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
 
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages
 mv "$__TOOLRUNTIME_DIR/Microsoft.CSharp.targets" "$__TOOLRUNTIME_DIR/Microsoft.CSharp.Targets"


### PR DESCRIPTION
No longer depend on `find`, which isn't available in our Fedora builds, and `-iwholename`, which isn't available in our Alpine builds. Allow lowercased package ids using character groups in the path glob.

Undoes the way https://github.com/dotnet/buildtools/pull/1114 solved the problem, which added full insensitivity. We only need to allow for proper-cased and lowercased paths, not any case. I also found `shopt -s nocaseglob` which could help in any other cases if real insensitivity is needed.

Should fix https://github.com/dotnet/buildtools/issues/1201. I haven't tested the full init-tools flow yet.

@ericstj
/cc @ellismg @chcosta @mellinoe