### PR TITLE
Fix Condition on optional.json

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
@@ -33,7 +33,7 @@
   <Target Name="GetOptionalToolingPaths">
     <PropertyGroup>
       <OptionalToolingDir>$(ToolsDir)optional-tool-runtime\</OptionalToolingDir>
-      <OptionalToolingJsonPath Condition="'$(OptionalToolingProjectJsonPath)' == ''">$(OptionalToolingDir)optional.json</OptionalToolingJsonPath>
+      <OptionalToolingJsonPath Condition="'$(OptionalToolingJsonPath)' == ''">$(OptionalToolingDir)optional.json</OptionalToolingJsonPath>
       <OptionalToolingProjectJsonPath>$(OptionalToolingDir)project.json</OptionalToolingProjectJsonPath>
       <OptionalToolingProjectLockJsonPath>$(OptionalToolingDir)project.lock.json</OptionalToolingProjectLockJsonPath>
     </PropertyGroup>


### PR DESCRIPTION
FYI: @weshaggard 

I got the original condition for this wrong checking the incorrect variable. This will actually check if the optional.json path is already set.