### PR TITLE
Fix conditional in Dumpling.txt command template

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.txt
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.txt
@@ -21,7 +21,7 @@ CollectDumps()
     echo command failed, trying to collect dumps
     _corefile=$(ls . | grep -E --max-count=1 '^core(\..*)?$')
     echo corefile: $_corefile
-    if [ -n "$_corefile" ]
+    if [[ -n $_corefile ]]
     then
       echo uploading core to dumpling service
       python ~/.dumpling/dumpling.py upload --dumppath $_corefile --noprompt --triage full --displayname $_ProjectName --properties STRESS_TESTID=$_ProjectName --verbose


### PR DESCRIPTION
The current version did not work because of the way we are reading the lines out of this file and injecting them into another script. I tested this by causing a test to fail both:

* normally, through an unhandled System.Exception()
* by forcibly seg-faulting the test

Without this change, the first test case was still trying to call Dumpling.py, but with invalid arguments, because no core file was found.

@sepidehMS 