### PR TITLE
Fix incorrect including global prefix for Attribute

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -198,12 +198,7 @@ namespace Microsoft.Cci.Writers.CSharp
             if (parameters.Length > 0)
             {
                 WriteSymbol("(");
-                _writer.WriteList(parameters, p =>
-                    {
-                        if (_forCompilationIncludeGlobalprefix)
-                            p = "global::" + p;
-                        Write(p);
-                    });
+                _writer.WriteList(parameters, p => Write(p));
                 WriteSymbol(")");
             }
 
@@ -309,7 +304,7 @@ namespace Microsoft.Cci.Writers.CSharp
             }
             else if (value is int)
             {
-                // int is the default and most used constant value so lets 
+                // int is the default and most used constant value so lets
                 // special case int to avoid a bunch of useless casts.
                 Write(value.ToString());
             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Cci.Writers.CSharp
                 string structLayout = "System.Runtime.InteropServices.StructLayoutAttribute";
                 string layoutKind = string.Format("System.Runtime.InteropServices.LayoutKind.{0}", type.Layout.ToString());
 
+                if (_forCompilationIncludeGlobalprefix)
+                    layoutKind = "global::" + layoutKind;
+
                 if (type.SizeOf != 0)
                 {
                     string sizeOf = string.Format("Size={0}", type.SizeOf);
@@ -73,7 +76,7 @@ namespace Microsoft.Cci.Writers.CSharp
 
         // Note that the metadata order for interfaces may change from one release to another.
         // This isn't an incompatibility in surface area.  So, we must sort our list of base types
-        // to reflect this.  
+        // to reflect this.
         private void WriteBaseTypes(ITypeDefinition type)
         {
             List<ITypeReference> baseTypes = new List<ITypeReference>();


### PR DESCRIPTION
GenAPI adds incorrect "global" prefix when the parameter of Attribute is not type name.

When using -global option to include "global::" prefix in types, following code can not be built with the generated source code. 
```
using System.Runtime.InteropServices;
namespace Test {
  [StructLayout(LayoutKind.Sequential, Size=4)]
  public struct MyStruct {
    public int X {get; set;}
  }
}
```

Because Microsoft.Cci.Extensions adds global prefix to every parameter of StructLayout.
Generated code:
```
namespace Test
{
 [global::System.Runtime.InteropServices.StructLayoutAttribute(global::System.Runtime.InteropServices.LayoutKind.Sequential, global::Size=4)]
    public partial struct MyStruct
    {
        public int X { [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]get { throw null; } [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute]set { } }
    }
}
```

CSDeclarationWriter::WriteFakeAttributes() adds the global prefix, but the parameters of this method can be non-type name such as "Size={0}", 

Thus, it is more desirable to determine whether the caller is to attach the "global::" prefix.
