### PR TITLE
Automatically detect TestNugetRuntimeId

### DIFF
--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -55,6 +55,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Vsts
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks.net45", "Microsoft.DotNet.Build.Tasks.net45\Microsoft.DotNet.Build.Tasks.net45.csproj", "{B3331D88-7569-42D5-919B-F267DA011911}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks.Packaging", "Microsoft.DotNet.Build.Tasks.Packaging\src\Microsoft.DotNet.Build.Tasks.Packaging.csproj", "{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks.Packaging.Desktop", "Microsoft.DotNet.Build.Tasks.Packaging\src.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.Desktop.csproj", "{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -379,6 +383,46 @@ Global
 		{B3331D88-7569-42D5-919B-F267DA011911}.Release|x64.Build.0 = Release|Any CPU
 		{B3331D88-7569-42D5-919B-F267DA011911}.Release|x86.ActiveCfg = Release|Any CPU
 		{B3331D88-7569-42D5-919B-F267DA011911}.Release|x86.Build.0 = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|ARM.Build.0 = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|x64.Build.0 = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Debug|x86.Build.0 = Debug|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|ARM.ActiveCfg = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|ARM.Build.0 = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|x64.ActiveCfg = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|x64.Build.0 = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|x86.ActiveCfg = Release|Any CPU
+		{C2CB2F39-91FB-4050-9DD2-6E5DD6460ED8}.Release|x86.Build.0 = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|x64.Build.0 = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Debug|x86.Build.0 = Debug|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|ARM.Build.0 = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|x64.ActiveCfg = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|x64.Build.0 = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|x86.ActiveCfg = Release|Any CPU
+		{440527ED-C69A-4EC6-8E63-AB1624BD7D8B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks", "Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.csproj", "{17C66BCE-EB35-44CA-893C-8AAFB67708E9}"
 EndProject
@@ -51,8 +51,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xunit.runner.uwp", "xunit.r
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.VersionTools", "Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj", "{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.VstsBuildsApi", "Microsoft.DotNet.Build.VSTSBuildsApi\Microsoft.DotNet.Build.VstsBuildsApi.csproj", "{DD658734-88B2-48AD-8ADC-69D5C5798D9B}"  
-EndProject  
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.VstsBuildsApi", "Microsoft.DotNet.Build.VSTSBuildsApi\Microsoft.DotNet.Build.VstsBuildsApi.csproj", "{DD658734-88B2-48AD-8ADC-69D5C5798D9B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks.net45", "Microsoft.DotNet.Build.Tasks.net45\Microsoft.DotNet.Build.Tasks.net45.csproj", "{B3331D88-7569-42D5-919B-F267DA011911}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -293,36 +295,30 @@ Global
 		{36219AA4-D36A-4CB4-9C7B-FB48641D411A}.Release|x64.Build.0 = Release|Any CPU
 		{36219AA4-D36A-4CB4-9C7B-FB48641D411A}.Release|x86.ActiveCfg = Release|Any CPU
 		{36219AA4-D36A-4CB4-9C7B-FB48641D411A}.Release|x86.Build.0 = Release|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|ARM.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|ARM.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Mixed Platforms.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x64.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x64.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x86.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x86.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Any CPU.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|ARM.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|ARM.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|ARM.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Mixed Platforms.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Mixed Platforms.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x64.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x64.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x64.Deploy.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.ActiveCfg = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.Build.0 = Debug|Any CPU
-		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.Deploy.0 = Debug|Any CPU
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|ARM.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|Mixed Platforms.Deploy.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x64.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x86.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x86.Build.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Debug|x86.Deploy.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Any CPU.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Any CPU.Build.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Any CPU.Deploy.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|ARM.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|ARM.Build.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|ARM.Deploy.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Mixed Platforms.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Mixed Platforms.Build.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|Mixed Platforms.Deploy.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x64.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x64.Build.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x64.Deploy.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.ActiveCfg = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.Build.0 = Debug|x86
+		{BB960A1D-DE0B-43F5-ACA1-0BDEA8E63CDD}.Release|x86.Deploy.0 = Debug|x86
 		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -343,9 +339,48 @@ Global
 		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|x64.Build.0 = Release|Any CPU
 		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|x86.ActiveCfg = Release|Any CPU
 		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|x86.Build.0 = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|x64.Build.0 = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Debug|x86.Build.0 = Debug|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|ARM.Build.0 = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|x64.ActiveCfg = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|x64.Build.0 = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|x86.ActiveCfg = Release|Any CPU
+		{DD658734-88B2-48AD-8ADC-69D5C5798D9B}.Release|x86.Build.0 = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|ARM.Build.0 = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|x64.Build.0 = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Debug|x86.Build.0 = Debug|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|ARM.ActiveCfg = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|ARM.Build.0 = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|x64.ActiveCfg = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|x64.Build.0 = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|x86.ActiveCfg = Release|Any CPU
+		{B3331D88-7569-42D5-919B-F267DA011911}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal
-

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetApplicableAssetsFromPackages.cs
@@ -135,7 +135,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 }
             }
 
-            if (RuntimeAssets == null)
+            if (!string.IsNullOrEmpty(TargetRuntime) && RuntimeAssets == null)
             {
                 Log.LogError($"Could not locate runtime assets for any of the frameworks {String.Join(";", runtimeFxs.Select(fx => fx.ToString()))}");
             }

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
@@ -6,6 +6,7 @@
     <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
     <ImportedProjectRelativePath>..\Microsoft.DotNet.Build.Tasks\</ImportedProjectRelativePath>
+    <ProjectGuid>{B3331D88-7569-42D5-919B-F267DA011911}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.csproj" />
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Packaging": "3.6.0-rc-1987",

--- a/src/Microsoft.DotNet.Build.Tasks/GetTargetMachineInfo.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetTargetMachineInfo.cs
@@ -5,9 +5,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System.Runtime.InteropServices;
-using System;
-using System.IO;
-using System.Linq;
+using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
@@ -18,6 +16,9 @@ namespace Microsoft.DotNet.Build.Tasks
 
         [Output]
         public string TargetArch { get; set; }
+
+        [Output]
+        public string RuntimeIdentifier { get; set; }
 
         public override bool Execute()
         {
@@ -47,6 +48,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 TargetOS = "FreeBSD";
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")))
                 TargetOS = "NetBSD";
+
+            RuntimeIdentifier = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
 
             if (TargetArch == null)
             {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -12,11 +12,6 @@
     <TargetOS Condition="'$(OSGroup)'!='AnyOS'">$(OSGroup)</TargetOS>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
-    <TestNugetRuntimeId Condition="'$(TestNugetRuntimeId)' == ''">win7-$(TestArchitecture)</TestNugetRuntimeId>
-  </PropertyGroup>
-
   <Target Name="CopyTestToTestDirectory"
           DependsOnTargets="DiscoverTestInputs" Condition="'$(DisableCopyTestToTestDirectory)'!='true'">
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -281,6 +281,23 @@
             Files="$(TestsSuccessfulSemaphore)" />
   </Target>
 
+  <Target Name="GetDefaultTestRid">
+    <GetTargetMachineInfo>
+      <Output TaskParameter="RuntimeIdentifier" PropertyName="DefaultTestNugetRuntimeId" />
+    </GetTargetMachineInfo>
+    <!-- On Windows, we always use win7-x64 as the default test RID because the build context,
+         usually 32-bit full-framework MSBuild, is not a good default test context. -->
+    <PropertyGroup>
+      <DefaultTestNugetRuntimeId Condition="$(DefaultTestNugetRuntimeId.StartsWith('win'))">win7-x64</DefaultTestNugetRuntimeId>
+      <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
+      <TestNugetRuntimeId Condition="'$(TestNugetRuntimeId)' == ''">$(DefaultTestNugetRuntimeId)</TestNugetRuntimeId>
+    </PropertyGroup>
+  </Target>
+
+  <PropertyGroup>
+    <ResolvePkgProjReferencesDependsOn>GetDefaultTestRid;$(ResolvePkgProjReferencesDependsOn)</ResolvePkgProjReferencesDependsOn>
+  </PropertyGroup>
+
   <Target Name="CheckTestPlatforms">
     <GetTargetMachineInfo Condition="'$(TargetOS)' == ''">
       <Output TaskParameter="TargetOS" PropertyName="TargetOS" />
@@ -292,7 +309,7 @@
       Text="Skipping tests in $(AssemblyName) because it is not supported on $(TargetOS)" />
   </Target>
 
-  <Target Name="SetupTestProperties" DependsOnTargets="CheckTestPlatforms;CheckTestCategories" />
+  <Target Name="SetupTestProperties" DependsOnTargets="GetDefaultTestRid;CheckTestPlatforms;CheckTestCategories" />
 
   <PropertyGroup>
     <TestDependsOn>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -8,6 +8,7 @@
         "Microsoft.Build.Utilities.Core": "0.1.0-preview-00024-160610",
         "Microsoft.Build.Targets": "0.1.0-preview-00024-160610",
         "Microsoft.Build": "0.1.0-preview-00024-160610",
+        "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
         "Microsoft.Net.Compilers.netcore": "2.0.0-beta3",
         "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
         "Microsoft.Cci": "4.0.0-rc4-24217-00",

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -3,6 +3,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "NETStandard.Library": "1.6.0",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Packaging": "3.6.0-rc-1987",


### PR DESCRIPTION
Re-submitting #1210 with slight changes. This fixes an issue in the `GetApplicableAssetsFromPackages` task if no target runtime is passed in.

@weshaggard @ericstj 