### PR TITLE
Fix null-ref when unexpected -? args come in

### DIFF
--- a/src/Run/Setup.cs
+++ b/src/Run/Setup.cs
@@ -484,11 +484,11 @@ namespace Microsoft.DotNet.Execute
         public string FormatSetting(string option, string value, string type, string toolName)
         {
             string commandOption = null;
-            if (type.Equals("passThrough"))
+            if (type != null && type.Equals("passThrough"))
             {
                 commandOption = string.Format(" {0}", toolName.Equals("console") ? "" : value);
             }
-            else if (type.Equals(RunToolSettingValueTypeReservedKeyword)) { /* do nothing */ }
+            else if (type != null && type.Equals(RunToolSettingValueTypeReservedKeyword)) { /* do nothing */ }
             else
             {
                 Tool toolFormat;


### PR DESCRIPTION
Addresses https://github.com/dotnet/buildtools/issues/1305.  

However, to get the command they're using in that issue to work as expected, we'll also have to change build.cmd/sh.

@danmosemsft 