### PR TITLE
Add ARM64 to nuspec generation list

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -129,7 +129,7 @@
     <!-- build if PackagePlatforms is not specified and the PackageTargetRuntime contains the current architecture -->
     <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND $(PackageTargetRuntime.Contains('-$(PackagePlatform)'))">true</ShouldGenerateNuSpec>
     <!-- build if PackagePlatforms is not specified and arch is x86 or AnyCPU -->
-    <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND ('$(PackagePlatform)' == 'x86' OR '$(PackagePlatform)' == 'AnyCPU')">true</ShouldGenerateNuSpec>
+    <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND ('$(PackagePlatform)' == 'ARM64' OR '$(PackagePlatform)' == 'x86' OR '$(PackagePlatform)' == 'AnyCPU')">true</ShouldGenerateNuSpec>
     <!-- if we built a nuspec, also create layout and pack unless explicitly set -->
     <ShouldCreateLayout Condition="'$(ShouldCreateLayout)' == ''">$(ShouldGenerateNuSpec)</ShouldCreateLayout>
     <ShouldCreatePackage Condition="'$(ShouldCreatePackage)' == ''">$(ShouldGenerateNuSpec)</ShouldCreatePackage>


### PR DESCRIPTION
This is to unblock building managed packages for arm64 alongside the native ones so we don't have to do two separate builds to get the entire package set that we need for testing. Without this change, I have to do full build-managed.cmd's - one with /p:Platform=arm64 and one without.

@karajas @mellinoe this resolves the issue I had yesterday.