### PR TITLE
Update VersionTools nuspec dependencies to match its project.json

### DIFF
--- a/src/nuget/Microsoft.DotNet.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.VersionTools.nuspec
@@ -18,8 +18,8 @@
       <group targetFramework="netstandard1.5">
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="Newtonsoft.Json" version="9.0.1" />
-        <dependency id="NuGet.Packaging" version="3.5.0-beta2-1456" />
-        <dependency id="NuGet.Versioning" version="3.5.0-beta2-1456" />
+        <dependency id="NuGet.Packaging" version="4.0.0-rc-2129" />
+        <dependency id="NuGet.Versioning" version="4.0.0-rc-2129" />
         <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
       </group>


### PR DESCRIPTION
Make the NuGet package dependencies match the VersionTools project.json to avoid a mismatch trying to build downstream projects.

Hit in https://github.com/dotnet/dotnet-docker-nightly/pull/253#discussion_r108549418