### PR TITLE
Fix dependencylist naming behavior

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -189,7 +189,7 @@
 
     <MakeDir Directories="$(OutputFolderForTestDependencies)" />
     <PropertyGroup>
-      <_TestDependencyListRoot>$(AssemblyName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
+      <_TestDependencyListRoot>$(MSBuildProjectName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
       <_TestDependencyListRoot Condition="'$(TargetGroup)' != ''">$(_TestDependencyListRoot).$(TargetGroup)</_TestDependencyListRoot>
       <_TestDependencyListRoot Condition="'$(TargetGroup)' == ''">$(_TestDependencyListRoot).default</_TestDependencyListRoot>
       <_TestDependencyListRoot Condition="'$(TestTFM)' != ''">$(_TestDependencyListRoot).$(TestTFM)</_TestDependencyListRoot>


### PR DESCRIPTION
Sometimes folks will copy and paste a test project without updating the assembly name.  Currently we have a subtle bug where if two test projects produce an assembly with the same name, Rid and TxM combination, a race condition can occur failing test build.  This is much less likely to happen using the project name, which in almost all cases matches the assembly name (or should)

@weshaggard @joperezr 