### PR TITLE
Update shared framework to 1.1.0, change CLI version to 1.0.0-preview2-1-003182

### DIFF
--- a/bootstrap/bootstrap.ps1
+++ b/bootstrap/bootstrap.ps1
@@ -6,6 +6,7 @@ param
     [Parameter(Mandatory=$false)][string]$SharedFrameworkSymlinkPath = (Join-Path $ToolsLocalPath "dotnetcli\shared\Microsoft.NETCore.App\version"),
     [Parameter(Mandatory=$false)][string]$SharedFrameworkVersion = "<auto>",
     [Parameter(Mandatory=$false)][string]$Architecture = "<auto>",
+    [Parameter(Mandatory=$false)][string]$DotNetInstallBranch = "rel/1.0.0",
     [switch]$Force = $false
 )
 
@@ -39,7 +40,7 @@ else
 }
 
 # download CLI boot-strapper script
-Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $dotnetInstallPath
+Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/$DotNetInstallBranch/scripts/obtain/dotnet-install.ps1" -OutFile $dotnetInstallPath
 
 # load the version of the CLI
 $rootCliVersion = Join-Path $RepositoryRoot ".cliversion"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -80,6 +80,7 @@ sharedFxVersion="<auto>"
 force=
 forcedCliLocalPath="<none>"
 architecture="<auto>"
+dotNetInstallBranch="rel/1.0.0"
 
 while [ $# -ne 0 ]
 do
@@ -104,6 +105,10 @@ do
         -a|--architecture|-[Aa]rchitecture)
             shift
             architecture="$1"
+            ;;
+        --dotNetInstallBranch|-[Dd]ot[Nn]et[Ii]nstall[Bb]ranch)
+            shift
+            dotNetInstallBranch="$1"
             ;;
         --sharedFrameworkSymlinkPath|--symlink|-[Ss]haredFrameworkSymlinkPath)
             shift
@@ -172,7 +177,7 @@ if [ $forcedCliLocalPath = "<none>" ]; then
     check_min_reqs
 
     # download CLI boot-strapper script
-    download "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh" "$dotnetInstallPath"
+    download "https://raw.githubusercontent.com/dotnet/cli/$dotNetInstallBranch/scripts/obtain/dotnet-install.sh" "$dotnetInstallPath"
     chmod u+x "$dotnetInstallPath"
 
     # load the version of the CLI

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BclRewriter.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/BclRewriter.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenAPI.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenAPI.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenFacades.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenFacades.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/MSBuild.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/MSBuild.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/csc.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/csc.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/vbc.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/vbc.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/src/Run/run.runtimeconfig.json
+++ b/src/Run/run.runtimeconfig.json
@@ -2,7 +2,7 @@
   "runtimeOptions": {
     "framework": {
       "name": "Microsoft.NETCore.App",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   }
 }


### PR DESCRIPTION
Upgrades buildtools shared framework version to 1.1.0. Helps with https://github.com/dotnet/corefx/issues/14215 by letting CoreFX use CLI version `1.0.0-preview2-1-003182.`

If I stopped there, buildtools would be blocked from uptaking a newer version of itself because bootstrap.sh/ps1 don't support fetching CLI `1.0.0-preview2-1-003182` to get the 1.1.0 framework. To fix this I added `DotNetInstallBranch` that configures which CLI branch dotnet-install comes from. To uptake a new buildtools package, the CLI version will have to be changed and `-DotNetInstallBranch "rel/1.0.0-preview2.1"` passed into bootstrap.ps1 by run.ps1.

~~I also added `invoke_annotated` to bootstrap.sh to remove duplicated code.~~

@crummel @ellismg PTAL
/cc @naamunds 