### PR TITLE
Better approach to injecting private corelib for tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -85,10 +85,10 @@
      </ItemGroup>
 
     <ItemGroup Condition="'$(CoreLibRoot)' != ''">
-      <TestCopyLocal Include="$(CoreLibRoot)\mscorlib.dll" />
-      <TestCopyLocal Include="$(CoreLibRoot)\System.Private.CoreLib.dll" />
-      <TestCopyLocal Include="$(CoreLibRoot)\PDB\mscorlib.pdb" />
-      <TestCopyLocal Include="$(CoreLibRoot)\PDB\System.Private.CoreLib.pdb" />
+      <RunTestsForProjectInputs Include="$(CoreLibRoot)\mscorlib.dll" />
+      <RunTestsForProjectInputs Include="$(CoreLibRoot)\System.Private.CoreLib.dll" />
+      <RunTestsForProjectInputs Include="$(CoreLibRoot)\PDB\mscorlib.pdb" />
+      <RunTestsForProjectInputs Include="$(CoreLibRoot)\PDB\System.Private.CoreLib.pdb" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(CoreLibRoot)' != ''">


### PR DESCRIPTION
Although the last approach was working at the time, this seems to work better.

Holding off on merging until I've had time to make sure it's really right.