### PR TITLE
Change Package Report back to using symbols as well as resolved assets.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
@@ -128,7 +128,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
                     buildProjects.AddRange(runtimeItems.Select(ri => BuildProjectFromPackageItem(ri)).Where(bp => bp != null));
 
-                    RuntimeAssets = runtimeItems.Select(ri => PackageItemAsResolvedAsset(ri)).ToArray();
+                    RuntimeAssets = runtimeItems.SelectMany(ri => PackageItemAndSymbolsAsResolvedAsset(ri)).ToArray();
 
                     Log.LogMessage($"Resolved runtime assets from {runtimeFx.ToString()}: {String.Join(";", RuntimeAssets.Select(r => r.ItemSpec))}");
                     break;


### PR DESCRIPTION
Fixes #1144 and https://github.com/dotnet/corefx/issues/12927.