### PR TITLE
Set output type on tool-runtime project

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -5,6 +5,7 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001776-00</RuntimeFrameworkVersion>
     <RuntimeIdentifiers>centos.7-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;opensuse.13.2-x64;opensuse.42.1-x64;osx.10.10-x64;rhel.7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;win7-x64;win7-x86</RuntimeIdentifiers>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">


### PR DESCRIPTION
Working around https://github.com/dotnet/sdk/issues/1198

/cc @weshaggard @eerhardt @mellinoe 