### PR TITLE
Update xunit constants and TargetFrameworkMonikers to be non-versioned

### DIFF
--- a/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -49,10 +49,10 @@ namespace Xunit.NetCore.Extensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
             if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.NetcoreUap))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreUapTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.NetcoreUapAot))
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreUapAotTest);
+            if (platform.HasFlag(TargetFrameworkMonikers.Uap))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
+            if (platform.HasFlag(TargetFrameworkMonikers.UapAot))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
             if (platform.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
         }

--- a/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -45,6 +45,16 @@ namespace Xunit.NetCore.Extensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreapp1_0Test);
             if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp1_1))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreapp1_1Test);
+            if (platform.HasFlag(TargetFrameworkMonikers.NetFramework))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+            if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
+            if (platform.HasFlag(TargetFrameworkMonikers.NetcoreUap))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreUapTest);
+            if (platform.HasFlag(TargetFrameworkMonikers.NetcoreUapAot))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreUapAotTest);
+            if (platform.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
         }
     }
 }

--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -22,8 +22,8 @@ namespace Xunit
         Netcoreapp1_1 = 0x400,
         NetFramework = 0x800,
         Netcoreapp = 0x1000,
-        NetcoreUap = 0x2000,
-        NetcoreUapAot = 0x4000,
+        Uap = 0x2000,
+        UapAot = 0x4000,
         NetcoreCoreRT = 0x8000
     }
 }

--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using Xunit.Sdk;
 
 namespace Xunit
 {
@@ -17,19 +16,14 @@ namespace Xunit
         Net461 = 0x10,
         Net462 = 0x20,
         Net463 = 0x40,
-
         Netcore50 = 0x80,
         Netcore50aot = 0x100,
-
         Netcoreapp1_0 = 0x200,
         Netcoreapp1_1 = 0x400,
-
-        NetFramework = Net45 | Net451 | Net452 | Net46 | Net461 | Net462 | Net463,
-        NetFramework45 = Net45 | Net451 | Net452,
-        NetFramework46 = Net46 | Net461 | Net462,
-
-        Netcoreapp = Netcoreapp1_0 | Netcoreapp1_1,
-
-        NetcoreUwp = Netcore50 | Netcore50aot
+        NetFramework = 0x800,
+        Netcoreapp = 0x1000,
+        NetcoreUap = 0x2000,
+        NetcoreUapAot = 0x4000,
+        NetcoreCoreRT = 0x8000
     }
 }

--- a/src/xunit.netcore.extensions/XunitConstants.cs
+++ b/src/xunit.netcore.extensions/XunitConstants.cs
@@ -27,6 +27,13 @@ namespace Xunit.NetCore.Extensions
         internal static string NonNetcoreapp1_0Test = "nonnetcoreapp1.0tests";
         internal static string NonNetcoreapp1_1Test = "nonnetcoreapp1.1tests";
 
+        //Non version framework constants
+        internal static string NonNetfxTest = "nonnetfxtests";
+        internal static string NonNetcoreUapTest = "nonnetcoreuaptests";
+        internal static string NonNetcoreUapAotTest = "nonnetcoreuapaottests";
+        internal static string NonNetcoreappTest = "nonnetcoreapptests";
+        internal static string NonNetcoreCoreRTTest = "nonnetcorecorerttests";
+
         internal const string Failing = "failing";
         internal const string ActiveIssue = "activeissue";
         internal const string OuterLoop = "outerloop";

--- a/src/xunit.netcore.extensions/XunitConstants.cs
+++ b/src/xunit.netcore.extensions/XunitConstants.cs
@@ -29,8 +29,8 @@ namespace Xunit.NetCore.Extensions
 
         //Non version framework constants
         internal static string NonNetfxTest = "nonnetfxtests";
-        internal static string NonNetcoreUapTest = "nonnetcoreuaptests";
-        internal static string NonNetcoreUapAotTest = "nonnetcoreuapaottests";
+        internal static string NonUapTest = "nonuaptests";
+        internal static string NonUapAotTest = "nonuapaottests";
         internal static string NonNetcoreappTest = "nonnetcoreapptests";
         internal static string NonNetcoreCoreRTTest = "nonnetcorecorerttests";
 


### PR DESCRIPTION
We are currently testing only against latest version of every target framework. We need to update the `Xunit.Netcore.Extensions` to have a non-version behavior when discovering tests. This will help consolidate the behavior when using `SkipOnTargetFramework` test attribute. This is also needed for netfx vertical test runs in order to filter the tests correctly. 

Currently working on the necessary changes in corefx tests to make them build successfully when we try to ingest the new buildtools version.

/cc @weshaggard @ericstj 