### PR TITLE
For checked in definition client, fix VSTS build API url

### DIFF
--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildHttpClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildHttpClient.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Build.VstsBuildsApi
 {
     internal class VstsBuildHttpClient : VstsDefinitionHttpClient
     {
-        private const string BuildApiType = "builds";
+        private const string BuildApiType = "build";
 
         public VstsBuildHttpClient(JObject definition, VstsApiEndpointConfig config)
             : base(new Uri(definition["project"]["url"].ToString()), config, BuildApiType)


### PR DESCRIPTION
`builds` should be `build`.

I messed up my last refactor in https://github.com/dotnet/buildtools/pull/1270 and must have only tested the Release flow. Now I've actually pulled this package into pipebuild and running with a fuller scenario I noticed.

FYI @MichaelSimons @chcosta 