### PR TITLE
Add local build-info flow for source build

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -59,6 +59,7 @@
     <Compile Include="VersionTools\UpdateDependenciesAndSubmitPullRequest.cs" />
     <Compile Include="VersionTools\TraceListenerCollectionExtensions.cs" />
     <Compile Include="VersionTools\UpdateDependencies.cs" />
+    <Compile Include="VersionTools\LocalUpdatePublishedVersions.cs" />
     <Compile Include="VersionTools\UpdatePublishedVersions.cs" />
     <Compile Include="VersionTools\VerifyDependencies.cs" />
     <Compile Include="VisitProjectDependencies.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -33,7 +33,7 @@
 
   <Target Name="LocalUpdatePublishedVersions">
     <LocalUpdatePublishedVersions ShippedNuGetPackage="@(ShippedNuGetPackage)"
-                                  VersionsRepoDir="$(VersionsRepoDir)"
+                                  VersionsRepoLocalBaseDir="$(VersionsRepoLocalBaseDir)"
                                   VersionsRepoPath="$(VersionsRepoPath)" />
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -13,8 +13,9 @@
     </UpdateStep>
   </ItemGroup>
 
-  <!-- Task to update the dotnet/versions repository. -->
+  <!-- Tasks to update the dotnet/versions repository. -->
   <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="LocalUpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <ItemGroup Condition="'$(ShippedNuGetPackageGlobPath)'!=''">
     <ShippedNuGetPackage Include="$(ShippedNuGetPackageGlobPath)" />
@@ -28,6 +29,12 @@
                              GitHubEmail="$(GitHubEmail)"
                              VersionsRepo="$(VersionsRepo)"
                              VersionsRepoOwner="$(VersionsRepoOwner)" />
+  </Target>
+
+  <Target Name="LocalUpdatePublishedVersions">
+    <LocalUpdatePublishedVersions ShippedNuGetPackage="@(ShippedNuGetPackage)"
+                                  VersionsRepoDir="$(VersionsRepoDir)"
+                                  VersionsRepoPath="$(VersionsRepoPath)" />
   </Target>
 
   <!-- Task to update dependencies to expected values. -->

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -165,18 +165,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                 buildInfoPath = $"{buildInfoPath}/{currentBranch}";
             }
 
-            if (!string.IsNullOrEmpty(rawVersionsBaseUrl) &&
-                !string.IsNullOrEmpty(buildInfoPath) &&
-                !string.IsNullOrEmpty(currentRef))
-            {
-                return BuildInfo.CachedGet(
-                    item.ItemSpec,
-                    rawVersionsBaseUrl,
-                    currentRef,
-                    buildInfoPath,
-                    cacheDir);
-            }
-            
+            // Optional: override base url with a local directory.
             string versionsRepoDir = item.GetMetadata(VersionsRepoDirMetadataName);
 
             if (!string.IsNullOrEmpty(versionsRepoDir) &&
@@ -188,6 +177,18 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                     buildInfoPath,
                     // Don't fetch latest release file: it may not be present in build from source.
                     fetchLatestReleaseFile: false).Result;
+            }
+
+            if (!string.IsNullOrEmpty(rawVersionsBaseUrl) &&
+                !string.IsNullOrEmpty(buildInfoPath) &&
+                !string.IsNullOrEmpty(currentRef))
+            {
+                return BuildInfo.CachedGet(
+                    item.ItemSpec,
+                    rawVersionsBaseUrl,
+                    currentRef,
+                    buildInfoPath,
+                    cacheDir);
             }
 
             string packageId = item.GetMetadata(PackageIdMetadataName);

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
     {
         internal const string RawUrlMetadataName = "RawUrl";
         internal const string RawVersionsBaseUrlMetadataName = "RawVersionsBaseUrl";
+        internal const string VersionsRepoDirMetadataName = "VersionsRepoDir";
         internal const string BuildInfoPathMetadataName = "BuildInfoPath";
         internal const string CurrentRefMetadataName = "CurrentRef";
         internal const string CurrentBranchMetadataName = "CurrentBranch";
@@ -159,22 +160,34 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
             string currentRef = item.GetMetadata(CurrentRefMetadataName);
             // Optional
             string currentBranch = item.GetMetadata(CurrentBranchMetadataName);
+            if (!string.IsNullOrEmpty(currentBranch) && !string.IsNullOrEmpty(buildInfoPath))
+            {
+                buildInfoPath = $"{buildInfoPath}/{currentBranch}";
+            }
 
             if (!string.IsNullOrEmpty(rawVersionsBaseUrl) &&
                 !string.IsNullOrEmpty(buildInfoPath) &&
                 !string.IsNullOrEmpty(currentRef))
             {
-                if (!string.IsNullOrEmpty(currentBranch))
-                {
-                    buildInfoPath = $"{buildInfoPath}/{currentBranch}";
-                }
-
                 return BuildInfo.CachedGet(
                     item.ItemSpec,
                     rawVersionsBaseUrl,
                     currentRef,
                     buildInfoPath,
                     cacheDir);
+            }
+            
+            string versionsRepoDir = item.GetMetadata(VersionsRepoDirMetadataName);
+
+            if (!string.IsNullOrEmpty(versionsRepoDir) &&
+                !string.IsNullOrEmpty(buildInfoPath))
+            {
+                return BuildInfo.LocalFileGetAsync(
+                    item.ItemSpec,
+                    versionsRepoDir,
+                    buildInfoPath,
+                    // Don't fetch latest release file: it may not be present in build from source.
+                    fetchLatestReleaseFile: false).Result;
             }
 
             string packageId = item.GetMetadata(PackageIdMetadataName);

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.VersionTools.Automation;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.VersionTools
+{
+    public class LocalUpdatePublishedVersions : Task
+    {
+        [Required]
+        public ITaskItem[] ShippedNuGetPackage { get; set; }
+
+        [Required]
+        public string VersionsRepoDir { get; set; }
+
+        [Required]
+        public string VersionsRepoPath { get; set; }
+
+        public override bool Execute()
+        {
+            MsBuildTraceListener[] listeners = Trace.Listeners.AddMsBuildTraceListeners(Log);
+
+            var updater = new LocalVersionsRepoUpdater();
+
+            updater.UpdateBuildInfoLatestPackages(
+                ShippedNuGetPackage.Select(item => item.ItemSpec),
+                VersionsRepoDir,
+                VersionsRepoPath);
+
+            Trace.Listeners.RemoveMsBuildTraceListeners(listeners);
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
         public ITaskItem[] ShippedNuGetPackage { get; set; }
 
         [Required]
-        public string VersionsRepoDir { get; set; }
+        public string VersionsRepoLocalBaseDir { get; set; }
 
         [Required]
         public string VersionsRepoPath { get; set; }
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
 
             updater.UpdateBuildInfoLatestPackages(
                 ShippedNuGetPackage.Select(item => item.ItemSpec),
-                VersionsRepoDir,
+                VersionsRepoLocalBaseDir,
                 VersionsRepoPath);
 
             Trace.Listeners.RemoveMsBuildTraceListeners(listeners);

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
 
             var gitHubAuth = new GitHubAuth(GitHubAuthToken, GitHubUser, GitHubEmail);
 
-            var updater = new VersionsRepoUpdater(gitHubAuth, VersionsRepoOwner, VersionsRepo);
+            var updater = new GitHubVersionsRepoUpdater(gitHubAuth, VersionsRepoOwner, VersionsRepo);
 
             updater.UpdateBuildInfoAsync(
                 ShippedNuGetPackage.Select(item => item.ItemSpec),

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubVersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubVersionsRepoUpdater.cs
@@ -1,0 +1,205 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.VersionTools.Automation
+{
+    public class GitHubVersionsRepoUpdater : VersionsRepoUpdater
+    {
+        private const int MaxTries = 10;
+        private const int RetryMillisecondsDelay = 5000;
+
+        private GitHubAuth _gitHubAuth;
+        private GitHubProject _project;
+
+        public GitHubVersionsRepoUpdater(
+            GitHubAuth gitHubAuth,
+            string versionsRepoOwner = null,
+            string versionsRepo = null)
+            : this(
+                gitHubAuth,
+                new GitHubProject(versionsRepo ?? "versions", versionsRepoOwner))
+        {
+        }
+
+        public GitHubVersionsRepoUpdater(GitHubAuth gitHubAuth, GitHubProject project)
+        {
+            if (gitHubAuth == null)
+            {
+                throw new ArgumentNullException(nameof(gitHubAuth));
+            }
+            _gitHubAuth = gitHubAuth;
+
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+            _project = project;
+        }
+
+        /// <param name="updateLatestVersion">If true, updates Latest.txt with a prerelease moniker. If there isn't one, makes the file empty.</param>
+        /// <param name="updateLatestPackageList">If true, updates Latest_Packages.txt.</param>
+        /// <param name="updateLastBuildPackageList">If true, updates Last_Build_Packages.txt, and enables keeping old packages in Latest_Packages.txt.</param>
+        public async Task UpdateBuildInfoAsync(
+            IEnumerable<string> packagePaths,
+            string versionsRepoPath,
+            bool updateLatestPackageList = true,
+            bool updateLatestVersion = true,
+            bool updateLastBuildPackageList = true)
+        {
+            if (packagePaths == null)
+            {
+                throw new ArgumentNullException(nameof(packagePaths));
+            }
+            if (versionsRepoPath == null)
+            {
+                throw new ArgumentNullException(nameof(versionsRepoPath));
+            }
+
+            NupkgInfo[] packages = CreatePackageInfos(packagePaths).ToArray();
+
+            string prereleaseVersion = packages
+                .Select(t => t.Prerelease)
+                .FirstOrDefault(prerelease => !string.IsNullOrEmpty(prerelease))
+                ?? "stable";
+
+            Dictionary<string, string> packageDictionary = CreatePackageInfoDictionary(packages);
+
+            using (GitHubClient client = new GitHubClient(_gitHubAuth))
+            {
+                for (int i = 0; i < MaxTries; i++)
+                {
+                    try
+                    {
+                        // Master commit to use as new commit's parent.
+                        string masterRef = "heads/master";
+                        GitReference currentMaster = await client.GetReferenceAsync(_project, masterRef);
+                        string masterSha = currentMaster.Object.Sha;
+
+                        List<GitObject> objects = new List<GitObject>();
+
+                        if (updateLastBuildPackageList)
+                        {
+                            objects.Add(new GitObject
+                            {
+                                Path = $"{versionsRepoPath}/Last_Build_Packages.txt",
+                                Type = GitObject.TypeBlob,
+                                Mode = GitObject.ModeFile,
+                                Content = CreatePackageListFile(packageDictionary)
+                            });
+                        }
+
+                        if (updateLatestPackageList)
+                        {
+                            string latestPackagesPath = $"{versionsRepoPath}/Latest_Packages.txt";
+
+                            var allPackages = new Dictionary<string, string>(packageDictionary);
+
+                            if (updateLastBuildPackageList)
+                            {
+                                Dictionary<string, string> existingPackages = await GetPackagesAsync(client, latestPackagesPath);
+
+                                if (existingPackages == null)
+                                {
+                                    Trace.TraceInformation(
+                                        "No exising Latest_Packages file found; one will be " +
+                                        $"created in '{versionsRepoPath}'");
+                                }
+                                else
+                                {
+                                    // Add each existing package if there isn't a new package with the same id.
+                                    foreach (var package in existingPackages)
+                                    {
+                                        if (!allPackages.ContainsKey(package.Key))
+                                        {
+                                            allPackages[package.Key] = package.Value;
+                                        }
+                                    }
+                                }
+                            }
+
+                            objects.Add(new GitObject
+                            {
+                                Path = latestPackagesPath,
+                                Type = GitObject.TypeBlob,
+                                Mode = GitObject.ModeFile,
+                                Content = CreatePackageListFile(allPackages)
+                            });
+                        }
+
+                        if (updateLatestVersion)
+                        {
+                            objects.Add(new GitObject
+                            {
+                                Path = $"{versionsRepoPath}/Latest.txt",
+                                Type = GitObject.TypeBlob,
+                                Mode = GitObject.ModeFile,
+                                Content = prereleaseVersion
+                            });
+                        }
+
+                        string message = $"Updating {versionsRepoPath}";
+                        if (string.IsNullOrEmpty(prereleaseVersion))
+                        {
+                            message += ". No prerelease versions published.";
+                        }
+                        else
+                        {
+                            message += $" for {prereleaseVersion}";
+                        }
+
+                        GitTree tree = await client.PostTreeAsync(_project, masterSha, objects.ToArray());
+                        GitCommit commit = await client.PostCommitAsync(_project, message, tree.Sha, new[] { masterSha });
+
+                        // Only fast-forward. Don't overwrite other changes: throw exception instead.
+                        await client.PatchReferenceAsync(_project, masterRef, commit.Sha, force: false);
+
+                        Trace.TraceInformation($"Committed build-info update on attempt {i + 1}.");
+                        break;
+                    }
+                    catch (HttpRequestException ex)
+                    {
+                        int nextTry = i + 1;
+                        if (nextTry < MaxTries)
+                        {
+                            Trace.TraceInformation($"Encountered exception committing build-info update: {ex.Message}");
+                            Trace.TraceInformation($"Trying again in {RetryMillisecondsDelay}ms. {MaxTries - nextTry} tries left.");
+                            await Task.Delay(RetryMillisecondsDelay);
+                        }
+                        else
+                        {
+                            Trace.TraceInformation("Encountered exception committing build-info update.");
+                            throw;
+                        }
+                    }
+                }
+            }
+        }
+
+        private async Task<Dictionary<string, string>> GetPackagesAsync(GitHubClient client, string path)
+        {
+            string latestPackages = await client.GetGitHubFileContentsAsync(
+                path,
+                new GitHubBranch("master", _project));
+
+            if (latestPackages == null)
+            {
+                return null;
+            }
+
+            using (var reader = new StringReader(latestPackages))
+            {
+                return await BuildInfo.ReadPackageListAsync(reader);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubVersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubVersionsRepoUpdater.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
                                 Path = $"{versionsRepoPath}/Last_Build_Packages.txt",
                                 Type = GitObject.TypeBlob,
                                 Mode = GitObject.ModeFile,
-                                Content = CreatePackageListFile(packageDictionary)
+                                Content = CreatePackageListContent(packageDictionary)
                             });
                         }
 
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
                                 Path = latestPackagesPath,
                                 Type = GitObject.TypeBlob,
                                 Mode = GitObject.ModeFile,
-                                Content = CreatePackageListFile(allPackages)
+                                Content = CreatePackageListContent(allPackages)
                             });
                         }
 

--- a/src/Microsoft.DotNet.VersionTools/Automation/LocalVersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/LocalVersionsRepoUpdater.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Automation
+{
+    public class LocalVersionsRepoUpdater
+    {
+        /// <summary>
+        /// Updates only the Latest_Packages file in the specified on-disk versions repository dir.
+        /// </summary>
+        public void UpdateBuildInfoLatestPackages(
+            IEnumerable<string> packagePaths,
+            string versionsRepoDir,
+            string versionsRepoPath)
+        {
+            if (packagePaths == null)
+            {
+                throw new ArgumentNullException(nameof(packagePaths));
+            }
+            if (string.IsNullOrEmpty(versionsRepoDir))
+            {
+                throw new ArgumentException(nameof(versionsRepoDir));
+            }
+            if (string.IsNullOrEmpty(versionsRepoPath))
+            {
+                throw new ArgumentException(nameof(versionsRepoPath));
+            }
+
+            Dictionary<string, string> packages = packagePaths
+                .Select(path => new NupkgNameInfo(path))
+                // Ignore symbol packages.
+                .Where(t => !t.SymbolPackage)
+                .ToDictionary(t => t.Id, t => t.Version);
+
+            string latestPackagesDir = Path.Combine(
+                versionsRepoDir,
+                versionsRepoPath);
+
+            Directory.CreateDirectory(latestPackagesDir);
+
+            File.WriteAllText(
+                Path.Combine(latestPackagesDir, BuildInfo.LatestPackagesTxtFilename),
+                VersionsRepoUpdater.CreatePackageListFile(packages));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Automation/LocalVersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/LocalVersionsRepoUpdater.cs
@@ -15,16 +15,16 @@ namespace Microsoft.DotNet.VersionTools.Automation
         /// </summary>
         public void UpdateBuildInfoLatestPackages(
             IEnumerable<string> packagePaths,
-            string versionsRepoDir,
+            string localBaseDir,
             string versionsRepoPath)
         {
             if (packagePaths == null)
             {
                 throw new ArgumentNullException(nameof(packagePaths));
             }
-            if (string.IsNullOrEmpty(versionsRepoDir))
+            if (string.IsNullOrEmpty(localBaseDir))
             {
-                throw new ArgumentException(nameof(versionsRepoDir));
+                throw new ArgumentException(nameof(localBaseDir));
             }
             if (string.IsNullOrEmpty(versionsRepoPath))
             {
@@ -34,14 +34,14 @@ namespace Microsoft.DotNet.VersionTools.Automation
             Dictionary<string, string> packages = CreatePackageInfoDictionary(CreatePackageInfos(packagePaths));
 
             string latestPackagesDir = Path.Combine(
-                versionsRepoDir,
+                localBaseDir,
                 versionsRepoPath);
 
             Directory.CreateDirectory(latestPackagesDir);
 
             File.WriteAllText(
                 Path.Combine(latestPackagesDir, BuildInfo.LatestPackagesTxtFilename),
-                CreatePackageListFile(packages));
+                CreatePackageListContent(packages));
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Automation/LocalVersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/LocalVersionsRepoUpdater.cs
@@ -5,11 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {
-    public class LocalVersionsRepoUpdater
+    public class LocalVersionsRepoUpdater : VersionsRepoUpdater
     {
         /// <summary>
         /// Updates only the Latest_Packages file in the specified on-disk versions repository dir.
@@ -32,11 +31,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
                 throw new ArgumentException(nameof(versionsRepoPath));
             }
 
-            Dictionary<string, string> packages = packagePaths
-                .Select(path => new NupkgNameInfo(path))
-                // Ignore symbol packages.
-                .Where(t => !t.SymbolPackage)
-                .ToDictionary(t => t.Id, t => t.Version);
+            Dictionary<string, string> packages = CreatePackageInfoDictionary(CreatePackageInfos(packagePaths));
 
             string latestPackagesDir = Path.Combine(
                 versionsRepoDir,
@@ -46,7 +41,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
             File.WriteAllText(
                 Path.Combine(latestPackagesDir, BuildInfo.LatestPackagesTxtFilename),
-                VersionsRepoUpdater.CreatePackageListFile(packages));
+                CreatePackageListFile(packages));
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Automation/NupkgInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/NupkgInfo.cs
@@ -7,9 +7,9 @@ using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {
-    class NupkgNameInfo
+    public class NupkgInfo
     {
-        public NupkgNameInfo(string path)
+        public NupkgInfo(string path)
         {
             using (PackageArchiveReader archiveReader = new PackageArchiveReader(path))
             {
@@ -21,9 +21,9 @@ namespace Microsoft.DotNet.VersionTools.Automation
             SymbolPackage = path.EndsWith(".symbols.nupkg");
         }
 
-        public string Id { get; set; }
-        public string Version { get; set; }
-        public string Prerelease { get; set; }
-        public bool SymbolPackage { get; set; }
+        public string Id { get; }
+        public string Version { get; }
+        public string Prerelease { get; }
+        public bool SymbolPackage { get; }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Automation/NupkgInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/NupkgInfo.cs
@@ -18,12 +18,12 @@ namespace Microsoft.DotNet.VersionTools.Automation
                 Version = identity.Version.ToString();
                 Prerelease = identity.Version.Release;
             }
-            SymbolPackage = path.EndsWith(".symbols.nupkg");
         }
 
         public string Id { get; }
         public string Version { get; }
         public string Prerelease { get; }
-        public bool SymbolPackage { get; }
+
+        public static bool IsSymbolPackagePath(string path) => path.EndsWith(".symbols.nupkg");
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -13,9 +13,9 @@ namespace Microsoft.DotNet.VersionTools.Automation
         protected static IEnumerable<NupkgInfo> CreatePackageInfos(IEnumerable<string> packagePaths)
         {
             return packagePaths
-                .Select(path => new NupkgInfo(path))
                 // Ignore symbol packages.
-                .Where(t => !t.SymbolPackage);
+                .Where(path => !NupkgInfo.IsSymbolPackagePath(path))
+                .Select(path => new NupkgInfo(path));
         }
 
         protected static Dictionary<string, string> CreatePackageInfoDictionary(IEnumerable<NupkgInfo> infos)
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
             return infos.ToDictionary(i => i.Id, i => i.Version);
         }
 
-        protected static string CreatePackageListFile(Dictionary<string, string> packages)
+        protected static string CreatePackageListContent(Dictionary<string, string> packages)
         {
             return string.Join(
                 Environment.NewLine,

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.VersionTools.Automation
             }
         }
 
-        private static string CreatePackageListFile(Dictionary<string, string> packages)
+        public static string CreatePackageListFile(Dictionary<string, string> packages)
         {
             return string.Join(
                    Environment.NewLine,

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -2,219 +2,34 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {
-    public class VersionsRepoUpdater
+    public abstract class VersionsRepoUpdater
     {
-        private const int MaxTries = 10;
-        private const int RetryMillisecondsDelay = 5000;
-
-        private GitHubAuth _gitHubAuth;
-        private GitHubProject _project;
-
-        public VersionsRepoUpdater(
-            GitHubAuth gitHubAuth,
-            string versionsRepoOwner = null,
-            string versionsRepo = null)
-            : this(
-                gitHubAuth,
-                new GitHubProject(versionsRepo ?? "versions", versionsRepoOwner))
+        protected static IEnumerable<NupkgInfo> CreatePackageInfos(IEnumerable<string> packagePaths)
         {
-        }
-
-        public VersionsRepoUpdater(GitHubAuth gitHubAuth, GitHubProject project)
-        {
-            if (gitHubAuth == null)
-            {
-                throw new ArgumentNullException(nameof(gitHubAuth));
-            }
-            _gitHubAuth = gitHubAuth;
-
-            if (project == null)
-            {
-                throw new ArgumentNullException(nameof(project));
-            }
-            _project = project;
-        }
-
-        /// <param name="updateLatestVersion">If true, updates Latest.txt with a prerelease moniker. If there isn't one, makes the file empty.</param>
-        /// <param name="updateLatestPackageList">If true, updates Latest_Packages.txt.</param>
-        /// <param name="updateLastBuildPackageList">If true, updates Last_Build_Packages.txt, and enables keeping old packages in Latest_Packages.txt.</param>
-        public async Task UpdateBuildInfoAsync(
-            IEnumerable<string> packagePaths,
-            string versionsRepoPath,
-            bool updateLatestPackageList = true,
-            bool updateLatestVersion = true,
-            bool updateLastBuildPackageList = true)
-        {
-            if (packagePaths == null)
-            {
-                throw new ArgumentNullException(nameof(packagePaths));
-            }
-            if (versionsRepoPath == null)
-            {
-                throw new ArgumentNullException(nameof(versionsRepoPath));
-            }
-
-            NupkgNameInfo[] packages = packagePaths
-                .Select(path => new NupkgNameInfo(path))
+            return packagePaths
+                .Select(path => new NupkgInfo(path))
                 // Ignore symbol packages.
-                .Where(t => !t.SymbolPackage)
-                .ToArray();
-
-            string prereleaseVersion = packages
-                .Select(t => t.Prerelease)
-                .FirstOrDefault(prerelease => !string.IsNullOrEmpty(prerelease))
-                ?? "stable";
-
-            Dictionary<string, string> packageDictionary = packages.ToDictionary(
-                    t => t.Id,
-                    t => t.Version);
-
-            using (GitHubClient client = new GitHubClient(_gitHubAuth))
-            {
-                for (int i = 0; i < MaxTries; i++)
-                {
-                    try
-                    {
-                        // Master commit to use as new commit's parent.
-                        string masterRef = "heads/master";
-                        GitReference currentMaster = await client.GetReferenceAsync(_project, masterRef);
-                        string masterSha = currentMaster.Object.Sha;
-
-                        List<GitObject> objects = new List<GitObject>();
-
-                        if (updateLastBuildPackageList)
-                        {
-                            objects.Add(new GitObject
-                            {
-                                Path = $"{versionsRepoPath}/Last_Build_Packages.txt",
-                                Type = GitObject.TypeBlob,
-                                Mode = GitObject.ModeFile,
-                                Content = CreatePackageListFile(packageDictionary)
-                            });
-                        }
-
-                        if (updateLatestPackageList)
-                        {
-                            string latestPackagesPath = $"{versionsRepoPath}/Latest_Packages.txt";
-
-                            var allPackages = new Dictionary<string, string>(packageDictionary);
-
-                            if (updateLastBuildPackageList)
-                            {
-                                Dictionary<string, string> existingPackages = await GetPackagesAsync(client, latestPackagesPath);
-
-                                if (existingPackages == null)
-                                {
-                                    Trace.TraceInformation(
-                                        "No exising Latest_Packages file found; one will be " +
-                                        $"created in '{versionsRepoPath}'");
-                                }
-                                else
-                                {
-                                    // Add each existing package if there isn't a new package with the same id.
-                                    foreach (var package in existingPackages)
-                                    {
-                                        if (!allPackages.ContainsKey(package.Key))
-                                        {
-                                            allPackages[package.Key] = package.Value;
-                                        }
-                                    }
-                                }
-                            }
-
-                            objects.Add(new GitObject
-                            {
-                                Path = latestPackagesPath,
-                                Type = GitObject.TypeBlob,
-                                Mode = GitObject.ModeFile,
-                                Content = CreatePackageListFile(allPackages)
-                            });
-                        }
-
-                        if (updateLatestVersion)
-                        {
-                            objects.Add(new GitObject
-                            {
-                                Path = $"{versionsRepoPath}/Latest.txt",
-                                Type = GitObject.TypeBlob,
-                                Mode = GitObject.ModeFile,
-                                Content = prereleaseVersion
-                            });
-                        }
-
-                        string message = $"Updating {versionsRepoPath}";
-                        if (string.IsNullOrEmpty(prereleaseVersion))
-                        {
-                            message += ". No prerelease versions published.";
-                        }
-                        else
-                        {
-                            message += $" for {prereleaseVersion}";
-                        }
-
-                        GitTree tree = await client.PostTreeAsync(_project, masterSha, objects.ToArray());
-                        GitCommit commit = await client.PostCommitAsync(_project, message, tree.Sha, new[] { masterSha });
-
-                        // Only fast-forward. Don't overwrite other changes: throw exception instead.
-                        await client.PatchReferenceAsync(_project, masterRef, commit.Sha, force: false);
-
-                        Trace.TraceInformation($"Committed build-info update on attempt {i + 1}.");
-                        break;
-                    }
-                    catch (HttpRequestException ex)
-                    {
-                        int nextTry = i + 1;
-                        if (nextTry < MaxTries)
-                        {
-                            Trace.TraceInformation($"Encountered exception committing build-info update: {ex.Message}");
-                            Trace.TraceInformation($"Trying again in {RetryMillisecondsDelay}ms. {MaxTries - nextTry} tries left.");
-                            await Task.Delay(RetryMillisecondsDelay);
-                        }
-                        else
-                        {
-                            Trace.TraceInformation("Encountered exception committing build-info update.");
-                            throw;
-                        }
-                    }
-                }
-            }
+                .Where(t => !t.SymbolPackage);
         }
 
-        private async Task<Dictionary<string, string>> GetPackagesAsync(GitHubClient client, string path)
+        protected static Dictionary<string, string> CreatePackageInfoDictionary(IEnumerable<NupkgInfo> infos)
         {
-            string latestPackages = await client.GetGitHubFileContentsAsync(
-                path,
-                new GitHubBranch("master", _project));
-
-            if (latestPackages == null)
-            {
-                return null;
-            }
-
-            using (var reader = new StringReader(latestPackages))
-            {
-                return await BuildInfo.ReadPackageListAsync(reader);
-            }
+            return infos.ToDictionary(i => i.Id, i => i.Version);
         }
 
-        public static string CreatePackageListFile(Dictionary<string, string> packages)
+        protected static string CreatePackageListFile(Dictionary<string, string> packages)
         {
             return string.Join(
-                   Environment.NewLine,
-                   packages
-                       .OrderBy(t => t.Key)
-                       .Select(t => $"{t.Key} {t.Value}"));
+                Environment.NewLine,
+                packages
+                    .OrderBy(t => t.Key)
+                    .Select(t => $"{t.Key} {t.Value}"));
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
@@ -187,8 +187,8 @@ namespace Microsoft.DotNet.VersionTools
 
             return
                 versions.FirstOrDefault(v => v.IsPrerelease)?.Release ??
-                // if there are no prerelease versions, just grab the first version
-                versions.FirstOrDefault()?.ToNormalizedString();
+                    // if there are no prerelease versions, just grab the first version
+                    versions.FirstOrDefault()?.ToNormalizedString();
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="Automation\DependencyUpdateResults.cs" />
     <Compile Include="Automation\GitHubApi\HttpFailureResponseException.cs" />
+    <Compile Include="Automation\LocalVersionsRepoUpdater.cs" />
     <Compile Include="Dependencies\DependencyBuildInfo.cs" />
     <Compile Include="Dependencies\DependencyUpdateTask.cs" />
     <Compile Include="Automation\GitHubApi\GitHubClient.cs" />

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -23,6 +23,7 @@
     <Compile Include="Automation\DependencyUpdateResults.cs" />
     <Compile Include="Automation\GitHubApi\HttpFailureResponseException.cs" />
     <Compile Include="Automation\LocalVersionsRepoUpdater.cs" />
+    <Compile Include="Automation\GitHubVersionsRepoUpdater.cs" />
     <Compile Include="Dependencies\DependencyBuildInfo.cs" />
     <Compile Include="Dependencies\DependencyUpdateTask.cs" />
     <Compile Include="Automation\GitHubApi\GitHubClient.cs" />
@@ -43,7 +44,7 @@
     <Compile Include="Util\CommandResult.cs" />
     <Compile Include="Util\FileUtils.cs" />
     <Compile Include="Automation\GitHubAuth.cs" />
-    <Compile Include="Automation\NupkgNameInfo.cs" />
+    <Compile Include="Automation\NupkgInfo.cs" />
     <Compile Include="Dependencies\FileRegexUpdater.cs" />
     <Compile Include="Dependencies\IDependencyUpdater.cs" />
     <Compile Include="BuildInfo.cs" />


### PR DESCRIPTION
Adds `VersionsRepoDir`, which points the tasks to use a versions-repo-like directory on disk.

For dependency update, change the `DependencyBuildInfo` to specify `VersionsRepoDir` metadata rather than `RawVersionsBaseUrl` metadata. E.g. https://github.com/dagood/corefx/commit/4e43203298e1d9c81daa5be91287371e69587716.

The packages created during a source build can be written to the local versions repo directory using `LocalUpdatePublishedVersions`, enabling local flow between two repos.