### PR TITLE
Don't convert to meta-package reference for packages that are part of the meta-package

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -710,8 +710,10 @@
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />
     </PromoteDependencies>
 
-    <ApplyMetaPackages OriginalDependencies="@(FilePackageDependency)"
-                       PackageIndexes="@(PackageIndex)">
+    <ApplyMetaPackages PackageId="$(Id)"
+                       OriginalDependencies="@(FilePackageDependency)"
+                       PackageIndexes="@(PackageIndex)"
+                       Condition="'$(SkipApplyMetaPackages)' != 'true'">
       <Output TaskParameter="UpdatedDependencies" ItemName="_ConsolidatedDependencies" />
     </ApplyMetaPackages>
                        


### PR DESCRIPTION
For some packages they are already referenced by the meta-package and for those we should
not convert them to having a reference to the meta-package as it will create a cycle. Instead
those still need to reference the individual packages.

cc @ericstj 

This fixes the current package cycle we have in System.Net.Http and System.Runtime.InteropServices.RuntimeInformation packages.