### PR TITLE
Enable build of partial reference facades

### DIFF
--- a/src/GenFacades/GenFacades.Console/Program.cs
+++ b/src/GenFacades/GenFacades.Console/Program.cs
@@ -14,6 +14,7 @@ namespace GenFacades
             Version assemblyFileVersion = null;
             bool clearBuildAndRevision = false;
             bool ignoreMissingTypes = false;
+            bool buildPartialReferenceFacade = false;
             bool ignoreBuildAndRevisionMismatch = false;
             bool buildDesignTimeFacades = false;
             string inclusionContracts = null;
@@ -33,6 +34,7 @@ namespace GenFacades
                 parser.DefineOptionalQualifier("clearBuildAndRevision", ref clearBuildAndRevision, "Generate facade assembly version x.y.0.0 for contract version x.y.z.w");
                 parser.DefineOptionalQualifier("ignoreBuildAndRevisionMismatch", ref ignoreBuildAndRevisionMismatch, "Ignore a mismatch in revision and build for partial facade.");
                 parser.DefineOptionalQualifier("ignoreMissingTypes", ref ignoreMissingTypes, "Ignore types that cannot be found in the seed assemblies. This is not recommended but is sometimes helpful while hacking around or trying to produce partial facades.");
+                parser.DefineOptionalQualifier("buildPartialReferenceFacade", ref buildPartialReferenceFacade, "Preserves all metadata from the contract and replaces types that can be found in the seeds with type forwards.");
                 parser.DefineOptionalQualifier("designTime", ref buildDesignTimeFacades, "Enable design-time facade generation (marks facades with reference assembly flag and attribute).");
                 parser.DefineOptionalQualifier("include", ref inclusionContracts, "Add types from these contracts to the facades. Can contain multiple assemblies or directories delimited by ',' or ';'.");
                 parser.DefineOptionalQualifier("seedError", ref seedLoadErrorTreatment, "Error handling for seed assembly load failure.");
@@ -65,7 +67,8 @@ namespace GenFacades
                 seedTypePreferencesUnsplit,
                 forceZeroVersionSeeds,
                 producePdb,
-                partialFacadeAssemblyPath);
+                partialFacadeAssemblyPath,
+                buildPartialReferenceFacade);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
@@ -46,6 +46,8 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public string PartialFacadeAssemblyPath { get; set; }
 
+        public bool BuildPartialReferenceFacade { get; set; }
+
         public override bool Execute()
         {
             TraceLogger logger = new TraceLogger(Log);
@@ -87,7 +89,8 @@ namespace Microsoft.DotNet.Build.Tasks
                     seedTypePreferencesUnsplit,
                     ForceZeroVersionSeeds,
                     ProducePdb,
-                    PartialFacadeAssemblyPath);
+                    PartialFacadeAssemblyPath,
+                    BuildPartialReferenceFacade);
 
                 if (!result)
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.exe.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.exe.targets
@@ -11,22 +11,6 @@
     </TargetsTriggeredByCompilation>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
-    <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
-    <ResolveMatchingContract>true</ResolveMatchingContract>
-  </PropertyGroup>
-
-  <!-- Inputs and outputs of FillPartialFacade -->
-  <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
-    <PartialFacadeAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</PartialFacadeAssemblyPath>
-    <PartialFacadeSymbols>$(IntermediateOutputPath)$(TargetName).pdb</PartialFacadeSymbols>
-    <GenFacadesInputPath>$(IntermediateOutputPath)PreGenFacades/</GenFacadesInputPath>
-    <GenFacadesInputAssembly>$(GenFacadesInputPath)$(TargetName)$(TargetExt)</GenFacadesInputAssembly>
-    <GenFacadesInputSymbols>$(GenFacadesInputPath)$(TargetName).pdb</GenFacadesInputSymbols>
-    <GenFacadesOutputPath>$(IntermediateOutputPath)</GenFacadesOutputPath>
-    <GenFacadesResponseFile>$(GenFacadesInputPath)genfacades.rsp</GenFacadesResponseFile>
-  </PropertyGroup>
-
   <!-- FillPartialFacade
        Inputs:
          * An "input assembly"
@@ -36,18 +20,24 @@
        Fills the "input assembly" by finding types in the contract assembly that are missing from it, and adding type-forwards
          to those matching types in the seed assemblies.
   -->
-  <Target Name="FillPartialFacadeUsingExe" DependsOnTargets="EnsureBuildToolsRuntime;ResolveMatchingContract">
+  <Target Name="FillPartialFacadeUsingExe" DependsOnTargets="$(FillPartialFacadeDependsOn)">
 
     <ItemGroup>
       <!-- References used for compilation are automatically included as seed assemblies -->
       <GenFacadesSeeds Include="@(ReferencePath)" />
     </ItemGroup>
 
-    <Error Text="No single matching contract found." Condition="'@(ResolvedMatchingContract->Count())' != '1'" />
+    <Error Text="No single matching contract found." Condition="'$(IsReferenceAssembly)' != 'true' AND '@(ResolvedMatchingContract->Count())' != '1'" />
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(IsReferenceAssembly)' != 'true'">
       <GenFacadesArgs>$(GenFacadesArgs) -partialFacadeAssemblyPath:"$(GenFacadesInputAssembly)"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -contracts:"%(ResolvedMatchingContract.Identity)"</GenFacadesArgs>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(IsReferenceAssembly)' == 'true'">
+      <GenFacadesArgs>$(GenFacadesArgs) -contracts:"$(GenFacadesInputAssembly)"</GenFacadesArgs>
+      <GenFacadesArgs>$(GenFacadesArgs) -buildPartialReferenceFacade</GenFacadesArgs>
+    </PropertyGroup>
+    <PropertyGroup>
       <GenFacadesArgs>$(GenFacadesArgs) -seeds:"@(GenFacadesSeeds, ',')"</GenFacadesArgs>
       <GenFacadesArgs>$(GenFacadesArgs) -facadePath:"$(GenFacadesOutputPath.TrimEnd('/'))"</GenFacadesArgs>
       <GenFacadesArgs Condition="'$(DebugSymbols)' == 'false' OR '$(DebugType)'=='Portable'">$(GenFacadesArgs) -producePdb:false</GenFacadesArgs>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.targets
@@ -1,5 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <FillPartialFacadeDependsOn>
+      EnsureBuildToolsRuntime
+    </FillPartialFacadeDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(IsReferenceAssembly)' != 'true'">
+    <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
+    <ResolveMatchingContract>true</ResolveMatchingContract>
+    <FillPartialFacadeDependsOn>
+      $(FillPartialFacadeDependsOn);ResolveContract
+    </FillPartialFacadeDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true' AND '$(IsReferenceAssembly)' == 'true'">
+    <!-- reference facades will always have overlapping types so suppress compiler warnings -->
+    <NoWarn>$(NoWarn);0436</NoWarn>
+  </PropertyGroup>
+
+  <!-- Inputs and outputs of FillPartialFacade -->
+  <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
+    <PartialFacadeAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</PartialFacadeAssemblyPath>
+    <PartialFacadeSymbols>$(IntermediateOutputPath)$(TargetName).pdb</PartialFacadeSymbols>
+    <GenFacadesInputPath>$(IntermediateOutputPath)PreGenFacades/</GenFacadesInputPath>
+    <GenFacadesInputAssembly>$(GenFacadesInputPath)$(TargetName)$(TargetExt)</GenFacadesInputAssembly>
+    <GenFacadesInputSymbols>$(GenFacadesInputPath)$(TargetName).pdb</GenFacadesInputSymbols>
+    <GenFacadesOutputPath>$(IntermediateOutputPath)</GenFacadesOutputPath>
+    <GenFacadesResponseFile>$(GenFacadesInputPath)genfacades.rsp</GenFacadesResponseFile>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)partialfacades.task.targets" Condition="'$(UseLegacyGenFacadesExe)' != 'true'"/>
   <Import Project="$(MSBuildThisFileDirectory)partialfacades.exe.targets" Condition="'$(UseLegacyGenFacadesExe)' == 'true'"/>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
@@ -13,22 +13,6 @@
     </TargetsTriggeredByCompilation>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
-    <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
-    <ResolveMatchingContract>true</ResolveMatchingContract>
-  </PropertyGroup>
-
-  <!-- Inputs and outputs of FillPartialFacade -->
-  <PropertyGroup Condition="'$(IsPartialFacadeAssembly)' == 'true'">
-    <PartialFacadeAssemblyPath>$(IntermediateOutputPath)$(TargetName)$(TargetExt)</PartialFacadeAssemblyPath>
-    <PartialFacadeSymbols>$(IntermediateOutputPath)$(TargetName).pdb</PartialFacadeSymbols>
-    <GenFacadesInputPath>$(IntermediateOutputPath)PreGenFacades/</GenFacadesInputPath>
-    <GenFacadesInputAssembly>$(GenFacadesInputPath)$(TargetName)$(TargetExt)</GenFacadesInputAssembly>
-    <GenFacadesInputSymbols>$(GenFacadesInputPath)$(TargetName).pdb</GenFacadesInputSymbols>
-    <GenFacadesOutputPath>$(IntermediateOutputPath)</GenFacadesOutputPath>
-    <GenFacadesResponseFile>$(GenFacadesInputPath)genfacades.rsp</GenFacadesResponseFile>
-  </PropertyGroup>
-
   <!-- FillPartialFacade
        Inputs:
          * An "input assembly"
@@ -38,14 +22,14 @@
        Fills the "input assembly" by finding types in the contract assembly that are missing from it, and adding type-forwards
          to those matching types in the seed assemblies.
   -->
-  <Target Name="FillPartialFacadeUsingTask" DependsOnTargets="EnsureBuildToolsRuntime;ResolveMatchingContract">
+  <Target Name="FillPartialFacadeUsingTask" DependsOnTargets="$(FillPartialFacadeDependsOn)">
 
     <ItemGroup>
       <!-- References used for compilation are automatically included as seed assemblies -->
       <GenFacadesSeeds Include="@(ReferencePath)" />
     </ItemGroup>
 
-    <Error Text="No single matching contract found." Condition="'@(ResolvedMatchingContract->Count())' != '1'" />
+    <Error Text="No single matching contract found." Condition="'$(IsReferenceAssembly)' != 'true' AND '@(ResolvedMatchingContract->Count())' != '1'" />
 
     <MakeDir Directories="$(GenFacadesInputPath)" />
 
@@ -67,15 +51,26 @@
       <GenFacadesIgnoreBuildAndRevisionMismatch Condition="'$(GenFacadesIgnoreBuildAndRevisionMismatch)' == ''">false</GenFacadesIgnoreBuildAndRevisionMismatch>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(IsReferenceAssembly)' != 'true'">
+      <GenFacadesPartialFacadeAssemblyPath>$(GenFacadesInputAssembly)</GenFacadesPartialFacadeAssemblyPath>
+      <GenFacadesContracts>%(ResolvedMatchingContract.Identity)</GenFacadesContracts>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(IsReferenceAssembly)' == 'true'">
+      <GenFacadesContracts>$(GenFacadesInputAssembly)</GenFacadesContracts>
+      <GenFacadesBuildPartialReferenceFacade>true</GenFacadesBuildPartialReferenceFacade>
+    </PropertyGroup>
+
     <GenFacadesTask
-      PartialFacadeAssemblyPath="$(GenFacadesInputAssembly)"
-      Contracts="%(ResolvedMatchingContract.Identity)"
+      PartialFacadeAssemblyPath="$(GenFacadesPartialFacadeAssemblyPath)"
+      Contracts="$(GenFacadesContracts)"
       Seeds="@(GenFacadesSeeds, ',')"
       FacadePath="$(GenFacadesOutputPath.TrimEnd('/'))"
       SeedTypePreferencesUnsplit="@(SeedTypePreference)"
       ProducePdb="$(ProducePdb)"
       IgnoreMissingTypes="$(GenFacadesIgnoreMissingTypes)"
       IgnoreBuildAndRevisionMismatch="$(GenFacadesIgnoreBuildAndRevisionMismatch)"
+      BuildPartialReferenceFacade="$(GenFacadesBuildPartialReferenceFacade)"
     />
 
     <ItemGroup>


### PR DESCRIPTION
Adds a mode to GenFacades that starts with an assembly and replaces any
types present in the seeds with typeforwards.  Types not in the seeds
will remain in the assembly.

We'll use this for generating desktop reference facades.

To use this feature set IsPartialFacadeAssembly=true in a reference
project.

After the source is compiled GenFacades will examine all references and
replace any type def in the reference assembly that exists in the
references.

To keep a type in the reference assembly even if it exists in a
reference create an item in the reference project as follows:
```
    <SeedTypePreference Include="namespace.type">
      <Assembly>assemblyName</Assembly>
    </SeedTypePreference>
```

/cc @mellinoe @weshaggard 