### PR TITLE
VSTS Agent cleanup task tweaks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 if (!knownDirectories.Contains(workingDirectory))
                 {
-                    cleanupTasks.Add(CleanupAgentDirectoryAsync(workingDirectory, 0));
+                    cleanupTasks.Add(CleanupAgentDirectoryAsync(workingDirectory));
                 }
             }
             System.Threading.Tasks.Task.WaitAll(cleanupTasks.ToArray());
@@ -206,12 +206,12 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private async System.Threading.Tasks.Task<bool> CleanupAgentAsync(string workDirectory, string sourceFolderJson)
         {
-            bool returnStatus = await CleanupAgentDirectoryAsync(workDirectory, 0);
-            returnStatus &= await CleanupAgentDirectoryAsync(sourceFolderJson, 0).ConfigureAwait(false);
+            bool returnStatus = await CleanupAgentDirectoryAsync(workDirectory);
+            returnStatus &= await CleanupAgentDirectoryAsync(sourceFolderJson).ConfigureAwait(false);
             return returnStatus;
         }
 
-        private async System.Threading.Tasks.Task<bool> CleanupAgentDirectoryAsync(string directory, int attempts)
+        private async System.Threading.Tasks.Task<bool> CleanupAgentDirectoryAsync(string directory, int attempts = 0)
         {
             try
             {

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -24,14 +24,15 @@ namespace Microsoft.DotNet.Build.Tasks
         public int? Retries { get; set; }
 
         public int? SleepTimeInMilliseconds { get; set; }
+        public ITaskItem[] ProcessNamesToKill { get; set; }
 
-        private static readonly int s_DefaultRetries = 5;
+        private static readonly int s_DefaultRetries = 3;
         private static readonly int s_DefaultSleepTime = 2000;
-        private static string[] processNamesToKill = new string[] { "git" };
 
         public override bool Execute()
         {
-            if(!Directory.Exists(AgentDirectory))
+            KillStaleProcesses();
+            if (!Directory.Exists(AgentDirectory))
             {
                 Console.WriteLine($"Agent directory specified: '{AgentDirectory}' does not exist.");
                 return false;
@@ -67,7 +68,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         private void KillStaleProcesses()
         {
-            foreach (string imageName in processNamesToKill)
+            foreach (string imageName in ProcessNamesToKill.Select(t => t.ItemSpec))
             {
                 Process[] allInstances = Process.GetProcessesByName(imageName);
                 foreach (Process proc in allInstances)

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -22,6 +22,6 @@
                       RetentionDays="$(RetentionDays)"
                       Clean="$(DoClean)"
                       Report="$(DoReport)"
-                      ProcessNamesToKill="@(ProcessNamesToKill)"/>
+                      ProcessNamesToKill="@(ProcessNamesToKill)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -12,11 +12,16 @@
     <DoReport Condition="'$(DoReport)' == ''">true</DoReport>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProcessNamesToKill Condition="'@(ProcessNamesToKill)' == ''" Include="git;vbcscompiler" />
+  </ItemGroup>
+
   <Target Name="Clean">
     <Error Condition="'$(AgentDirectory)' == ''" Text="No value specified for 'AgentDirectory'." />
     <CleanupVSTSAgent AgentDirectory="$(AgentDirectory)"
                       RetentionDays="$(RetentionDays)"
                       Clean="$(DoClean)"
-                      Report="$(DoReport)"/>
+                      Report="$(DoReport)"
+                      ProcessNamesToKill="@(ProcessNamesToKill)"/>
   </Target>
 </Project>


### PR DESCRIPTION
- Kill git.exe before starting execution; many failures seen recently are due to .idx files being in use when cleanup was attempted, typical of git gc behavior.
- Do unknown folder cleanup in the same way as known folder (previously was only starting the next task after when the first one failed for the first time, which takes too much time).  
- Reduce sleep time to 2 sec default.

@chcosta @markwilkie 

Builds cleanly, tested locally using @chcosta's sample data.