### PR TITLE
Move RestoreOptimizationDataPackage to Sync

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -13,7 +13,7 @@
   <!-- If IBC data hasn't been merged with the IL yet, preprocess it first -->
   <Target Name="PreProcessIBCData"
           BeforeTargets="OptimizeWithTrainingData"
-          DependsOnTargets="RestoreOptimizationDataPackage;ResolveOptionalTools"
+          DependsOnTargets="ResolveOptionalTools"
           Condition="'$(OS)'=='Windows_NT' and '$(EnableProfileGuidedOptimization)'=='true' and Exists('$(OptimizationDataDir)$(AssemblyName).dll')">
 
     <!-- Find IBCMerge as a resolved optional tool. -->
@@ -44,7 +44,7 @@
   <Target Name="OptimizeWithTrainingData"
           AfterTargets="AfterBuild"
           BeforeTargets="CopyFilesToOutputDirectory"
-          DependsOnTargets="RestoreOptimizationDataPackage;ResolveOptionalTools"
+          DependsOnTargets="ResolveOptionalTools"
           Condition="'$(OS)'=='Windows_NT' and '$(EnableProfileGuidedOptimization)'=='true' and Exists('$(OptimizationDataDir)$(AssemblyName).pgo')">
 
     <!-- Find IBCMerge as a resolved optional tool. -->
@@ -81,7 +81,8 @@
   </Target>
 
   <!-- We need the OptimizationData package in order to be able to optimize the assembly -->
-  <Target Name="RestoreOptimizationDataPackage" BeforeTargets="CoreCompile"
+  <Target Name="RestoreOptimizationDataPackage"
+          BeforeTargets="Sync"
           Condition="'$(EnableProfileGuidedOptimization)'=='true' and '$(RestoreDefaultOptimizationDataPackage)'=='true' and !Exists('$(OptimizationDataDir)project.json')">
 
     <!-- Dynamically create a project.json file used to restore the optimization data-->


### PR DESCRIPTION
This matches a change in CoreFX Tools-Override to restore the data package during Sync, not the build. The build's parallelization can cause this to be a race condition.