### PR TITLE
Remove all global fields and methods in GenFacades.

### DIFF
--- a/src/GenFacades/GenFacades.Core/GenFacades.cs
+++ b/src/GenFacades/GenFacades.Core/GenFacades.cs
@@ -666,8 +666,14 @@ namespace GenFacades
                 // Add reference to seed core assembly up-front so that we keep the same order as the C# compiler.
                 assembly.AssemblyReferences.Add(_seedCoreAssemblyReference);
 
-                // Remove all type definitions except for the "<Module>" type.
+                // Remove all type definitions except for the "<Module>" type. Remove all fields and methods from it.
                 assembly.AllTypes.RemoveAll(t => t.Name.Value != "<Module>");
+                NamespaceTypeDefinition moduleType = assembly.AllTypes.SingleOrDefault(t => t.Name.Value == "<Module>") as NamespaceTypeDefinition;
+                if (moduleType != null)
+                {
+                    moduleType.Fields?.Clear();
+                    moduleType.Methods?.Clear();
+                }
 
                 // Remove any preexisting typeforwards.
                 assembly.ExportedTypes = new List<IAliasForType>();

--- a/src/GenFacades/GenFacades.Core/GenFacades.cs
+++ b/src/GenFacades/GenFacades.Core/GenFacades.cs
@@ -667,12 +667,13 @@ namespace GenFacades
                 assembly.AssemblyReferences.Add(_seedCoreAssemblyReference);
 
                 // Remove all type definitions except for the "<Module>" type. Remove all fields and methods from it.
-                assembly.AllTypes.RemoveAll(t => t.Name.Value != "<Module>");
                 NamespaceTypeDefinition moduleType = assembly.AllTypes.SingleOrDefault(t => t.Name.Value == "<Module>") as NamespaceTypeDefinition;
+                assembly.AllTypes.Clear();
                 if (moduleType != null)
                 {
                     moduleType.Fields?.Clear();
                     moduleType.Methods?.Clear();
+                    assembly.AllTypes.Add(moduleType);
                 }
 
                 // Remove any preexisting typeforwards.


### PR DESCRIPTION
It seems that some compilers, like the managed C++ compiler, will emit a bunch of global methods and fields into assemblies. We are removing a lot of other assembly-level metadata from projects being rewritten with GenFacades, but not those. This change causes us to clear out the "<Module>" type, which will wipe out all of those extra global members.

@weshaggard 