### PR TITLE
Move Inbox data to package index

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
@@ -15,13 +15,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
     public class CreateTrimDependencyGroups : PackagingTask
     {
         [Required]
-        public string FrameworkListsPath
-        {
-            get;
-            set;
-        }
-
-        [Required]
         public ITaskItem[] Dependencies
         {
             get;
@@ -34,6 +27,17 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             get;
             set;
         }
+
+        /// <summary>
+        /// Package index files used to define stable package list.
+        /// </summary>
+        [Required]
+        public ITaskItem[] PackageIndexes
+        {
+            get;
+            set;
+        }
+
 
         [Output]
         public ITaskItem[] TrimmedDependencies
@@ -53,11 +57,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 Log.LogError("Dependencies argument must be specified");
                 return false;
             }
-            if (null == FrameworkListsPath)
+            if (PackageIndexes == null && PackageIndexes.Length == 0)
             {
-                Log.LogError("FrameworkListsPath argument must be specified");
+                Log.LogError("PackageIndexes argument must be specified");
                 return false;
             }
+
+            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
 
             // Retrieve the list of generation dependency group TFM's
             var dependencyGroups = Dependencies.GroupBy(d => d.GetMetadata("TargetFramework")).Select(dg => new
@@ -82,7 +88,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             {
                 // Determine inbox frameworks for this generation that don't already have explicit groups
                 HashSet<NuGetFramework> inboxFrameworksList = new HashSet<NuGetFramework>(
-                    Frameworks.GetAlllInboxFrameworks(FrameworkListsPath)
+                    index.GetAlllInboxFrameworks()
                     .Where(fx => !fx.IsPCL)
                     .Where(fx => Generations.DetermineGenerationForFramework(fx, UseNetPlatform) >= portableDependencyGroup.Framework.Version &&
                         !frameworksToExclude.Any(exFx => exFx.Framework == fx.Framework && exFx.Version <= fx.Version)));
@@ -103,7 +109,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     {
                         string version = GetVersion(dependency);
                         
-                        if (!Frameworks.IsInbox(FrameworkListsPath, framework, dependency.ItemSpec, version))
+                        if (!index.IsInbox(dependency.ItemSpec, framework, version))
                         {
                             addedDependencyToFramework = true;
                             AddDependency(addedDependencies, new TaskItem(dependency), framework, portableDependencyGroup.Framework);

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GeneratePackageReport.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GeneratePackageReport.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         public string RuntimeFile { get; set; }
 
         [Required]
-        public string FrameworkListsPath
+        public ITaskItem[] PackageIndexes
         {
             get;
             set;
@@ -234,10 +234,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
 
             // inspect any TFMs inbox
-            var frameworkData = FrameworkSet.Load(FrameworkListsPath);
-            var inboxFrameworks = frameworkData.Frameworks.SelectMany(f => f.Value)
-                .Where(fx => fx.Assemblies.ContainsKey(PackageId))
-                .Select(fx => NuGetFramework.Parse(fx.FrameworkName.FullName));
+            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            var inboxFrameworks = index.GetInboxFrameworks(PackageId).NullAsEmpty();
             
             foreach (var inboxFramework in inboxFrameworks)
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetPackageFromModule.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public override bool Execute()
         {
-            Dictionary<string, string> modulesToPackages;
+            IDictionary<string, string> modulesToPackages;
 
             if (PackageIndexes != null && PackageIndexes.Length > 0)
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -41,7 +41,6 @@
     <Compile Include="CreateTrimDependencyGroups.cs" />
     <Compile Include="ApplyBaseLine.cs" />
     <Compile Include="Extensions.cs" />
-    <Compile Include="Framework.cs" />
     <Compile Include="FrameworkUtilities.cs" />
     <Compile Include="GenerateNuSpec.cs" />
     <Compile Include="GenerateRuntimeDependencies.cs" />
@@ -66,14 +65,14 @@
     <Compile Include="VersionUtility.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="PackageFiles\Packaging.targets">
+    <None Include="$(MSBuildThisFileDirectory)PackageFiles\Packaging.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </None>
-    <None Include="PackageFiles\PackageLibs.targets">
+    <None Include="$(MSBuildThisFileDirectory)PackageFiles\PackageLibs.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="PackageFiles\_._">
+    <None Include="$(MSBuildThisFileDirectory)PackageFiles\_._">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="project.json" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -67,7 +67,9 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)PackageFiles\Packaging.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)PackageFiles\Packaging.common.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="$(MSBuildThisFileDirectory)PackageFiles\PackageLibs.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -2,16 +2,6 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="'$(_PackagingCommonTargetsImported)' != 'true'" Project="Packaging.common.targets"/>
 
-  <PropertyGroup>
-    <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
-    <GenerationDefinitionFile Condition="'$(GenerationDefinitionFile)' == ''">$(MSBuildThisFileDirectory)Generations.json</GenerationDefinitionFile>
-    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == '' AND Exists('$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json')">$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
-    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
-  </PropertyGroup>
-
-  <UsingTask TaskName="GetApplicableAssetsFromPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetPackageDestination" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-
   <Target Name="UpdatePkgProjProjectReferences" BeforeTargets="AssignProjectConfiguration">
     <!-- Update PkgProj references to call the GetPackageAssets target -->
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(_PackagingCommonTargetsImported)' != 'true'" Project="Packaging.common.targets"/>
+
   <PropertyGroup>
     <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
     <GenerationDefinitionFile Condition="'$(GenerationDefinitionFile)' == ''">$(MSBuildThisFileDirectory)Generations.json</GenerationDefinitionFile>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
@@ -3,4 +3,35 @@
   <PropertyGroup>
     <_PackagingCommonTargetsImported>true</_PackagingCommonTargetsImported>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
+    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == '' AND Exists('$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json')">$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
+    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
+  </PropertyGroup>
+
+  <UsingTask TaskName="ApplyBaseLine" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="ApplyPreReleaseSuffix" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="CreateTrimDependencyGroups" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="FilterUnknownPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GenerateNuSpec" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GeneratePackageReport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GenerateRuntimeDependencies" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetApplicableAssetsFromPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetAssemblyReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetInboxFrameworks" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetLastStablePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetMinimumNETStandard" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetPackageDescription" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetPackageDestination" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetPackageFromModule" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetPackageVersion" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="HarvestPackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="PromoteDependencies" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="SplitDependenciesBySupport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="SplitReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="ValidatePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="VerifyClosure" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_PackagingCommonTargetsImported>true</_PackagingCommonTargetsImported>
+  </PropertyGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
@@ -10,6 +10,11 @@
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(PackageTargetRuntimeSuffix)' != ''">
+    <PackageTargetRuntime Condition="'$(PackageTargetRuntime)' != ''">$(PackageTargetRuntime)-$(PackageTargetRuntimeSuffix)</PackageTargetRuntime>
+    <PackageTargetRuntime Condition="'$(PackageTargetRuntime)' == ''">$(PackageTargetRuntimeSuffix)</PackageTargetRuntime>
+  </PropertyGroup>
+
   <UsingTask TaskName="ApplyBaseLine" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="ApplyPreReleaseSuffix" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="CreateTrimDependencyGroups" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -66,12 +66,10 @@
   <PropertyGroup>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(BaseOutputPath)symbolpkg/</SymbolPackageOutputPath>
-    <PackageInstallPath Condition="'$(PackageInstallPath)' == ''">$(BaseOutputPath)localpkg/</PackageInstallPath>
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
     <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(PackageOutputPath)reports/</PackageReportDir>
-    <PackageLayoutDir Condition="'$(PackageLayoutDir)' == ''">$(PackageOutputPath)layout/</PackageLayoutDir>
     <PackageReportPath>$(PackageReportDir)$(Id)$(NuspecSuffix).json</PackageReportPath>
     <TargetPath>$(NuSpecPath)</TargetPath>
     <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)/runtime.json</RuntimeFilePath>
@@ -109,8 +107,6 @@
   <UsingTask TaskName="GetPackageFromModule" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="FilterUnknownPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GeneratePackageReport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="InstallPackageFromFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-  <UsingTask TaskName="GetLayoutFiles" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="VerifyClosure" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
   
@@ -129,11 +125,8 @@
     <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND $(PackageTargetRuntime.Contains('-$(PackagePlatform)'))">true</ShouldGenerateNuSpec>
     <!-- build if PackagePlatforms is not specified and arch is x86 or AnyCPU -->
     <ShouldGenerateNuSpec Condition="'$(PackagePlatforms)' == '' AND ('$(PackagePlatform)' == 'x86' OR '$(PackagePlatform)' == 'AnyCPU')">true</ShouldGenerateNuSpec>
-    <!-- if we built a nuspec, also create layout and pack unless explicitly set -->
-    <ShouldCreateLayout Condition="'$(ShouldCreateLayout)' == ''">$(ShouldGenerateNuSpec)</ShouldCreateLayout>
     <ShouldCreatePackage Condition="'$(ShouldCreatePackage)' == ''">$(ShouldGenerateNuSpec)</ShouldCreatePackage>
     <BuildDependsOn Condition="'$(ShouldGenerateNuSpec)' == 'true'">GenerateNuSpec</BuildDependsOn>
-    <BuildDependsOn Condition="'$(ShouldCreateLayout)' == 'true'">$(BuildDependsOn);CreateLayout</BuildDependsOn>
     <BuildDependsOn Condition="'$(ShouldCreatePackage)' == 'true'">$(BuildDependsOn);CreatePackage</BuildDependsOn>
     <BuildDependsOn Condition="'$(ShouldCreatePackage)' == 'true' OR '$(ShouldGenerateNuSpec)' == 'true'">$(BuildDependsOn);GetPackageReport;ValidatePackage</BuildDependsOn>
   </PropertyGroup>
@@ -1208,23 +1201,6 @@
                       Overwrite="true"
                       Condition="'$(_SkipCreatePackage)' != 'true'"/>
   </Target>
-  
-  <!-- Installs locally built package into a packageinstalldir for consuming -->
-  <!-- Overwrites previous installs, supports only one version installed -->
-  <Target Name="InstallLocallyBuiltPackages"
-          Condition="'$(SkipInstallLocallyBuiltPackages)' != 'true' AND '$(_SkipCreatePackage)' != 'true'"
-          AfterTargets="CreatePackage">
-    
-    <Error Text="Package not installed as it was not found at $(PackageOutputPath)$(Id).$(PackageVersion).nupkg" 
-           Condition="!Exists('$(PackageOutputPath)$(Id).$(PackageVersion).nupkg')" />
-    
-    <!-- Force overwrite install directory of package to allow only one version installed -->
-    <RemoveDir Directories="$(PackageInstallPath)\$(Id)" />
-
-    <InstallPackageFromFile PackageFile="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg"
-                            PackagesFolder="$(PackageInstallPath)" />
-      
-  </Target>
 
   <!-- Updates the packageIndex with information from the built package for this project -->
   <!-- Intentionally not sequenced, invoked directly through /t:UpdatePackageIndex -->
@@ -1260,35 +1236,5 @@
                         ModuleToPackages="@(ModuleToPackage)"
                         InboxFrameworkListFolder="$(FrameworkListsFolder)"
                         InboxFrameworkLayoutFolders="@(FrameworkLayout)" />
-  </Target>
-
-  <Target Name="CreateLayout"
-          Condition="'$(IsRuntimePackage)' != 'true' AND '$(PackageTargetRuntime)' == ''"
-          DependsOnTargets="GetPackageReport">
-
-    <ItemGroup>
-      <LayoutFrameworks Condition="'@(LayoutFrameworks)' == ''" Include="NETCoreApp,Version=v1.1" />
-    </ItemGroup>
-
-    <GetLayoutFiles PackageReports="$(PackageReportPath)"
-                    Frameworks="@(LayoutFrameworks)"
-                    DestinationDirectory="$(PackageLayoutDir)">
-      <Output TaskParameter="LayoutFiles" ItemName="LayoutFiles"/>
-    </GetLayoutFiles>
-
-    <ItemGroup>
-      <_missingLayoutFiles Include="@(LayoutFiles)" Condition="!Exists('%(FullPath)')" />
-      <LayoutFiles Remove="@(_missingLayoutFiles)" />
-    </ItemGroup>
-
-    <Message Text="Skipping '%(_missingLayoutFiles.FullPath) because it does not exist." Condition="'@(_missingLayoutFiles)' != ''" />
-
-    <Copy SourceFiles="@(LayoutFiles)"
-          DestinationFiles="@(LayoutFiles->'%(Destination)')"
-          SkipUnchangedFiles="true"
-          OverwriteReadOnlyFiles="true"
-          Retries="$(CopyRetryCount)"
-          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
-          UseHardlinksIfPossible="true" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" TreatAsLocalProperty="BuildProjectReferences" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(_PackagingCommonTargetsImported)' != 'true'" Project="Packaging.common.targets"/>
 
   <!-- The following properties are expected to change as we transition from
        Beta -> RC - RTM. We should set $(IncludeBuildNumberInPackageVersion)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -76,39 +76,13 @@
     <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)/runtime.json</RuntimeFilePath>
     <PlaceholderFile>$(MSBuildThisFileDirectory)_._</PlaceholderFile>
     <PackageDescriptionFile Condition="'$(PackageDescriptionFile)' == ''">path to descriptions.json must be specified</PackageDescriptionFile>
-    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == '' AND Exists('$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json')">$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
-    <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
     <ValidationSuppressionFile Condition="'$(ValidationSuppressionFile)' == ''">ValidationSuppression.txt</ValidationSuppressionFile>
     <SyncInfoFile Condition="'$(SyncInfoFile)' == ''">unspecified</SyncInfoFile>
-    <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
     <LineupPackageId Condition="'$(LineupPackageId)' == ''">Microsoft.NETCore.Targets</LineupPackageId>
     <LineupPackageVersion Condition="'$(LineupPackageVersion)' == ''">1.0.1</LineupPackageVersion>
     <PlatformPackageId Condition="'$(PlatformPackageId)' == ''">Microsoft.NETCore.Platforms</PlatformPackageId>
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.1</PlatformPackageVersion>
   </PropertyGroup>
-
-  <UsingTask TaskName="ApplyPreReleaseSuffix" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetAssemblyReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="SplitReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GenerateRuntimeDependencies" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetPackageDescription" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetInboxFrameworks" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetPackageVersion" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="ValidatePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="CreateTrimDependencyGroups" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GenerateNuSpec" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="ApplyBaseLine" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="PromoteDependencies" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetMinimumNETStandard" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="SplitDependenciesBySupport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetLastStablePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="HarvestPackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GetPackageFromModule" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="FilterUnknownPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="GeneratePackageReport" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
-  <UsingTask TaskName="VerifyClosure" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 
   
   <!-- Determine if we actually need to build for this architecture -->

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -79,7 +79,6 @@
     <PackageDescriptionFile Condition="'$(PackageDescriptionFile)' == ''">path to descriptions.json must be specified</PackageDescriptionFile>
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == '' AND Exists('$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json')">$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
-    <FrameworkListsPath Condition="'$(FrameworkListsPath)' == ''">$(MSBuildThisFileDirectory)FrameworkLists</FrameworkListsPath>
     <ValidationSuppressionFile Condition="'$(ValidationSuppressionFile)' == ''">ValidationSuppression.txt</ValidationSuppressionFile>
     <SyncInfoFile Condition="'$(SyncInfoFile)' == ''">unspecified</SyncInfoFile>
     <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
@@ -635,7 +634,7 @@
 
     <SplitReferences References="@(_FileReferencedAssemblies)"
                      TargetFramework="$(_TargetFramework)"
-                     FrameworkListsPath="$(FrameworkListsPath)">
+                     PackageIndexes="@(PackageIndex)">
       <Output TaskParameter="FrameworkReferences" ItemName="_FileFrameworkReference"/>
       <Output TaskParameter="PackageReferences" ItemName="_FilePackageReferenceUnfiltered"/>
     </SplitReferences>
@@ -729,7 +728,7 @@
          compile/runtime.  This reduces the noise when consuming our packages in
          packages.config based projects.  -->
     <CreateTrimDependencyGroups Dependencies="@(FilePackageDependency);@(Dependency)"
-                      FrameworkListsPath="$(FrameworkListsPath)"
+                      PackageIndexes="@(PackageIndex)"
                       Files="@(File)"
                       UseNetPlatform="$(UseNetPlatform)"
                       Condition="'@(FilePackageDependency)' != '' AND '$(PackageTargetRuntime)' == ''">
@@ -738,7 +737,7 @@
 
     <!-- Promote dependencies from ref to lib and vice-versa -->
     <PromoteDependencies Dependencies="@(FilePackageDependency)"
-                         FrameworkListsPath="$(FrameworkListsPath)"
+                         PackageIndexes="@(PackageIndex)"
                          Condition="'@(FilePackageDependency)' != ''">
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
     </PromoteDependencies>
@@ -1064,7 +1063,7 @@
                      Files="@(PackageAsset)"
                      Frameworks="@(DefaultValidateFramework)"
                      RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
-                     FrameworkListsPath="$(FrameworkListsPath)"
+                     PackageIndexes="@(PackageIndex)"
                      ReportFile="$(PackageReportPath)" />
   </Target>
 
@@ -1097,7 +1096,6 @@
     </ItemGroup>
 
     <ValidatePackage ContractName="$(BaseId)"
-                     FrameworkListsPath="$(FrameworkListsPath)"
                      Frameworks="@(ValidateFramework)"
                      PackageId="$(Id)"
                      PackageIndexes="@(PackageIndex)"
@@ -1251,13 +1249,17 @@
     <!-- Set BaseLinePackage to packageId identity with 'Version' metadata to define the set of packages which should set their baseline to a particular version -->
     <!-- Set StablePackage to packageId identity with 'Version' metadata to define the set of packages which should be set as stable -->
     <!-- Set ModuleToPackage to module name identity with 'Package' metadata to define mappings from native modules to package IDs which contain those -->
+    <!-- Set FrameworkListsFolder to the path to a set of directories containing framework lists, where the subdirectory name is the TFM.  These lists will determine what is inbox on that framework. -->
+    <!-- Set FrameowrkLayout to folder identity with 'TargetFramework' metadata to consider files within that folder inbox on that framework.-->
 
     <UpdatePackageIndex PackageIndexFile="$(PackageIndexFile)"
                         PackageIds="@(PackageIds)"
                         PackageFolders="@(PackageFolders)"
                         BaselinePackages="@(BaselinePackage)"
                         StablePackages="@(StablePackage)"
-                        ModuleToPackages="@(ModuleToPackage)" />
+                        ModuleToPackages="@(ModuleToPackage)"
+                        InboxFrameworkListFolder="$(FrameworkListsFolder)"
+                        InboxFrameworkLayoutFolders="@(FrameworkLayout)" />
   </Target>
 
   <Target Name="CreateLayout"

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PromoteDependencies.cs
@@ -39,9 +39,12 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             var refSets = dependencies.Where(d => d.Id != "_._").Where(d => d.IsReference).GroupBy(d => d.TargetFramework).ToDictionary(g => NuGetFramework.Parse(g.Key), g => g.ToArray());
             var refFxs = refSets.Keys.ToArray();
 
+            Log.LogMessage(LogImportance.Low, $"Ref frameworks {string.Join(";", refFxs.Select(f => f.ToString()))}");
+
             var libSets = dependencies.Where(d => !d.IsReference).GroupBy(d => d.TargetFramework).ToDictionary(g => NuGetFramework.Parse(g.Key), g => g.ToArray());
             var libFxs = libSets.Keys.ToArray();
 
+            Log.LogMessage(LogImportance.Low, $"Lib frameworks {string.Join(";", libFxs.Select(f => f.ToString()))}");
 
             if (libFxs.Length > 0)
             {
@@ -64,13 +67,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     // find best lib (if any)
                     var nearestRefFx = FrameworkUtilities.GetNearest(libFx, refFxs);
 
-                    if (nearestRefFx == null && !nearestRefFx.Equals(libFx))
-                    {
-                        // This should never happen and indicates a bug in the package.  If a package contains references,
-                        // all implementations should have an applicable reference assembly.
-                        Log.LogError($"Could not find applicable reference assembly for implementation framework {libFx} from reference frameworks {string.Join(", ", refFxs.Select(f => f.GetShortFolderName()))}");
-                    }
-                    else
+                    if (nearestRefFx != null && !nearestRefFx.Equals(libFx))
                     {
                         promotedDependencies.AddRange(CopyDependencies(refSets[nearestRefFx], libFx));
                     }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -467,9 +467,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     // not in the native module map, see if any of the modules in this package are present
                     // (with a different package, as would be the case for runtime-specific packages)
                     var moduleNames = allDlls.Select(d => Path.GetFileNameWithoutExtension(d.LocalPath));
-                    if (moduleNames.Any() && !moduleNames.Any(m => index.ModulesToPackages.ContainsKey(m)))
+                    var missingModuleNames = moduleNames.Where(m => !index.ModulesToPackages.ContainsKey(m));
+                    if (missingModuleNames.Any())
                     {
-                        Log.LogError($"PackageIndex from {String.Join(", ", PackageIndexes.Select(i => i.ItemSpec))} is missing ModulesToPackages entry(s) for {String.Join(", ", allDlls)} to package {PackageId}.  Please add a an entry for the appropriate package.");
+                        Log.LogError($"PackageIndex from {String.Join(", ", PackageIndexes.Select(i => i.ItemSpec))} is missing ModulesToPackages entry(s) for {String.Join(", ", missingModuleNames)} to package {PackageId}.  Please add a an entry for the appropriate package.");
                     }
                 }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -94,14 +94,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             set;
         }
 
-
-        [Required]
-        public string FrameworkListsPath
-        {
-            get;
-            set;
-        }
-
         public bool SkipGenerationCheck
         {
             get;
@@ -160,10 +152,9 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// </summary>
         private Dictionary<Suppression, HashSet<string>> _suppressions;
         private Dictionary<NuGetFramework, ValidationFramework> _frameworks;
-        private FrameworkSet _frameworkSet;
+        private PackageIndex _index;
         private PackageReport _report;
         private string _generationIdentifier = FrameworkConstants.FrameworkIdentifiers.NetStandard;
-        private static Version s_maxVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
 
         public override bool Execute()
         {
@@ -710,51 +701,46 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
 
             // determine which Frameworks should support inbox
-            _frameworkSet = FrameworkSet.Load(FrameworkListsPath);
-            foreach (IEnumerable<Framework> inboxFxGroup in _frameworkSet.Frameworks.Values)
+            _index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            foreach (var inboxPair in _index.GetInboxVersions(ContractName).NullAsEmpty())
             {
-                foreach (Framework inboxFx in inboxFxGroup)
+                var fx = inboxPair.Key;
+                var inboxVersion = inboxPair.Value;
+
+                if (inboxVersion != null)
                 {
-                    // get currently supported version to see if we have OOB'ed it
-                    Version inboxVersion = null;
-                    inboxFx.Assemblies.TryGetValue(ContractName, out inboxVersion);
-
-                    if (inboxVersion != null)
+                    ValidationFramework validationFramework = null;
+                    if (_frameworks.TryGetValue(fx, out validationFramework))
                     {
-                        NuGetFramework fx = FrameworkUtilities.ParseNormalized(inboxFx.ShortName);
-                        ValidationFramework validationFramework = null;
-                        if (_frameworks.TryGetValue(fx, out validationFramework))
+                        Version supportedVersion = validationFramework.SupportedVersion;
+
+                        if (supportedVersion != null &&
+                            (supportedVersion.Major > inboxVersion.Major ||
+                            (supportedVersion.Major == inboxVersion.Major && supportedVersion.Minor > inboxVersion.Minor)))
                         {
-                            Version supportedVersion = validationFramework.SupportedVersion;
-
-                            if (supportedVersion != null &&
-                                (supportedVersion.Major > inboxVersion.Major ||
-                                (supportedVersion.Major == inboxVersion.Major && supportedVersion.Minor > inboxVersion.Minor)))
-                            {
-                                // Higher major.minor
-                                Log.LogMessage(LogImportance.Low, $"Framework {fx} supported {ContractName} as inbox but the current supported version {supportedVersion} is higher in major.minor than inbox version {inboxVersion}.  Assuming out of box.");
-                                continue;
-                            }
-                            else if (supportedVersion != null && supportedVersion < inboxVersion && inboxVersion != s_maxVersion)
-                            {
-                                // Lower version
-                                Log.LogError($"Framework {fx} supports {ContractName} as inbox but the current supported version {supportedVersion} is lower than the inbox version {inboxVersion}");
-                            }
-
-                            // equal major.minor, build.revision difference is permitted, prefer the version listed by ContractSupport item
+                            // Higher major.minor
+                            Log.LogMessage(LogImportance.Low, $"Framework {fx} supported {ContractName} as inbox but the current supported version {supportedVersion} is higher in major.minor than inbox version {inboxVersion}.  Assuming out of box.");
+                            continue;
+                        }
+                        else if (supportedVersion != null && supportedVersion < inboxVersion && inboxVersion != VersionUtility.MaxVersion)
+                        {
+                            // Lower version
+                            Log.LogError($"Framework {fx} supports {ContractName} as inbox but the current supported version {supportedVersion} is lower than the inbox version {inboxVersion}");
                         }
 
-                        if (validationFramework == null)
-                        {
-                            // we may not be explicitly validating for this framework so add it to validate inbox assets.
-                            _frameworks[fx] = validationFramework = new ValidationFramework(fx)
-                            {
-                                SupportedVersion = inboxVersion
-                            };
-                        }
-
-                        validationFramework.IsInbox = true;
+                        // equal major.minor, build.revision difference is permitted, prefer the version listed by ContractSupport item
                     }
+
+                    if (validationFramework == null)
+                    {
+                        // we may not be explicitly validating for this framework so add it to validate inbox assets.
+                        _frameworks[fx] = validationFramework = new ValidationFramework(fx)
+                        {
+                            SupportedVersion = inboxVersion
+                        };
+                    }
+
+                    validationFramework.IsInbox = true;
                 }
             }
 
@@ -764,7 +750,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             // their own implementation via a lineup/runtime.json.
 
             // only consider frameworks that support the contract at a specific version
-            var inferFrameworks = _frameworks.Values.Where(fx => fx.SupportedVersion != null && fx.SupportedVersion != s_maxVersion).ToArray();
+            var inferFrameworks = _frameworks.Values.Where(fx => fx.SupportedVersion != null && fx.SupportedVersion != VersionUtility.MaxVersion).ToArray();
 
             var genVersionSuppression = GetSuppressionValues(Suppression.PermitPortableVersionMismatch) ?? new HashSet<string>();
             var inferNETStandardSuppression = GetSuppressionValues(Suppression.SuppressNETStandardInference) ?? new HashSet<string>();
@@ -800,12 +786,6 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             {
                 _frameworks.Add(generation.Key, generation.Value);
             }
-        }
-
-        private string GetVersionString(Version version)
-        {
-            // normalize to API version
-            return version == s_maxVersion ? "Any" : _frameworkSet.GetApiVersion(ContractName, version)?.ToString();
         }
 
         private class ValidationFramework

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VersionUtility.cs
@@ -11,6 +11,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 {
     internal static class VersionUtility
     {
+        public static readonly Version MaxVersion = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
+
         public static bool IsCompatibleApiVersion(Version referenceVersion, Version definitionVersion)
         {
             return (referenceVersion.Major == definitionVersion.Major &&

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/CreateTrimDependencyGroupsTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/CreateTrimDependencyGroupsTests.cs
@@ -16,11 +16,21 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
     {
         private Log _log;
         private TestBuildEngine _engine;
+        private ITaskItem[] packageIndexes;
+
+        private const string FrameworkListsPath = "FrameworkLists";
 
         public CreateTrimDependencyGroupsTests(ITestOutputHelper output)
         {
             _log = new Log(output);
             _engine = new TestBuildEngine(_log);
+
+
+            var packageIndexPath = $"packageIndex.{Guid.NewGuid()}.json";
+            PackageIndex index = new PackageIndex();
+            index.MergeFrameworkLists(FrameworkListsPath);
+            index.Save(packageIndexPath);
+            packageIndexes = new[] { new TaskItem(packageIndexPath) };
         }
 
         [Fact]
@@ -74,14 +84,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateDependencyItem(@"System.Globalization", "4.0.0", "netstandard1.0"),
                 CreateDependencyItem(@"System.Threading", "4.0.0", "netstandard1.0")
             };
-            string frameworkListsPath = "FrameworkLists";
 
             CreateTrimDependencyGroups task = new CreateTrimDependencyGroups()
             {
                 BuildEngine = _engine,
                 Files = files,
                 Dependencies = dependencies,
-                FrameworkListsPath = frameworkListsPath
+                PackageIndexes = packageIndexes
             };
 
             _log.Reset();
@@ -114,14 +123,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateDependencyItem(@"System.Globalization", "4.0.0", "netstandard1.0"),
                 CreateDependencyItem(@"System.Threading", "4.0.0", "netstandard1.0")
             };
-            string frameworkListsPath = "FrameworkLists";
 
             CreateTrimDependencyGroups task = new CreateTrimDependencyGroups()
             {
                 BuildEngine = _engine,
                 Files = files,
                 Dependencies = dependencies,
-                FrameworkListsPath = frameworkListsPath
+                PackageIndexes = packageIndexes
             };
 
             _log.Reset();
@@ -194,14 +202,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateDependencyItem(@"System.Collections.Immutable", "4.0.20", "netstandard1.3"),
                 CreateDependencyItem(@"System.Runtime", "4.0.20", ".NETCore50")
             };
-            string frameworkListsPath = "FrameworkLists";
 
             CreateTrimDependencyGroups task = new CreateTrimDependencyGroups()
             {
                 BuildEngine = _engine,
                 Files = files,
                 Dependencies = dependencies,
-                FrameworkListsPath = frameworkListsPath
+                PackageIndexes = packageIndexes
             };
 
             _log.Reset();
@@ -245,14 +252,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateDependencyItem(@"System.Runtime.Handles", "4.0.0", "netcoreapp1.0"),
                 CreateDependencyItem(@"System.Threading", "4.0.10", "netcoreapp1.0")
             };
-            string frameworkListsPath = "FrameworkLists";
 
             CreateTrimDependencyGroups task = new CreateTrimDependencyGroups()
             {
                 BuildEngine = _engine,
                 Files = files,
                 Dependencies = dependencies,
-                FrameworkListsPath = frameworkListsPath
+                PackageIndexes = packageIndexes
             };
 
             _log.Reset();
@@ -292,14 +298,13 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
                 CreateDependencyItem(@"System.Collections.Immutable", "1.1.37", "netstandard1.1"),
                 CreateDependencyItem(@"System.Collections.Immutable", "1.1.37", "portable-net45+win80")
             };
-            string frameworkListsPath = "FrameworkLists";
 
             CreateTrimDependencyGroups task = new CreateTrimDependencyGroups()
             {
                 BuildEngine = _engine,
                 Files = files,
                 Dependencies = dependencies,
-                FrameworkListsPath = frameworkListsPath
+                PackageIndexes = packageIndexes
             };
 
             _log.Reset();

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -47,7 +47,6 @@
     <file src="Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\NuGet.*.dll" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks.Packaging\FrameworkLists\**\*.*" target="lib\FrameworkLists" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />


### PR DESCRIPTION
We're growing the inbox concept to accomodate the flat framework packages (eg: NETStandard.Library, MS.NETCore.App, UWP).  As such it no longer makes sense to have these things defined as static framework lists that live in the buildtools package.  I've moved the data into the packageindex and created mechanisms for migration.

/cc @weshaggard @joperezr 