### PR TITLE
For pure facades type forwards get ignored

### DIFF
--- a/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Cci.Traversers
 
         public virtual void Visit(IEnumerable<INamespaceDefinition> namespaces)
         {
-            namespaces = namespaces.Where(_filter.Include);
+            namespaces = namespaces.Where(ns => ns.GetTypes(this.IncludeForwardedTypes).Any(_filter.Include));
             namespaces = namespaces.OrderBy(GetNamespaceKey, StringComparer.OrdinalIgnoreCase);
 
             foreach (var ns in namespaces)


### PR DESCRIPTION
For namespaces that don't have anything but type forwards they get
skipped because the namespace gets filtered out. Since there are multiple
filters that could be used we can do the filtering of namespaces in
the traversals at the type level to handle this difference.