### PR TITLE
Fix nuget framework compare with long name

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/FilterRuntimesFromSupports.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/FilterRuntimesFromSupports.cs
@@ -43,7 +43,8 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             if (framework != null)
             {
-                tfmRidPairs.RemoveAll(x => !framework.Equals(x.framework));
+                string longFramework = NuGetFramework.Parse(framework).ToString();
+                tfmRidPairs.RemoveAll(x => !longFramework.Equals(x.framework));
             }
             if (runtimeIdentifier != null)
             {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/buildagainstpackages.targets
@@ -163,7 +163,7 @@
                                   UseNewestAvailablePackages="$(UseNewestAvailablePackages)"
                                   SupportsFile="$(SupportsDefinitionFile)"
                                   TestRuntime="$(TestNugetRuntimeId)"
-                                  TestTargetFramework="$(FilterToTestTFM)"
+                                  TestTargetFramework="$(FilterTestNugetTargetMoniker)"
                                   />
 
     <Message Condition="'$(ErrorNoVersion)' == ''" Text="Generated project.json file - '$(ProjectJson)'" />


### PR DESCRIPTION
Replace FilterToTestTFM with FilterTestNugetTargetMoniker in buildagainstpackages.targets