### PR TITLE
Initial version of init-docker.sh

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -137,6 +137,7 @@
     <None Include="PackageFiles\RunnerTemplate.Unix.txt" />
     <None Include="PackageFiles\RunnerTemplate.Windows.txt" />
     <None Include="PackageFiles\scripts\docker\cleanup-docker.sh" />
+    <None Include="PackageFiles\scripts\docker\init-docker.sh" />
     <None Include="PackageFiles\sign.targets" />
     <None Include="PackageFiles\Test.snk" />
     <None Include="PackageFiles\tests.targets" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/init-docker.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/init-docker.sh
@@ -6,7 +6,7 @@ set -e
 set -u
 
 say_err() {
-  printf "%b\n" "Error: $1" >&2
+    printf "%b\n" "Error: $1" >&2
 }
 
 showHelp() {
@@ -49,15 +49,15 @@ image=
 while [ $# -ne 0 ]; do
     name=$1
     case $name in
-        -h|--help|--[Hh]elp)
+        -h|--help)
             showHelp
             exit 0
             ;;
-        -r|--retryCount|--[Rr]etry[Cc]ount)
+        -r|--retryCount)
             shift
             retries=$1
             ;;
-        -w|--waitFactor|--[Ww]ait[Ff]actor)
+        -w|--waitFactor)
             shift
             waitFactor=$1
             ;;
@@ -67,8 +67,8 @@ while [ $# -ne 0 ]; do
             ;;
         *)
             if [ ! -z "$image" ]; then
-              say_err "Unknown argument: \`$name\`"
-              exit 1
+                say_err "Unknown argument: \`$name\`"
+                exit 1
             fi
 
             image="$1"
@@ -87,6 +87,6 @@ echo "Cleaning Docker Artifacts"
 echo
 
 if [ ! -z "$image" ]; then
-  echo "Pulling Docker image $image"
-  execute docker pull $image
+    echo "Pulling Docker image $image"
+    execute docker pull $image
 fi

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/init-docker.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/init-docker.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+scriptName=$0
+
+function usage {
+    echo "Usage: $scriptName image"
+    echo "  image      Name of the Docker image to pull"
+
+    exit 1
+}
+
+# Executes a command and retry up to 5 times until if it fails.
+function execute {
+  local retries=5
+  local waitFactor=3
+
+  local count=0
+  until "$@"; do  
+    count=$(($count + 1))
+    if [ $count -lt $retries ]; then
+      local wait=$((waitFactor ** count))
+      echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+      sleep $wait
+    else
+      local exit=$?
+      echo "Retry $count/$retries exited $exit, no more retries left."
+      return $exit
+    fi
+  done
+
+  return 0
+}
+
+if [ -z "$1" ]; then
+  usage
+fi
+
+# Capture Docker version for diagnostic purposes
+docker --version
+echo 
+
+echo "Cleaning Docker Artifacts"
+./cleanup-docker.sh
+echo
+
+image=$1
+echo "Pulling Docker image $image"
+execute docker pull $image

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/init-docker.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/docker/init-docker.sh
@@ -83,7 +83,8 @@ docker --version
 echo
 
 echo "Cleaning Docker Artifacts"
-./cleanup-docker.sh
+sourceDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+"$sourceDir/cleanup-docker.sh"
 echo
 
 if [ ! -z "$image" ]; then


### PR DESCRIPTION
The idea behind this script is that we would call it at the beginning of build definitions that utilize Docker images.  This would replace the call to cleanup-docker and the build step to capture the docker version.  The retry logic here will hopefully address some of the flakiness we have been seeing when pulling images.

related to https://github.com/dotnet/core-eng/issues/437