### PR TITLE
Add System namespace to PNSE Message in GenAPI

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 if(_platformNotSupportedExceptionMessage.Length == 0)
                     Write("System.PlatformNotSupportedException();");
                 else if(_platformNotSupportedExceptionMessage.StartsWith("SR."))
-                    Write($"System.PlatformNotSupportedException({_platformNotSupportedExceptionMessage}); ");
+                    Write($"System.PlatformNotSupportedException(System.{_platformNotSupportedExceptionMessage}); ");
                 else
                     Write($"System.PlatformNotSupportedException(\"{_platformNotSupportedExceptionMessage}\"); ");
             }


### PR DESCRIPTION
This should fix errors in https://github.com/dotnet/corefx/pull/19506. When using resource strings as the message for auto-generated PNSE, few projects like the following hit `The name 'SR' does not exist in the current context` errors, as the `System` namespace is missing:

- Microsoft.Win32.Registry
- Microsoft.Win32.Registry.AccessControl
- System.Security.Cryptography.Cng (In some configurations contains APIs from Microsoft.Win32.SafeHandles)

cc: @ericstj @danmosemsft 