### PR TITLE
Add WarnAsError Logger

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -58,6 +58,7 @@
     <Compile Include="VersionTools\VerifyDependencies.cs" />
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
+    <Compile Include="WarnAsErrorLogger.cs" />
     <Compile Include="WriteSigningRequired.cs" />
     <Compile Include="WriteVisualBasicDefineResponseFile.cs" />
     <Compile Include="ZipFileCreateFromDependencyLists.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/WarnAsErrorLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/WarnAsErrorLogger.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             if (_warningsLogged)
             {
-                throw new Exception("Warings were logged, failing the build.");
+                throw new Exception("Warnings were logged, failing the build.");
             }
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks/WarnAsErrorLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/WarnAsErrorLogger.cs
@@ -1,0 +1,32 @@
+﻿
+using Microsoft.Build.Framework;
+using System;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class WarnAsErrorLogger : ILogger
+    {
+        private bool _warningsLogged;
+
+        public string Parameters { get; set; }
+        public LoggerVerbosity Verbosity { get; set; }
+
+        public void Initialize(IEventSource eventSource)
+        {
+            eventSource.WarningRaised += EventSource_WarningRaised;
+        }
+
+        private void EventSource_WarningRaised(object sender, BuildWarningEventArgs e)
+        {
+            _warningsLogged = true;
+        }
+
+        public void Shutdown()
+        {
+            if (_warningsLogged)
+            {
+                throw new Exception("Warings were logged, failing the build.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
We want to allow hard failing the build if any warnings
are raised. Starting simple- we can allow configuring for
specific warnings as we hit the need.

@weshaggard @ericstj 