### PR TITLE
Change auto-generated build version file path to use UTC 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BuildVersion.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BuildVersion.targets
@@ -1,9 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
   <PropertyGroup>
-    <TodayTimeStamp>$([System.DateTime]::Now.ToString(yyyyMMdd))</TodayTimeStamp>
+    <UtcTodayTimeStamp>$([System.DateTime]::UtcNow.ToString(yyyyMMdd))</UtcTodayTimeStamp>
     <BuildVersionFilePath>$(BaseIntermediateOutputPath)</BuildVersionFilePath>
-    <BuildVersionFile Condition="'$(BuildVersionFile)'==''">$(BuildVersionFilePath)BuildVersion-$(TodayTimeStamp).props</BuildVersionFile>
+    <BuildVersionFile Condition="'$(BuildVersionFile)'==''">$(BuildVersionFilePath)BuildVersion-$(UtcTodayTimeStamp).props</BuildVersionFile>
   </PropertyGroup>
 
   <!-- If BuildVersion.props exists already then import it to get BuildNumberMajor, else generate it and override props values. -->


### PR DESCRIPTION
Use UTC instead of current Time Zone.  Ideally this should move to using OfficialBuildId I think but for some reason @joperezr made that change and reverted it way back in July, so I suspect there's a technical hurdle to that approach.  Since TodayTimeStamp was used nowhere else, I've renamed the property for clarity.

Either way, our VSO agents do run in UTC time zones and standardizing on this makes the most sense.

@dagood @markwilkie 