### PR TITLE
Add additional IBCMerge customization options

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -6,6 +6,7 @@
     <OptimizationDataVersion Condition="'$(OptimizationDataVersion)'==''">2.0.0-rc-61101-16</OptimizationDataVersion>
     <OptimizationDataPackageName Condition="'$(OptimizationDataPackageName)'==''">RoslynDependencies.OptimizationData</OptimizationDataPackageName>
     <OptimizationDataDir Condition="'$(OptimizationDataDir)'==''">$(ToolsDir)OptimizationData/</OptimizationDataDir>
+    <RestoreDefaultOptimizationDataPackage Condition="'$(RestoreDefaultOptimizationDataPackage)'==''">true</RestoreDefaultOptimizationDataPackage>
     <UsePartialNGENOptimization Condition="'$(UsePartialNGENOptimization)'==''">true</UsePartialNGENOptimization>
   </PropertyGroup>
 
@@ -81,7 +82,7 @@
 
   <!-- We need the OptimizationData package in order to be able to optimize the assembly -->
   <Target Name="RestoreOptimizationDataPackage" BeforeTargets="CoreCompile"
-          Condition="'$(EnableProfileGuidedOptimization)'=='true' and !Exists('$(OptimizationDataDir)project.json')">
+          Condition="'$(EnableProfileGuidedOptimization)'=='true' and '$(RestoreDefaultOptimizationDataPackage)'=='true' and !Exists('$(OptimizationDataDir)project.json')">
 
     <!-- Dynamically create a project.json file used to restore the optimization data-->
     <Message Text="Generating project.json for optimization data"  Importance="low" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -9,6 +9,36 @@
     <UsePartialNGENOptimization Condition="'$(UsePartialNGENOptimization)'==''">true</UsePartialNGENOptimization>
   </PropertyGroup>
 
+  <!-- If IBC data hasn't been merged with the IL yet, preprocess it first -->
+  <Target Name="PreProcessIBCData"
+          BeforeTargets="OptimizeWithTrainingData"
+          DependsOnTargets="RestoreOptimizationDataPackage;ResolveOptionalTools"
+          Condition="'$(OS)'=='Windows_NT' and '$(EnableProfileGuidedOptimization)'=='true' and Exists('$(OptimizationDataDir)$(AssemblyName).dll')">
+
+    <!-- Find IBCMerge as a resolved optional tool. -->
+    <PropertyGroup>
+      <IBCMergeToolPath Condition="'%(Filename)%(Extension)'=='ibcmerge.exe'">@(ResolvedOptionalToolReferences)</IBCMergeToolPath>
+    </PropertyGroup>
+
+    <!-- Enumerate the various files that need merging -->
+    <PropertyGroup>
+      <InputAssemblyFile>$(OptimizationDataDir)$(AssemblyName).dll</InputAssemblyFile>
+      <TargetOptimizationDataFile>$(OptimizationDataDir)$(AssemblyName).pgo</TargetOptimizationDataFile>
+    </PropertyGroup>
+    <ItemGroup>
+      <RawOptimizationDataFiles Include="$(OptimizationDataDir)$(AssemblyName)*.ibc" />
+    </ItemGroup>
+
+    <!-- Merge the optimization data into the source DLL -->
+    <Exec Command="$(IBCMergeToolPath) -q -f -delete -mo $(InputAssemblyFile) @(RawOptimizationDataFiles, ' ')" />
+
+    <!-- Verify that the optimization data has been merged -->
+    <Exec Command="$(IBCMergeToolPath) -mi $(InputAssemblyFile)" />
+
+    <!-- Save the module as *.pgo to match the convention expected in target OptimizeWithTrainingData -->
+    <Copy SourceFiles="$(InputAssemblyFile)" DestinationFiles="$(TargetOptimizationDataFile)" />
+  </Target>
+
   <!-- We should only run this target on Windows and only if EnableProfileGuidedOptimization is set and we have training data -->
   <Target Name="OptimizeWithTrainingData"
           AfterTargets="AfterBuild"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -6,6 +6,7 @@
     <OptimizationDataVersion Condition="'$(OptimizationDataVersion)'==''">2.0.0-rc-61101-16</OptimizationDataVersion>
     <OptimizationDataPackageName Condition="'$(OptimizationDataPackageName)'==''">RoslynDependencies.OptimizationData</OptimizationDataPackageName>
     <OptimizationDataDir Condition="'$(OptimizationDataDir)'==''">$(ToolsDir)OptimizationData/</OptimizationDataDir>
+    <UsePartialNGENOptimization Condition="'$(UsePartialNGENOptimization)'==''">true</UsePartialNGENOptimization>
   </PropertyGroup>
 
   <!-- We should only run this target on Windows and only if EnableProfileGuidedOptimization is set and we have training data -->
@@ -25,12 +26,18 @@
       <OptimizedAssemblyFile>$(OptimizedAssemblyDir)/$(AssemblyName).dll</OptimizedAssemblyFile>
     </PropertyGroup>
 
+    <!-- Customize IBCMerge's arguments depending on input props -->
+    <PropertyGroup>
+      <IBCMergeArguments>-q -f -mo $(OptimizedAssemblyFile) -incremental $(OptimizationDataDir)$(AssemblyName).pgo</IBCMergeArguments>
+      <IBCMergeArguments Condition="$(UsePartialNGENOptimization)">$(IBCMergeArguments) -partialNGEN -minify</IBCMergeArguments>
+    </PropertyGroup>
+
     <!-- Copy the compiled assembly into a folder for further processing -->
     <MakeDir Directories="$(OptimizedAssemblyDir)" />
     <Copy SourceFiles="@(IntermediateAssembly)" DestinationFolder="$(OptimizedAssemblyDir)" />
 
     <!-- Apply optimization data to the compiled assembly -->
-    <Exec Command="$(IBCMergeToolPath) -q -f -partialNGEN -minify -mo $(OptimizedAssemblyFile) -incremental $(OptimizationDataDir)$(AssemblyName).pgo" />
+    <Exec Command="$(IBCMergeToolPath) $(IBCMergeArguments)" />
 
     <!-- Verify that the optimization data has been applied -->
     <Exec Command="$(IBCMergeToolPath) -mi $(OptimizedAssemblyFile)" />


### PR DESCRIPTION
The end goal is to make IBCMerge's invocation more flexible so that it can be more directly applied in calling repositories:
* `/p:RestoreDefaultOptimizationDataPackage` can be set to false to avoid restoring the default project.json
* `/p:UsePartialNGENOptimization` can be set to false to avoid passing `-partialNGEN -minify`
* Add pre-pass to merge `*.ibc` into `*.dll` and rename the result to `*.pgo` (in case IBC data doesn't come pre-merged into the source IL assembly)
