### PR TITLE
Add Extensibility point to optional.json so that it can be overwritten in repos

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
@@ -33,7 +33,7 @@
   <Target Name="GetOptionalToolingPaths">
     <PropertyGroup>
       <OptionalToolingDir>$(ToolsDir)optional-tool-runtime\</OptionalToolingDir>
-      <OptionalToolingJsonPath>$(OptionalToolingDir)optional.json</OptionalToolingJsonPath>
+      <OptionalToolingJsonPath Condition="'$(OptionalToolingProjectJsonPath)' == ''">$(OptionalToolingDir)optional.json</OptionalToolingJsonPath>
       <OptionalToolingProjectJsonPath>$(OptionalToolingDir)project.json</OptionalToolingProjectJsonPath>
       <OptionalToolingProjectLockJsonPath>$(OptionalToolingDir)project.lock.json</OptionalToolingProjectLockJsonPath>
     </PropertyGroup>


### PR DESCRIPTION
cc: @weshaggard @dagood 
FYI: @AlexGhiondea 

Conditioning the optional.json path so that it can be overwritten in a specific repo. The reason for this is that we want to also restore TestILC from the private feed, but we need the version of the package to match the one from the ProjectN TargetingPack which means that this optional.json needs to live in corefx side.