### PR TITLE
Update license for .NET Core NuGet packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -54,11 +54,11 @@
     <Authors>Microsoft</Authors>
     <Owners>microsoft,dotnetframework</Owners>
     <Description>TODO</Description>
-    <LicenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</LicenseUrl>
+    <LicenseUrl>https://github.com/dotnet/corefx/blob/master/LICENSE</LicenseUrl>
     <IconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</IconUrl>
-    <Copyright>&#169; Microsoft Corporation.  All rights reserved.</Copyright>
+    <Copyright>.NET Foundation and Contributors</Copyright>
     <Tags></Tags>
-    <RequireLicenseAcceptance>true</RequireLicenseAcceptance>
+    <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
     <Serviceable Condition="'$(Serviceable)' == ''">true</Serviceable>
     <!-- we depend on nuget v2.12 / v3.4 behavior NuGet doesn't support two different min client versions
          so we declare 2.12 and mention in package description that when using 3.x we require 3.4 or later -->


### PR DESCRIPTION
We are adopting a plan to change the license and copyright of .NET Core packages. We want to make this change for open source packages. If there are packages that are still closed source, in part of in full, they should not be affected by this change.

Is this the right change to make to achieve the stated goal, above?

I saw that there are [nuspecs in this repo](https://github.com/dotnet/buildtools/search?utf8=%E2%9C%93&q=329770&type=) and know that Roslyn and other components have their own approach. I thought we should start here.

More context: https://github.com/dotnet/corefx/issues/12190