### PR TITLE
Fix meta-package suppression

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -23,6 +23,7 @@
     <ProjectProperties></ProjectProperties>
 
     <BaseLinePackageDependencies Condition="'$(BaseLinePackageDependencies)' == ''">true</BaseLinePackageDependencies>
+    <ApplyMetaPackages Condition="'$(ApplyMetaPackages)' == ''">true</ApplyMetaPackages>
 
     <!-- By default we'll build libraries referenced by packages -->
     <BuildPackageLibraryReferences Condition="'$(BuildPackageLibraryReferences)' == ''">true</BuildPackageLibraryReferences>
@@ -717,7 +718,8 @@
     <ApplyMetaPackages PackageId="$(Id)"
                        OriginalDependencies="@(FilePackageDependency)"
                        PackageIndexes="@(PackageIndex)"
-                       Condition="'$(SkipApplyMetaPackages)' != 'true'">
+                       SuppressMetaPackages="@(SuppressMetaPackage)"
+                       Apply="$(ApplyMetaPackages)">
       <Output TaskParameter="UpdatedDependencies" ItemName="_ConsolidatedDependencies" />
     </ApplyMetaPackages>
 


### PR DESCRIPTION
The condition added previously didn't work because it didn't populate
the trimmed item _ConsolidatedDependencies.

I fixed this by passing the property into the task similar to
ApplyBaseline.

I also added support for an item @(SuppressMetaPackage) that can be used
to suppress a specific meta-package by name.

/cc @weshaggard