### PR TITLE
Upgrade net45 System.Runtime.InteropServices.RuntimeInformation

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -19,10 +19,17 @@
     <CurrentRefXmlPath>$(MSBuildThisFileFullPath)</CurrentRefXmlPath>
   </PropertyGroup>
 
+  <!-- Packages that don't take versions from the corefx build-info. -->
+  <PropertyGroup>
+    <!-- Take new version of RuntimeInformation that doesn't use api-set dlls to fix win7 build. -->
+    <CoreFxBuildInfoDisabledPackages>System.Runtime.InteropServices.RuntimeInformation;$(CoreFxBuildInfoDisabledPackages)</CoreFxBuildInfoDisabledPackages>
+  </PropertyGroup>
+
   <ItemGroup>
     <RemoteDependencyBuildInfo Include="CoreFx">
       <BuildInfoPath>$(BaseDotNetBuildInfo)corefx/release/1.1.0</BuildInfoPath>
       <CurrentRef>$(CoreFxCurrentRef)</CurrentRef>
+      <DisabledPackages>$(CoreFxBuildInfoDisabledPackages)</DisabledPackages>
     </RemoteDependencyBuildInfo>
     <RemoteDependencyBuildInfo Include="CoreClr">
       <BuildInfoPath>$(BaseDotNetBuildInfo)coreclr/$(DependencyBranch)</BuildInfoPath>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -8,7 +8,7 @@
     "NuGet.Versioning": "3.6.0-rc-1987",
     "System.Collections.Immutable": "1.1.37",
     "System.Reflection.Metadata": "1.1.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },
   "frameworks": {
     "net45": {}


### PR DESCRIPTION
Upgrade `System.Runtime.InteropServices.RuntimeInformation` to take a change that removed the need for api-set DLLs, described in https://github.com/dotnet/corefx/issues/13566. This was causing win7 runs to fail. A repro I had of the issue goes away when I use a buildtools package produced with this change.

The only package diff from this is `lib/net45/System.Runtime.InteropServices.RuntimeInformation.dll`.

Is depending on the prerelease package during the buildtools build ok, or should we avoid it at all costs?

Fixes (when flowed through) https://github.com/dotnet/corefx/issues/14165.

@weshaggard @JohnChen0 @stephentoub 
/cc @dleeapho 