### PR TITLE
Clean IL.targets and make it call TargetsTriggeredByCompilation.

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -3,7 +3,7 @@
   <!-- Source of truth for dependency tooling: the commit hash of the dotnet/versions master branch as of the last auto-upgrade. -->
   <PropertyGroup>
     <CoreFxCurrentRef>12abd697857d39b1a07dfae9e01d31f875500ebf</CoreFxCurrentRef>
-    <CoreClrCurrentRef>a8be270baa206a3d87112b7912869661b0c46f0a</CoreClrCurrentRef>
+    <CoreClrCurrentRef>a0ed75550803dad6df36961c168c21f33cd86f6d</CoreClrCurrentRef>
     <ProjectKTfsCurrentRef>b6fe7bf0d879e7a750b15e90743d5191e3b478de</ProjectKTfsCurrentRef>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
@@ -4,35 +4,29 @@
   <!-- Required by Microsoft.Common.targets -->
   <Target Name="CreateManifestResourceNames" Condition="'@(EmbeddedResource)' != ''" />
 
-  <Target Name="GetIlasmPath"
-          Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <GetFrameworkPath>
-      <Output TaskParameter="Path" PropertyName="IlasmPath" />
-    </GetFrameworkPath>
-    <PropertyGroup>
-      <IlasmPath>$(IlasmPath)\</IlasmPath>
-    </PropertyGroup>
-  </Target>
+  <PropertyGroup>
+    <IlasmToolPath Condition="'$(IlasmToolPath)' == ''">$(ToolsDir)ilasm</IlasmToolPath>
+  </PropertyGroup>
 
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
                   @(Compile)"
           Outputs="@(IntermediateAssembly);"
           Returns=""
-          DependsOnTargets="GetIlasmPath;$(CoreCompileDependsOn)">
+          DependsOnTargets="$(CoreCompileDependsOn)">
     <PropertyGroup>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">-DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">-EXE</_OutputTypeArgument>
 
       <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">-KEY=$(KeyOriginatorFile)</_KeyFileArgument>
-
-      <IlasmExePath Condition="'$(IlasmExePath)' == ''">$(IlasmPath)ilasm</IlasmExePath>
     </PropertyGroup>
 
-    <Exec Command="$(IlasmExePath) -QUIET $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile, ' ')">
+    <Exec Command="$(IlasmToolPath) -QUIET $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile, ' ')">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
     <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />
+
+    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''"/>
   </Target>
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -21,7 +21,10 @@
         "NETStandard.Library": {
           "version": "1.6.1",
           "exclude": "runtime"
-        }
+        },
+        "Microsoft.NETCore.Platforms": "1.1.0",
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0",
+        "Microsoft.NETCore.ILAsm": "2.0.0-beta-25027-03",
       },
       "imports": [
         "dnxcore50",


### PR DESCRIPTION
I did a few things here:

* Cleaned up how the "GetIlasmPath" target worked so that we always use that absolute path on Windows. Previously, if you weren't building from VS, we would just use the name "ilasm" to start the process. That only worked if you were in a developer command prompt. Which is most of the time, admittedly, but this way is cleaner and works just as well.
* Give an error if `IlasmToolPath` is not set, which should only happen outside of Windows. Repos need to set that property, for now at least, until we figure out a better way to restore and deploy native assets along with buildtools.
* Call `TargetsTriggeredByCompilation`, which fixes https://github.com/dotnet/buildtools/issues/1338

@weshaggard, @ericstj

This stuff isn't strictly required for us to upgrade ilasm in corefx (we're just going to override the path property anyways), but it does clean things up and will also cause ApiCompat to run for our IL project.