### PR TITLE
Create BuildConfiguration and TestConfiguration properties

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.targets
@@ -27,8 +27,8 @@
   <PropertyGroup>
     <ContainerName>build-$([System.Guid]::NewGuid().ToString("N"))</ContainerName>
     <ContainerName>$(ContainerName.ToLower())</ContainerName>
-    <FuncTestListFilename>FuncTests.$(OSGroup).$(Platform)$(ConfigurationGroup).json</FuncTestListFilename>
-    <PerfTestListFilename>PerfTests.$(OSGroup).$(Platform)$(ConfigurationGroup).json</PerfTestListFilename>
+    <FuncTestListFilename>FuncTests.$(BuildConfiguration).json</FuncTestListFilename>
+    <PerfTestListFilename>PerfTests.$(BuildConfiguration).json</PerfTestListFilename>
     <!-- Test builds consist of the tests that are platform specific in one root, plus others in AnyOS. -->
     <AnyOSPlatformConfig>AnyOS.AnyCPU.$(ConfigurationGroup)</AnyOSPlatformConfig>
     <AnyOsArchivesRoot>$(TestWorkingDir)$(AnyOSPlatformConfig)/archive/</AnyOsArchivesRoot>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -23,6 +23,20 @@
 
   <!-- Common BuildTools properties -->
   <PropertyGroup>
+    <!--
+        Build Configuration is composed by: $(OSGroup).$(Platform).$(ConfigurationGroup).$(TargetGroup)
+        TargetGroup will be "default" if no value is specified. 
+    -->
+    <BuildConfiguration>$(OSGroup).$(Platform).$(ConfigurationGroup)</BuildConfiguration>
+    <BuildConfiguration Condition="'$(TargetGroup)'!=''">$(BuildConfiguration).$(TargetGroup)</BuildConfiguration>
+    <BuildConfiguration Condition="'$(TargetGroup)'==''">$(BuildConfiguration).default</BuildConfiguration>
+    <!--
+        Test Configuration is composed by: $(OSGroup).$(Platform).$(ConfigurationGroup).$(TargetGroup).$(TestTFM)
+        TargetGroup will be "default" if no value is specified.
+        TestTFM will be "default" if no value is specified. 
+    -->
+    <TestConfiguration Condition="'$(TestTFM)'!=''">$(BuildConfiguration).$(TestTFM)</TestConfiguration>
+    <TestConfiguration Condition="'$(TestTFM)'==''">$(BuildConfiguration).default</TestConfiguration>
     <ToolRuntimePath Condition="'$(ToolRuntimePath)'=='' and '$(ProjectDir)'==''">$(MSBuildThisFileDirectory)</ToolRuntimePath>
     <ToolRuntimePath Condition="'$(ToolRuntimePath)'=='' and '$(ProjectDir)'!=''">$(ProjectDir)Tools/</ToolRuntimePath>
     <ToolsDir Condition="'$(ToolsDir)'==''">$(MSBuildThisFileDirectory)</ToolsDir>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -21,8 +21,8 @@
     <GetNuGetPackageVersionsDependsOn>CreateVersionFileDuringBuild</GetNuGetPackageVersionsDependsOn>
   </PropertyGroup>
 
-  <!-- Common BuildTools properties -->
-  <PropertyGroup>
+
+  <PropertyGroup Condition="'$(BuildConfiguration)'==''">
     <!--
         Build Configuration is composed by: $(OSGroup).$(Platform).$(ConfigurationGroup).$(TargetGroup)
         TargetGroup will be "default" if no value is specified. 
@@ -30,6 +30,10 @@
     <BuildConfiguration>$(OSGroup).$(Platform).$(ConfigurationGroup)</BuildConfiguration>
     <BuildConfiguration Condition="'$(TargetGroup)'!=''">$(BuildConfiguration).$(TargetGroup)</BuildConfiguration>
     <BuildConfiguration Condition="'$(TargetGroup)'==''">$(BuildConfiguration).default</BuildConfiguration>
+  </PropertyGroup>
+
+  <!-- Common BuildTools properties -->
+  <PropertyGroup>
     <!--
         Test Configuration is composed by: $(OSGroup).$(Platform).$(ConfigurationGroup).$(TargetGroup).$(TestTFM)
         TargetGroup will be "default" if no value is specified.

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -189,10 +189,7 @@
 
     <MakeDir Directories="$(OutputFolderForTestDependencies)" />
     <PropertyGroup>
-      <_TestDependencyListRoot>$(MSBuildProjectName)-$(OSGroup).$(Platform).$(ConfigurationGroup)</_TestDependencyListRoot>
-      <_TestDependencyListRoot Condition="'$(TargetGroup)' != ''">$(_TestDependencyListRoot).$(TargetGroup)</_TestDependencyListRoot>
-      <_TestDependencyListRoot Condition="'$(TargetGroup)' == ''">$(_TestDependencyListRoot).default</_TestDependencyListRoot>
-      <_TestDependencyListRoot Condition="'$(TestTFM)' != ''">$(_TestDependencyListRoot).$(TestTFM)</_TestDependencyListRoot>
+      <_TestDependencyListRoot>$(MSBuildProjectName)-$(TestConfiguration)</_TestDependencyListRoot>
       <_TestDependencyListFileName>$(_TestDependencyListRoot).dependencylist.txt</_TestDependencyListFileName>
       <TestDependencyListFilePath>$(OutputFolderForTestDependencies)/$(_TestDependencyListFileName)</TestDependencyListFilePath>
     </PropertyGroup>


### PR DESCRIPTION
Creating two centralized common properties that will be used in our targets and props files in order to get individual build and test configurations for a project. This will help avoiding build and test clashes in different targets.

cc: @weshaggard @MattGal 

Fixes: https://github.com/dotnet/buildtools/issues/1121