### PR TITLE
Add custom PNSE message to GenAPI

### DIFF
--- a/src/GenAPI/Program.cs
+++ b/src/GenAPI/Program.cs
@@ -151,7 +151,6 @@ namespace GenAPI
                         writer.HighlightBaseMembers = s_hightlightBaseMembers;
                         writer.HighlightInterfaceMembers = s_hightlightInterfaceMembers;
                         writer.PutBraceOnNewLine = true;
-                        writer.ThrowPlatformNotSupportedForCompilation = s_throw;
                         writer.PlatformNotSupportedExceptionMessage = s_exceptionMessage;
                         writer.IncludeGlobalPrefixForCompilation = s_global;
                         return writer;
@@ -238,7 +237,6 @@ namespace GenAPI
         private static bool s_hightlightBaseMembers;
         private static bool s_hightlightInterfaceMembers;
         private static bool s_all;
-        private static bool s_throw;
         private static string s_exceptionMessage;
         private static bool s_global;
 
@@ -269,8 +267,7 @@ namespace GenAPI
                 parser.DefineAliases("hightlightInterfaceMembers", "him");
                 parser.DefineOptionalQualifier("hightlightInterfaceMembers", ref s_hightlightInterfaceMembers, "(-him) [CSDecl] Highlight interface implementation members.");
                 parser.DefineAliases("throw", "t");
-                parser.DefineOptionalQualifier("throw", ref s_throw, "(-t) Method bodies should throw PlatformNotSupportedException.");
-                parser.DefineOptionalQualifier("exceptionMessage", ref s_exceptionMessage, "PlatformNotSupportedException custom message.");
+                parser.DefineOptionalQualifier("throw", ref s_exceptionMessage, "(-t) Method bodies should throw PlatformNotSupportedException with custom message. (Pass Default for PNSE default message)");
                 parser.DefineAliases("global", "g");
                 parser.DefineOptionalQualifier("global", ref s_global, "(-g) Include global prefix for compilation.");
                 parser.DefineQualifier("assembly", ref s_assembly, "Path for an specific assembly or a directory to get all assemblies.");

--- a/src/GenAPI/Program.cs
+++ b/src/GenAPI/Program.cs
@@ -267,7 +267,7 @@ namespace GenAPI
                 parser.DefineAliases("hightlightInterfaceMembers", "him");
                 parser.DefineOptionalQualifier("hightlightInterfaceMembers", ref s_hightlightInterfaceMembers, "(-him) [CSDecl] Highlight interface implementation members.");
                 parser.DefineAliases("throw", "t");
-                parser.DefineOptionalQualifier("throw", ref s_exceptionMessage, "(-t) Method bodies should throw PlatformNotSupportedException with custom message. (Pass Default for PNSE default message)");
+                parser.DefineOptionalQualifier("throw", ref s_exceptionMessage, "(-t) Method bodies should throw PlatformNotSupportedException.");
                 parser.DefineAliases("global", "g");
                 parser.DefineOptionalQualifier("global", ref s_global, "(-g) Include global prefix for compilation.");
                 parser.DefineQualifier("assembly", ref s_assembly, "Path for an specific assembly or a directory to get all assemblies.");

--- a/src/GenAPI/Program.cs
+++ b/src/GenAPI/Program.cs
@@ -152,6 +152,7 @@ namespace GenAPI
                         writer.HighlightInterfaceMembers = s_hightlightInterfaceMembers;
                         writer.PutBraceOnNewLine = true;
                         writer.ThrowPlatformNotSupportedForCompilation = s_throw;
+                        writer.PlatformNotSupportedExceptionMessage = s_exceptionMessage;
                         writer.IncludeGlobalPrefixForCompilation = s_global;
                         return writer;
                     }
@@ -238,6 +239,7 @@ namespace GenAPI
         private static bool s_hightlightInterfaceMembers;
         private static bool s_all;
         private static bool s_throw;
+        private static string s_exceptionMessage;
         private static bool s_global;
 
         private static void ParseCommandLine(string[] args)
@@ -268,6 +270,7 @@ namespace GenAPI
                 parser.DefineOptionalQualifier("hightlightInterfaceMembers", ref s_hightlightInterfaceMembers, "(-him) [CSDecl] Highlight interface implementation members.");
                 parser.DefineAliases("throw", "t");
                 parser.DefineOptionalQualifier("throw", ref s_throw, "(-t) Method bodies should throw PlatformNotSupportedException.");
+                parser.DefineOptionalQualifier("exceptionMessage", ref s_exceptionMessage, "PlatformNotSupportedException custom message.");
                 parser.DefineAliases("global", "g");
                 parser.DefineOptionalQualifier("global", ref s_global, "(-g) Include global prefix for compilation.");
                 parser.DefineQualifier("assembly", ref s_assembly, "Path for an specific assembly or a directory to get all assemblies.");

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -206,7 +206,10 @@ namespace Microsoft.Cci.Writers.CSharp
                 Write("throw new ");
                 if (_forCompilationIncludeGlobalprefix)
                     Write("global::");
-                Write("System.PlatformNotSupportedException(); ");
+                if(_platformNotSupportedExceptionMessage == null)
+                    Write("System.PlatformNotSupportedException();");
+                else
+                    Write($"System.PlatformNotSupportedException(\"{_platformNotSupportedExceptionMessage}\"); ");
             }
             else if (method.ContainingTypeDefinition.IsValueType && method.IsConstructor)
             {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 Write("throw new ");
                 if (_forCompilationIncludeGlobalprefix)
                     Write("global::");
-                if(_platformNotSupportedExceptionMessage.Equals("Default"))
+                if(_platformNotSupportedExceptionMessage.Length == 0)
                     Write("System.PlatformNotSupportedException();");
                 else if(_platformNotSupportedExceptionMessage.StartsWith("SR."))
                     Write($"System.PlatformNotSupportedException({_platformNotSupportedExceptionMessage}); ");

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -201,13 +201,15 @@ namespace Microsoft.Cci.Writers.CSharp
 
             WriteOutParameterInitializations(method);
 
-            if (_forCompilationThrowPlatformNotSupported)
+            if (_platformNotSupportedExceptionMessage != null)
             {
                 Write("throw new ");
                 if (_forCompilationIncludeGlobalprefix)
                     Write("global::");
-                if(_platformNotSupportedExceptionMessage == null)
+                if(_platformNotSupportedExceptionMessage.Equals("Default"))
                     Write("System.PlatformNotSupportedException();");
+                else if(_platformNotSupportedExceptionMessage.StartsWith("SR."))
+                    Write($"System.PlatformNotSupportedException({_platformNotSupportedExceptionMessage}); ");
                 else
                     Write($"System.PlatformNotSupportedException(\"{_platformNotSupportedExceptionMessage}\"); ");
             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Cci.Writers.CSharp
         private readonly ICciFilter _filter;
         private bool _forCompilation;
         private bool _forCompilationIncludeGlobalprefix;
-        private bool _forCompilationThrowPlatformNotSupported;
         private string _platformNotSupportedExceptionMessage;
         private bool _includeFakeAttributes;
 
@@ -38,7 +37,6 @@ namespace Microsoft.Cci.Writers.CSharp
             _filter = filter;
             _forCompilation = forCompilation;
             _forCompilationIncludeGlobalprefix = false;
-            _forCompilationThrowPlatformNotSupported = false;
             _platformNotSupportedExceptionMessage = null;
             _includeFakeAttributes = false;
         }
@@ -60,11 +58,7 @@ namespace Microsoft.Cci.Writers.CSharp
             get { return _forCompilationIncludeGlobalprefix; }
             set { _forCompilationIncludeGlobalprefix = value; }
         }
-        public bool ForCompilationThrowPlatformNotSupported
-        {
-            get { return _forCompilationThrowPlatformNotSupported; }
-            set { _forCompilationThrowPlatformNotSupported = value; }
-        }
+
         public string PlatformNotSupportedExceptionMessage
         {
             get { return _platformNotSupportedExceptionMessage; }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Cci.Writers.CSharp
         private bool _forCompilation;
         private bool _forCompilationIncludeGlobalprefix;
         private bool _forCompilationThrowPlatformNotSupported;
+        private string _platformNotSupportedExceptionMessage;
         private bool _includeFakeAttributes;
 
         public CSDeclarationWriter(ISyntaxWriter writer)
@@ -38,6 +39,7 @@ namespace Microsoft.Cci.Writers.CSharp
             _forCompilation = forCompilation;
             _forCompilationIncludeGlobalprefix = false;
             _forCompilationThrowPlatformNotSupported = false;
+            _platformNotSupportedExceptionMessage = null;
             _includeFakeAttributes = false;
         }
 
@@ -62,6 +64,11 @@ namespace Microsoft.Cci.Writers.CSharp
         {
             get { return _forCompilationThrowPlatformNotSupported; }
             set { _forCompilationThrowPlatformNotSupported = value; }
+        }
+        public string PlatformNotSupportedExceptionMessage
+        {
+            get { return _platformNotSupportedExceptionMessage; }
+            set { _platformNotSupportedExceptionMessage = value; }
         }
 
         public ISyntaxWriter SyntaxtWriter { get { return _writer; } }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -55,6 +55,11 @@ namespace Microsoft.Cci.Writers
             get { return _declarationWriter.ForCompilationThrowPlatformNotSupported; }
             set { _declarationWriter.ForCompilationThrowPlatformNotSupported = value; }
         }
+        public string PlatformNotSupportedExceptionMessage
+        {
+            get { return _declarationWriter.PlatformNotSupportedExceptionMessage; }
+            set { _declarationWriter.PlatformNotSupportedExceptionMessage = value; }
+        }
 
         public void WriteAssemblies(IEnumerable<IAssembly> assemblies)
         {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -50,11 +50,7 @@ namespace Microsoft.Cci.Writers
             get { return _declarationWriter.ForCompilationIncludeGlobalPrefix; }
             set { _declarationWriter.ForCompilationIncludeGlobalPrefix = value; }
         }
-        public bool ThrowPlatformNotSupportedForCompilation
-        {
-            get { return _declarationWriter.ForCompilationThrowPlatformNotSupported; }
-            set { _declarationWriter.ForCompilationThrowPlatformNotSupported = value; }
-        }
+
         public string PlatformNotSupportedExceptionMessage
         {
             get { return _declarationWriter.PlatformNotSupportedExceptionMessage; }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -41,6 +41,7 @@
       <GenAPIArgs>$(GenAPIArgs) -libPath:"@(_referencePathDirectories)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -out:"$(NotSupportedSourceFile)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -throw</GenAPIArgs>
+      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly_Message)' != ''">$(GenAPIArgs) -exceptionMessage:"$(GeneratePlatformNotSupportedAssembly_Message)"</GenAPIArgs>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
+  <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
     <NotSupportedSourceFile>$(IntermediateOutputPath)$(TargetName).notsupported.cs</NotSupportedSourceFile>
     <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateNotSupportedSource</CoreCompileDependsOn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
+  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
     <AssemblyMetadata Include="NotSupported">
       <Value>True</Value>
     </AssemblyMetadata>
@@ -39,7 +39,7 @@
       <GenAPIArgs>-assembly:"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -libPath:"@(_referencePathDirectories)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -out:"$(NotSupportedSourceFile)"</GenAPIArgs>
-      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) -throw:"$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
+      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) -throw:"$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true'">
+  <PropertyGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
     <!-- Tell ResolveMatchingContract to run and resolve contract to project reference -->
     <ResolveMatchingContract>true</ResolveMatchingContract>
     <NotSupportedSourceFile>$(IntermediateOutputPath)$(TargetName).notsupported.cs</NotSupportedSourceFile>
     <CoreCompileDependsOn>$(CoreCompileDependsOn);GenerateNotSupportedSource</CoreCompileDependsOn>
-    <OmitResources>true</OmitResources>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true'">
+  <ItemGroup Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">
     <AssemblyMetadata Include="NotSupported">
       <Value>True</Value>
     </AssemblyMetadata>
@@ -40,8 +39,7 @@
       <GenAPIArgs>-assembly:"%(ResolvedMatchingContract.Identity)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -libPath:"@(_referencePathDirectories)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -out:"$(NotSupportedSourceFile)"</GenAPIArgs>
-      <GenAPIArgs>$(GenAPIArgs) -throw</GenAPIArgs>
-      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly_Message)' != ''">$(GenAPIArgs) -exceptionMessage:"$(GeneratePlatformNotSupportedAssembly_Message)"</GenAPIArgs>
+      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) -throw:"$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Resolves https://github.com/dotnet/buildtools/issues/1449. Enables assemblies that set `<GeneratePlatformNotSupportedAssembly>` to pass in an extra optional property to set a custom message for PlatformNotSupportedException like the following:

`<GeneratePlatformNotSupportedAssembly_Message>Operations with CNG keys are only supported on Windows platforms.</GeneratePlatformNotSupportedAssembly_Message>`

cc: @ericstj @weshaggard @danmosemsft 