### PR TITLE
Make RuntimeInformation package version consistent across BuildTools

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -65,6 +65,10 @@
     </StaticDependency>
     -->
 
+    <StaticDependency Include="System.Runtime.InteropServices.RuntimeInformation">
+      <Version>4.4.0-beta-24813-03</Version>
+    </StaticDependency>
+
     <NuGetDependency Include="NuGet.Client"/>
     <NuGetDependency Include="NuGet.Packaging"/>
     <NuGetDependency Include="NuGet.ProjectModel"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/project.json
@@ -5,7 +5,7 @@
     "NuGet.Client": "4.0.0-rc-2129",
     "NuGet.ProjectModel": "4.0.0-rc-2129",
     "System.Reflection.Metadata": "1.0.22",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },
   "frameworks": {
     "net45": {}

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi.net45/project.json
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi.net45/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Newtonsoft.Json": "9.0.1",
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },
   "frameworks": {
     "net45": {}

--- a/src/Microsoft.DotNet.VersionTools.net45/project.json
+++ b/src/Microsoft.DotNet.VersionTools.net45/project.json
@@ -4,7 +4,7 @@
     "NuGet.Packaging": "4.0.0-rc-2129",
     "NuGet.Versioning": "4.0.0-rc-2129",
     "Microsoft.NETCore.Platforms": "1.0.1",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },
   "frameworks": {
     "net45": {}

--- a/src/common/test-runtime/project.json
+++ b/src/common/test-runtime/project.json
@@ -6,7 +6,7 @@
     "NETStandard.Library": "1.6.0",
     "System.Diagnostics.Contracts": "4.0.1",
     "System.IO.Compression": "4.1.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03",
     "System.Linq.Parallel": "4.0.1",
     "coveralls.io": "1.4",
     "OpenCover": "4.6.519",


### PR DESCRIPTION
Enforce `System.Runtime.InteropServices.RuntimeInformation` `4.4.0-beta-24813-03` across buildtools by making it a dependency verification rule.

This is a fix to https://github.com/dotnet/buildtools/pull/1249 which only upgraded this package for one project, causing VersionTools to fail when attempting to create an auto-update PR: https://devdiv.visualstudio.com/DevDiv/_build?buildId=471628:

```
System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
File name: 'System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at Microsoft.DotNet.VersionTools.Util.Command.ShouldUseCmd(String executable)
...
```

@weshaggard @stephentoub 