### PR TITLE
Move Dumpling target before GenerateTestExecutionScripts

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -1,7 +1,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Setup Dumpling service to collect crash dumps -->
   <Target Name="SetupDumpling"
-          BeforeTargets="RunTestsForProject"
+          BeforeTargets="GenerateTestExecutionScripts"
           Condition="'$(TargetOS)'!='Windows_NT'">
     <ReadLinesFromFile File="$(MSBuildThisFileDirectory)Dumpling.txt">
       <Output TaskParameter="Lines" ItemName="DumplingCommands" />


### PR DESCRIPTION
In PR https://github.com/dotnet/buildtools/pull/1254, Dumpling service (a service to collect core dumps) option was added to non-Windows test runs, being ON by default for Helix runs. However, Dumpling.target should have run before target `GenerateTestExecutionScripts` instead of `RunTestsForProject`, to actually be added to `RunTests.sh`. This PR fixes that.

The current changes have been tested on CoreFx locally by pointing CoreFx to packages built by a local BuildTools repo. Also, to make sure Helix would pick Dumpling up for `RunTests` script, the Helix zipped test directory was generated locally by running:

`msbuild <TestProjectPath> /p:EnableDumpling=true /p:SkipTests=true /p:ArchiveTests=true`

and it was verified that Dumpling commands appeared in `RunTests` script.

cc: @danmosemsft @MattGal @mellinoe @ericstj @karajas 