### PR TITLE
Remove duplicate GenFacades.Core entry in nuspec

### DIFF
--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -31,7 +31,6 @@
     <file src="BclRewriter\BclRewriter.exe" target="lib" />
     <file src="GenFacades.Console\GenFacades.exe" target="lib" />
     <file src="GenFacades.Core\GenFacades.Core.dll" target="lib" />
-    <file src="GenFacades.Core\GenFacades.Core.dll" target="lib/net46" />
     <file src="GenAPI\GenAPI.exe" target="lib" />
     <file src="ApiCompat\ApiCompat.exe" target="lib" />
     <file src="Microsoft.DotNet.CodeAnalysis\Microsoft.DotNet.CodeAnalysis.dll" target="lib\analyzers" />


### PR DESCRIPTION
Apparently the previous line was causing GenFacades.Core.dll to be placed into the lib/net46 folder anyways, so this line was not needed. The nuget publisher gave an error because of this duplicate file, although everything built fine locally.