### PR TITLE
Allow additional parameters to be passed to restore command

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -37,7 +37,7 @@
 
     <PropertyGroup>
       <_DnuRestoreCommandRidPortion Condition="'$(RidSpecificAssets)' == 'true'">-r $(NuGetRuntimeIdentifier)</_DnuRestoreCommandRidPortion>
-      <_DnuRestoreCommandFull>$(DnuRestoreCommand) $(ProjectJson) /p:TargetGroup=$(TargetGroup) /p:ConfigurationGroup=$(ConfigurationGroup) /p:ArchGroup=$(ArchGroup) /p:OSGroup=$(OSGroup) /p:TargetFramework=$(NuGetTargetMonikerShort) $(_DnuRestoreCommandRidPortion)</_DnuRestoreCommandFull>
+      <_DnuRestoreCommandFull>$(DnuRestoreCommand) $(ProjectJson) /p:TargetGroup=$(TargetGroup) /p:ConfigurationGroup=$(ConfigurationGroup) /p:ArchGroup=$(ArchGroup) /p:OSGroup=$(OSGroup) /p:TargetFramework=$(NuGetTargetMonikerShort) $(_DnuRestoreCommandRidPortion) $(AdditionalRestoreArgs)</_DnuRestoreCommandFull>
     </PropertyGroup>
     <Exec Condition="Exists('$(ProjectJson)') AND '$(RestoreRequired)' == 'true'" Command="$(_DnuRestoreCommandFull)" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
     


### PR DESCRIPTION
This allows you to control arbitrary project properties on the projects you are restoring. This is useful when you want to set things outside of the usual `TargetFramework`, `RuntimeIdentifier` properties, like the `BaseOutputPath`, etc.