### PR TITLE
Add VerifyTypes task to catch duplicate types

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/Microsoft.DotNet.Build.Tasks.Packaging.Desktop.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src.Desktop/Microsoft.DotNet.Build.Tasks.Packaging.Desktop.csproj
@@ -22,6 +22,7 @@
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.IO" />
     <TargetingPackReference Include="System.IO.Compression" />
+    <TargetingPackReference Include="System.Reflection.Primitives" />
     <TargetingPackReference Include="System.Runtime" />
     <TargetingPackReference Include="System.Xml" />
     <TargetingPackReference Include="System.Xml.Linq" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Microsoft.DotNet.Build.Tasks.Packaging.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ValidateFrameworkPackage.cs" />
     <Compile Include="ValidatePackage.cs" />
     <Compile Include="PackageReport.cs" />
+    <Compile Include="VerifyTypes.cs" />
     <Compile Include="VerifyClosure.cs" />
     <Compile Include="VersionUtility.cs" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.common.targets
@@ -44,5 +44,6 @@
   <UsingTask TaskName="ValidatePackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="ValidateFrameworkPackage" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="VerifyClosure" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
+  <UsingTask TaskName="VerifyTypes" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
   <UsingTask TaskName="GetSupportedPackagesFromPackageReports" AssemblyFile="$(PackagingTaskDir)Microsoft.DotNet.Build.Tasks.Packaging.dll"/>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Build.Framework;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -7,7 +11,6 @@ using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.Packaging
@@ -101,7 +104,18 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 AssemblyInfo existingInfo;
                 if (assemblies.TryGetValue(assemblyInfo.Name, out existingInfo))
                 {
-                    Log.LogError($"Duplicate entries for {assemblyInfo.Name} : {assemblyInfo.Path} & {existingInfo.Path}");
+                    var fileName = Path.GetFileName(assemblyInfo.Path);
+                    var existingFileName = Path.GetFileName(existingInfo.Path);
+
+                    if (fileName.Equals(existingFileName))
+                    {
+                        Log.LogError($"Duplicate entries for {assemblyInfo.Name} : {assemblyInfo.Path} & {existingInfo.Path}");
+                    }
+                    else
+                    {
+                        // tolerate mismatched filenames, eg: foo.dll and foo.ni.dll
+                        Log.LogMessage($"Duplicate entries for {assemblyInfo.Name}, but different filenames : preferring {existingInfo.Path} over {assemblyInfo.Path}.");
+                    }
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyTypes.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyTypes.cs
@@ -1,0 +1,234 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging
+{
+    /// <summary>
+    /// Verifies no type overlap in a set of DLLs
+    /// </summary>
+    public class VerifyTypes : PackagingTask
+    {
+
+        /// <summary>
+        /// Sources to scan.  Items can be directories or files.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+        
+        /// <summary>
+        /// Dependencies to ignore.
+        ///     Identity: FileName
+        ///     Version: Maximum version to ignore, if not specified all versions will be ignored.
+        /// </summary>
+        public ITaskItem[] IgnoredTypes { get; set; }
+
+        private Dictionary<string, AssemblyInfo> assemblies = new Dictionary<string, AssemblyInfo>();
+        private HashSet<string> ignoredTypes = new HashSet<string>();
+
+        public override bool Execute()
+        {
+            if (Sources == null || Sources.Length == 0)
+            {
+                Log.LogError("No sources to scan.");
+                return false;
+            }
+
+            LoadIgnoredTypes();
+            LoadSources();
+
+            var types = new Dictionary<string, AssemblyInfo>();
+
+            foreach(var assembly in assemblies.Values)
+            {
+                foreach (var type in assembly.Types)
+                {
+                    AssemblyInfo existingAssembly;
+
+                    if (types.TryGetValue(type, out existingAssembly))
+                    {
+                        if (ignoredTypes.Contains(type))
+                        {
+                            Log.LogMessage($"Ignored duplicate type {type} in both {existingAssembly.Path} and {assembly.Path}.");
+                        }
+                        else
+                        {
+                            Log.LogError($"Duplicate type {type} in both {existingAssembly.Path} and {assembly.Path}.");
+                        }
+                    }
+                    else
+                    {
+                        types.Add(type, assembly);
+                    }
+                }
+            }
+            
+            return !Log.HasLoggedErrors;
+        }
+
+        private void LoadSources()
+        {
+            foreach (var source in Sources)
+            {
+                var path = source.GetMetadata("FullPath");
+
+                if (Directory.Exists(path))
+                {
+                    foreach (var file in Directory.EnumerateFiles(path))
+                    {
+                        AddSourceFile(file);
+                    }
+                }
+                else
+                {
+                    AddSourceFile(path);
+                }
+            }
+        }
+
+        private void AddSourceFile(string file)
+        {
+            var assemblyInfo = AssemblyInfo.GetAssemblyInfo(file);
+
+            if (assemblyInfo != null)
+            {
+                AssemblyInfo existingInfo;
+                if (assemblies.TryGetValue(assemblyInfo.Name, out existingInfo))
+                {
+                    var fileName = Path.GetFileName(assemblyInfo.Path);
+                    var existingFileName = Path.GetFileName(existingInfo.Path);
+
+                    if (fileName.Equals(existingFileName))
+                    {
+                        Log.LogError($"Duplicate entries for {assemblyInfo.Name} : {assemblyInfo.Path} & {existingInfo.Path}");
+                    }
+                    else
+                    {
+                        // tolerate mismatched filenames, eg: foo.dll and foo.ni.dll
+                        Log.LogMessage($"Duplicate entries for {assemblyInfo.Name}, but different filenames : preferring {existingInfo.Path} over {assemblyInfo.Path}.");
+                    }
+                }
+                else
+                {
+                    assemblies[assemblyInfo.Name] = assemblyInfo;
+                }
+            }
+        }
+
+        private void LoadIgnoredTypes()
+        {
+            foreach(var ignoredType in IgnoredTypes.NullAsEmpty())
+            {
+                ignoredTypes.Add(ignoredType.ItemSpec);
+            }
+        }
+
+        class AssemblyInfo
+        {
+            public AssemblyInfo(string path, string name, string[] types)
+            {
+                Path = path;
+                Name = name;
+                Types = types;
+            }
+
+            public string Path { get; }
+            public string Name { get; }
+            public string[] Types { get; }
+
+            public static AssemblyInfo GetAssemblyInfo(string path)
+            {
+                try
+                {
+                    using (PEReader peReader = new PEReader(new FileStream(path, FileMode.Open, FileAccess.Read)))
+                    {
+                        if (peReader.HasMetadata)
+                        {
+                            MetadataReader contractReader = peReader.GetMetadataReader();
+                            AssemblyDefinition assembly = contractReader.GetAssemblyDefinition();
+
+                            var name = contractReader.GetString(assembly.Name);
+                            var publicTypes = GetPublicTypes(contractReader);
+
+                            return new AssemblyInfo(path, name, publicTypes);
+                        }
+                    }
+                }
+                catch (BadImageFormatException)
+                {
+                    //not a PE
+                }
+
+                return null;
+            }
+
+            private static string[] GetPublicTypes(MetadataReader reader)
+            {
+                var types = new List<string>();
+
+                foreach (var typeDefHandle in reader.TypeDefinitions)
+                {
+                    bool isPublic;
+                    var typeName = GetTypeFromDefinition(reader, typeDefHandle, out isPublic);
+                    if (isPublic)
+                    {
+                        types.Add(typeName);
+                    }
+                }
+
+                return types.ToArray();
+            }
+
+            private static string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, out bool isPublic)
+            {
+                TypeDefinition definition = reader.GetTypeDefinition(handle);
+                isPublic = IsPublic(definition.Attributes);
+
+                string name = definition.Namespace.IsNil
+                    ? reader.GetString(definition.Name)
+                    : reader.GetString(definition.Namespace) + "." + reader.GetString(definition.Name);
+
+                if (IsNested(definition.Attributes))
+                {
+                    TypeDefinitionHandle declaringTypeHandle = definition.GetDeclaringType();
+
+                    bool parentIsPublic;
+                    name = GetTypeFromDefinition(reader, declaringTypeHandle, out parentIsPublic) + "/" + name;
+                    isPublic &= parentIsPublic;
+                }
+
+                return name;
+            }
+
+            private static bool IsPublic(TypeAttributes attr)
+            {
+                var typeVisibility = attr & TypeAttributes.VisibilityMask;
+
+                switch (typeVisibility)
+                {
+                    case TypeAttributes.Public:
+                    case TypeAttributes.NestedPublic:
+                    case TypeAttributes.NestedFamily:
+                    case TypeAttributes.NestedFamORAssem:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+
+            private const TypeAttributes NestedMask = (TypeAttributes)0x00000006;
+            private static bool IsNested(TypeAttributes attr)
+            {
+                return (attr & NestedMask) != 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a task which accepts a set of files and flags duplicate public
types in that set.

/cc @weshaggard 