### PR TITLE
Provide a package for CCI + CCI Extensions

### DIFF
--- a/src/nuget/Microsoft.DotNet.BuildTools.Cci.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.Cci.nuspec
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.BuildTools.Cci</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft DotNet BuildTools CCI</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>.NET Core Framework Build Tools</summary>
+    <description>This package provides build-time support for the .NET Core Framework libraries.  You should not need to reference this package from your project.</description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+        <dependency id="System.Collections" version="4.3.0" />
+        <dependency id="System.Collections.NonGeneric" version="4.0.1" />
+        <dependency id="System.Composition.AttributedModel" version="1.0.30" />
+        <dependency id="System.Composition.Hosting" version="1.0.30" />
+        <dependency id="System.Composition.Runtime" version="1.0.30" />
+        <dependency id="System.Composition.TypedParts" version="1.0.30" />
+        <dependency id="System.Console" version="4.3.0" />
+        <dependency id="System.Diagnostics.Debug" version="4.3.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+        <dependency id="System.Globalization" version="4.3.0" />
+        <dependency id="System.IO" version="4.3.0" />
+        <dependency id="System.IO.FileSystem" version="4.3.0" />
+        <dependency id="System.IO.FileSystem.Primitives" version="4.3.0" />
+        <dependency id="System.Linq" version="4.3.0" />
+        <dependency id="System.Reflection" version="4.3.0" />
+        <dependency id="System.Resources.ResourceManager" version="4.3.0" />
+        <dependency id="System.Runtime" version="4.3.0" />
+        <dependency id="System.Runtime.Extensions" version="4.3.0" />
+        <dependency id="System.Runtime.InteropServices" version="4.3.0" />
+        <dependency id="System.Text.Encoding" version="4.3.0" />
+        <dependency id="System.Text.RegularExpressions" version="4.3.0" />
+        <dependency id="System.Threading" version="4.3.0" />
+        <dependency id="System.Xml.XDocument" version="4.3.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="BclRewriter\Microsoft.Cci.dll" target="lib\netstandard13" />
+    <file src="Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.dll" target="lib\netstandard13" />
+  </files>
+</package>


### PR DESCRIPTION
There is currently now way to acquire CCI by itself; one can install the build tools package directly but this also installs a bunch of targets which regular projects most likely cannot use anyway.

@weshaggard 