### PR TITLE
Fix minor bug with scriptrunner.py

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
@@ -84,7 +84,7 @@ def main(args=None):
 
         return return_code
 
-    return command_main(_main, ['script='], args)
+    return command_main(_main, ['script=', 'args='], args)
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Add 'args=' to command_main invocation as this can break for some legitimate usages of --args.

Previously we'd always used the script without explicitly stating --args, and due to luck, random pythonism, and my choice of variable names this just worked.  Adding this tweak makes @wtgodbe's (correct) interpretation of how the script should work ALSO work.