### PR TITLE
Update MSBuild package versions and account for breaking changes.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RoslynVersion>2.0.0-rc</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.Compilers</RoslynPackageName>
+    <RoslynTargetsPath>$(ToolRuntimePath)</RoslynTargetsPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -68,7 +68,7 @@ if not [%RESTORE_PORTABLETARGETS_ERROR_LEVEL%]==[0] (
 	echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" restore "%PORTABLETARGETS_PROJECTJSON%"'. Please check above for more details.
 	exit /b %RESTORE_PORTABLETARGETS_ERROR_LEVEL%
 )
-Robocopy "%PACKAGES_DIR%\Microsoft.Portable.Targets\%PORTABLETARGETS_VERSION%\contentFiles\any\any\." "%TOOLRUNTIME_DIR%\." /E
+Robocopy "%PACKAGES_DIR%\Microsoft.Portable.Targets\%PORTABLETARGETS_VERSION%\contentFiles\any\any\Extensions." "%TOOLRUNTIME_DIR%\." /E
 Robocopy "%PACKAGES_DIR%\MicroBuild.Core\%MICROBUILD_VERSION%\build\." "%TOOLRUNTIME_DIR%\." /E
 
 :: Copy Roslyn Compilers Over to ToolRuntime

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -98,7 +98,7 @@ echo "Running: \"$__DOTNET_CMD\" restore \"${__PORTABLETARGETS_PROJECTJSON}\" $_
 $__DOTNET_CMD restore "${__PORTABLETARGETS_PROJECTJSON}" $__INIT_TOOLS_RESTORE_ARGS --packages "${__PACKAGES_DIR}/."
 
 # Copy portable and MicroBuild targets from packages, allowing for lowercased package IDs.
-cp -R "${__PACKAGES_DIR}"/[Mm]icrosoft.[Pp]ortable.[Tt]argets/"${__PORTABLETARGETS_VERSION}/contentFiles/any/any/." "$__TOOLRUNTIME_DIR/."
+cp -R "${__PACKAGES_DIR}"/[Mm]icrosoft.[Pp]ortable.[Tt]argets/"${__PORTABLETARGETS_VERSION}/contentFiles/any/any/Extensions/." "$__TOOLRUNTIME_DIR/."
 cp -R "${__PACKAGES_DIR}"/[Mm]icro[Bb]uild.[Cc]ore/"${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
 
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.exe $*
+$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.dll $*
 exit $?

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -2,12 +2,11 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "MSBuild": "0.1.0-preview-00024-160610",
-        "Microsoft.Build.Framework": "0.1.0-preview-00024-160610",
-        "Microsoft.Build.Tasks.Core": "0.1.0-preview-00024-160610",
-        "Microsoft.Build.Utilities.Core": "0.1.0-preview-00024-160610",
-        "Microsoft.Build.Targets": "0.1.0-preview-00024-160610",
-        "Microsoft.Build": "0.1.0-preview-00024-160610",
+        "Microsoft.Build.Framework": "15.1.0-preview-000523-01",
+        "Microsoft.Build.Runtime": "15.1.0-preview-000523-01",
+        "Microsoft.Build.Tasks.Core": "15.1.0-preview-000523-01",
+        "Microsoft.Build.Utilities.Core": "15.1.0-preview-000523-01",
+        "Microsoft.Build": "15.1.0-preview-000523-01",
         "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
         "Microsoft.Net.Compilers.netcore": "2.0.0-rc",
         "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",


### PR DESCRIPTION
We are using a very old version of .NET Core MSBuild (from last June). This commit updates the versions we are using. The "MSBuild" and "Microsoft.Build.Targets" packages have been replaced by the "Microsoft.Build.Runtime" package, which I've switched to. There are a couple of path-related breaking changes that I needed to react to in this change, as well.

All of these new packages are available on nuget.org.

@weshaggard @joperezr 