### PR TITLE
Add framework package inbox validation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -61,6 +61,8 @@
     <Compile Include="PackageMetadata.cs" />
     <Compile Include="PackagingTask.cs" />
     <Compile Include="SplitReferences.cs" />
+    <Compile Include="ValidationTask.cs" />
+    <Compile Include="ValidateFrameworkPackage.cs" />
     <Compile Include="ValidatePackage.cs" />
     <Compile Include="PackageReport.cs" />
     <Compile Include="VerifyClosure.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
@@ -42,6 +42,7 @@
   <UsingTask TaskName="SplitReferences" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="UpdatePackageIndex" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="ValidatePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="ValidateFrameworkPackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="VerifyClosure" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetSupportedPackagesFromPackageReports" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -261,6 +261,7 @@
     </ItemGroup>
 
     <Error Condition="'$(SkipPackageFileCheck)' != 'true' AND
+                      '$(IsFrameworkPackage)' != 'true' AND
                       '%(File.SkipPackageFileCheck)' != 'true' AND
                       '%(File.FileName)' != '_' AND
                       '%(File.FileName)%(File.Extension)' != 'runtime.json' AND
@@ -1019,7 +1020,9 @@
 
   <PropertyGroup>
     <AllXamarinFrameworks Condition="'$(AllXamarinFrameworks)' == ''">MonoAndroid10;MonoTouch10;xamarinios10;xamarinmac20;xamarintvos10;xamarinwatchos10</AllXamarinFrameworks>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(IsFrameworkPackage)' != 'true'">
     <!-- Skip validation of runtime packages, they will be validated in the context of their reference package -->
     <SkipValidatePackage Condition="'$(SkipValidateTargetFrameworks)' == '' AND '$(PackageTargetRuntime)' != ''">true</SkipValidatePackage>
     <SkipSupportCheck Condition="'$(SkipSupportCheck)' == '' AND ($(Id.StartsWith('System.Private.')) OR $(Id.StartsWith('Microsoft.NETCore.')))">true</SkipSupportCheck>
@@ -1066,9 +1069,9 @@
                      ReportFile="$(PackageReportPath)" />
   </Target>
 
-  <Target Name="ValidatePackage"
+  <Target Name="ValidateLibraryPackage"
           DependsOnTargets="GetPackageReport"
-          Condition="'$(SkipValidatePackage)' != 'true'">
+          Condition="'$(IsFrameworkPackage)' != 'true'">
 
     <ItemGroup>
       <!-- Validation framework metadata can be sepecified in multiple ways.
@@ -1105,11 +1108,24 @@
                      SkipSupportCheck="$(SkipSupportCheck)"
                      SupportedFrameworks="@(SupportedFramework)"
                      Suppressions="@(ValidatePackageSuppression)"
-                     SuppressionFile="$(ValidationSuppressionFile)"
                      UseNetPlatform="$(UseNetPlatform)"
                      ReportFile="$(PackageReportPath)" />
 
   </Target>
+
+  <Target Name="ValidateFrameworkPackage"
+          DependsOnTargets="GetPackageReport"
+          Condition="'$(IsFrameworkPackage)' == 'true'">
+    <ValidateFrameworkPackage Framework="$(TargetFramework)"
+                              Runtime="$(PackageTargetRuntime)"
+                              PackageIndexes="@(PackageIndex)"
+                              ReportFile="$(PackageReportPath)"
+                              Suppressions="@(ValidatePackageSuppression)" />
+  </Target>
+  
+  <Target Name="ValidatePackage"
+          DependsOnTargets="ValidateLibraryPackage;ValidateFrameworkPackage"
+          Condition="'$(SkipValidatePackage)' != 'true'" />
 
   <!-- Required by Common.Targets when evaluating projectReferences -->
   <Target Name="GetNativeManifest" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageIndex.cs
@@ -578,6 +578,21 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             }
         }
 
+        public bool IsAnyVersionInbox(NuGetFramework framework)
+        {
+            var normalizedFramework = NormalizeFramework(framework);
+            var key = GetFrameworkKey(normalizedFramework);
+
+            SortedDictionary<Version, Version> mappings;
+            if (!inboxVersions.TryGetValue(key, out mappings))
+            {
+                // no inbox info for this framework
+                return false;
+            }
+
+            return mappings.Keys.Any(fxVer => fxVer <= framework.Version);
+        }
+
         public bool IsInbox(NuGetFramework framework, Version assemblyVersion, bool permitRevisions = false)
         {
             var normalizedFramework = NormalizeFramework(framework);

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateFrameworkPackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidateFrameworkPackage.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using PropertyNames = NuGet.Client.ManagedCodeConventions.PropertyNames;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public class ValidateFrameworkPackage : ValidationTask
+    {
+        [Required]
+        public string Framework
+        {
+            get;
+            set;
+        }
+        
+        public string Runtime
+        {
+            get;
+            set;
+        }
+
+        public override bool Execute()
+        {
+            InitializeValidationTask();
+
+            var fx = NuGetFramework.Parse(Framework);
+
+            var testAssets = GetTestAssets(fx, Runtime);
+            var testAssetsByName = testAssets.Where(a => Path.GetExtension(a.PackagePath) == ".dll")
+                                             .ToDictionary(a => Path.GetFileNameWithoutExtension(a.PackagePath), a => a);
+
+            var permittedInbox = GetSuppressionValues(Suppression.PermitInbox) ?? new HashSet<string>();
+
+            foreach (var testAssetByName in testAssetsByName)
+            {
+                var name = testAssetByName.Key;
+                var testAsset = testAssetByName.Value;
+
+                var logMissingInbox = permittedInbox.Contains(name) ? 
+                    new Action<string>(s => Log.LogMessage(LogImportance.Low, $"Suppressed: {s}")) :
+                    new Action<string>(s => Log.LogError(s));
+
+                PackageInfo packageInfo;
+                if (!_index.Packages.TryGetValue(name, out packageInfo))
+                {
+                    logMissingInbox($"File {name} was included framework package {_report.Id}/{_report.Version} but that file is missing from package index {string.Join(";", _index.IndexSources)}.  Please add it with approriate {nameof(PackageInfo.InboxOn)} entry for {Framework} or suppress this message with {nameof(Suppression.PermitInbox)} suppression.");
+                    continue;
+                }
+
+                if (!packageInfo.InboxOn.IsInbox(fx, testAsset.Version))
+                {
+                    logMissingInbox($"File {name}, version {testAsset.Version} was included framework package {_report.Id}/{_report.Version} but that version is not considered inbox in package index {string.Join(";", _index.IndexSources)}.  Please add it with approriate {nameof(PackageInfo.InboxOn)} entry for {Framework} or suppress this message with {nameof(Suppression.PermitInbox)} suppression.");
+                    continue;
+                }
+            }
+
+            var permittedMissingInbox = GetSuppressionValues(Suppression.PermitMissingInbox) ?? new HashSet<string>();
+            
+            var missingInboxAssemblies = _index.Packages.Where(packageInfo => packageInfo.Value.InboxOn.IsAnyVersionInbox(fx) && !testAssetsByName.ContainsKey(packageInfo.Key));
+
+            foreach(var missingInboxAssembly in missingInboxAssemblies)
+            {
+                var logMissingPackage = permittedMissingInbox.Contains(missingInboxAssembly.Key) ?
+                    new Action<string>(s => Log.LogMessage(LogImportance.Low, $"Suppressed: {s}")) :
+                    new Action<string>(s => Log.LogError(s));
+
+                logMissingPackage($"File {missingInboxAssembly.Key}.dll is marked as inbox for framework {Framework} but was missing from framework package {_report.Id}/{_report.Version}.  Either add the file or update {nameof(PackageInfo.InboxOn)} entry in {string.Join(";", _index.IndexSources)}.   This may be suppressed with with {nameof(Suppression.PermitMissingInbox)} suppression");
+            }
+            
+            return !Log.HasLoggedErrors;
+        }
+
+        private IEnumerable<PackageAsset> GetTestAssets(NuGetFramework fx, string runtimeId)
+        {
+
+            var targetKey = string.IsNullOrEmpty(runtimeId) ? fx.ToString() : $"{fx}/{runtimeId}";
+
+            Target target = null;
+            if (!_report.Targets.TryGetValue(targetKey, out target))
+            {
+                Log.LogError($"Could not find target {targetKey} in {ReportFile}.");
+                return Enumerable.Empty<PackageAsset>();
+            }
+
+            return string.IsNullOrEmpty(Runtime) ? target.CompileAssets : target.RuntimeAssets;
+        }
+    }
+
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using PropertyNames = NuGet.Client.ManagedCodeConventions.PropertyNames;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    public abstract class ValidationTask : PackagingTask
+    {
+        /// <summary>
+        /// Suppressions
+        ///     Identity: suppression name
+        ///     Value: optional semicolon-delimited list of values for the suppression
+        /// </summary>
+        public ITaskItem[] Suppressions { get;set; }
+        
+
+        /// <summary>
+        /// JSON file describing results of validation
+        /// </summary>
+        public string ReportFile
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Package index files used to define package version mapping.
+        /// </summary>
+        [Required]
+        public ITaskItem[] PackageIndexes { get; set; }
+
+        /// <summary>
+        /// property bag of error suppressions
+        /// </summary>
+        private Dictionary<Suppression, HashSet<string>> _suppressions;
+        protected PackageIndex _index;
+        protected PackageReport _report;
+
+        protected void InitializeValidationTask()
+        {
+            LoadSuppressions();
+            LoadReport();
+            LoadIndex();
+        }
+
+        protected HashSet<string> GetSuppressionValues(Suppression key)
+        {
+            HashSet<string> values;
+            _suppressions.TryGetValue(key, out values);
+            return values;
+        }
+
+        protected string GetSingleSuppressionValue(Suppression key)
+        {
+            var values = GetSuppressionValues(key);
+            return (values != null && values.Count == 1) ? values.Single() : null;
+        }
+
+
+        protected bool HasSuppression(Suppression key)
+        {
+            return _suppressions.ContainsKey(key);
+        }
+
+        protected bool HasSuppression(Suppression key, string value)
+        {
+            HashSet<string> values;
+            if (_suppressions.TryGetValue(key, out values) && values != null)
+            {
+                return values.Contains(value);
+            }
+            return false;
+        }
+
+        private void LoadSuppressions()
+        {
+            _suppressions = new Dictionary<Suppression, HashSet<string>>();
+
+            if (Suppressions != null)
+            {
+                foreach(var suppression in Suppressions)
+                {
+                    AddSuppression(suppression.ItemSpec, suppression.GetMetadata("Value"));
+                }
+            }
+        }
+
+        private void AddSuppression(string keyString, string valueString)
+        {
+            Suppression key;
+            HashSet<string> values = null;
+
+            if (!Enum.TryParse<Suppression>(keyString, out key))
+            {
+                Log.LogError($"Unknown suppression {keyString}");
+                return;
+            }
+
+            _suppressions.TryGetValue(key, out values);
+
+            if (valueString != null)
+            {
+                var valuesToAdd = valueString.Split(';').Select(v => v.Trim());
+
+                if (values == null)
+                {
+                    values = new HashSet<string>(valuesToAdd);
+                }
+                else
+                {
+                    foreach(var valueToAdd in valuesToAdd)
+                    {
+                        values.Add(valueToAdd);
+                    }
+                }
+            }
+
+            _suppressions[key] = values;
+        }
+
+        private void LoadReport()
+        {
+            _report = PackageReport.Load(ReportFile);
+        }
+        private void LoadIndex()
+        {
+            _index = PackageIndex.Load(PackageIndexes.Select(pi => pi.GetMetadata("FullPath")));
+        }
+    }
+
+    public enum Suppression
+    {
+        /// <summary>
+        /// Permits a runtime asset of the targets specified, semicolon delimited
+        /// </summary>
+        PermitImplementation,
+        /// <summary>
+        /// Permits an absent runtime asset on the targets specified, semicolon delimited
+        /// </summary>
+        PermitMissingImplementation,
+        /// <summary>
+        /// Permits a higher revision/build to still be considered as a match for an inbox assembly
+        /// </summary>
+        PermitInboxRevsion,
+        /// <summary>
+        /// Permits a lower version on specified frameworks, semicolon delimitied, than the generation supported by that framework
+        /// </summary>
+        PermitPortableVersionMismatch,
+        /// <summary>
+        /// Permits a compatible API version match between ref and impl, rather than exact match
+        /// </summary>
+        PermitHigherCompatibleImplementationVersion,
+        /// <summary>
+        /// Permits a non-matching targetFramework asset to be used even when a matching one exists.
+        /// </summary>
+        PermitRuntimeTargetMonikerMismatch,
+        /// <summary>
+        /// Permits an assembly to be inbox even if it is missing inbox data from the PackageIndex.  This is used for cases where we specifically want implementation-only assemblies.
+        /// </summary>
+        PermitInbox,
+        /// <summary>
+        /// Permits an inbox assembly to be missing from framework package.  This is used for cases where the assembly is part of the framework itself (eg: in desktop).
+        /// </summary>
+        PermitMissingInbox
+    }
+}


### PR DESCRIPTION
This adds a task that will run on framework packages and ensure the
package content is consistent with the package index.

I've also taken the opportunity to add some special cases for
IsFrameworkPackage to remove those from the CoreFx targets.

CoreFx changes: https://github.com/ericstj/corefx/commit/ce4d47b43ff6c44ecc3f1c55e0d53e7b69cf90e4

/cc @weshaggard @joperezr 