### PR TITLE
Provide a way to ignore missing files during pack

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <PackagesOutDir Condition="'$(PackagesOutDir)' == ''">$(OutDir)Packages\</PackagesOutDir>
     <PackagesBasePath Condition="'$(PackagesBasePath)' == ''">$(OutDir)</PackagesBasePath>
+    <IgnoreMissingFilesInNuspec Condition="'$(IgnoreMissingFilesInNuspec)' == ''">false</IgnoreMissingFilesInNuspec>
   </PropertyGroup>
 
   <UsingTask TaskName="NuGetPack" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
@@ -29,7 +30,9 @@
       BaseDirectory="$(PackagesBasePath)"
       PackageVersion="%(PackagesNuSpecFiles.PackageVersion)"
       ExcludeEmptyDirectories="true"
-      NuspecProperties="@(NuspecProperties)"/>
+      NuspecProperties="@(NuspecProperties)"
+      IgnoreMissingFiles="$(IgnoreMissingFilesInNuspec)"
+      />
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"


### PR DESCRIPTION
On some platforms (e.g. Unix) we can't build desktop assets. Provide a way
for these projects to signal that when packing nuspec's if files are
missing it's okay and they should just be dropped from the package
(instead of the NuGet logic throwing an exception).