### PR TITLE
Fix GenerateTestBindingRedirects merge

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -152,18 +152,20 @@
           Condition="'$(TestAgainstDesktop)' == 'true' and '$(LocalAppConfigFile)' == ''"
           DependsOnTargets="DiscoverTestInputs;DiscoverTestDependencies">
     <ItemGroup>
-      <_FilteredAssembliesForBindingRedirect Include="%(_FinalListOfTestAssetsByFileName.SourcePath)" Condition="'%(_FinalListOfTestAssetsByFileName.Extension)'=='.dll' or '%(_FinalListOfTestAssetsByFileName.Extension)'=='.exe'" />
-      <ExecutablesForBindingRedirect Include="%(_SourcesToCopyToTestDirByFileName.SourcePath)" Condition="'%(_SourcesToCopyToTestDirByFileName.Extension)'!='.pdb'"/>
+      <_CombinedListOfTestAssets Include="@(IncludedFileForRunnerScript->'%(SourcePath)')" />
+      <_CombinedListOfTestAssets Include="@(SourcesToCopyToTestDir)" />
+      
+      <_FilteredAssembliesForBindingRedirect Include="@(_CombinedListOfTestAssets)" Condition="'%(Extension)'=='.dll' or '%(Extension)'=='.exe'" />
+      <_ExecutablesForBindingRedirect Include="@(SourcesToCopyToTestDir)" Condition="'%(Extension)'!='.pdb'" />
     </ItemGroup>
-    <FilterNativeAssemblies Condition="'$(TestAgainstDesktop)' == 'true'" Assemblies="@(_FilteredAssembliesForBindingRedirect)">
-      <Output TaskParameter="ManagedAssemblies" ItemName="ManagedTestAssemblyIdentities"/>
+    <FilterNativeAssemblies Assemblies="@(_FilteredAssembliesForBindingRedirect)">
+      <Output TaskParameter="ManagedAssemblies" ItemName="ManagedTestAssemblyIdentities" />
     </FilterNativeAssemblies>
-    <GetAssemblyIdentity Condition="'$(TestAgainstDesktop)' == 'true'" AssemblyFiles="@(ManagedTestAssemblyIdentities)">
+    <GetAssemblyIdentity AssemblyFiles="@(ManagedTestAssemblyIdentities)">
       <Output TaskParameter="Assemblies" ItemName="TestAssemblyIdentities"/>
     </GetAssemblyIdentity>
     
-    <GenerateBindingRedirect Condition="'$(TestAgainstDesktop)' == 'true' and '$(LocalAppConfigFile)' == ''"
-                             Executables="@(ExecutablesForBindingRedirect)"
+    <GenerateBindingRedirect Executables="@(_ExecutablesForBindingRedirect)"
                              AssemblyIdentities="@(TestAssemblyIdentities)"
                              OutputPath="$(TestPath)"
     />
@@ -171,7 +173,6 @@
 
   <Target Name="GenerateTestExecutionScripts"
           DependsOnTargets="DiscoverTestInputs;DiscoverTestDependencies;CheckTestCategories">
-
     <ItemGroup>
       <RunWithoutTraits Condition="'$(TargetOS)'=='Windows_NT'" Include="nonwindowstests" />
       <RunWithoutTraits Condition="'$(TargetOS)'=='Linux'" Include="nonlinuxtests" />


### PR DESCRIPTION
Revert GenerateTestBindingRedirects to use _CombinedListOfTestAssets and
remove the Conditions from the task calls.  The only intended changes to
this target in #1263 were to add the call to FilterNativeAssemblies and
use the output of that as the input to GetAssemblyIdentity.

/cc @karajas @MattGal @ericstj 