### PR TITLE
Remove the restore/publish of ilasm and its dependencies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
@@ -4,16 +4,24 @@
   <!-- Required by Microsoft.Common.targets -->
   <Target Name="CreateManifestResourceNames" Condition="'@(EmbeddedResource)' != ''" />
 
-  <PropertyGroup>
-    <IlasmToolPath Condition="'$(IlasmToolPath)' == ''">$(ToolsDir)ilasm</IlasmToolPath>
-  </PropertyGroup>
+  <Target Name="GetIlasmPath"
+          Condition="'$(OS)' == 'Windows_NT' And '$(IlasmToolPath)' == ''">
+    <GetFrameworkPath>
+      <Output TaskParameter="Path" PropertyName="IlasmPath" />
+    </GetFrameworkPath>
+    <PropertyGroup>
+      <IlasmPath>$(IlasmPath)\</IlasmPath>
+      <IlasmToolPath>$(IlasmPath)ilasm</IlasmToolPath>
+    </PropertyGroup>
+  </Target>
 
   <Target Name="CoreCompile"
           Inputs="$(MSBuildAllProjects);
                   @(Compile)"
           Outputs="@(IntermediateAssembly);"
           Returns=""
-          DependsOnTargets="$(CoreCompileDependsOn)">
+          DependsOnTargets="GetIlasmPath;$(CoreCompileDependsOn)">
+    <Error Condition="'$(IlasmToolPath)' == ''" Text="IlasmToolPath must be set in order to build ilproj's outside of Windows." />
     <PropertyGroup>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">-DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">-EXE</_OutputTypeArgument>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.json
@@ -21,10 +21,7 @@
         "NETStandard.Library": {
           "version": "1.6.1",
           "exclude": "runtime"
-        },
-        "Microsoft.NETCore.Platforms": "1.1.0",
-        "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0",
-        "Microsoft.NETCore.ILAsm": "2.0.0-beta-25027-03",
+        }
       },
       "imports": [
         "dnxcore50",


### PR DESCRIPTION
Buildtools consumers need to set the IlAsmToolPath property directly in order to build .ilproj files outside of Windows. An error is given outside of Windows if this property is not set. On Windows, we still auto-detect the globally-installed version of ilasm if it is not provided.

@weshaggard Along with a depproj in corefx, this will accomplish what we discussed in-person. For people working in repos that don't have such a depproj for ilasm, they will get a relatively actionable error message instead.