### PR TITLE
Add task for getting supported frameworks

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetSupportedPackagesFromPackageReports.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetSupportedPackagesFromPackageReports.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class GetSupportedPackagesFromPackageReports : PackagingTask
+    {
+        [Required]
+        public string[] PackageReports { get; set; }
+
+        [Output]
+        public ITaskItem[] SupportedPackages { get; set; }
+
+        public override bool Execute()
+        {
+            var supportedPackages = new List<ITaskItem>();
+            foreach (var packageReport in PackageReports.NullAsEmpty())
+            {
+                var report = PackageReport.Load(packageReport);
+                var packageId = report.Id;
+                var packageVersion = report.Version;
+
+                var supportedTargets = report.Targets.Values.Where(target => report.SupportedFrameworks.ContainsKey(target.Framework));
+                var fxRIDGroupings = supportedTargets.GroupBy(target => target.Framework, target => target.RuntimeID);
+
+                foreach (var fxRIDGrouping in fxRIDGroupings)
+                {
+                    var fx = fxRIDGrouping.Key;
+                    var rids = fxRIDGrouping.ToArray();
+
+                    var supportedPackage = new TaskItem(packageId);
+                    supportedPackage.SetMetadata("Version", packageVersion);
+                    supportedPackage.SetMetadata("TargetFramework", fx);
+
+                    var ridList = string.Join(";", rids);
+
+                    if (!String.IsNullOrEmpty(ridList))
+                    {
+                        supportedPackage.SetMetadata("RuntimeIdentifiers", ridList);
+                    }
+
+                    supportedPackages.Add(supportedPackage);
+                }
+            }
+
+            SupportedPackages = supportedPackages.ToArray();
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ApplyMetaPackages.cs" />
+    <Compile Include="GetSupportedPackagesFromPackageReports.cs" />
     <Compile Include="GetLayoutFiles.cs" />
     <Compile Include="FilterUnknownPackages.cs" />
     <Compile Include="GetPackageDestination.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
@@ -8,6 +8,9 @@
     <PackagingTaskDir Condition="'$(PackagingTaskDir)' == ''">$(MSBuildThisFileDirectory)</PackagingTaskDir>
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == '' AND Exists('$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json')">$(ProjectDir)pkg/Microsoft.NETCore.Platforms/runtime.json</RuntimeIdGraphDefinitionFile>
     <RuntimeIdGraphDefinitionFile Condition="'$(RuntimeIdGraphDefinitionFile)' == ''">$(MSBuildThisFileDirectory)runtime.json</RuntimeIdGraphDefinitionFile>
+
+    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>
+    <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(PackageOutputPath)reports/</PackageReportDir>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PackageTargetRuntimeSuffix)' != ''">
@@ -40,4 +43,5 @@
   <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="ValidatePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="VerifyClosure" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="GetSupportedPackagesFromPackageReports" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -68,12 +68,10 @@
 
   <!-- Shared properties -->
   <PropertyGroup>
-    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(BaseOutputPath)pkg/</PackageOutputPath>
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(BaseOutputPath)symbolpkg/</SymbolPackageOutputPath>
     <OutputPath>$(PackageOutputPath)</OutputPath>
     <NuSpecOutputPath Condition="'$(NuSpecOutputPath)' == ''">$(PackageOutputPath)specs/</NuSpecOutputPath>
     <NuSpecPath>$(NuSpecOutputPath)$(Id)$(NuspecSuffix).nuspec</NuSpecPath>
-    <PackageReportDir Condition="'$(PackageReportDir)' == ''">$(PackageOutputPath)reports/</PackageReportDir>
     <PackageReportPath>$(PackageReportDir)$(Id)$(NuspecSuffix).json</PackageReportPath>
     <TargetPath>$(NuSpecPath)</TargetPath>
     <RuntimeFilePath Condition="'$(RuntimeFilePath)' == ''">$(NuSpecOutputPath)$(Id)$(NuspecSuffix)/runtime.json</RuntimeFilePath>
@@ -927,7 +925,7 @@
       <RuntimeIDs>win7-x86;win7-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;linuxmint.17-x64;opensuse.13.2-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="netcoreapp1.1">
-      <RuntimeIDs>win7-x86;win7-x64;win10-arm64;alpine.3.4.3-x64;osx.10.10-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;linuxmint.17-x64;opensuse.13.2-x64;opensuse.42.1-x64;rhel.7-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64</RuntimeIDs>
+      <RuntimeIDs>win7-x86;win7-x64;osx.10.10-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;linuxmint.17-x64;opensuse.13.2-x64;opensuse.42.1-x64;rhel.7-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64</RuntimeIDs>
     </DefaultValidateFramework>
     <DefaultValidateFramework Include="netcoreapp2.0">
       <RuntimeIDs>win7-x86;win7-x64;win10-arm64;alpine.3.4.3-x64;osx.10.10-x64;osx.10.11-x64;centos.7-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;linuxmint.17-x64;opensuse.13.2-x64;opensuse.42.1-x64;rhel.7-x64;rhel.7.2-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64</RuntimeIDs>


### PR DESCRIPTION
This task reads supported framework targeting information from package
reports.

It lets us write tests that can generate project files targeting all of
the frameworks supported by a particular package.

I've also removed two of the validation RIDs that were incorrectly added
to netcoreapp1.1 but weren't actually supported until netcoreapp2.0.

/cc @weshaggard @chcosta 
