### PR TITLE
Passing path when saving build definitions in VSTS.

### DIFF
--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/Configuration/VstsDefinitionClientConfig.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/Configuration/VstsDefinitionClientConfig.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Linq;
+
 namespace Microsoft.DotNet.Build.VstsBuildsApi.Configuration
 {
     /// <summary>
@@ -11,7 +14,35 @@ namespace Microsoft.DotNet.Build.VstsBuildsApi.Configuration
     /// </summary>
     public class VstsDefinitionClientConfig
     {
-        public VstsApiEndpointConfig BuildDefinitionEndpointConfig { get; set; }
+        private static string[] invalidBuildIdentifiableFields =
+            {
+                /* If included in the list of identifiable fields, it would be
+                 * excluded from create requests, which would prevent VSTS from
+                 * saving the build definition at the correct path.
+                 */
+                "path",
+            };
+
+        private VstsApiEndpointConfig buildDefinitionEndpointConfig;
+
+        public VstsApiEndpointConfig BuildDefinitionEndpointConfig
+        {
+            get
+            {
+                return buildDefinitionEndpointConfig;
+            }
+            set
+            {
+                if (value.InstanceIdentifiableFields.Intersect(invalidBuildIdentifiableFields).Any())
+                {
+                    throw new ArgumentException(
+                        $"{nameof(BuildDefinitionEndpointConfig.InstanceIdentifiableFields)} cannot contain any" +
+                        $" of the following fields: {string.Join(",", invalidBuildIdentifiableFields)}");
+                }
+
+                buildDefinitionEndpointConfig = value;
+            }
+        }
 
         public VstsApiEndpointConfig ReleaseDefinitionEndpointConfig { get; set; }
     }

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/Configuration/VstsDefinitionClientConfig.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/Configuration/VstsDefinitionClientConfig.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
-
 namespace Microsoft.DotNet.Build.VstsBuildsApi.Configuration
 {
     /// <summary>
@@ -14,35 +11,7 @@ namespace Microsoft.DotNet.Build.VstsBuildsApi.Configuration
     /// </summary>
     public class VstsDefinitionClientConfig
     {
-        private static string[] invalidBuildIdentifiableFields =
-            {
-                /* If included in the list of identifiable fields, it would be
-                 * excluded from create requests, which would prevent VSTS from
-                 * saving the build definition at the correct path.
-                 */
-                "path",
-            };
-
-        private VstsApiEndpointConfig buildDefinitionEndpointConfig;
-
-        public VstsApiEndpointConfig BuildDefinitionEndpointConfig
-        {
-            get
-            {
-                return buildDefinitionEndpointConfig;
-            }
-            set
-            {
-                if (value.InstanceIdentifiableFields.Intersect(invalidBuildIdentifiableFields).Any())
-                {
-                    throw new ArgumentException(
-                        $"{nameof(BuildDefinitionEndpointConfig.InstanceIdentifiableFields)} cannot contain any" +
-                        $" of the following fields: {string.Join(",", invalidBuildIdentifiableFields)}");
-                }
-
-                buildDefinitionEndpointConfig = value;
-            }
-        }
+        public VstsApiEndpointConfig BuildDefinitionEndpointConfig { get; set; }
 
         public VstsApiEndpointConfig ReleaseDefinitionEndpointConfig { get; set; }
     }

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildHttpClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsBuildHttpClient.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.Build.VstsBuildsApi.Configuration;
 using Newtonsoft.Json.Linq;
 using System;
+using System.IO;
 
 namespace Microsoft.DotNet.Build.VstsBuildsApi
 {
@@ -19,8 +20,17 @@ namespace Microsoft.DotNet.Build.VstsBuildsApi
 
         protected override bool IsMatching(JObject localDefinition, JObject retrievedDefinition)
         {
+            string localDefinitionPath = localDefinition["path"].ToString();
+
+            // If it's not the root directory.
+            if (Path.GetDirectoryName(localDefinitionPath) != null) {
+                // Remove trailing path separators since VSTS does the same when creating definitions.
+                localDefinitionPath = localDefinitionPath.TrimEnd(
+                    Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            }
+
             return localDefinition["quality"].ToString() == "definition" &&
-                localDefinition["path"].ToString() == retrievedDefinition["path"].ToString();
+                localDefinitionPath == retrievedDefinition["path"].ToString();
         }
 
         protected override string GetDefinitionProject(JObject definition)

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsDefinitionClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsDefinitionClient.cs
@@ -131,7 +131,6 @@ namespace Microsoft.DotNet.Build.VstsBuildsApi
                         "comment",
                         "createdDate",
                         "id",
-                        "path",
                         "revision",
                         "uri",
                         "url",

--- a/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsDefinitionHttpClient.cs
+++ b/src/Microsoft.DotNet.Build.VstsBuildsApi/VstsDefinitionHttpClient.cs
@@ -55,15 +55,19 @@ namespace Microsoft.DotNet.Build.VstsBuildsApi
                 definition);
 
         /// <summary>
-        /// Retrieve a VSTS Definition by name and VSTS folder path
+        /// Retrieve a VSTS Definition by ID.
         /// </summary>
+        /// <param name="definition">A definition containing the definition ID.</param>
+        /// <returns>The VSTS definition.</returns>
         public async Task<JObject> RetrieveDefinitionByIdAsync(JObject definition) =>
             await JsonClient.GetAsync(
                 GetRequestUri(definition, $"definitions/{definition["id"]}"));
 
         /// <summary>
-        /// Retrieve a VSTS Definition by name and VSTS folder path
+        /// Retrieve a list of VSTS Definitions by name and VSTS folder path.
         /// </summary>
+        /// <param name="definition">A definition containing the definition's name and path in VSTS.</param>
+        /// <returns>A list of VSTS definitions with summarized data (not the full definition data in VSTS).</returns>
         public async Task<IReadOnlyList<JObject>> RetrieveDefinitionsListByNameAndPathAsync(JObject definition)
         {
             string requestUrl = GetRequestUri(


### PR DESCRIPTION
@markwilkie @chcosta @dagood 

Creating this to discuss the fix for dotnet/core-eng#163.

Some further questions:

- The method RemoveIdentifiableInformation, which removes instance identifiable fields, is called on the local checked in definition, but the examples I've seen of local definitions never seem to have these fields; only VSTS seems to know about them. Is this just a validation mechanism to ensure local definitions are not written with these fields by accident?
- It looks like the path was not being sent to VSTS because the logic considered it an instance identifiable field. If we remove it from that list of identifiable fields, the path can be sent and retrieved from VSTS normally; are there any other consequences I'm missing for removing this field from that list?
- These changes fix the issue when using the default config for VstsDefinitionClientConfig; however, if using a custom config that adds the path again to the list of identifiable fields, this would break again in the same way. Is this (using a different config) something common that we should defend against?
- Regarding the extra logic in IsMatching to remove the trailing separators, added this because the Build API does this on their end, so saving /ABC/ the first time would break on the second time since we would be comparing local: /ABC/ against retrieved: /ABC . If there is another tool that validates definitions before checking them in, would it be better to move this check there to ensure no checked-in definition ever have trailing separators?

Added some comments in VstsDefinitionHttpClient.cs because I was a little confused about why both of those methods were called before updating (the reason being only RetrieveDefinitionByIdAsync gets the full definition data) :)

Tested these cases:

1. Saving a definition with the root path. Running again updates the same definition.
2. Saving the same definition but with \SomePath\. It creates a new definition under the specified path. Running again updates the same definition.
3. Saving the same definition but with \SometPath. It updates the same definition as the previous test.
