### PR TITLE
Remove coveralls.io support

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -7,7 +7,6 @@
   <PropertyGroup>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
     <ReportGeneratorVersion>2.5.0</ReportGeneratorVersion>
-    <CoverallsUploaderVersion>1.4</CoverallsUploaderVersion>
   </PropertyGroup>
   
   <!-- Coverage options -->
@@ -85,17 +84,6 @@
 
     <Exec Command="start $(CoverageReportDir)index.htm"
           Condition="'$(PopCoverageReport)' == 'true'" />          
-
-    <PropertyGroup>
-      <CoverallsUploaderCommandLine>$(PackagesDir)coveralls.io.$(CoverallsUploaderVersion)\tools\coveralls.net.exe</CoverallsUploaderCommandLine>
-      <CoverallsUploaderOptions>--opencover $(CoverageReportDir)\*.coverage.xml --repo-token $(CoverallsToken)</CoverallsUploaderOptions>
-    </PropertyGroup>
-
-    <Exec Command="$(CoverallsUploaderCommandLine) $(CoverallsUploaderOptions)"
-          ContinueOnError="ErrorAndContinue"
-          WorkingDirectory="$(ProjectDir)"
-          Condition="'$(UploadCoverallsData)'=='true'" />
-
   </Target>
 
   <UsingTask TaskName="ParseTestCoverageInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>

--- a/src/common/test-runtime/project.json
+++ b/src/common/test-runtime/project.json
@@ -8,7 +8,6 @@
     "System.IO.Compression": "4.1.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03",
     "System.Linq.Parallel": "4.0.1",
-    "coveralls.io": "1.4",
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.5.0",
     "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0035",


### PR DESCRIPTION
The version we depend on is gone and this tool is rarely used anyway

/cc @stephentoub 