### PR TITLE
Add support for capturing windows crash dumps to Dumpling.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -3,16 +3,23 @@
     <Content Include="$(MSBuildThisFileDirectory)Dumpling.sh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)DumplingHelper.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <!-- Setup Dumpling service to collect crash dumps -->
   <Target Name="SetupDumpling"
-          BeforeTargets="GenerateTestExecutionScripts"
-          Condition="'$(TargetOS)'!='Windows_NT'">
-    <ItemGroup>
+          BeforeTargets="GenerateTestExecutionScripts">
+    <ItemGroup Condition="'$(TargetOS)'!='Windows_NT'">
       <TestCommandLines Include="source Dumpling.sh" />
-    </ItemGroup>
-    <ItemGroup>
       <PostExecutionTestCommandLines Include="CollectDumps $%3f $(MSBuildProjectName)" />
+    </ItemGroup>
+    <Error Condition="'$(CrashDumpFolder)' == ''" Text="CrashDumpFolder must be set to use Dumpling on Windows." />
+    <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
+      <TestCommandLines Include="python DumplingHelper.py install_dumpling" />
+      <!-- This gets a "before execution" timestamp. It is used in DumplingHelper.py to determine which crash dump files to consider uploading. -->
+      <TestCommandLines Include="for /f &quot;delims=&quot; %%a in ('python DumplingHelper.py get_timestamp') do @set __TIMESTAMP=%%a" />
+      <PostExecutionTestCommandLines Include="python DumplingHelper.py collect_dump %ERRORLEVEL% $(CrashDumpFolder) %__TIMESTAMP% $(MSBuildProjectName)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -14,7 +14,7 @@
       <TestCommandLines Include="source Dumpling.sh" />
       <PostExecutionTestCommandLines Include="CollectDumps $%3f $(MSBuildProjectName)" />
     </ItemGroup>
-    <Error Condition="'$(CrashDumpFolder)' == ''" Text="CrashDumpFolder must be set to use Dumpling on Windows." />
+    <Error Condition="'$(TargetOS)' == 'Windows_NT' And '$(CrashDumpFolder)' == ''" Text="CrashDumpFolder must be set to use Dumpling on Windows." />
     <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
       <TestCommandLines Include="python DumplingHelper.py install_dumpling" />
       <!-- This gets a "before execution" timestamp. It is used in DumplingHelper.py to determine which crash dump files to consider uploading. -->

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -1,0 +1,75 @@
+import os
+import platform
+import urllib
+import glob
+import time
+import sys
+import subprocess
+
+def get_timestamp():
+  print(time.time())
+
+def install_dumpling():
+  if (not os.path.isfile(dumplingPath)):
+    url = "https://dumpling.azurewebsites.net/api/client/dumpling.py"
+    urllib.urlretrieve(url, "dumpling.py")
+    execfile("dumpling.py install --update")
+  subprocess.call([sys.executable, dumplingPath, "install", "--full"])
+
+def find_latest_dump(folder, startTimeStr):
+  startTime = float(startTimeStr)
+  allFiles = glob.glob(folder + "/*");
+  latestFile = max(allFiles, key=os.path.getctime)
+  latestTime = os.path.getctime(latestFile)
+  if (latestTime > startTime):
+    return latestFile
+  else:
+    return None
+
+def collect_dump(exitcode, folder, startTimeStr, projectName):
+  if (exitcode == "0"):
+    return
+  print("Trying to find crash dumps for project: " + projectName)
+  file = find_latest_dump(folder, startTimeStr)
+  if (file is None):
+    print("No new dump file was found in " + folder)
+  else:
+    print("Uploading dump file: " + file)
+    subprocess.call(
+      [sys.executable, dumplingPath, "upload",
+      "--dumppath", file,
+      "--noprompt",
+      "--triage", "full",
+      "--displayname", projectName,
+      "--properties", "STRESS_TESTID="+projectName,
+      "--verbose" ])
+
+def print_usage():
+  print("DumplingHelper.py <command>")
+  print("Commands:")
+  print("  install_dumpling:")
+  print("      - Installs dumpling globally on the machine.")
+  print("  get_timestamp:")
+  print("      - Prints out the current timestamp of the machine.")
+  print("  collect_dump <exitcode> <folder> <starttime> <projectname>:")
+  print("      - Collects and uploads the latest dump (after start time) from the folder to the dumpling service.")
+
+# Main
+def main(argv):
+  if (len(argv) <= 1):
+    print_usage()
+    return
+  if (argv[1] == "install_dumpling"):
+    install_dumpling()
+  elif (argv[1] == "get_timestamp"):
+    get_timestamp()
+  elif (argv[1] == "collect_dump"):
+    collect_dump(argv[2], argv[3], argv[4], argv[5])
+  else:
+    print(argv[1] + " is not a valid command.")
+    print_usage()
+    return
+
+dumplingPath = os.path.expanduser("~/.dumpling/dumpling.py")
+if __name__ == '__main__':
+  main(sys.argv)


### PR DESCRIPTION
@sepidehMS Could you take a look?

This adds support for collecting crash dumps on Windows. The differences between this and the Unix script are just a consequence of the different crash dump collection facilities on the operating systems. Unix systems allow us to have the crash dump files placed directly next to the executable file, which makes them very easy to discover. On Windows, we are able to configure a global location for crash dumps via the registry, and our CI machines are configured to do so.

In addition to specifying `EnableDumpling=true`, Windows users must also specify `CrashDumpFolder=<SOMETHING>` in order for this to discover new crash dumps. The process is as follows:

* Ensure dumpling is installed.
* Collect a timestamp and store it in `__TIMESTAMP`.
* Run the tests.
* Call the DumplingHelper.py script with the above `__TIMESTAMP`, the exit code of the tests, `CrashDumpFolder`, and the name of the project
* If the exit code is non-zero, and a crash dump newer than `__TIMESTAMP` is found, then upload it with some metadata (same as Unix).

I've chosen to write the script in Python. In my opinion, we should unify the applicable portions of the Unix script into DumplingHelper.py, but I haven't done that, yet. We still need some parts of the Unix script to be external to the python script, like the part that sets `ulimit -c unlimited`, which needs to affect the calling process rather than the python sub-process. We should be able to merge things like the actual crash dump uploading logic, though.

The Unix path should be unaffected by these changes.