### PR TITLE
Fix incorrect generation of GenAPI when ns is not declared

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -75,11 +75,18 @@ namespace Microsoft.Cci.Writers
 
         public override void Visit(INamespaceDefinition ns)
         {
-            _declarationWriter.WriteDeclaration(ns);
-
-            using (_syntaxWriter.StartBraceBlock(PutBraceOnNewLine))
+            if (ns != null && string.IsNullOrEmpty(ns.Name.Value))
             {
                 base.Visit(ns);
+            }
+            else
+            {
+                _declarationWriter.WriteDeclaration(ns);
+
+                using (_syntaxWriter.StartBraceBlock(PutBraceOnNewLine))
+                {
+                    base.Visit(ns);
+                }
             }
 
             _syntaxWriter.WriteLine();


### PR DESCRIPTION
If a class is declared without a namespace, 
```
public class MyTest {
}
```
GenAPI generates following incorrect code. 
```
namespace 
{
    public partial class MyTest
    {
        public MyTest() { }
    }
}
```

If a type is declared without a namespace, the namespace block shouldn't be created.





