### PR TITLE
Ensure PackageIndex is not mutated during build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyBaseLine.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyBaseLine.cs
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public void GetBaseLinedDependenciesFromIndex()
         {
-            PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
 
             List<ITaskItem> baseLinedDependencies = new List<ITaskItem>();
 
@@ -117,11 +117,11 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 // if we have an assembly version see if we have a better package version
                 if (assemblyVersion != null)
                 {
-                    packageVersion = PackageIndex.Current.GetPackageVersionForAssemblyVersion(packageId, assemblyVersion);
+                    packageVersion = index.GetPackageVersionForAssemblyVersion(packageId, assemblyVersion);
                 }
 
                 if (Apply &&
-                    PackageIndex.Current.TryGetBaseLineVersion(packageId, out baseLineVersion) &&
+                    index.TryGetBaseLineVersion(packageId, out baseLineVersion) &&
                     (packageVersion == null || baseLineVersion > packageVersion))
                 {
                     packageVersion = baseLineVersion;

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyPreReleaseSuffix.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
     public class ApplyPreReleaseSuffix : PackagingTask
     {
         private Dictionary<string, Version> _stablePackageVersions;
-
+        private PackageIndex _index;
         /// <summary>
         /// Original dependencies without pre-release specifier.
         /// </summary>
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (PackageIndexes != null && PackageIndexes.Length > 0)
             {
-                PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+                _index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
             }
             else
             {
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
             else
             {
-                isStable = PackageIndex.Current.IsStable(packageId, packageVersion);
+                isStable = _index.IsStable(packageId, packageVersion);
             }
 
             return isStable;
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         private string GetSuffix(string packageId)
         {
-            return PackageIndex.Current.GetPreRelease(packageId) ?? PreReleaseSuffix;
+            return _index.GetPreRelease(packageId) ?? PreReleaseSuffix;
         }
 
         private static Version ParseAs3PartVersion(string versionString)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/FilterUnknownPackages.cs
@@ -39,8 +39,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (PackageIndexes != null && PackageIndexes.Length > 0)
             {
-                PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
-                isKnownPackage = packageId => PackageIndex.Current.Packages.ContainsKey(packageId);
+                var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+                isKnownPackage = packageId => index.Packages.ContainsKey(packageId);
             }
             else
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public void GetLastStablePackagesFromIndex()
         {
-            PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
 
             List<ITaskItem> lastStablePackages = new List<ITaskItem>();
 
@@ -133,7 +133,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 var latestVersion = nuGetVersion?.Version;
 
                 PackageInfo info;
-                if (PackageIndex.Current.Packages.TryGetValue(packageId, out info))
+                if (index.Packages.TryGetValue(packageId, out info))
                 {
                     var candidateVersions = (latestVersion == null) ? info.StableVersions : info.StableVersions.Where(sv => sv < latestVersion);
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
@@ -42,9 +42,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
             if (PackageIndexes != null && PackageIndexes.Length > 0)
             {
-                PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+                var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
 
-                modulesToPackages = PackageIndex.Current.ModulesToPackages;
+                modulesToPackages = index.ModulesToPackages;
             }
             else
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -407,10 +407,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 return;
             }
 
-            PackageIndex.Current.Merge(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
 
             PackageInfo info;
-            if (!PackageIndex.Current.Packages.TryGetValue(PackageId, out info))
+            if (!index.Packages.TryGetValue(PackageId, out info))
             {
                 Log.LogError($"PackageIndex from {String.Join(", ", PackageIndexes.Select(i => i.ItemSpec))} is missing an entry for package {PackageId}.  Please run /t:UpdatePackageIndex on this project to commit an update.");
                 return;
@@ -454,7 +454,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 info.AssemblyVersionInPackageVersion.Count == 0)
             {
                 // if in the native module map
-                if (PackageIndex.Current.ModulesToPackages.Values.Any(p => p.Equals(PackageId)))
+                if (index.ModulesToPackages.Values.Any(p => p.Equals(PackageId)))
                 {
                     // ensure the baseline is set
                     if (info.BaselineVersion != thisPackageVersion)
@@ -467,7 +467,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     // not in the native module map, see if any of the modules in this package are present
                     // (with a different package, as would be the case for runtime-specific packages)
                     var moduleNames = allDlls.Select(d => Path.GetFileNameWithoutExtension(d.LocalPath));
-                    if (moduleNames.Any() && !moduleNames.Any(m => PackageIndex.Current.ModulesToPackages.ContainsKey(m)))
+                    if (moduleNames.Any() && !moduleNames.Any(m => index.ModulesToPackages.ContainsKey(m)))
                     {
                         Log.LogError($"PackageIndex from {String.Join(", ", PackageIndexes.Select(i => i.ItemSpec))} is missing ModulesToPackages entry(s) for {String.Join(", ", allDlls)} to package {PackageId}.  Please add a an entry for the appropriate package.");
                     }


### PR DESCRIPTION
Previously we'd merge any index we saw during build into an index
singleton.  This was because initially the index was seen as repo data
and not project specific data.  I broke that assumption when I started
using a different index in packages which wanted a different baseline.
I began using indexes specific to individual projects.  This caused
state to bleed across packages.

Fix this by always calling Load and backing it with a cache that will
not reload the index if the same index set was already loaded.

Thanks @StephenBonikowsky for pointing this out.