### PR TITLE
Build & package .NET Framework versions of API Compat and Gen Facades

### DIFF
--- a/src/ApiCompat.Desktop/ApiCompat.Desktop.csproj
+++ b/src/ApiCompat.Desktop/ApiCompat.Desktop.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ApiCompat</RootNamespace>
+    <AssemblyName>ApiCompat</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
+    <CLSCompliant>false</CLSCompliant>
+    <ApiCompatSrc>..\ApiCompat</ApiCompatSrc>
+    <ProjectGuid>{74B5F416-4C61-4543-A34B-EE182F3A1929}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <ItemGroup>
+    <Compile Include="$(ApiCompatSrc)\**\*.cs" />
+  </ItemGroup>
+  <!-- Common command-line helper sources -->
+  <ItemGroup>
+    <Compile Include="$(CommonPath)\CommandLine.cs">
+      <Link>Common\CommandLine.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\CommandLineTraceHandler.cs">
+      <Link>Common\CommandLineTraceHandler.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\ConsoleTraceListener.cs">
+      <Link>Common\ConsoleTraceListener.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.CCI.Extensions\Microsoft.CCI.Extensions.csproj" />
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), publishexe.targets))\publishexe.targets" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/ApiCompat.Desktop/App.config
+++ b/src/ApiCompat.Desktop/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/src/ApiCompat.Desktop/project.json
+++ b/src/ApiCompat.Desktop/project.json
@@ -1,0 +1,20 @@
+{
+  "dependencies": {
+    "Microsoft.Cci": "4.0.0-rc4-24217-00",
+    "Microsoft.Composition": "1.0.30",
+    "System.Console": "4.0.0",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0",
+    "System.Diagnostics.TraceSource": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.0.0",
+    "System.Runtime": "4.0.20"
+  },
+  "frameworks": {
+    "net46": {}
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
+}

--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -61,6 +61,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenFacades.Core", "GenFacad
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenFacades.Console", "GenFacades\GenFacades.Console\GenFacades.Console.csproj", "{FBF64156-B82B-421C-AADB-8F7BAC3B0D7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiCompat.Desktop", "ApiCompat.Desktop\ApiCompat.Desktop.csproj", "{74B5F416-4C61-4543-A34B-EE182F3A1929}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiCompat", "ApiCompat\ApiCompat.csproj", "{D0BA507E-778D-4BB3-9128-68177117E13C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -425,6 +429,46 @@ Global
 		{FBF64156-B82B-421C-AADB-8F7BAC3B0D7F}.Release|x64.Build.0 = Release|Any CPU
 		{FBF64156-B82B-421C-AADB-8F7BAC3B0D7F}.Release|x86.ActiveCfg = Release|Any CPU
 		{FBF64156-B82B-421C-AADB-8F7BAC3B0D7F}.Release|x86.Build.0 = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|ARM.Build.0 = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|x64.Build.0 = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Debug|x86.Build.0 = Debug|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|ARM.ActiveCfg = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|ARM.Build.0 = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|x64.ActiveCfg = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|x64.Build.0 = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|x86.ActiveCfg = Release|Any CPU
+		{74B5F416-4C61-4543-A34B-EE182F3A1929}.Release|x86.Build.0 = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|ARM.Build.0 = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Debug|x86.Build.0 = Debug|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|ARM.ActiveCfg = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|ARM.Build.0 = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|x64.ActiveCfg = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|x64.Build.0 = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|x86.ActiveCfg = Release|Any CPU
+		{D0BA507E-778D-4BB3-9128-68177117E13C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/nuget/Microsoft.DotNet.BuildTools.ApiCompat.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.ApiCompat.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.BuildTools.ApiCompat</id>
+    <version>1.0.0-beta3</version>
+    <title>API Compatibility Checker (ApiCompat)</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>A tool that can be used to generate source for a reference assembly.</summary>
+    <description>This package provides a tool to check whether a compiling against assembly A will produce code that can run on assembly set B.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+      <!-- Currently we redistribute the dependencies locally since nuget has no 
+           support for treating packages as build dependencies.-->
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="ApiCompat.Desktop\ApiCompat.exe" target="tools" />
+    <file src="ApiCompat.Desktop\ApiCompat.exe.config" target="tools" />
+    <file src="ApiCompat.Desktop\*.dll" target="tools" />
+  </files>  
+</package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.GenFacades.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.GenFacades.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.BuildTools.GenFacades</id>
+    <version>1.0.0-beta3</version>
+    <title>Facade Generator (GenFacade)</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>A tool that can be used to generate source for a reference assembly.</summary>
+    <description>This package provides build-time support generating reference facade assemblies.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+      <!-- Currently we redistribute the dependencies locally since nuget has no 
+           support for treating packages as build dependencies.-->
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="GenFacades.Console.net46\*.*" target="tools" />
+  </files>  
+</package>


### PR DESCRIPTION
The .NET Framework version of GenAPI is already packaged as

    Microsoft.DotNet.BuildTools.GenAPI

This commit adds similar packages for API Compat and GenFacades.

@weshaggard 