### PR TITLE
Add support for by-ref returns from methods and properties

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Cci.Writers.CSharp
             if (!isOperator && !method.IsConstructor)
             {
                 WriteAttributes(method.ReturnValueAttributes, true);
+
+                if (method.ReturnValueIsByRef)
+                    WriteKeyword("ref");
+
                 // We are ignoring custom modifiers right now, we might need to add them later.
                 WriteTypeName(method.Type, method.ContainingType, isDynamic: IsDynamic(method.ReturnValueAttributes));
             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -63,7 +63,11 @@ namespace Microsoft.Cci.Writers.CSharp
             if (property.GetHiddenBaseProperty(_filter) != Dummy.Property)
                 WriteKeyword("new");
 
+            if (property.ReturnValueIsByRef)
+                WriteKeyword("ref");
+
             WriteTypeName(property.Type);
+
             if (isIndexer)
             {
                 int index = property.Name.Value.LastIndexOf(".");


### PR DESCRIPTION
Here is the diff when running on `System.Runtime.CompilerServices.Unsafe`:

```diff
--- D:\Temp\usnafe_compare\before.cs	2017-03-07 15:06:54.000000000 -0800
+++ D:\Temp\usnafe_compare\after.cs	2017-03-07 15:07:46.000000000 -0800
@@ -10,23 +10,23 @@
 [assembly:System.Reflection.AssemblyTitleAttribute("System.Runtime.CompilerServices.Unsafe")]
 [assembly:System.Runtime.CompilerServices.CompilationRelaxationsAttribute(8)]
 [assembly:System.Runtime.CompilerServices.RuntimeCompatibilityAttribute(WrapNonExceptionThrows=true)]
 namespace System.Runtime.CompilerServices {
   public static partial class Unsafe {
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
-    public static T Add<T>(ref T source, int elementOffset) { return default(T); }
+    public static ref T Add<T>(ref T source, int elementOffset) { return default(T); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public static bool AreSame<T>(ref T left, ref T right) { return default(bool); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public static T As<T>(object o) where T : class { return default(T); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
-    public static TTo As<TFrom, TTo>(ref TFrom source) { return default(TTo); }
+    public static ref TTo As<TFrom, TTo>(ref TFrom source) { return default(TTo); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public unsafe static void* AsPointer<T>(ref T value) { return default(void*); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
-    public unsafe static T AsRef<T>(void* source) { return default(T); }
+    public unsafe static ref T AsRef<T>(void* source) { return default(T); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public unsafe static void Copy<T>(ref T destination, void* source) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public unsafe static void Copy<T>(void* destination, ref T source) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public unsafe static void CopyBlock(void* destination, void* source, uint byteCount) { }
@@ -34,11 +34,11 @@
     public unsafe static void InitBlock(void* startAddress, byte value, uint byteCount) { }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public unsafe static T Read<T>(void* source) { return default(T); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public static int SizeOf<T>() { return default(int); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
-    public static T Subtract<T>(ref T source, int elementOffset) { return default(T); }
+    public static ref T Subtract<T>(ref T source, int elementOffset) { return default(T); }
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)][System.Runtime.Versioning.NonVersionableAttribute]
     public unsafe static void Write<T>(void* destination, T value) { }
   }
 }
```

I also compared the previous/new output for .NET Framework 4.6.2. A few ref returns showed up, but they are all in the Microsoft.VisualC assembly, which tells they are expected, too.

@weshaggard 