### PR TITLE
Fix overwrite of VB response file

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/WriteVisualBasicDefineResponseFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/WriteVisualBasicDefineResponseFile.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
-            using (var streamWriter = new StreamWriter(System.IO.File.OpenWrite(File)))
+            using (var streamWriter = new StreamWriter(System.IO.File.Open(File, FileMode.Create)))
             {
                 streamWriter.Write("/define:\"");
                 streamWriter.Write(DefineConstants.Replace("\"", "\\\""));


### PR DESCRIPTION
We write VB defines to a defines.rsp for the VB compiler to work around an MSBuild issue. If the file is already present and already has longer content this task will corrupt it causing a build failure. It should replace the content.

@mellinoe 