### PR TITLE
Make Dumpling.targets use a proper shell script.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.sh
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 if [ ! -f ~/.dumpling/dumpling.py ]
 then
   echo Dumpling not found, installing...
@@ -11,7 +13,9 @@ fi
 echo executing ulimit -c unlimited
 ulimit -c unlimited
 echo 0x3F > /proc/self/coredump_filter
-CollectDumps()
+
+
+function CollectDumps()
 {
   _EXITCODE=$1
   _ProjectName=$2

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -1,13 +1,15 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)Dumpling.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <!-- Setup Dumpling service to collect crash dumps -->
   <Target Name="SetupDumpling"
           BeforeTargets="GenerateTestExecutionScripts"
           Condition="'$(TargetOS)'!='Windows_NT'">
-    <ReadLinesFromFile File="$(MSBuildThisFileDirectory)Dumpling.txt">
-      <Output TaskParameter="Lines" ItemName="DumplingCommands" />
-    </ReadLinesFromFile>
     <ItemGroup>
-      <TestCommandLines Include="@(DumplingCommands)" />
+      <TestCommandLines Include="source Dumpling.sh" />
     </ItemGroup>
     <ItemGroup>
       <PostExecutionTestCommandLines Include="CollectDumps $%3f $(MSBuildProjectName)" />


### PR DESCRIPTION
Instead of reading a text file and inserting raw script lines into RunTests.sh, I'm simply running a Dumpling.sh script from RunTests.sh. The way lines were being copied into RunTests.sh was very fragile and was not working anyways. Instead of fixing it, I've just switched to this, which should be simpler and less error-prone.

@sepidehMS 