### PR TITLE
Fix bug in GenerateTestExecutionScripts by wrapping echoCommands in quotes

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.txt
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.txt
@@ -21,7 +21,7 @@ CollectDumps()
     echo command failed, trying to collect dumps
     _corefile=$(ls . | grep -E --max-count=1 '^core(\..*)?$')
     echo corefile: $_corefile
-    if [ -n '$_corefile' ]
+    if [ -n "$_corefile" ]
     then
       echo uploading core to dumpling service
       python ~/.dumpling/dumpling.py upload --dumppath $_corefile --noprompt --triage full --displayname $_ProjectName --properties STRESS_TESTID=$_ProjectName --verbose

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Build.Tasks
             foreach (string runCommand in TestCommands)
             {
                 testRunCommands.Append($"{runCommand}\n");
-                testRunEchoes.Append($"echo {runCommand}\n".Replace("(", "").Replace(")", ""));  // Remove parentheses from echo command to avoid errors on Linux
+                testRunEchoes.Append($"echo \"{runCommand.Replace("\"", "").Replace("(", "").Replace(")", "")}\"\n");  // Remove parentheses and quotes from echo command before wrapping it in quotes to avoid errors on Linux
             }
             shExecutionTemplate = shExecutionTemplate.Replace("[[TestRunCommands]]", testRunCommands.ToString());
             shExecutionTemplate = shExecutionTemplate.Replace("[[TestRunCommandsEcho]]", testRunEchoes.ToString());


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/15472

This PR fixes two issues:

**One.** When we echo all commands in RunTests.sh, the echo of a dumpling command 

`echo echo 0x3F > /proc/self/coredump_filter`

fails with error: `echo: write error: Invalid argument`

The fix to this is to wrap all commands in double quotes (`echo "echo 0x3F > /proc/self/coredump_filter"`)


**Two.** When a test fails but no core file was dumped, Dumpling.targets was trying to upload the non-existing file as the following check wasn't working as expected:
`if [ -n '$_corefile' ]`

converting the line to `if [ -n "$_corefile" ]` fixes the problem.

@MattGal @mellinoe 
