### PR TITLE
Add casting statement on assignment for const Enum type

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
@@ -52,7 +52,11 @@ namespace Microsoft.Cci.Writers.CSharp
                 {
                     WriteSpace();
                     WriteSymbol("=", true);
-                    WriteMetadataConstant(field.Constant);
+                    if (field.Type.IsEnum) {
+                        WriteFieldDefinitionValue(field);
+                    } else {
+                        WriteMetadataConstant(field.Constant);
+                    }
                 }
 
                 WriteSymbol(";");
@@ -68,6 +72,29 @@ namespace Microsoft.Cci.Writers.CSharp
                 }
                 WriteSymbol(",");
             }
+        }
+
+        private void WriteFieldDefinitionValue(IFieldDefinition field) {
+            var resolvedType = field.Type.ResolvedType;
+
+            if (resolvedType != null) {
+                foreach (var enumField in resolvedType.Fields) {
+                    var enumFieldValue = enumField?.Constant?.Value;
+                    if (enumFieldValue != null && enumFieldValue.Equals(field.Constant.Value))
+                    {
+                        WriteTypeName(field.Type, noSpace: true);
+                        WriteSymbol(".");
+                        WriteIdentifier(enumField.Name);
+                        return;
+                    }
+                }
+            }
+
+            // couldn't find a symbol for enum, just cast it
+            WriteSymbol("(");
+            WriteTypeName(field.Type, noSpace: true);
+            WriteSymbol(")");
+            WriteMetadataConstant(field.Constant);
         }
     }
 }


### PR DESCRIPTION
In case of using "const enum type field" with initialzation, the constant value
is assigned to the const enum field without casting in the generated code from GenAPI

For example, When using const enum field with initialization as follows:
```
using System;

namespace MyTest
{
  public class MyClass
  {
    public const MyEnum ConstEnum1 = MyEnum.A;
  }

  public enum MyEnum
  {
    A = 1,
    B = 2,
  }
}
```

GenAPI generates following source code:
```
namespace MyTest
{
    public partial class MyClass
    {
        public const MyTest.MyEnum ConstEnum1 = 1;
        public MyClass() { }
    }
    public enum MyEnum
    {
        A = 1,
        B = 2,
    }
}
```

"MyEnum.A" is converted to a constant value "1", but this constant value can not be assigned to "Enum" type variable without casting.

In CSDeclarationWriter::WriteFieldDefinition() of Cci.Extensions, the "casting" should be added if the field type is Enum.
