### PR TITLE
Rewrite type refs in partial reference facades

### DIFF
--- a/src/GenFacades/GenFacades.Core/GenFacades.Core.csproj
+++ b/src/GenFacades/GenFacades.Core/GenFacades.Core.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
 
   <ItemGroup>
+    <Compile Include="TypeReferenceRewriter.cs" />
     <Compile Include="FacadeGenerationException.cs" />
     <Compile Include="GenFacades.cs" />
     <Compile Include="VersionResourceSerializer.cs" />

--- a/src/GenFacades/GenFacades.Core/TypeReferenceRewriter.cs
+++ b/src/GenFacades/GenFacades.Core/TypeReferenceRewriter.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Cci;
+using Microsoft.Cci.MutableCodeModel;
+using System;
+
+namespace GenFacades
+{
+    internal sealed class TypeReferenceRewriter : MetadataRewriter
+    {
+        private readonly Func<ITypeReference, ITypeReference> transform;
+
+        public TypeReferenceRewriter(IMetadataHost host, Func<ITypeReference, ITypeReference> transform): base(host, true)
+        {
+            this.transform = transform;
+        }
+
+        T TransformType<T>(T oldValue) where T: class, ITypeReference
+        {
+            return transform(oldValue) as T;
+        }
+
+        public override INamespaceTypeReference Rewrite(INamespaceTypeReference namespaceTypeReference)
+        {
+            return base.Rewrite(TransformType(namespaceTypeReference));
+        }
+
+        public override INestedTypeReference Rewrite(INestedTypeReference nestedTypeReference)
+        {
+            return base.Rewrite(TransformType(nestedTypeReference));
+        }
+
+        public override void RewriteChildren(GenericTypeInstanceReference genericTypeInstanceReference)
+        {
+            genericTypeInstanceReference.GenericType = TransformType(genericTypeInstanceReference.GenericType);
+            base.RewriteChildren(genericTypeInstanceReference);
+            genericTypeInstanceReference.GenericArguments = this.Rewrite(genericTypeInstanceReference.GenericArguments);
+            genericTypeInstanceReference.GenericType = this.Rewrite(genericTypeInstanceReference.GenericType);
+        }
+    }
+}


### PR DESCRIPTION
When creating a partial reference facade we remove types from the
assembly and replace them with typeforwards.

For the types that are left in the reference facade we need to make sure
they refer to the forwarded types rather than local type defs.
