### PR TITLE
Add version.txt to every BuildTools package root

### DIFF
--- a/src/nuget/Microsoft.DotNet.BuildTools.ApiCompat.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.ApiCompat.nuspec
@@ -23,5 +23,7 @@
     <file src="ApiCompat.Desktop\ApiCompat.exe" target="tools" />
     <file src="ApiCompat.Desktop\ApiCompat.exe.config" target="tools" />
     <file src="ApiCompat.Desktop\*.dll" target="tools" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>  
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.Cci.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.Cci.nuspec
@@ -43,5 +43,7 @@
   <files>
     <file src="BclRewriter\Microsoft.Cci.dll" target="lib\netstandard13" />
     <file src="Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.dll" target="lib\netstandard13" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.GenAPI.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.GenAPI.nuspec
@@ -25,6 +25,8 @@
     <file src="GenAPI.Desktop\*.dll" target="tools" />
 
     <file src="GenAPI.Desktop\Microsoft.DotNet.BuildTools.GenAPI.targets" target="build" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
   
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.GenFacades.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.GenFacades.nuspec
@@ -21,5 +21,7 @@
   </metadata>
   <files>
     <file src="GenFacades.Console.net46\*.*" target="tools" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>  
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
@@ -29,5 +29,7 @@
     <file src="RepoUtil.Desktop\RepoUtil.exe" target="tools\net46" />
     <file src="RepoUtil.Desktop\RepoUtil.exe.config" target="tools\net46" />
     <file src="RepoUtil.Desktop\*.dll" target="tools\net46" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.Run.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.Run.nuspec
@@ -21,5 +21,7 @@
     <file src="run\run.runtimeconfig.json" target="tools\netcoreapp1.0" />
     <file src="run\Newtonsoft.Json.dll" target="tools\netcoreapp1.0" />
     <file src="run\System.Runtime.Serialization.Primitives.dll" target="tools\netcoreapp1.0" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
@@ -37,5 +37,7 @@
   </metadata>
   <files>
     <file src="Microsoft.DotNet.BuildTools.TestSuite\runtime.json" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
@@ -24,5 +24,7 @@
   <files>
     <file src="Microsoft.DotNet.Build.VstsBuildsApi\*.dll" target="lib\netstandard1.5" />
     <file src="Microsoft.DotNet.Build.VstsBuildsApi.net45\*.dll" target="lib\net45" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -52,5 +52,7 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
     <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.VersionTools.nuspec
@@ -26,6 +26,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />  
+    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
+++ b/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
@@ -20,5 +20,7 @@
   </metadata>
   <files>
     <file src="Microsoft.xunit.extensibility.execution.netcore\xunit.execution.dotnet.dll" target="lib/netstandard1.0" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
+++ b/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
@@ -39,5 +39,7 @@
   </metadata>
   <files>
     <file src="xunit.netcore.extensions\xunit.netcore.extensions.dll" target="lib/netstandard1.0" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -49,6 +49,8 @@
     <file src="xunit.console.netcore\_._" target="lib\dnxcore50" />
     <file src="xunit.console.netcore\_._" target="lib\dotnet" />
     <file src="xunit.console.netcore\xunit.console.netcore.exe" target="runtimes\any\native" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
   
 </package>

--- a/src/nuget/xunit.runner.uwp.nuspec
+++ b/src/nuget/xunit.runner.uwp.nuspec
@@ -34,6 +34,8 @@
     <file src="xunit.console.uwp\**\*.*" target="" />
 	
     <file src="xunit.runner.uwp\_._" target="lib\uap10.0" />
+
+    <file src="..\obj\version.txt" target="" />
   </files>
   
 </package>


### PR DESCRIPTION
Putting version.txt (containing the built commit hash) in the packages makes them traceable for automation and people. CoreFX is currently doing this for its packages (using the packaging targets rather than manual nuspecs).

We can use this file to update a checked-in bootstrap script in product repos. An auto-upgrader can take the commit hash from the BuildTools being consumed and download the bootstrap scripts from BuildTools at that hash. It would be better if it were checked into dotnet/versions, but this is an alternative. @MichaelSimons

This also allows the submodule updaters (https://github.com/dotnet/buildtools/pull/1324) to auto-update a BuildTools submodule based on successful builds, by setting BuildTools as an indicator package. @ellismg 