### PR TITLE
ApiCompat CannotMakeMoreVisible rule shouldn't differentiate between Familiy and FamilyOrAssembly

### DIFF
--- a/src/ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
+++ b/src/ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Cci.Differs.Rules
             // If implementation is protected then contract must be protected as well. 
             if (impl.Visibility == TypeMemberVisibility.Family)
             {
-                if (contract.Visibility != TypeMemberVisibility.Family)
+                if (contract.Visibility != TypeMemberVisibility.Family && contract.Visibility != TypeMemberVisibility.FamilyOrAssembly)
                 {
                     differences.AddIncompatibleDifference(this,
                         "Visibility of member '{0}' is '{1}' in the implementation but '{2}' in the contract.",
@@ -47,7 +47,7 @@ namespace Microsoft.Cci.Differs.Rules
             // If implementation is protected then contract must be protected as well. 
             if (impl.GetVisibility() == TypeMemberVisibility.Family)
             {
-                if (contract.GetVisibility() != TypeMemberVisibility.Family)
+                if (contract.GetVisibility() != TypeMemberVisibility.Family && contract.GetVisibility() != TypeMemberVisibility.FamilyOrAssembly)
                 {
                     differences.AddIncompatibleDifference(this,
                         "Visibility of type '{0}' is '{1}' in the implementation but '{2}' in the contract.",

--- a/src/ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
+++ b/src/ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Cci.Differs.Rules
             if (impl.Visibility == TypeMemberVisibility.Public)
                 return DifferenceType.Unknown;
 
-            // If implementation is protected then contract must be protected as well. 
-            if (impl.Visibility == TypeMemberVisibility.Family)
+            // If implementation is protected or protected internal then contract must be protected or protected internal as well.
+            if (impl.Visibility == TypeMemberVisibility.Family || impl.Visibility == TypeMemberVisibility.FamilyOrAssembly)
             {
                 if (contract.Visibility != TypeMemberVisibility.Family && contract.Visibility != TypeMemberVisibility.FamilyOrAssembly)
                 {
@@ -44,8 +44,8 @@ namespace Microsoft.Cci.Differs.Rules
             if (impl.GetVisibility() == TypeMemberVisibility.Public)
                 return DifferenceType.Unknown;
 
-            // If implementation is protected then contract must be protected as well. 
-            if (impl.GetVisibility() == TypeMemberVisibility.Family)
+            // If implementation is protected or protected internal then contract must be protected or protected internal as well.
+            if (impl.GetVisibility() == TypeMemberVisibility.Family || impl.GetVisibility() == TypeMemberVisibility.FamilyOrAssembly)
             {
                 if (contract.GetVisibility() != TypeMemberVisibility.Family && contract.GetVisibility() != TypeMemberVisibility.FamilyOrAssembly)
                 {


### PR DESCRIPTION
fixes https://github.com/dotnet/buildtools/issues/1418