### PR TITLE
Set ContinueOnError for GetAssemblyIdentity:

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -215,7 +215,7 @@
       <_FilteredAssembliesForBindingRedirect Include="%(_FinalListOfTestAssetsByFileName.SourcePath)" Condition="'%(_FinalListOfTestAssetsByFileName.Extension)'=='.dll' or '%(_FinalListOfTestAssetsByFileName.Extension)'=='.exe'" />
       <ExecutablesForBindingRedirect Include="%(_SourcesToCopyToTestDirByFileName.SourcePath)" Condition="'%(_SourcesToCopyToTestDirByFileName.Extension)'!='.pdb'"/>
     </ItemGroup>
-    <GetAssemblyIdentity Condition="'$(TestAgainstDesktop)' == 'true'" AssemblyFiles="@(_FilteredAssembliesForBindingRedirect)">
+    <GetAssemblyIdentity Condition="'$(TestAgainstDesktop)' == 'true'" AssemblyFiles="@(_FilteredAssembliesForBindingRedirect)" ContinueOnError="WarnAndContinue" >
       <Output TaskParameter="Assemblies" ItemName="TestAssemblyIdentities"/>
     </GetAssemblyIdentity>
     


### PR DESCRIPTION
Errors here with native dlls are causing test build failures.

Eventual "proper" solution may involve writing a custom version of the task that handles non-managed assemblies without a warning (i.e. anything without a managed header?) but for now this stops build breaks.  (Note there is no version of ContinueOnError, including "true" that doesn't produce a warning)

Tested using build steps from build 20151213-121.

@karajas 