### PR TITLE
Detach GenFacadesTask trace listener

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
@@ -98,9 +98,12 @@ namespace Microsoft.DotNet.Build.Tasks
             }
             catch (Exception e)
             {
-                Trace.Listeners.Remove(logger);
                 Log.LogErrorFromException(e, showStackTrace: false);
                 return false;
+            }
+            finally
+            {
+                Trace.Listeners.Remove(logger);
             }
         }
     }


### PR DESCRIPTION
This task was leaking the TraceListener then which caused a later
project to log to a previous project's dead TaskLoggingHelper.
On MSBuild core this is causing an error.

/cc @mellinoe @weshaggard 