### PR TITLE
If no "Latest_Packages" versions repository file exists, create one

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -62,8 +62,15 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             string path,
             GitHubBranch branch)
         {
-            GitHubContents file = await GetGitHubFileAsync(path, branch);
-            return FromBase64(file.Content);
+            try
+            {
+                GitHubContents file = await GetGitHubFileAsync(path, branch);
+                return FromBase64(file.Content);
+            }
+            catch (HttpFailureResponseException ex) when (ex.HttpStatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
         }
 
         public async Task PutGitHubFileAsync(
@@ -339,7 +346,7 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
                 {
                     message += $" with content: {failureContent}";
                 }
-                throw new HttpRequestException(message);
+                throw new HttpFailureResponseException(response.StatusCode, message);
             }
         }
 

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/HttpFailureResponseException.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/HttpFailureResponseException.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net;
+using System.Net.Http;
+
+namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
+{
+    public class HttpFailureResponseException : HttpRequestException
+    {
+        public HttpStatusCode HttpStatusCode { get; }
+
+        public HttpFailureResponseException(
+            HttpStatusCode httpStatusCode,
+            string message)
+            : base(message)
+        {
+            HttpStatusCode = httpStatusCode;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -199,7 +199,6 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
             if (latestPackages == null)
             {
-                Trace.TraceInformation($"No versions repository file '{path}' found.");
                 return null;
             }
 

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -114,12 +114,21 @@ namespace Microsoft.DotNet.VersionTools.Automation
                             {
                                 Dictionary<string, string> existingPackages = await GetPackagesAsync(client, latestPackagesPath);
 
-                                // Add each existing package if there isn't a new package with the same id.
-                                foreach (var package in existingPackages)
+                                if (existingPackages == null)
                                 {
-                                    if (!allPackages.ContainsKey(package.Key))
+                                    Trace.TraceInformation(
+                                        "No exising Latest_Packages file found; one will be " +
+                                        $"created in '{versionsRepoPath}'");
+                                }
+                                else
+                                {
+                                    // Add each existing package if there isn't a new package with the same id.
+                                    foreach (var package in existingPackages)
                                     {
-                                        allPackages[package.Key] = package.Value;
+                                        if (!allPackages.ContainsKey(package.Key))
+                                        {
+                                            allPackages[package.Key] = package.Value;
+                                        }
                                     }
                                 }
                             }
@@ -187,6 +196,12 @@ namespace Microsoft.DotNet.VersionTools.Automation
             string latestPackages = await client.GetGitHubFileContentsAsync(
                 path,
                 new GitHubBranch("master", _project));
+
+            if (latestPackages == null)
+            {
+                Trace.TraceInformation($"No versions repository file '{path}' found.");
+                return null;
+            }
 
             using (var reader = new StringReader(latestPackages))
             {

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Automation\DependencyUpdateResults.cs" />
+    <Compile Include="Automation\GitHubApi\HttpFailureResponseException.cs" />
     <Compile Include="Dependencies\DependencyBuildInfo.cs" />
     <Compile Include="Dependencies\DependencyUpdateTask.cs" />
     <Compile Include="Automation\GitHubApi\GitHubClient.cs" />


### PR DESCRIPTION
This allows a build to succeed on a branch that doesn't have a build-info entry. Without this change, the build would fail to find an existing entry and fail with a 404.

Implemented by catching the 404 in the specific case of requesting file contents, and returning `null` contents. A GitHub 404 can also be an authentication error, so I don't want to catch it very broadly.

@StephenBonikowsky This will fix the publish build problems you're hitting with manual builds of new WCF branches.

@weshaggard @gkhanna79 This will also let us stop having to manually create blank build-info files when setting up new release branch builds.