### PR TITLE
First iteration of CloudTest.targets refactoring

### DIFF
--- a/Documentation/Samples/CloudTest.Helix.targets.sampleproject
+++ b/Documentation/Samples/CloudTest.Helix.targets.sampleproject
@@ -1,0 +1,51 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- The only required item type is HelixWorkItem -->
+  <ItemGroup>
+    <HelixWorkItem Include="Demo Work item #1">
+      <Command>call DoStuff.bat</Command>
+      <!-- Needs to be a zip file that contains DoStuff.bat, adjust accordingly -->
+      <PayloadFile>Path to zip</PayloadFile>
+      <WorkItemId>Demo Work item #1</WorkItemId>
+      <TimeoutInSeconds>300</TimeoutInSeconds>
+    </HelixWorkItem>
+
+    <HelixWorkItem Include="Demo Work item #2">
+      <Command>call DoStuff.bat</Command>
+      <!-- Needs to be a zip file that contains DoStuff.bat, adjust accordingly -->
+      <PayloadFile>Path to zip</PayloadFile>
+      <WorkItemId>Demo Work item #2</WorkItemId>
+      <TimeoutInSeconds>200</TimeoutInSeconds>
+    </HelixWorkItem>
+    
+  </ItemGroup>
+  
+  <!-- optionally, we can specify Correlation payload files -->
+  <ItemGroup>
+    <HelixCorrelationPayloadFile Include="CorrelationPayload.zip" />    
+  </ItemGroup>  
+ 
+  <!-- Required properties -->
+  <PropertyGroup>
+    <HelixApiEndpoint>https://helix.int-dot.net/api/2016-06-28/jobs</HelixApiEndpoint>
+    <HelixApiAccessKey></HelixApiAccessKey>
+    <HelixJobType>unspecified/</HelixJobType>
+    <HelixSource>pr/unspecified/</HelixSource>
+    <TargetQueues>Windows.10.Amd64;Windows.7.Amd64;Windows.81.Amd64;Windows.10.Core.Amd64;</TargetQueues>
+    <BuildMoniker>20170301.0000</BuildMoniker>
+    <!-- Use any valid Connection string here --> 
+    <CloudDropConnectionString>...</CloudDropConnectionString>
+    <CloudResultsConnectionString>...</CloudResultsConnectionString>
+    <ArchivesRoot>.</ArchivesRoot>
+    <HelixJobProperties>{ &quot;architecture&quot; : &quot;x64&quot;, &quot;configuration&quot;: &quot;Debug&quot;, &quot;operatingSystem&quot; : &quot;Windows_NT&quot; }</HelixJobProperties>
+  </PropertyGroup>
+
+  <!-- Generally need to have the above stuff defined before import... -->
+  <Import Project="$(BuildToolsTaskDir)\CloudTest.Helix.targets" />
+
+  <Target Name="Build">
+    <Message Text="Beginning Cloud Build!" />
+    <HelixCloudBuild/>
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -24,11 +24,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         ///     The storage api version.
         /// </summary>
         public static readonly string StorageApiVersion = "2015-04-05";
-
         public const string DateHeaderString = "x-ms-date";
-
         public const string VersionHeaderString = "x-ms-version";
-
         public const string AuthorizationHeaderString = "Authorization";
 
         public enum SasAccessType

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -20,6 +20,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="SendJobsToHelix.cs" />
+    <Compile Include="ValidateWorkItems.cs" />
     <Compile Include="AzureConnectionStringBuildTask.cs" />
     <Compile Include="AzureHelper.cs" />
     <Compile Include="CreateAzureContainer.cs" />
@@ -31,6 +33,7 @@
     <Compile Include="UploadClient.cs" />
     <Compile Include="UploadToAzure.cs" />
     <Compile Include="WriteBuildStatsJson.cs" />
+    <Compile Include="RemoveItemMetadata.cs" />
     <Compile Include="WriteItemsToJson.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -1,0 +1,311 @@
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="CreateAzureContainer"             AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="RemoveItemMetadata"               AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="SendJobsToHelix"                  AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="UploadToAzure"                    AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="ValidateWorkItems"                AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="WriteItemsToJson"                 AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="WriteTestBuildStatsJson"          AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="ZipFileCreateFromDirectory"       AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ZipFileCreateFromDependencyLists" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+
+  <!-- See Documentation\Samples\CloudTest.Helix.targets.sampleproject for a sample project.
+  
+       Variables that CloudTest.Helix.Targets cares about:
+       **********************************************************************************************************************************
+       Required Properties:
+       **********************************************************************************************************************************
+       HelixApiAccessKey            - GitHub API Access Key for sending jobs to Helix.  Get from https://helix.dot.net/UserProfile/Index/
+       HelixJobType                 - Job Type formatting string, used for sorting and display of jobs.
+       HelixSource                  - Job Source formatting string, used for sorting and display of jobs.
+       TargetQueues                 - Queue(s) to send Jobs to. (TODO: Need discoverability for users)
+       BuildMoniker                 - Identifying name for build when sending to Helix.  Used for labelling runs.
+       CloudDropConnectionString    - Azure Storage account connection string used for payloads.
+       CloudResultsConnectionString - Azure Storage account connection string used for results.
+       ArchivesRoot                 - Relative path for work item payloads to use.  Blob Uris will be made relative to this.
+       
+       **********************************************************************************************************************************
+       Optional Properties:
+       **********************************************************************************************************************************
+       TestListFilename  - File name to use for test list sent to Helix.                      Default: TestList.json
+       OverwriteOnUpload - Whether to overwrite blobs if they already exist on upload.        Default: False
+       ContainerName     - Container name for uploaded files.                                 Default: build-<Random GUID>. 
+       IsOfficial        - Boolean flag for display on Mission Control.                       Default: False:
+       HelixApiEndpoint  - Endpoint to send jobs to.                                          Default: https://helix.dot.net/api/2016-06-28/jobs
+       CloudResultsReadTokenValidDays  - Days that result URLs produced will be readble       Default: 30
+       CloudResultsWriteTokenValidDays - Days that result URLs produced will be writeable     Default: 4
+       SupplementalPayloadDir - Temp (deletable) dir for assembling supplemental payloads     Default: Random folder in %TEMP%
+       HelixLogFolder    - Folder for storing JSON files describing job start and other info  Default: <Blank>
+       
+       **********************************************************************************************************************************
+       Required ITaskItems:
+       **********************************************************************************************************************************
+       HelixWorkItem         - Zip files to be uploaded as payloads. 
+       
+       **********************************************************************************************************************************
+       Optional ITaskItems:
+       **********************************************************************************************************************************
+       HelixCorrelationPayloadFile - Zip files to be uploaded as correlation payloads (shared by all work items, cached where possible)       
+    -->
+
+  <!-- Main entry point -->
+  <Target Name="HelixCloudBuild"
+          DependsOnTargets="VerifyInputs;PreCloudBuild;ValidateWorkItems;UploadContent;CreateTestListJson" />
+
+  <PropertyGroup>
+    <OverwriteOnUpload Condition="'$(OverwriteOnUpload)' == ''">false</OverwriteOnUpload>
+    <ContainerName Condition="'$(ContainerName)'== ''">build-$([System.Guid]::NewGuid().ToString("N"))</ContainerName>
+    <ContainerName>$(ContainerName.ToLower())</ContainerName>
+    <TestListFilename Condition="'$(TestListFilename)'==''">TestList.json</TestListFilename>
+    <SupplementalPayloadDir Condition="'$(SupplementalPayloadDir)' == ''">$([System.IO.Path]::GetTempPath())$([System.IO.Path]::GetRandomFileName())/SupplementalPayload/</SupplementalPayloadDir>
+    <SupplementalPayloadFilename>SupplementalPayload.zip</SupplementalPayloadFilename>
+    <SupplementalPayloadFile>$(ArchivesRoot)$(SupplementalPayloadFilename)</SupplementalPayloadFile>
+    <IsOfficial Condition="'$(IsOfficial)'!=''">false</IsOfficial>
+    <HelixApiEndpoint Condition="'$(HelixApiEndpoint)'==''">https://helix.dot.net/api/2016-06-28/jobs</HelixApiEndpoint>
+  </PropertyGroup>
+
+  <Target Name="VerifyInputs">
+    <!-- Verify all required properties have been specified.  Update the comment above if you update this list! -->
+    <Error Condition="'$(ArchivesRoot)' == ''"                                         Text="Missing required property ArchivesRoot." />
+    <Error Condition="'$(HelixApiAccessKey)' == ''"                                    Text="Missing required property HelixApiAccessKey." />
+    <Error Condition="'$(HelixJobType)' == ''"                                         Text="Missing required property HelixJobType." />
+    <Error Condition="'$(HelixSource)' == ''"                                          Text="Missing required property HelixSource." />
+    <Error Condition="'$(TargetQueues)' == ''"                                         Text="Missing required property TargetQueues." />
+    <Error Condition="'$(BuildMoniker)' == ''"                                         Text="Missing required property BuildMoniker." />
+    <Error Condition="'$(CloudDropConnectionString)' == ''"                            Text="Missing required property CloudDropConnectionString." />
+    <Error Condition="'$(CloudResultsConnectionString)' == ''"                         Text="Missing required property CloudResultsConnectionString." />
+    <Error Condition="'$(SkipSendToHelix)' != 'true' and '$(HelixApiAccessKey)' == ''" Text="HelixApiAccessKey must be set to start Helix jobs" />
+    <Error Condition="'$(HelixJobProperties)' == ''"                                   Text="HelixJobProperties must be set to start Helix jobs" />
+  </Target>
+
+  <!-- Provided as an extensibility point for targets to run before the real work begins -->
+  <Target Name="PreCloudBuild">
+
+    <!-- Copy runner scripts so they can be uploaded as supplemental payload -->
+    <ItemGroup>
+      <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.py" />
+      <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.sh" />
+      <RunnerScripts Include="$(ToolsDir)RunnerScripts/**/*.txt" />
+    </ItemGroup>
+
+    <!-- Split up Target Queues list -->
+    <ItemGroup>
+      <TargetQueue Include="$(TargetQueues)" />
+    </ItemGroup>
+    <Message Text="Will Enqueue to @(TargetQueue->Count()) Queue(s) : @(TargetQueue)" />
+
+    <!-- Compress the supplemental payload directory for upload -->
+    <MakeDir Directories="$(SupplementalPayloadDir)"/>
+    <Copy SourceFiles="@(RunnerScripts)"
+          DestinationFiles="@(RunnerScripts->'$(SupplementalPayloadDir)RunnerScripts/%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="true" />
+    <ZipFileCreateFromDirectory
+        SourceDirectory="$(SupplementalPayloadDir)"
+        DestinationArchive="$(SupplementalPayloadFile)"
+        OverwriteDestination="true" />
+    <RemoveDir Directories="$(SupplementalPayloadDir)"/>
+    <ItemGroup>
+      <SupplementalPayload Include="$(SupplementalPayloadFile)">
+        <RelativeBlobPath>$(SupplementalPayloadFilename)</RelativeBlobPath>
+      </SupplementalPayload>
+    </ItemGroup>
+  </Target>
+
+  <!-- Make sure the work items included contain all the required fields, calculate relative blob paths -->
+  <Target Name="ValidateWorkItems">
+    <ValidateWorkItems WorkItems="@(HelixWorkItem)" WorkItemArchiveRoot="$(ArchivesRoot)">
+      <Output TaskParameter="ProcessedWorkItems" ItemName="HelixProcessedWorkItem"/>
+    </ValidateWorkItems>
+  </Target>
+
+  <!-- Create Azure containers and file shares -->
+  <Target Name="CreateAzureStorage">
+    <CreateAzureContainer
+      ConnectionString="$(CloudDropConnectionString)"
+      ContainerName="$(ContainerName)"
+      ReadOnlyTokenDaysValid="30">
+      <Output TaskParameter="StorageUri" PropertyName="DropUri" />
+      <Output TaskParameter="ReadOnlyToken" PropertyName="DropUriReadOnlyToken" />
+    </CreateAzureContainer>
+
+    <PropertyGroup>
+      <CloudResultsReadTokenValidDays  Condition="'$(CloudResultsReadTokenValidDays)' == ''">30</CloudResultsReadTokenValidDays>
+      <CloudResultsWriteTokenValidDays Condition="'$(CloudResultsWriteTokenValidDays)' == ''">4</CloudResultsWriteTokenValidDays>
+    </PropertyGroup>
+
+    <CreateAzureContainer
+      ConnectionString="$(CloudResultsConnectionString)"
+      ContainerName="$(ContainerName)"
+      ReadOnlyTokenDaysValid ="$(CloudResultsReadTokenValidDays)"
+      WriteOnlyTokenDaysValid="$(CloudResultsWriteTokenValidDays)">
+
+      <Output TaskParameter="StorageUri"     PropertyName="ResultsUri" />
+      <Output TaskParameter="ReadOnlyToken"  PropertyName="ResultsReadOnlyToken" />
+      <Output TaskParameter="WriteOnlyToken" PropertyName="ResultsWriteOnlyToken" />
+    </CreateAzureContainer>
+  </Target>
+
+  <!-- Upload content to Azure (Everything except test list) -->
+  <Target Name="UploadContent" DependsOnTargets="CreateAzureStorage">
+    <ItemGroup>
+      <LocalFileForUpload Include="@(HelixProcessedWorkItem->Metadata('PayloadFile'))">
+        <RelativeBlobPath>%(RelativeBlobPath)</RelativeBlobPath>
+      </LocalFileForUpload>
+      <!-- For now assume these all go in the root of the container -->
+      <LocalPayloadFileForUpload Include="@(HelixCorrelationPayloadFile)">
+        <RelativeBlobPath>%(FileName)%(Extension)</RelativeBlobPath>
+      </LocalPayloadFileForUpload>
+    </ItemGroup>
+
+    <!-- Debug output of work items, and a warning if there are none. -->
+    <Message Text="Files for upload :: @(LocalFileForUpload)" Importance="Low" />
+
+    <!-- Verify the test archives were created -->
+    <Warning Condition="'@(LocalFileForUpload->Count())' == '0'" Text="Didn't find any archives in supplied HelixWorkItem(s)." />
+
+    <!-- Work Item payloads -->
+    <UploadToAzure
+      Condition="'@(LocalFileForUpload->Count())' != '0'"
+      ConnectionString="$(CloudDropConnectionString)"
+      ContainerName="$(ContainerName)"
+      Items="@(LocalFileForUpload->Distinct())"
+      Overwrite="$(OverwriteOnUpload)" />
+
+    <!-- Correlation payload(s) -->
+    <UploadToAzure
+      Condition="'@(LocalPayloadFileForUpload->Count())' != '0'"
+      ConnectionString="$(CloudDropConnectionString)"
+      ContainerName="$(ContainerName)"
+      Items="@(LocalPayloadFileForUpload->Distinct())"
+      Overwrite="$(OverwriteOnUpload)" />
+
+    <!-- Supplemental payload.  TODO: This could be combined with Correlation Payload items, there's not much(any?) difference -->
+    <UploadToAzure
+      ConnectionString="$(CloudDropConnectionString)"
+      ContainerName="$(ContainerName)"
+      Items="@(SupplementalPayload)"
+      Overwrite="$(OverwriteOnUpload)"
+      Condition="'@(SupplementalPayload)' != ''" />
+
+  </Target>
+
+  <Target Name="CreateTestListJson">
+    <!-- We always bring the supplemental payload folder.  
+         This contains whatever's in src\Microsoft.DotNet.Build.CloudTestTasks\RunnerScripts,
+         but can also contain various other stuff.  
+         -->
+    <ItemGroup>
+      <CorrelationPayloadUri Include="@(SupplementalPayload->'$(DropUri)%(RelativeBlobPath)$(DropUriReadOnlyToken)')" />
+      <CorrelationPayloadUri Include="@(LocalPayloadFileForUpload->'$(DropUri)%(RelativeBlobPath)$(DropUriReadOnlyToken)')" />
+    </ItemGroup>
+    <PropertyGroup>
+      <!-- Flatten it into a property as msbuild chokes on @(CorrelationPayloadUri) in CorrelationPayloadUris -->
+      <CorrelationPayloadUris>@(CorrelationPayloadUri)</CorrelationPayloadUris>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <HelixProcessedWorkItem>
+        <Command>%(Command)</Command>
+        <CorrelationPayloadUris>[$(CorrelationPayloadUris)]</CorrelationPayloadUris>
+        <PayloadUri>$(DropUri)%(RelativeBlobPath)$(DropUriReadOnlyToken)</PayloadUri>
+        <WorkItemId>%(WorkItemId)</WorkItemId>
+        <TimeoutInSeconds>%(TimeoutInSeconds)</TimeoutInSeconds>
+      </HelixProcessedWorkItem>
+    </ItemGroup>
+
+    <!-- I'd love a built-in way to do this, but I'm compromising here since this lets us use 
+         arbitrary extra metadata in the future to compose work items, then strip out extra stuff used along the way.
+         It lets us use a single item to bring along everything we might possibly need in the future -->
+    <RemoveItemMetadata Items="@(HelixProcessedWorkItem)" FieldsToRemove="RelativeBlobPath;PayloadFile">
+      <Output TaskParameter="ProcessedItems" ItemName="HelixProcessedWorkItemForList"/>
+    </RemoveItemMetadata>
+
+    <WriteItemsToJson JsonFileName="$(TestListFilename)" Items="@(HelixProcessedWorkItemForList)" />
+    <ItemGroup>
+      <HelixWorkItemList Include="$(TestListFilename)">
+        <RelativeBlobPath>$(TestListFilename)</RelativeBlobPath>
+        <BuildCompleteJson>$(HelixLogFolder)BuildComplete.json</BuildCompleteJson>
+        <OfficialBuildJson>$(HelixLogFolder)OfficialBuild.json</OfficialBuildJson>
+        <HelixJobUploadCompletePath>$(HelixLogFolder)helixjobuploadcomplete.sem</HelixJobUploadCompletePath>
+      </HelixWorkItemList>
+    </ItemGroup>
+
+    <UploadToAzure
+     ConnectionString="$(CloudDropConnectionString)"
+     ContainerName="$(ContainerName)"
+     Items="@(HelixWorkItemList)"
+     Overwrite="$(OverwriteOnUpload)" />
+  </Target>
+
+  <!-- Write event hub notification JSON files -->
+  <Target Name="WriteCompletionEvent"
+          AfterTargets="CreateTestListJson"
+          Inputs="%(HelixWorkItemList.Identity)"
+          Outputs="%(HelixWorkItemList.BuildCompleteJson)">
+
+    <CreateItem Include="@(TargetQueue)" AdditionalMetadata="ResultsUri=$(ResultsUri)%(TargetQueue.Identity)/;QueueId=%(TargetQueue.Identity)">
+      <Output TaskParameter="Include" ItemName="BuildCompleteTemplateV2" />
+    </CreateItem>
+
+    <ItemGroup>
+      <!-- V1 is long since deprecated, and not supported here.  
+           Keeping the name for clarity.                       -->
+      <BuildCompleteTemplateV2>
+        <DropContainerSAS>$(DropUriReadOnlyToken)</DropContainerSAS>
+        <ListUri>$(DropUri)%(HelixWorkItemList.Filename)%(HelixWorkItemList.Extension)$(DropUriReadOnlyToken)</ListUri>
+        <ResultsUriRSAS>$(ResultsReadOnlyToken)</ResultsUriRSAS>
+        <ResultsUriWSAS>$(ResultsWriteOnlyToken)</ResultsUriWSAS>
+        <Build>$(BuildMoniker)</Build>
+        <Type>$(HelixJobType)</Type>
+        <Source>$(HelixSource)</Source>
+        <Properties>$(HelixJobProperties)</Properties>
+      </BuildCompleteTemplateV2>
+      <BuildComplete Include="@(BuildCompleteTemplateV2)"/>
+    </ItemGroup>
+
+    <WriteItemsToJson JsonFileName="%(HelixWorkItemList.BuildCompleteJson)" Items="@(BuildComplete)" />
+    <Message Text="Wrote build complete JSON for @(BuildComplete->Count()) Queues." />
+
+  </Target>
+
+  <!-- Send completion event to Helix API -->
+  <Target Name="SendCompletionEvent"
+          AfterTargets="WriteCompletionEvent"
+          Inputs="%(HelixWorkItemList.BuildCompleteJson)"
+          Outputs="%(HelixWorkItemList.HelixJobUploadCompletePath)"
+          Condition="'$(SkipSendToHelix)' != 'true'">
+    <Error Condition=" '$(HelixApiAccessKey)' == '' " Text="Either provide a value for HelixApiAccessKey or set SkipSendToHelix to 'true'" ContinueOnError="false" />
+    <SendJobsToHelix
+      AccessToken="$(HelixApiAccessKey)"
+      ApiEndpoint="$(HelixApiEndpoint)"
+      EventDataPath="%(HelixWorkItemList.BuildCompleteJson)">
+      <Output TaskParameter="JobIds" ItemName="GeneratedCorrelationId" />
+    </SendJobsToHelix>
+
+    <!-- Upload the Correlation Ids generated to the test drop container for tracking purposes-->
+    <PropertyGroup>
+      <CorrelationFileName>Helix-correlation-infos.txt</CorrelationFileName>
+      <GeneratedCorrelationIds>@(GeneratedCorrelationId)</GeneratedCorrelationIds>
+    </PropertyGroup>
+    <WriteLinesToFile File="%(HelixWorkItemList.HelixJobUploadCompletePath)" Overwrite="true" Lines="Correlation Ids : $(GeneratedCorrelationIds) "/>
+    <ItemGroup>
+      <CorrelationFile Include="$(ArchivesRoot)$(CorrelationFileName)">
+        <RelativeBlobPath>Tracking/$(CorrelationFileName)</RelativeBlobPath>
+      </CorrelationFile>
+    </ItemGroup>
+
+    <WriteLinesToFile
+        File="@(CorrelationFile)"
+        Lines="@(GeneratedCorrelationId)"
+        Overwrite="true" />
+
+    <UploadToAzure
+        ConnectionString="$(CloudDropConnectionString)"
+        ContainerName="$(ContainerName)"
+        Items="@(CorrelationFile)"
+        Overwrite="true" />
+
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RemoveItemMetadata.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RemoveItemMetadata.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public sealed class RemoveItemMetadata : Task
+    {
+        /// <summary>
+        /// Semicolon or comma-delineated list of metadata fields to strip from items.
+        /// </summary>
+        [Required]
+        public string FieldsToRemove { get; set; }
+
+        /// <summary>
+        /// An item group to remove the specified metadata fields from.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        /// <summary>
+        /// Input items with metadata stripped out.
+        /// </summary>
+        [Output]
+        public ITaskItem[] ProcessedItems { get; set; }
+
+        public override bool Execute()
+        {
+            string [] fields = FieldsToRemove.Split(new char [] { ',', ';'});
+
+            if (fields.Length == 0)
+            {
+                Log.LogWarning("No metadata field names specified, returning");
+                return true;
+            }
+            ProcessedItems = new ITaskItem[Items.Length];
+            for (int i = 0; i < Items.Length; i++)
+            {
+                ITaskItem current = Items[i];
+                foreach (string fieldName in fields)
+                {
+                    if (current.GetMetadata(fieldName) != null)
+                    {
+                        current.RemoveMetadata(fieldName);
+                    }
+                }
+                ProcessedItems[i] = current;
+            }
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/SendJobsToHelix.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/SendJobsToHelix.cs
@@ -1,0 +1,160 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    // This is very similar to what SendToHelix does, with one difference:
+    // It accepts JSON containing an array of job objects, and deserializes them to a strongly typed object.
+    // This gives us error checking before pushing to Helix, and ensures "old" code does not break.
+    // We should eventually refactor both to use shared functionality.
+    public sealed class SendJobsToHelix : Microsoft.Build.Utilities.Task
+    {
+        /// <summary>
+        /// Api endpoint for sending jobs.
+        /// e.g. https://helixview.azurewebsites.net/api/jobs
+        /// </summary>
+        [Required]
+        public string ApiEndpoint { get; set; }
+
+        /// <summary>
+        /// Access token for API. To obtain, see the profile on the server corresponding to the API endpoint.
+        /// e.g. https://helixview.azurewebsites.net/UserProfile
+        /// </summary>
+        [Required]
+        public string AccessToken { get; set; }
+
+        /// <summary>
+        /// The event data path used to form the body stream.
+        /// </summary>
+        [Required]
+        public string EventDataPath { get; set; }
+
+        /// <summary>
+        /// Once a helix job is started, this is the identifier of that job
+        /// </summary>
+        [Output]
+        public string [] JobIds { get; set; }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task<bool> ExecuteAsync()
+        {
+            List<string> jobIds = new List<string>();
+            string joinCharacter = ApiEndpoint.Contains("?") ? "&" : "?";
+            string apiUrl = ApiEndpoint + joinCharacter + "access_token=" + Uri.EscapeDataString(AccessToken);
+
+            Log.LogMessage(MessageImportance.Normal, "Posting job to {0}", ApiEndpoint);
+            Log.LogMessage(MessageImportance.Low,    "Using Job Event json from ", EventDataPath);
+
+            string buildJsonText = File.ReadAllText(EventDataPath);
+
+            List<JObject> allBuilds = new List<JObject>();
+            try
+            {
+                allBuilds.AddRange(JsonConvert.DeserializeObject<List<JObject>>(buildJsonText));
+            }
+            catch (JsonSerializationException)
+            {
+                // If this fails, we'll let it tear us down.  
+                // Since if this isn't even valid JSON there's no use posting it.
+                allBuilds.Add(JsonConvert.DeserializeObject<JObject>(buildJsonText));
+            }
+
+            using (HttpClient client = new HttpClient())
+            {
+                const int MaxAttempts = 15;
+                // add a bit of randomness to the retry delay
+                var rng = new Random();
+                int retryCount = MaxAttempts;
+
+                foreach (JObject jobStartMessage in allBuilds)
+                {
+                    bool keepTrying = true;
+                    while (keepTrying)
+                    {
+                        HttpResponseMessage response = new HttpResponseMessage();
+
+                        try
+                        {
+                            // This tortured way to get the HTTPContent is to work around that StringContent doesn't allow application/json
+                            HttpContent contentStream = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jobStartMessage.ToString())));
+                            contentStream.Headers.Add("Content-Type", "application/json");
+                            response = await client.PostAsync(apiUrl, contentStream);
+
+                            if (response.IsSuccessStatusCode)
+                            {
+                                JObject responseObject = new JObject();
+                                using (Stream stream = await response.Content.ReadAsStreamAsync())
+                                using (StreamReader streamReader = new StreamReader(stream))
+                                {
+                                    string jsonResponse = streamReader.ReadToEnd();
+                                    try
+                                    {
+                                        using (JsonReader jsonReader = new JsonTextReader(new StringReader(jsonResponse)))
+                                        {
+                                            responseObject = JObject.Load(jsonReader);
+                                        }
+                                    }
+                                    catch 
+                                    {
+                                        Log.LogWarning($"Hit exception attempting to parse JSON response.  Raw response string: {Environment.NewLine} {jsonResponse}");
+                                    }
+                                }
+
+                                string jobId = (string)responseObject["Name"];
+                                jobIds.Add(jobId);
+                                if (String.IsNullOrEmpty(jobId))
+                                {
+                                    Log.LogError("Publish to '{0}' did not return a job ID", ApiEndpoint);
+                                }
+
+                                Log.LogMessage(MessageImportance.High, "Started Helix job: CorrelationId = {0}", jobId);
+                                keepTrying = false;
+                            }
+                            else
+                            {
+                                string responseContent = await response.Content.ReadAsStringAsync();
+                                Log.LogWarning($"Helix Api Response: StatusCode {response.StatusCode} {responseContent}");
+                            }
+                        }
+                        // still allow other types of exceptions to tear down the task for now
+                        catch (HttpRequestException toLog)
+                        {
+                            Log.LogWarning("Exception thrown attempting to submit job to Helix:");
+                            Log.LogWarningFromException(toLog, true);
+                        }
+
+                        if (retryCount-- <= 0)
+                        {
+                            Log.LogError($"Unable to publish to '{ApiEndpoint}' after {MaxAttempts} retries. Received status code: {response.StatusCode} {response.ReasonPhrase}");
+                            keepTrying = false;
+                        }
+                        if (keepTrying)
+                        {
+                            Log.LogWarning("Failed to publish to '{0}', {1} retries remaining", ApiEndpoint, retryCount);
+                            int delay = (MaxAttempts - retryCount) * rng.Next(1, 7);
+                            await System.Threading.Tasks.Task.Delay(delay * 1000);
+                        }
+                    }
+                }
+                JobIds = jobIds.ToArray();
+                // Number of queued builds = number in that file == success.
+                return allBuilds.Count == jobIds.Count;
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/ValidateWorkItems.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/ValidateWorkItems.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public class ValidateWorkItems : Task
+    {
+        private List<ITaskItem> processedWorkItems = new List<ITaskItem>();
+
+        /// <summary>
+        /// Helix work items to be validated.
+        /// Checks include making sure minimum metadata is present and that the path is relative to the supplied root path.
+        /// </summary>
+        public ITaskItem[] WorkItems { get; set; }
+
+        [Output]
+        public ITaskItem [] ProcessedWorkItems { get; set; }
+
+        /// <summary>
+        /// While we're validating, may as well calculate the relative blob path
+        /// Since we'd also like to be able to check that the path makes sense.
+        /// Ignore this check if the item already has this metadata.
+        /// </summary>
+        public String WorkItemArchiveRoot { get; set; }
+
+        private readonly string[] requiredMetadataFields = { "TimeoutInSeconds", "Command", "PayloadFile" };
+
+        public override bool Execute()
+        {
+            bool success = true;
+            foreach (ITaskItem workItem in WorkItems)
+            {
+                success &= ProcessWorkItem(workItem);
+            }
+            ProcessedWorkItems = processedWorkItems.ToArray();
+            Log.LogMessage(MessageImportance.Low, $"Examined {WorkItems.Length} workitems.  Success: {success}");
+
+            return success;
+        }
+
+        private bool ProcessWorkItem(ITaskItem workItem)
+        {
+            bool validWorkItem = true;
+            // For now, we'll just make sure the required fields are present.  
+            // Later, we could prevent extra stuff from going in, but that's 
+            // not necessary as we create the processed work items off a specific set.
+            foreach (string requiredField in requiredMetadataFields)
+            {
+                if (string.IsNullOrEmpty(workItem.GetMetadata(requiredField)))
+                {
+                    Log.LogError($"Work item '{workItem.ItemSpec}' is missing field {requiredField}");
+                    validWorkItem = false;
+                }
+            }
+
+            if (string.IsNullOrEmpty(workItem.GetMetadata("RelativeBlobPath")))
+            {
+                workItem.SetMetadata("RelativeBlobPath", GetRelativeFilePath(WorkItemArchiveRoot, workItem.GetMetadata("PayloadFile")));
+            }
+            // We could easily choose to not include invalid work items here, then warn instead of error.
+            processedWorkItems.Add(workItem);
+            return validWorkItem;
+        }
+
+        private string GetRelativeFilePath(string root, string path)
+        {
+            string fullRoot = Path.GetFullPath(root);
+            string fullPath = Path.GetFullPath(path);
+
+            if (fullPath.StartsWith(fullRoot))
+            {
+                string relativePath = fullPath.Substring(fullRoot.Length);
+                relativePath = relativePath.Replace('\\', '/');
+                // Trim off the slash, this confuses blob storage and makes a folder named "/"
+                if (relativePath.Length > 0 && relativePath.StartsWith("/"))
+                {
+                    relativePath = relativePath.Substring(1);
+                }
+                return relativePath;                
+            }
+            else
+            {
+                Log.LogWarning($"{path} is not contained under {root}!");
+                return Path.GetFileName(path);
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/WriteItemsToJson.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/WriteItemsToJson.cs
@@ -36,8 +36,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             if (Items.Length == 0)
                 throw new ArgumentException("The provided items contained zero entries.");
 
-            if (!Directory.Exists(Path.GetDirectoryName(JsonFileName)))
+            if (!Directory.Exists(Path.GetDirectoryName(Path.GetFullPath(JsonFileName))))
+            {
                 Directory.CreateDirectory(Path.GetDirectoryName(JsonFileName));
+            }
 
             JsonSerializer jsonSerializer = new JsonSerializer();
             using (FileStream fs = File.Create(JsonFileName))


### PR DESCRIPTION
Enables sending to > 1 queue and per-workitem settings.

Repo-independent logic now lives in CloudTest.Helix.Targets.  When a repo is ready for this, they simply construct the required items and properties, and invoke the HelixCloudBuild target.

Stop by my office for a demo of what a project/builds file consuming this would look like (will prepare a sample for the repo as well, but need to strip secrets out of it first)

@wtgodbe @weshaggard @joperezr 