### PR TITLE
Don't create layout for runtime packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -1258,7 +1258,7 @@
   </Target>
 
   <Target Name="CreateLayout"
-          Condition="'$(IsRuntimePackage)' != 'true'"
+          Condition="'$(IsRuntimePackage)' != 'true' AND '$(PackageTargetRuntime)' == ''"
           DependsOnTargets="GetPackageReport">
 
     <ItemGroup>


### PR DESCRIPTION
The identity package has all the layout information for all runtime
packages, so we shouldn't try to copy the layouts for both id and
runtime packages.  When we do it would cause a race if the two
were building at the same time.

I was trying to avoid this but didn't have the condition correct.

/cc @weshaggard @stephentoub 