### PR TITLE
Fix casing issue in PrereleaseResolveNuGetPackageAssets.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
@@ -902,7 +902,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 else
                 {
                     // Try a lower-case path.
-                    string lowerCasePath = Path.Combine(packagesFolder, packageId.ToLowerInvariant(), packageVersion);
+                    string lowerCasePath = Path.Combine(packagesFolder, packageId.ToLowerInvariant(), packageVersion.ToLowerInvariant());
                     if (_directoryExists(lowerCasePath))
                     {
                         return lowerCasePath;

--- a/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
@@ -902,7 +902,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 else
                 {
                     // Try a lower-case path.
-                    string lowerCasePath = packagePath.ToLowerInvariant();
+                    string lowerCasePath = Path.Combine(packagesFolder, packageId.ToLowerInvariant(), packageVersion);
                     if (_directoryExists(lowerCasePath))
                     {
                         return lowerCasePath;


### PR DESCRIPTION
Instead of making the entire package path lower-case, we should only lower-case the part that NuGet changes (the package ID).

@ericstj 