### PR TITLE
Hook GetDefaultTestRid before BeforeResolveReferences

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -25,7 +25,7 @@
   <PropertyGroup>
     <!-- Resolve from pkgProjs before nuget packages -->
     <ResolveNugetPackagesDependsOn>$(ResolveNugetPackagesDependsOn);ResolvePkgProjReferences</ResolveNugetPackagesDependsOn>
-    <ResolvePkgProjReferencesDependsOn>ResolveProjectReferences</ResolvePkgProjReferencesDependsOn>
+    <ResolvePkgProjReferencesDependsOn>$(ResolvePkgProjReferencesDependsOn);ResolveProjectReferences</ResolvePkgProjReferencesDependsOn>
   </PropertyGroup>
 
   <!-- Resolves applicable files from all files in PkgProjs. Similar to ResolveNuGetPackageAssets, except operates on a file list


### PR DESCRIPTION
Many of our test projects use P2P references to pkgproj's. In order for assets to be resolved correctly out of them for the test run, we need the `TestNugetRuntimeId` to already be set. So I've hooked the new target to before those project references are resolved so that the property is already set when they are built.

@weshaggard @karajas 