### PR TITLE
Fix BuildInfo cache collisions: use path, not name

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildInfo.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.VersionTools
                 gitRef.All("0123456789abcdef".Contains);
 
             string cachedPath = useCache
-                ? Path.Combine(cacheDir, gitRef, name, "buildinfo.json")
+                ? Path.Combine(cacheDir, gitRef, buildInfoPath, "buildinfo.json")
                 : null;
 
             if (useCache && File.Exists(cachedPath))


### PR DESCRIPTION
Fixes https://github.com/dotnet/buildtools/issues/1028.

It didn't have an effect on the clean machines used for auto-upgrade, but trying to change build info path branches as a dev is really confusing with this bug.