### PR TITLE
Allow __PUBLISH_RID detection in strict mode

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -38,7 +38,7 @@ if [ ! -d "$__TOOLRUNTIME_DIR" ]; then
     mkdir $__TOOLRUNTIME_DIR
 fi
 
-if [ -z "$__PUBLISH_RID" ]; then
+if [ -z "${__PUBLISH_RID:-}" ]; then
     OSName=$(uname -s)
     case $OSName in
         Darwin)


### PR DESCRIPTION
https://github.com/dotnet/buildtools/pull/1206 broke the condition that checked to see if `__PUBLISH_RID` has no value. This fix uses an empty string if `__PUBLISH_RID` is undefined rather than erroring out. (Mentioned at top of file.)

I didn't catch it because I only tested without auto-detection--I got an error when trying OSX.

@ellismg Could you take a quick look? Tiny fix.