### PR TITLE
Add submodule updaters to VersionTools

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -6,6 +6,13 @@
     <BuildInfoCacheDir>$(ToolsDir)BuildInfoCache/</BuildInfoCacheDir>
   </PropertyGroup>
 
+  <!-- For backward compatibility, Include XmlUpdateSteps as Xml-type updaters. -->
+  <ItemGroup>
+    <UpdateStep Include="@(XmlUpdateStep)">
+      <UpdaterType>Xml</UpdaterType>
+    </UpdateStep>
+  </ItemGroup>
+
   <!-- Task to update the dotnet/versions repository. -->
   <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
@@ -33,7 +40,7 @@
   <Target Name="UpdateDependencies">
     <UpdateDependencies DependencyBuildInfo="@(DependencyBuildInfo)"
                         ProjectJsonFiles="@(ProjectJsonFiles)"
-                        XmlUpdateStep="@(XmlUpdateStep)"
+                        UpdateStep="@(UpdateStep)"
                         BuildInfoCacheDir="$(BuildInfoCacheDir)" />
   </Target>
 
@@ -46,7 +53,7 @@
 
     <VerifyDependencies DependencyBuildInfo="@(DependencyBuildInfo)"
                         ProjectJsonFiles="@(ProjectJsonFiles)"
-                        XmlUpdateStep="@(XmlUpdateStep)"
+                        UpdateStep="@(UpdateStep)"
                         BuildInfoCacheDir="$(BuildInfoCacheDir)" />
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Verifying all auto-upgradeable dependencies... Done." />
@@ -58,7 +65,7 @@
   <Target Name="UpdateDependenciesAndSubmitPullRequest">
     <UpdateDependenciesAndSubmitPullRequest DependencyBuildInfo="@(DependencyBuildInfo)"
                                             ProjectJsonFiles="@(ProjectJsonFiles)"
-                                            XmlUpdateStep="@(XmlUpdateStep)"
+                                            UpdateStep="@(UpdateStep)"
                                             ProjectRepoName="$(ProjectRepoName)"
                                             ProjectRepoOwner="$(ProjectRepoOwner)"
                                             ProjectRepoBranch="$(ProjectRepoBranch)"

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using NuGet.Packaging.Core;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
+{
+    /// <summary>
+    /// Downloads a package specified from a dependency build info and updates the target git
+    /// submodule to match the version inside.
+    /// </summary>
+    public class IndicatorPackageSubmoduleUpdater : SubmoduleUpdater
+    {
+        /// <summary>
+        /// The NuGet v2 base url to use to download the indicator package, without a trailing '/'.
+        /// For example, https://dotnet.myget.org/F/dotnet-core/api/v2/package.
+        /// </summary>
+        public string PackageDownloadBaseUrl { get; set; }
+
+        public string IndicatorPackageId { get; }
+
+        public IndicatorPackageSubmoduleUpdater(string indicatorPackageId)
+        {
+            if (indicatorPackageId == null)
+            {
+                throw new ArgumentNullException(nameof(indicatorPackageId), "An indicator package must be specified.");
+            }
+            IndicatorPackageId = indicatorPackageId;
+        }
+
+        protected override string GetDesiredCommitHash(
+            IEnumerable<DependencyBuildInfo> dependencyBuildInfos,
+            out IEnumerable<DependencyBuildInfo> usedBuildInfos)
+        {
+            foreach (var info in dependencyBuildInfos)
+            {
+                PackageIdentity package = info.Packages
+                    .FirstOrDefault(p => p.Id == IndicatorPackageId);
+
+                if (package == null)
+                {
+                    continue;
+                }
+
+                using (ZipArchive archive = DownloadPackageAsync(info, package).Result)
+                {
+                    Stream versionTxt = archive.GetEntry("version.txt")?.Open();
+                    if (versionTxt == null)
+                    {
+                        Trace.TraceWarning(
+                            $"Downloaded '{package}' in '{info.BuildInfo.Name}' " +
+                            $"to upgrade '{Path}', but it had no version.txt file. Skipping.");
+                        continue;
+                    }
+
+                    string packageCommitHash = new StreamReader(versionTxt).ReadLine();
+                    Trace.TraceInformation($"Found commit '{packageCommitHash}' in versions.txt.");
+
+                    usedBuildInfos = new[] { info };
+                    return packageCommitHash;
+                }
+            }
+
+            Trace.TraceError($"Failed to find '{IndicatorPackageId}' specifying a commit in any build-info.");
+            usedBuildInfos = Enumerable.Empty<DependencyBuildInfo>();
+            return null;
+        }
+
+        protected async Task<ZipArchive> DownloadPackageAsync(DependencyBuildInfo info, PackageIdentity package)
+        {
+            if (PackageDownloadBaseUrl == null)
+            {
+                throw new NotSupportedException(
+                    $"A {nameof(PackageDownloadBaseUrl)} must be configured, " +
+                    "as build-infos do not have package feed details.");
+            }
+
+            string downloadUrl = $"{PackageDownloadBaseUrl}/package/{package.Id}/{package.Version}";
+            Trace.TraceInformation($"Downloading '{package}' from '{downloadUrl}'");
+
+            var client = new HttpClient();
+            Stream nupkgStream = await client.GetStreamAsync(downloadUrl);
+
+            return new ZipArchive(nupkgStream);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
@@ -32,9 +32,9 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
 
         public IndicatorPackageSubmoduleUpdater(string indicatorPackageId)
         {
-            if (indicatorPackageId == null)
+            if (string.IsNullOrEmpty(indicatorPackageId))
             {
-                throw new ArgumentNullException(nameof(indicatorPackageId), "An indicator package must be specified.");
+                throw new ArgumentException(nameof(indicatorPackageId), "An indicator package must be specified.");
             }
             IndicatorPackageId = indicatorPackageId;
         }
@@ -84,7 +84,8 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
         {
             if (PackageDownloadBaseUrl == null)
             {
-                throw new NotSupportedException(
+                // This isn't checked in the constructor because build-info may contain a download URL in the future.
+                throw new InvalidOperationException(
                     $"A {nameof(PackageDownloadBaseUrl)} must be configured, " +
                     "as build-infos do not have package feed details.");
             }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/LatestCommitSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/LatestCommitSubmoduleUpdater.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
+{
+    /// <summary>
+    /// Updates the submodule at the given path to the latest commit available from its target
+    /// repository.
+    /// </summary>
+    public class LatestCommitSubmoduleUpdater : SubmoduleUpdater
+    {
+        public string Repository { get; }
+
+        public string Ref { get; }
+
+        public LatestCommitSubmoduleUpdater(string repository, string @ref)
+        {
+            if (string.IsNullOrEmpty(repository))
+            {
+                throw new ArgumentException(
+                    "A repository must be specified. For example, 'origin'. Got null or empty string.",
+                    nameof(repository));
+            }
+            Repository = repository;
+
+            if (string.IsNullOrEmpty(@ref))
+            {
+                throw new ArgumentException(
+                    "A ref must be specified. For example, 'master'. Got null or empty string.",
+                    nameof(@ref));
+            }
+            Ref = @ref;
+        }
+
+        protected override string GetDesiredCommitHash(
+            IEnumerable<DependencyBuildInfo> dependencyBuildInfos,
+            out IEnumerable<DependencyBuildInfo> usedBuildInfos)
+        {
+            usedBuildInfos = Enumerable.Empty<DependencyBuildInfo>();
+
+            string remoteRefOutput = FetchGitOutput("ls-remote", Repository, Ref);
+
+            string[] remoteRefLines = remoteRefOutput
+                .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .ToArray();
+
+            if (remoteRefLines.Length != 1)
+            {
+                string allRefs = "";
+                if (remoteRefLines.Length > 1)
+                {
+                    allRefs = $" ({string.Join(", ", remoteRefLines)})";
+                }
+                throw new NotSupportedException(
+                    "The configured Ref must match exactly one ref on the remote. " +
+                    $"Matched {remoteRefLines.Length}{allRefs}.");
+            }
+
+            return remoteRefLines.Single().Split('\t').First();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/LatestCommitSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/LatestCommitSubmoduleUpdater.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
         {
             usedBuildInfos = Enumerable.Empty<DependencyBuildInfo>();
 
-            string remoteRefOutput = FetchGitOutput("ls-remote", Repository, Ref);
+            string remoteRefOutput = FetchGitOutput("ls-remote", "--heads", Repository, Ref);
 
             string[] remoteRefLines = remoteRefOutput
                 .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/SubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/SubmoduleUpdater.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
             return writer.ToString();
         }
 
-        internal Command GitInPath(params string[] args)
+        private Command GitInPath(params string[] args)
         {
             var dirArgs = new[]
             {

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/SubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/SubmoduleUpdater.cs
@@ -1,0 +1,82 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
+{
+    public abstract class SubmoduleUpdater : IDependencyUpdater
+    {
+        public string Path { get; set; }
+
+        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<DependencyBuildInfo> dependencyBuildInfos)
+        {
+            IEnumerable<DependencyBuildInfo> usedBuildInfos;
+            string desiredHash = GetDesiredCommitHash(dependencyBuildInfos, out usedBuildInfos);
+            string currentHash = GetCurrentCommitHash();
+
+            if (desiredHash == null)
+            {
+                Trace.TraceWarning($"Unable to find a desired hash for '{Path}', leaving as '{currentHash}'.");
+                yield break;
+            }
+
+            if (desiredHash == currentHash)
+            {
+                Trace.TraceInformation($"Nothing to upgrade for '{Path}' at '{desiredHash}'");
+                yield break;
+            }
+
+            Action update = () =>
+            {
+                Trace.TraceInformation($"Fetching all configured remotes for '{Path}' to move from '{currentHash}' to '{desiredHash}'.");
+                GitInPath("fetch", "--all").Execute();
+
+                Trace.TraceInformation($"In '{Path}', checking out '{desiredHash}'.");
+                GitInPath("checkout", desiredHash).Execute();
+            };
+
+            string[] updateStrings =
+            {
+                $"In '{Path}', HEAD '{currentHash}' must be '{desiredHash}'"
+            };
+
+            yield return new DependencyUpdateTask(update, usedBuildInfos.Select(d => d.BuildInfo), updateStrings);
+        }
+
+        protected abstract string GetDesiredCommitHash(
+            IEnumerable<DependencyBuildInfo> dependencyBuildInfos,
+            out IEnumerable<DependencyBuildInfo> usedBuildInfos);
+
+        protected string GetCurrentCommitHash()
+        {
+            return FetchGitOutput("rev-parse", "HEAD").Trim();
+        }
+
+        protected string FetchGitOutput(params string[] args)
+        {
+            var writer = new StringWriter();
+
+            GitInPath(args)
+                .ForwardStdOut(writer)
+                .Execute();
+
+            return writer.ToString();
+        }
+
+        internal Command GitInPath(params string[] args)
+        {
+            var dirArgs = new[]
+            {
+                "-C", Path
+            };
+            return Command.Git(dirArgs.Concat(args).ToArray());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -34,6 +34,9 @@
     <Compile Include="Dependencies\FileRegexReleaseUpdater.cs" />
     <Compile Include="Automation\IUpdateBranchNamingStrategy.cs" />
     <Compile Include="Automation\SingleBranchNamingStrategy.cs" />
+    <Compile Include="Dependencies\Submodule\LatestCommitSubmoduleUpdater.cs" />
+    <Compile Include="Dependencies\Submodule\IndicatorPackageSubmoduleUpdater.cs" />
+    <Compile Include="Dependencies\Submodule\SubmoduleUpdater.cs" />
     <Compile Include="Util\ArgumentEscaper.cs" />
     <Compile Include="Util\Command.cs" />
     <Compile Include="Util\CommandResult.cs" />


### PR DESCRIPTION
These will be used in build from source to automatically keep the submodules in sync with the individual product repositories.

`IndicatorPackageSubmoduleUpdater` looks for the current indicator package in dotnet/versions, downloads it, extracts the version.txt inside, and compares it to the submodule's current commit. This is good to only update to a commit that has had an official build, but it only works when the submodule actually points at the official repository. (Not the case for any submodules at the moment.)

`LatestCommitSubmoduleUpdater` uses git's `ls-remote` to check the current commit a remote ref is pointing to, and compares it to the submodule's current commit.

@ellismg 