### PR TITLE
Create updaters for tooling version files

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -72,6 +72,21 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                         yield return CreateXmlUpdater(step);
                         break;
 
+                    case "File":
+                        yield return new FilePackageUpdater
+                        {
+                            PackageId = GetRequiredMetadata(step, "PackageId"),
+                            Path = GetRequiredMetadata(step, "Path"),
+                        };
+                        break;
+
+                    case "Tool versions":
+                        yield return new ToolVersionsUpdater
+                        {
+                            Path = GetRequiredMetadata(step, "Path"),
+                        };
+                        break;
+
                     case "Submodule from package":
                         yield return new IndicatorPackageSubmoduleUpdater(
                             GetRequiredMetadata(step, "IndicatorPackage"))

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FilePackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FilePackageUpdater.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public class FilePackageUpdater : IDependencyUpdater
+    {
+        public string Path { get; set; }
+
+        public string PackageId { get; set; }
+
+        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(
+            IEnumerable<DependencyBuildInfo> dependencyBuildInfos)
+        {
+            foreach (var info in dependencyBuildInfos)
+            {
+                string version;
+                if (info.RawPackages.TryGetValue(PackageId, out version))
+                {
+                    string originalValue = null;
+
+                    Action updateTask = FileUtils.GetUpdateFileContentsTask(
+                        Path,
+                        content =>
+                        {
+                            int firstLineLength = content.IndexOf(Environment.NewLine);
+                            // Handle files with no newline ending.
+                            if (firstLineLength == -1)
+                            {
+                                firstLineLength = content.Length;
+                            }
+
+                            originalValue = content.Substring(0, firstLineLength);
+                            return content
+                                .Remove(0, firstLineLength)
+                                .Insert(0, version);
+                        });
+
+                    if (updateTask != null)
+                    {
+                        yield return new DependencyUpdateTask(
+                            updateTask,
+                            new[] { info.BuildInfo },
+                            new[] { $"In '{Path}', '{originalValue}' must be '{version}'." });
+                    }
+                    yield break;
+                }
+            }
+            Trace.TraceError($"For '{Path}', Could not find '{PackageId}' package version information.");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/ToolVersionsUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/ToolVersionsUpdater.cs
@@ -63,11 +63,18 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
 
             public ToolUpdateLineResult(string line, IEnumerable<DependencyBuildInfo> buildInfos)
             {
+                Content = line;
+
                 int separatorIndex = line.IndexOf('=');
-                string name = line.Substring(0, separatorIndex);
+                if (separatorIndex == -1)
+                {
+                    // Ignore lines without a 'name=version' string.
+                    return;
+                }
+
+                string name = line.Substring(0, separatorIndex).Trim();
                 string version = line.Substring(separatorIndex + 1);
 
-                Content = line;
                 OriginalVersion = version;
                 ToolName = name;
 

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/ToolVersionsUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/ToolVersionsUpdater.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public class ToolVersionsUpdater : IDependencyUpdater
+    {
+        public string Path { get; set; }
+
+        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(
+            IEnumerable<DependencyBuildInfo> dependencyBuildInfos)
+        {
+            var lineResults = new List<ToolUpdateLineResult>();
+
+            Action updateTask = FileUtils.GetUpdateFileContentsTask(
+                Path,
+                content =>
+                {
+                    var reader = new StringReader(content);
+                    var writer = new StringWriter();
+
+                    string line;
+                    while ((line = reader.ReadLine()) != null)
+                    {
+                        var result = new ToolUpdateLineResult(line, dependencyBuildInfos);
+                        writer.WriteLine(result.Content);
+                        if (result.UsedBuildInfo != null)
+                        {
+                            lineResults.Add(result);
+                        }
+                    }
+
+                    return writer.ToString();
+                });
+
+            if (updateTask != null)
+            {
+                yield return new DependencyUpdateTask(
+                    updateTask,
+                    lineResults.Select(c => c.UsedBuildInfo),
+                    lineResults.Select(c => $"In '{Path}', '{c.ToolName}' '{c.OriginalVersion}' must be '{c.NewVersion}'."));
+            }
+        }
+
+        private class ToolUpdateLineResult
+        {
+            public string Content { get; }
+
+            public BuildInfo UsedBuildInfo { get; }
+
+            public string ToolName { get; }
+
+            public string OriginalVersion { get; }
+
+            public string NewVersion { get; }
+
+            public ToolUpdateLineResult(string line, IEnumerable<DependencyBuildInfo> buildInfos)
+            {
+                int separatorIndex = line.IndexOf('=');
+                string name = line.Substring(0, separatorIndex);
+                string version = line.Substring(separatorIndex + 1);
+
+                Content = line;
+                OriginalVersion = version;
+                ToolName = name;
+
+                foreach (var info in buildInfos)
+                {
+                    if (info.RawPackages.TryGetValue(name, out version))
+                    {
+                        Content = $"{name}={version}";
+                        NewVersion = version;
+                        UsedBuildInfo = info.BuildInfo;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -32,6 +32,8 @@
     <Compile Include="Automation\GitHubProject.cs" />
     <Compile Include="Automation\PullRequestCreator.cs" />
     <Compile Include="Automation\GitHubApi\GitHubApiModel.cs" />
+    <Compile Include="Dependencies\ToolVersionsUpdater.cs" />
+    <Compile Include="Dependencies\FilePackageUpdater.cs" />
     <Compile Include="Dependencies\FileRegexPackageUpdater.cs" />
     <Compile Include="Dependencies\FileRegexReleaseUpdater.cs" />
     <Compile Include="Automation\IUpdateBranchNamingStrategy.cs" />


### PR DESCRIPTION
`ToolVersionsUpdater` is used on `.toolversions` files, for bootstrap-acquired dependencies.

`FilePackageUpdater` updates an entire file with a package's version, for `BuildToolsVersion.txt` (and `DotnetCLIVersion.txt`).

This is the first part of getting to this BfS objective:

> 2. We need a way to update the buildtools dependency of everything that uses it to consume the version we just built.

Steps are set up like this: https://github.com/dagood/corefx/commit/1623bdd45fcd13b7b92d03ce776ff8fec1cb4276 (the `DependencyBuildInfo` is for testing).