### PR TITLE
Update xunit to latest beta

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -61,7 +61,7 @@
     <XUnitDependency Include="xunit.runner.utility"/>
     <XUnitDependency Include="xunit.runner.console"/>
     <StaticDependency Include="@(XUnitDependency)">
-      <Version>2.2.0-beta2-build3300</Version>
+      <Version>2.2.0-beta5-build3474</Version>
     </StaticDependency>
     -->
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/publishtest.targets
@@ -38,11 +38,11 @@
     </PrereleaseResolveNuGetPackageAssets>
 
     <ItemGroup Condition="'$(TestWithCore)' != 'true'">
-      <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.2.0-beta2-build3300\tools\*.exe" />
-      <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.2.0-beta2-build3300\tools\*.dll" />
+      <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.2.0-beta5-build3474\tools\*.exe" />
+      <_TestCopyLocalXunitFiles Include="$(PackagesDir)xunit.runner.console\2.2.0-beta5-build3474\tools\*.dll" />
       <TestCopyLocal Include="@(_TestCopyLocalXunitFiles)" >
         <NuGetPackageId>%(FileName)</NuGetPackageId>
-        <NuGetPackageVersion>2.2.0-beta2-build3300</NuGetPackageVersion>
+        <NuGetPackageVersion>2.2.0-beta5-build3474</NuGetPackageVersion>
         <Private>false</Private>
       </TestCopyLocal>
     </ItemGroup>

--- a/src/Microsoft.DotNet.BuildTools.TestSuite/project.json
+++ b/src/Microsoft.DotNet.BuildTools.TestSuite/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "xunit": "2.2.0-beta2-build3300",
-    "xunit.runner.utility": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta5-build3474",
+    "xunit.runner.utility": "2.2.0-beta5-build3474"
   },
   "frameworks": {
     "netstandard1.1": {}

--- a/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
@@ -20,17 +20,17 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <dependencies>
         <group targetFramework="netstandard1.0">
-            <dependency id="xunit" version="2.2.0-beta2-build3300" />
-            <dependency id="xunit.runner.utility" version="2.2.0-beta2-build3300" />
+            <dependency id="xunit" version="2.2.0-beta5-build3474" />
+            <dependency id="xunit.runner.utility" version="2.2.0-beta5-build3474" />
         </group>
         <group targetFramework="net46">
-            <dependency id="xunit" version="2.2.0-beta2-build3300" />
-            <dependency id="xunit.runner.utility" version="2.2.0-beta2-build3300" />
-            <dependency id="xunit.runner.console" version="2.2.0-beta2-build3300" />
+            <dependency id="xunit" version="2.2.0-beta5-build3474" />
+            <dependency id="xunit.runner.utility" version="2.2.0-beta5-build3474" />
+            <dependency id="xunit.runner.console" version="2.2.0-beta5-build3474" />
         </group>
         <group targetFramework="uap10.0" targetRuntime="win-aot">
-            <dependency id="xunit" version="2.2.0-beta2-build3300" />
-            <dependency id="xunit.runner.utility" version="2.2.0-beta2-build3300" />
+            <dependency id="xunit" version="2.2.0-beta5-build3474" />
+            <dependency id="xunit.runner.utility" version="2.2.0-beta5-build3474" />
             <dependency id="Microsoft.DotNet.TestILC" version="1.4.24208-prerelease" />
         </group>
     </dependencies>

--- a/src/xunit.console.netcore/project.json
+++ b/src/xunit.console.netcore/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "xunit": "2.2.0-beta2-build3300",
-    "xunit.runner.utility": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-beta5-build3474",
+    "xunit.runner.utility": "2.2.0-beta5-build3474",
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.0"

--- a/src/xunit.console.uwp/packages.config
+++ b/src/xunit.console.uwp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net46" />
-  <package id="xunit.runner.utility" version="2.2.0-beta2-build3300" targetFramework="net46" />
+  <package id="xunit.runner.utility" version="2.2.0-beta5-build3474" targetFramework="net46" />
 </packages>

--- a/src/xunit.console.uwp/xunit.console.uwp.csproj
+++ b/src/xunit.console.uwp/xunit.console.uwp.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.runner.utility.desktop, Version=2.2.0.3300, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.runner.utility.2.2.0-beta2-build3300\lib\net45\xunit.runner.utility.desktop.dll</HintPath>
+    <Reference Include="xunit.runner.utility.desktop, Version=2.2.0.3474, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.runner.utility.2.2.0-beta5-build3474\lib\net45\xunit.runner.utility.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/xunit.netcore.extensions/project.json
+++ b/src/xunit.netcore.extensions/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "xunit": "2.2.0-beta2-build3300",
+    "xunit": "2.2.0-beta5-build3474",
   },
   "__comment": "RuntimeInformation and OSPlatform are not on netstandard1.0 hence 1.1 was selected",
   "frameworks": {

--- a/src/xunit.runner.uwp/project.json
+++ b/src/xunit.runner.uwp/project.json
@@ -1,8 +1,8 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
-    "xunit": "2.2.0-beta2-build3300",
-    "xunit.runner.utility": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta5-build3474",
+    "xunit.runner.utility": "2.2.0-beta5-build3474"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
I'm trying to pull the fix xunit/xunit#965 into corefx, to remove some unecessary workarounds.

However, I've updated the corefx packages, but it doesn't seem to be updated (I've verified the fix works)

Therefore, I think we also need to update the buildtools packages as well, and then synchronize them with corefx.