### PR TITLE
Copy S.P.Corelib to S.P.Corelib.ni.dll to ensure the UAP F5 tests con…

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -274,6 +274,9 @@ robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
       <TestCommandLines Include="mkdir WinMetadata" />
       <TestCommandLines Include="mklink /H %(RunnerFolderContents.RecursiveDir)%(RunnerFolderContents.Filename)%(RunnerFolderContents.Extension) %RUNTIME_PATH%\Runner\%(RunnerFolderContents.RecursiveDir)%(RunnerFolderContents.Filename)%(RunnerFolderContents.Extension)" />
 
+      <!-- We need to have the ni as well as the non-ni version of the binary. The host (being a rather old build) looks for the ni name first (so we need that as well for now.) -->
+      <TestCommandLines Include="xcopy /y %RUNTIME_PATH%\Runner\System.Private.CoreLib.dll %RUNTIME_PATH%\Runner\System.Private.CoreLib.ni.dll" />
+
       <!-- Copy the runtime binaries over -->
       <RuntimePathContents Include="$(RuntimePath)\**\*" />
       <TestCommandLines Include="mklink /H %(RuntimePathContents.RecursiveDir)%(RuntimePathContents.Filename)%(RuntimePathContents.Extension) $(_Runtime_Path)%(RuntimePathContents.Filename)%(RuntimePathContents.Extension)" />


### PR DESCRIPTION
…tinue to work

/cc @gkhanna79 @weshaggard @joperezr 