### PR TITLE
Fix lack of continuation token in DownloadFromAzure task

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -338,7 +338,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Dictionary<string, HashSet<string>> values = new Dictionary<string, HashSet<string>>();
             //Decode this to allow the regex to pull out the correct groups for signing
             address = new Uri(WebUtility.UrlDecode(address.ToString()));
-            Regex newreg = new Regex(@"\?(\w+)\=([\w|\=]+)|\&(\w+)\=([\w|\=]+)");
+            Regex newreg = new Regex(@"(?:\?|&)([^=]+)=([^&]+)");
             MatchCollection matches = newreg.Matches(address.Query);
             foreach (Match match in matches)
             {


### PR DESCRIPTION
Use NextMarker + Marker Uri parameter to allow downloading > 5000 blobs.   Bug found by @wtgodbe who somehow has a container with > 18K blobs!

Fix query string regex to allow ! in parameter strings. (Thanks @ChadNedzlek )