### PR TITLE
Ensure that TestNugetRuntimeId is computed when building in VS

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -13,7 +13,8 @@
   </PropertyGroup>
 
   <Target Name="CopyTestToTestDirectory"
-          DependsOnTargets="DiscoverTestInputs" Condition="'$(DisableCopyTestToTestDirectory)'!='true'">
+          Condition="'$(DisableCopyTestToTestDirectory)'!='true'"
+          DependsOnTargets="DiscoverTestInputs;GetDefaultTestRid">
 
     <PrereleaseResolveNuGetPackageAssets Condition="Exists($(ProjectLockJson))"
                                AllowFallbackOnTargetSelection="true"


### PR DESCRIPTION
Fixes #1238 

/cc @weshaggard 