### PR TITLE
Enable windows symbols packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     select new ManifestFile()
                     {
                         Source = f.GetMetadata(Metadata.FileSource),
-                        Target = f.GetMetadata(Metadata.FileTarget),
+                        Target = f.GetMetadata(Metadata.FileTarget).Replace('/', Path.DirectorySeparatorChar),
                         Exclude = f.GetMetadata(Metadata.FileExclude)
                     }).OrderBy(f => f.Target, StringComparer.OrdinalIgnoreCase).ToList();
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -197,7 +197,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     select new ManifestFile()
                     {
                         Source = f.GetMetadata(Metadata.FileSource),
-                        Target = f.GetMetadata(Metadata.FileTarget).Replace('/', Path.DirectorySeparatorChar),
+                        // Pattern matching in PathResolver requires that we standardize to OS specific directory separator characters
+                        Target = f.GetMetadata(Metadata.FileTarget).Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar),
                         Exclude = f.GetMetadata(Metadata.FileExclude)
                     }).OrderBy(f => f.Target, StringComparer.OrdinalIgnoreCase).ToList();
         }


### PR DESCRIPTION
The PathResolver class used in NuGetPack (https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs#L154), takes into account the OS path directory separator character.  See https://github.com/NuGet/NuGet.Client/blob/c98de8b0635144fb89fd2853b802c03b79f46c2e/src/NuGet.Core/NuGet.Common/PathUtil/PathResolver.cs#L56.  We were previously specifying the manifest file target with '/', which would not get matched by the path resolver on Windows (it wouldn't resolve src content).  This caused us to fail here, https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks.Packaging/src/NuGetPack.cs#L187, and not produce symbols packages.

/cc @dagood @ericstj @ellismg 
