### PR TITLE
Upload job start json messages; very useful for resending work.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -327,17 +327,17 @@
 
     <WriteItemsToJson JsonFileName="%(HelixWorkItemList.BuildCompleteJson)" Items="@(BuildComplete)" />
     <Message Text="Wrote job-start (build complete) JSON for @(BuildComplete->Count()) Queues." />
-	
+    
     <CreateItem Include="%(HelixWorkItemList.BuildCompleteJson)" AdditionalMetadata="RelativeBlobPath=JobStartJsonMessages.json">
       <Output TaskParameter="Include" ItemName="JobStartJsons" />
     </CreateItem>
-	
-	<UploadToAzure
+    
+    <UploadToAzure
      ConnectionString="$(CloudDropConnectionString)"
      ContainerName="$(ContainerName)"
      Items="@(JobStartJsons)"
      Overwrite="$(OverwriteOnUpload)" />
- 	<Message Text="Uploaded job-start JSON files to $(ContainerName).   These can be used for resending the same job for debugging purposes." />
+    <Message Text="Uploaded job-start JSON files to $(ContainerName).   These can be used for resending the same job for debugging purposes." />
 
   </Target>
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -326,7 +326,18 @@
     </ItemGroup>
 
     <WriteItemsToJson JsonFileName="%(HelixWorkItemList.BuildCompleteJson)" Items="@(BuildComplete)" />
-    <Message Text="Wrote build complete JSON for @(BuildComplete->Count()) Queues." />
+    <Message Text="Wrote job-start (build complete) JSON for @(BuildComplete->Count()) Queues." />
+	
+    <CreateItem Include="%(HelixWorkItemList.BuildCompleteJson)" AdditionalMetadata="RelativeBlobPath=JobStartJsonMessages.json">
+      <Output TaskParameter="Include" ItemName="JobStartJsons" />
+    </CreateItem>
+	
+	<UploadToAzure
+     ConnectionString="$(CloudDropConnectionString)"
+     ContainerName="$(ContainerName)"
+     Items="@(JobStartJsons)"
+     Overwrite="$(OverwriteOnUpload)" />
+ 	<Message Text="Uploaded job-start JSON files to $(ContainerName).   These can be used for resending the same job for debugging purposes." />
 
   </Target>
 


### PR DESCRIPTION
The JSON blobs here that get uploaded can be sent, with nothing more than an auth token in the header, to the Helix API;  this allows requeuing jobs for experimentation or other fun.

@smile21prc  this will allow you to send existing portable linux jobs to new queues for test with minimal effort.