### PR TITLE
Propagate errors for GenFacades

### DIFF
--- a/src/GenFacades/GenFacades.Core/GenFacades.cs
+++ b/src/GenFacades/GenFacades.Core/GenFacades.cs
@@ -18,7 +18,7 @@ namespace GenFacades
     {
         private const uint ReferenceAssemblyFlag = 0x70;
 
-        public static void Execute(
+        public static bool Execute(
             string seeds,
             string contracts,
             string facadePath,
@@ -105,6 +105,12 @@ namespace GenFacades
 
                         Assembly filledPartialFacade = facadeGenerator.GenerateFacade(contractAssembly, seedCoreAssemblyRef, ignoreMissingTypes, overrideContractAssembly: partialFacadeAssembly);
 
+                        if (filledPartialFacade == null)
+                        {
+                            Trace.TraceError("Errors were encountered while generating the facade.");
+                            return false;
+                        }
+
                         string pdbLocation = null;
 
                         if (producePdb)
@@ -130,13 +136,15 @@ namespace GenFacades
 #if !COREFX
                                 Debug.Assert(Environment.ExitCode != 0);
 #endif
-                                continue;
+                                return false;
                             }
 
                             OutputFacadeToFile(facadePath, seedHost, facade, contract);
                         }
                     }
                 }
+
+                return true;
             }
             catch (FacadeGenerationException ex)
             {
@@ -144,6 +152,7 @@ namespace GenFacades
 #if !COREFX
                 Debug.Assert(Environment.ExitCode != 0);
 #endif
+                return false;
             }
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     Trace.WriteLine("seedTypePreferencesUnsplit: " + string.Join(" || ", seedTypePreferencesUnsplit));
                 }
 
-                Generator.Execute(
+                bool result = Generator.Execute(
                     Seeds,
                     Contracts,
                     FacadePath,
@@ -89,7 +89,12 @@ namespace Microsoft.DotNet.Build.Tasks
                     ProducePdb,
                     PartialFacadeAssemblyPath);
 
-                return true;
+                if (!result)
+                {
+                    Log.LogError("Errors were encountered when generating facade(s).");
+                }
+
+                return result;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Instead of ignoring when `FacadeGenerator.GenerateFacade` returns null, I'm now detecting it and returning `false` from this method. The MSBuild task checks that result and propagates it.

@ericstj This should fix the NRE when GenFacades fails, and give better error messages.