### PR TITLE
Add -global option to GenAPI for including global prefix

### DIFF
--- a/src/GenAPI/Program.cs
+++ b/src/GenAPI/Program.cs
@@ -53,7 +53,7 @@ namespace GenAPI
                 }
             }
             else
-            { 
+            {
                 using (TextWriter output = GetOutput())
                 using (IStyleSyntaxWriter syntaxWriter = GetSyntaxWriter(output))
                 {
@@ -152,6 +152,7 @@ namespace GenAPI
                         writer.HighlightInterfaceMembers = s_hightlightInterfaceMembers;
                         writer.PutBraceOnNewLine = true;
                         writer.ThrowPlatformNotSupportedForCompilation = s_throw;
+                        writer.IncludeGlobalPrefixForCompilation = s_global;
                         return writer;
                     }
             }
@@ -237,6 +238,7 @@ namespace GenAPI
         private static bool s_hightlightInterfaceMembers;
         private static bool s_all;
         private static bool s_throw;
+        private static bool s_global;
 
         private static void ParseCommandLine(string[] args)
         {
@@ -266,6 +268,8 @@ namespace GenAPI
                 parser.DefineOptionalQualifier("hightlightInterfaceMembers", ref s_hightlightInterfaceMembers, "(-him) [CSDecl] Highlight interface implementation members.");
                 parser.DefineAliases("throw", "t");
                 parser.DefineOptionalQualifier("throw", ref s_throw, "(-t) Method bodies should throw PlatformNotSupportedException.");
+                parser.DefineAliases("global", "g");
+                parser.DefineOptionalQualifier("global", ref s_global, "(-g) Include global prefix for compilation.");
                 parser.DefineQualifier("assembly", ref s_assembly, "Path for an specific assembly or a directory to get all assemblies.");
             }, args);
         }


### PR DESCRIPTION
In case of using XXX.System namespace, types in System namespace of BCL can not be referenced at compilation time due to namespace conflicts. 

For example, 
```
namespace MyLib.System {
  public static partial class MyClass {
    public static bool IsChecked { get { throw new Systm.PlatformNotSupportedException(); } }
    ...
  }
}
```
at compilation time, Systm.PlatformNotSupportedException can not be found.

To avoid these conflicts, the -global option is needed to explicitly include the global prefix in every types.