### PR TITLE
Use StringComparer.OrdinalIgnoreCase in LINQ OrderBy calls

### DIFF
--- a/src/ApiCompat/Program.cs
+++ b/src/ApiCompat/Program.cs
@@ -48,7 +48,7 @@ namespace ApiCompat
 
                 var rules = c.GetExports<IDifferenceRule>();
 
-                foreach (var rule in rules.Select(r => r.GetType().Name).OrderBy(r => r))
+                foreach (var rule in rules.Select(r => r.GetType().Name).OrderBy(r => r, StringComparer.OrdinalIgnoreCase))
                 {
                     Console.WriteLine(rule);
                 }

--- a/src/ApiCompat/Rules/Compat/CannotRemoveGenerics.cs
+++ b/src/ApiCompat/Rules/Compat/CannotRemoveGenerics.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Writers.CSharp;
 using System.Linq;
@@ -59,8 +60,8 @@ namespace Microsoft.Cci.Differs.Rules
                         implParam.FullName(), target.FullName(), implParam.Variance, contractParam.Variance);
                 }
 
-                string implConstraints = string.Join(",", GetConstraints(implParam).OrderBy(s => s));
-                string contractConstraints = string.Join(",", GetConstraints(contractParam).OrderBy(s => s));
+                string implConstraints = string.Join(",", GetConstraints(implParam).OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
+                string contractConstraints = string.Join(",", GetConstraints(contractParam).OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
 
                 if (!string.Equals(implConstraints, contractConstraints))
                 {

--- a/src/GenFacades/GenFacades.Core/GenFacades.cs
+++ b/src/GenFacades/GenFacades.Core/GenFacades.cs
@@ -284,7 +284,7 @@ namespace GenFacades
             foreach (KeyValuePair<string, HashSet<string>> kv in mutableDocIdTable)
             {
                 string key = kv.Key;
-                IEnumerable<string> sortedDocIds = kv.Value.OrderBy(s => s);
+                IEnumerable<string> sortedDocIds = kv.Value.OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
                 docIdTable.Add(key, sortedDocIds);
             }
             return docIdTable;

--- a/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/TypeExtensions.cs
@@ -592,15 +592,15 @@ namespace Microsoft.Cci.Extensions
         public static IEnumerable<T> OrderByIdentity<T>(this IEnumerable<T> assemblies)
             where T : IAssemblyReference
         {
-            return assemblies.OrderBy(a => a.Name.Value)
-                             .ThenBy(a => a.GetPublicKeyToken())
+            return assemblies.OrderBy(a => a.Name.Value, StringComparer.OrdinalIgnoreCase)
+                             .ThenBy(a => a.GetPublicKeyToken(), StringComparer.OrdinalIgnoreCase)
                              .ThenBy(a => a.Version);
         }
 
         public static IEnumerable<AssemblyIdentity> OrderByIdentity(this IEnumerable<AssemblyIdentity> assemblies)
         {
-            return assemblies.OrderBy(a => a.Name.Value)
-                             .ThenBy(a => a.GetPublicKeyToken())
+            return assemblies.OrderBy(a => a.Name.Value, StringComparer.OrdinalIgnoreCase)
+                             .ThenBy(a => a.GetPublicKeyToken(), StringComparer.OrdinalIgnoreCase)
                              .ThenBy(a => a.Version);
         }
 

--- a/src/Microsoft.Cci.Extensions/Traversers/MappingsTypeMemberTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/MappingsTypeMemberTraverser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Cci.Comparers;
@@ -42,7 +43,7 @@ namespace Microsoft.Cci.Traversers
         public virtual void Visit(IEnumerable<AssemblyMapping> assemblies)
         {
             assemblies = assemblies.Where(this.DiffFilter.Include);
-            assemblies = assemblies.OrderBy(GetAssemblyKey);
+            assemblies = assemblies.OrderBy(GetAssemblyKey, StringComparer.OrdinalIgnoreCase);
 
             foreach (var assembly in assemblies)
                 Visit(assembly);
@@ -61,7 +62,7 @@ namespace Microsoft.Cci.Traversers
         public virtual void Visit(IEnumerable<NamespaceMapping> namespaces)
         {
             namespaces = namespaces.Where(this.DiffFilter.Include);
-            namespaces = namespaces.OrderBy(GetNamespaceKey);
+            namespaces = namespaces.OrderBy(GetNamespaceKey, StringComparer.OrdinalIgnoreCase);
 
             foreach (var ns in namespaces)
                 Visit(ns);
@@ -99,7 +100,7 @@ namespace Microsoft.Cci.Traversers
         public virtual void Visit(IEnumerable<MemberMapping> members)
         {
             members = members.Where(this.DiffFilter.Include);
-            members = members.OrderBy(GetMemberKey);
+            members = members.OrderBy(GetMemberKey, StringComparer.OrdinalIgnoreCase);
 
             foreach (var member in members)
                 Visit(member);

--- a/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Cci.Extensions;
@@ -36,7 +37,7 @@ namespace Microsoft.Cci.Traversers
         public virtual void Visit(IEnumerable<INamespaceDefinition> namespaces)
         {
             namespaces = namespaces.Where(_filter.Include);
-            namespaces = namespaces.OrderBy(GetNamespaceKey);
+            namespaces = namespaces.OrderBy(GetNamespaceKey, StringComparer.OrdinalIgnoreCase);
 
             foreach (var ns in namespaces)
                 Visit(ns);
@@ -55,7 +56,7 @@ namespace Microsoft.Cci.Traversers
         public virtual void Visit(IEnumerable<ITypeDefinition> types)
         {
             types = types.Where(_filter.Include);
-            types = types.OrderBy(GetTypeKey);
+            types = types.OrderBy(GetTypeKey, StringComparer.OrdinalIgnoreCase);
 
             foreach (var type in types)
                 Visit(type);
@@ -79,7 +80,7 @@ namespace Microsoft.Cci.Traversers
         public virtual void Visit(IEnumerable<ITypeDefinitionMember> members)
         {
             members = members.Where(_filter.Include);
-            members = members.OrderBy(GetMemberKey);
+            members = members.OrderBy(GetMemberKey, StringComparer.OrdinalIgnoreCase);
 
             foreach (var member in members)
                 Visit(member);

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Cci.Writers.CSharp
             if (!securityAttributes.SelectMany(s => s.Attributes).Any(IncludeAttribute))
                 return;
 
-            securityAttributes = securityAttributes.OrderBy(s => s.Action.ToString());
+            securityAttributes = securityAttributes.OrderBy(s => s.Action.ToString(), StringComparer.OrdinalIgnoreCase);
 
             bool first = true;
             WriteSymbol("[");

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Cci.Writers.CSharp
             if (baseType != null)
                 baseTypes.Add(baseType);
 
-            baseTypes.AddRange(type.Interfaces.Where(IncludeBaseType).OrderBy((t) => GetTypeName(t)));
+            baseTypes.AddRange(type.Interfaces.Where(IncludeBaseType).OrderBy((t) => GetTypeName(t), StringComparer.OrdinalIgnoreCase));
 
             if (baseTypes.Count == 0)
                 return;

--- a/src/Microsoft.Cci.Extensions/Writers/DocumentIdWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/DocumentIdWriter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -23,7 +24,7 @@ namespace Microsoft.Cci.Writers
 
         public void WriteAssemblies(IEnumerable<IAssembly> assemblies)
         {
-            assemblies = assemblies.OrderBy(a => a.Name.Value);
+            assemblies = assemblies.OrderBy(a => a.Name.Value, StringComparer.OrdinalIgnoreCase);
             foreach (var assembly in assemblies)
                 Visit(assembly);
         }


### PR DESCRIPTION
This makes sure the sort order is consistent even with different culture/locale settings.

I thought about using StringComparer.Ordinal since it feels like the more "correct" in this case but unfortunately this generates a huge diff in e.g. the dotnet/standard repo since APIs are being reordered.

Unfortunately, even StringComparer.OrdinalIgnoreCase doesn't produce the exact same result, but the diff is much smaller, e.g. https://github.com/akoeplinger/standard/commit/dd88153291ed83fd0dadfcb585ab4c2477702346.

With this, I can use GenAPI.exe on OSX and it generates the same file as on Windows.

Fixes https://github.com/dotnet/corefx/issues/15445

/cc @mellinoe @weshaggard 