### PR TITLE
Add xunit filter for method and class

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -90,6 +90,9 @@
 
     <XunitOptions Condition="'$(TestTFM)'!=''">$(XunitOptions) -notrait category=non$(TestTFM)tests</XunitOptions>
     <XunitOptions Condition="'$(XunitMaxThreads)'!=''">$(XunitOptions) -maxthreads $(XunitMaxThreads)</XunitOptions>
+    <XUnitOptions Condition="'$(XunitTestClass)' != ''">$(XunitOptions) -class $(XunitTestClass)</XUnitOptions>
+    <XUnitOptions Condition="'$(XunitTestMethod)' != ''">$(XunitOptions) -method $(XunitTestMethod)</XUnitOptions>
+    <XunitOptions>$(XUnitOptions) $(XunitAdditionalOptions)</XunitOptions>
     <XunitTestAssembly Condition="'$(XunitTestAssembly)' == ''">$(TargetFileName)</XunitTestAssembly>
     <XunitArguments>$(XunitTestAssembly) $(XunitOptions)</XunitArguments>
 


### PR DESCRIPTION
`/p:xunitoptions=xxx` blows away other options.

@weshaggard if you don't grab this, I'll merge after you go in. thanks!