### PR TITLE
Include Pdb for xunit console netcore

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,3 +1,3 @@
-Microsoft.DotNet.BuildTools=1.0.27-prerelease-01205-03
+Microsoft.DotNet.BuildTools=1.0.27-prerelease-01420-03
 Microsoft.DotNet.BuildTools.Run=1.0.1-prerelease-01205-03
 NuGet.CommandLine=3.4.3

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packages.targets
@@ -29,7 +29,8 @@
       BaseDirectory="$(PackagesBasePath)"
       PackageVersion="%(PackagesNuSpecFiles.PackageVersion)"
       ExcludeEmptyDirectories="true"
-      NuspecProperties="@(NuspecProperties)"/>
+      NuspecProperties="@(NuspecProperties)"
+      IncludeSymbolsInPackage="$(IncludeSymbolsInPackage)" />
 
     <Message
       Condition="'@(PackagesNuSpecFiles)'!=''"

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -49,6 +49,7 @@
     <file src="xunit.console.netcore\_._" target="lib\dnxcore50" />
     <file src="xunit.console.netcore\_._" target="lib\dotnet" />
     <file src="xunit.console.netcore\xunit.console.netcore.exe" target="runtimes\any\native" />
+    <file src="xunit.console.netcore\xunit.console.netcore.pdb" target="runtimes\any\native" />
 
     <file src="..\obj\version.txt" target="" />
   </files>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -10,6 +10,8 @@
          https://github.com/dotnet/buildtools/issues/780 -->
     <PackagingTaskDir Condition="'$(BuildToolsTargets45)' != 'true'">$(BinDir)AnyOS.AnyCPU.$(ConfigurationGroup)/Microsoft.DotNet.Build.Tasks.Packaging/</PackagingTaskDir>
     <PackagingTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(BinDir)AnyOS.AnyCPU.$(ConfigurationGroup)/Microsoft.DotNet.Build.Tasks.Packaging.Desktop/</PackagingTaskDir>
+
+    <IncludeSymbolsInPackage Condition="'$(IncludeSymbolsInPackage)'==''">true</IncludeSymbolsInPackage>
   </PropertyGroup>
 
   <Import Project="Microsoft.DotNet.Build.Tasks\PackageFiles\packages.targets" Condition="'$(ImportGetNuGetPackageVersions)' != 'false'" />


### PR DESCRIPTION
@weshaggard , @chcosta , @yizhang82 

This helps call stacks and debugging tests which use this executable.  

Since we provide no way to do this on a per-nuspec basis, I just did this for the entire buildtools repo;  since in most cases (some exceptions) files are included explicitly, this adds just 176.5 KB for the entire 8 MB suite of NuPKgs to bring along all adjacent pdbs that happened to already be included by the nuspecs.

It also turned out that the packaging .targets file never actually plumbed through the ability to set the IncludeSymbolsInPackage property, so I fixed that as well.  We may want to plumb through more there in the future.