### PR TITLE
Changing the test nuget moniker when TestArchitecture is passed in

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -115,6 +115,7 @@
     <PropertyGroup>
       <DefaultTestNugetRuntimeId Condition="$(DefaultTestNugetRuntimeId.StartsWith('win'))">win7-x64</DefaultTestNugetRuntimeId>
       <TestArchitecture Condition="'$(TestArchitecture)' == ''">x64</TestArchitecture>
+      <TestNugetRuntimeId Condition="'$(TestNugetRuntimeId)' == '' And '$(TestArchitecture)'=='x86'">win7-x86</TestNugetRuntimeId>
       <TestNugetRuntimeId Condition="'$(TestNugetRuntimeId)' == ''">$(DefaultTestNugetRuntimeId)</TestNugetRuntimeId>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
cc: @naamunds @weshaggard 

Fixes dotnet/corefx#13739

With this, people running `build.cmd -buildArch:x86` will actually have the tests running for x86