### PR TITLE
Pass ProjectReferencesCreatingPackages to resolve task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -90,7 +90,8 @@
                                RuntimeIdentifier="$(NuGetRuntimeIdentifier)"
                                ProjectLanguage="$(Language)"
                                ProjectLockFile="$(ProjectAssetsFile)"
-                               TargetMonikers="$(NuGetTargetMoniker)">
+                               TargetMonikers="$(NuGetTargetMoniker)"
+                               ProjectReferencesCreatingPackages="@(ProjectReference)">
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="_ReferenceFromPackage" />
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="_ReferenceCopyLocalPathsFromPackage" />


### PR DESCRIPTION
If a csproj has P2P references, this property needs to be passed for the PrereleaseResolveNugetPackageAssets to work. It just happens that none of our projects in corefx/standard have P2P references, so we've never hit it. core-setup has a project where we need this.

@weshaggard 