### PR TITLE
Add script that can do retry when git clone-ing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/CloneWithRetry.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/CloneWithRetry.cmd
@@ -1,0 +1,36 @@
+@echo off
+
+if "%1" == ""   goto :usage
+if "%2" == ""   goto :usage
+goto :main
+
+:usage
+echo Usage: %~n0 [repository url] [destination folder]
+echo.
+echo Clones a git repo using the specified URL with depth 1 (for performance), 
+echo retrying up to 10x if there is a failure.
+goto :eof
+
+:main
+set REPO_URL=%1
+set FOLDER_NAME=%2
+set /a RETRY_COUNT=10
+set /a SLEEP_TIME=10
+set /a CLONE_DEPTH=1
+
+IF NOT DEFINED GIT SET "GIT=C:\Program Files (x86)\Git\cmd\git.exe"
+
+:while
+call "%GIT%" clone %REPO_URL% %FOLDER_NAME% --depth %CLONE_DEPTH%
+if %ERRORLEVEL% EQU 0 goto :done
+:failed
+set /a RETRY_COUNT-=1
+echo Clone failed.  Removing %FOLDER_NAME% in an attempt to get clone working, will retry in ~%SLEEP_TIME% seconds.
+rd /s /q %FOLDER_NAME%
+ping -n %SLEEP_TIME% 127.0.0.1 > NUL
+
+if %RETRY_COUNT% EQU 0 goto :done
+goto :while
+
+
+:done

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/CloneWithRetry.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/CloneWithRetry.cmd
@@ -16,13 +16,13 @@ set REPO_URL=%1
 set FOLDER_NAME=%2
 set /a RETRY_COUNT=10
 set /a SLEEP_TIME=10
-set /a CLONE_DEPTH=1
 
 IF NOT DEFINED GIT SET "GIT=%PROGRAMFILES(X86)%\Git\cmd\git.exe"
 
 :while
-call "%GIT%" clone %REPO_URL% %FOLDER_NAME% --depth %CLONE_DEPTH%
+call "%GIT%" clone %REPO_URL% %FOLDER_NAME%
 if %ERRORLEVEL% EQU 0 goto :done
+
 :failed
 set /a RETRY_COUNT-=1
 echo Clone failed.  Removing %FOLDER_NAME% in an attempt to get clone working, will retry in ~%SLEEP_TIME% seconds.
@@ -31,6 +31,5 @@ ping -n %SLEEP_TIME% 127.0.0.1 > NUL
 
 if %RETRY_COUNT% EQU 0 goto :done
 goto :while
-
 
 :done

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/CloneWithRetry.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/CloneWithRetry.cmd
@@ -18,7 +18,7 @@ set /a RETRY_COUNT=10
 set /a SLEEP_TIME=10
 set /a CLONE_DEPTH=1
 
-IF NOT DEFINED GIT SET "GIT=C:\Program Files (x86)\Git\cmd\git.exe"
+IF NOT DEFINED GIT SET "GIT=%PROGRAMFILES(X86)%\Git\cmd\git.exe"
 
 :while
 call "%GIT%" clone %REPO_URL% %FOLDER_NAME% --depth %CLONE_DEPTH%


### PR DESCRIPTION
After wasting a lot of time trying to do this with inline powershell (just doesn't fit into what's allowed) I've made a .cmd version of this for running git clone with retry.  Additionally, I've made the clone default to --depth 1 to improve performance.  Retry count, sleep time, and depth can be made into parameters later if desired.
(There's little / no reason to have a non-Windows version of this script as there is a built-in git-retry command for *nix)

@chcosta 