### PR TITLE
Coverage flags

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -62,6 +62,10 @@
 
     <Exec Command="$(CoverageReportGeneratorCommandLine) -reports:$(CoverageOutputFilePath)"
           ContinueOnError="ErrorAndContinue" />
+
+    <Exec Command="start $(CoverageReportDir)index.htm"
+          Condition="'$(PopCoverageReport)' == 'true'" />
+
   </Target>
 
   <PropertyGroup Condition="'$(GenerateFullCoverageReport)'=='true'">
@@ -78,6 +82,9 @@
     <Exec Command="$(CoverageReportGeneratorCommandLine) -reports:$(CoverageReportDir)\*.coverage.xml"
           ContinueOnError="ErrorAndContinue"
           WorkingDirectory="$(ProjectDir)" />
+
+    <Exec Command="start $(CoverageReportDir)index.htm"
+          Condition="'$(PopCoverageReport)' == 'true'" />          
 
     <PropertyGroup>
       <CoverallsUploaderCommandLine>$(PackagesDir)coveralls.io.$(CoverallsUploaderVersion)\tools\coveralls.net.exe</CoverallsUploaderCommandLine>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -84,6 +84,18 @@
       <TestCopyLocal Include="@(OverridenRuntimeContent)" />
      </ItemGroup>
 
+    <ItemGroup Condition="'$(CoreLibRoot)' != ''">
+      <TestCopyLocal Include="$(CoreLibRoot)\mscorlib.dll" />
+      <TestCopyLocal Include="$(CoreLibRoot)\System.Private.CoreLib.dll" />
+      <TestCopyLocal Include="$(CoreLibRoot)\PDB\mscorlib.pdb" />
+      <TestCopyLocal Include="$(CoreLibRoot)\PDB\System.Private.CoreLib.pdb" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(CoreLibRoot)' != ''">
+      <!-- We're not copying native images for our private corelib -->
+      <TestWithoutNativeImages>true</TestWithoutNativeImages>
+    </PropertyGroup>
+
     <!-- Remove duplicates. Note that we mustn't just copy in sequence and let
          the last one win that way because it will cause copies to occur on
          every incremental build. -->


### PR DESCRIPTION
Allow /p:PopCoverageReport=true to cause the coverage report to open in your browser as soon as it's ready.

Allow eg /p:corelibroot=\git\coreclr.dan\bin\Product\Windows_NT.x64.Release to cause test runs to get your privately built corelib and symbols. This is an easy workaround until we have a fix for https://github.com/dotnet/corefx/issues/13094 (and useful anyway). Disables native images also, so it's not necessary to copy those.

@stephentoub 