### PR TITLE
Fix syntax for metadata access

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -5,7 +5,7 @@
   <Target Name="UpdatePkgProjProjectReferences" BeforeTargets="AssignProjectConfiguration">
     <!-- Update PkgProj references to call the GetPackageAssets target -->
     <ItemGroup>
-      <ProjectReference Condition="'%(Extension)'=='.pkgproj'">
+      <ProjectReference Condition="'%(ProjectReference.Extension)'=='.pkgproj'">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <Targets>GetPackageAssets</Targets>
         <OutputItemType>PkgProjAsset</OutputItemType>


### PR DESCRIPTION
Minor MSBuild syntax fix for accessing a metadata property. I discovered the issue while trying to get the Microsoft/visualfsharp build working on coreclr; some of the bootstrapping there is currently running via xbuild and mono, which is perhaps more strict about syntax checking.