### PR TITLE
Add support for meta-package harvesting

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyMetaPackages.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ApplyMetaPackages.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using NuGet.Frameworks;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    /// <summary>
+    /// Replaces package dependencies with meta-package dependencies where appropriate.
+    /// </summary>
+    public class ApplyMetaPackages : PackagingTask
+    {
+        /// <summary>
+        /// Original dependencies
+        /// </summary>
+        [Required]
+        public ITaskItem[] OriginalDependencies { get; set; }
+
+        /// <summary>
+        /// Package index files used to meta-package mappings
+        /// </summary>
+        public ITaskItem[] PackageIndexes { get; set; }
+        
+        [Output]
+        public ITaskItem[] UpdatedDependencies { get; set; }
+        
+        public override bool Execute()
+        {
+            var index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+            List<ITaskItem> updatedDependencies = new List<ITaskItem>();
+
+            // keep track of meta-package dependencies to add by framework so that we only add them once per framework.
+            Dictionary<string, HashSet<NuGetFramework>> metaPackagesToAdd = new Dictionary<string, HashSet<NuGetFramework>>();
+
+            foreach (var originalDependency in OriginalDependencies)
+            {
+                var metaPackage = index.MetaPackages.GetMetaPackageId(originalDependency.ItemSpec);
+
+                if (metaPackage != null)
+                {
+                    // convert to meta-package dependency
+                    var tfm = originalDependency.GetMetadata("TargetFramework");
+                    var fx = NuGetFramework.Parse(tfm);
+
+                    HashSet<NuGetFramework> metaPackageFrameworks;
+
+                    if (!metaPackagesToAdd.TryGetValue(metaPackage, out metaPackageFrameworks))
+                    {
+                        metaPackagesToAdd[metaPackage] = metaPackageFrameworks = new HashSet<NuGetFramework>();
+                    }
+
+                    metaPackageFrameworks.Add(fx);
+                }
+                else
+                {
+                    updatedDependencies.Add(originalDependency);
+                }
+            }
+
+            updatedDependencies.AddRange(metaPackagesToAdd.SelectMany(pair => pair.Value.Select(tfm => CreateDependency(pair.Key, tfm))));
+
+            UpdatedDependencies = updatedDependencies.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private ITaskItem CreateDependency(string id, NuGetFramework targetFramework)
+        {
+            var item = new TaskItem(id);
+            item.SetMetadata("TargetFramework", targetFramework.GetShortFolderName());
+            return item;
+        }
+        
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -20,6 +20,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ApplyMetaPackages.cs" />
     <Compile Include="GetLayoutFiles.cs" />
     <Compile Include="FilterUnknownPackages.cs" />
     <Compile Include="GetPackageDestination.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <UsingTask TaskName="ApplyBaseLine" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="ApplyMetaPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="ApplyPreReleaseSuffix" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="CreateTrimDependencyGroups" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="FilterUnknownPackages" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -710,9 +710,15 @@
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
     </PromoteDependencies>
 
-    <Error Condition="'@(PackageIndex)' == '' AND '@(BaseLinePackage)' == '' AND '@(FilePackageDependency)' != '' AND '$(BaseLinePackageDependencies)' != 'false'"
+    <ApplyMetaPackages OriginalDependencies="@(FilePackageDependency)"
+                       PackageIndexes="@(PackageIndex)">
+      <Output TaskParameter="UpdatedDependencies" ItemName="_ConsolidatedDependencies" />
+    </ApplyMetaPackages>
+                       
+    
+    <Error Condition="'@(PackageIndex)' == '' AND '@(BaseLinePackage)' == '' AND '@(_ConsolidatedDependencies)' != '' AND '$(BaseLinePackageDependencies)' != 'false'"
            Text="Neither PackageIndex nor BaseLinePackage items are defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
-    <ApplyBaseLine OriginalDependencies="@(FilePackageDependency)"
+    <ApplyBaseLine OriginalDependencies="@(_ConsolidatedDependencies)"
                    BaseLinePackages="@(BaseLinePackage)"
                    PackageIndexes="@(PackageIndex)"
                    Apply="$(BaseLinePackageDependencies)">


### PR DESCRIPTION
Allow PackageIndex to define package IDs that should be rolled into a
meta-package reference rather than individual package references.

/cc @weshaggard @terrajobst 

This lets us reference the NETStandard.Library meta-package instead of the granular packages.  Consumption side of this change looks like this: https://github.com/ericstj/corefx/commit/38c8073910701ed4934a0c65556c5e52a8433b78