### PR TITLE
Add blob prefix support to our download and upload tasks/targets

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -29,6 +29,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         [Required]
         public string DownloadDirectory { get; set; }
 
+        public string BlobNamePrefix { get; set; }
+
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -46,8 +48,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Log.LogMessage(MessageImportance.Normal, "Downloading contents of container {0} from storage account '{1}' to directory {2}.",
                 ContainerName, AccountName, DownloadDirectory);
 
+            string blobprefix = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
+
             List<string> blobsNames = new List<string>();
-            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list", AccountName, ContainerName);
+            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list{2}", AccountName, ContainerName, blobprefix);
 
             Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml;
-    
+
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
     public sealed class DownloadFromAzure : AzureConnectionStringBuildTask
@@ -48,10 +48,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Log.LogMessage(MessageImportance.Normal, "Downloading contents of container {0} from storage account '{1}' to directory {2}.",
                 ContainerName, AccountName, DownloadDirectory);
 
-            string blobprefix = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
+            string optionalBlobPrefixForQuery = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
 
             List<string> blobsNames = new List<string>();
-            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list{2}", AccountName, ContainerName, blobprefix);
+            string urlListBlobs = $"https://{AccountName}.blob.core.windows.net/{ContainerName}?restype=container&comp=list{optionalBlobPrefixForQuery}";
 
             Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
@@ -12,8 +12,8 @@
     <Error Condition="'$(PublishPattern)' == ''" Text="Please specify a value for PublishPattern using standard msbuild 'include' syntax." />
 
     <PropertyGroup>
-      <ReleativeBlobPathBase>$(BlobNamePrefix)</ReleativeBlobPathBase>
-      <ReleativeBlobPathBase Condition="'$(ReleativeBlobPathBase)' != '' and !HasTrailingSlash('$(ReleativeBlobPathBase)')">$(ReleativeBlobPathBase)</ReleativeBlobPathBase>
+      <RelativeBlobPathBase>$(BlobNamePrefix)</RelativeBlobPathBase>
+      <RelativeBlobPathBase Condition="'$(RelativeBlobPathBase)' != '' and !HasTrailingSlash('$(RelativeBlobPathBase)')">$(RelativeBlobPathBase)/</RelativeBlobPathBase>
     </PropertyGroup>
     <ItemGroup>
       <ForPublishing Include="$(PublishPattern)" />
@@ -21,7 +21,7 @@
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>
-        <RelativeBlobPath>$(ReleativeBlobPathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+        <RelativeBlobPath>$(RelativeBlobPathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
       </ForPublishing>
     </ItemGroup>
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
@@ -10,13 +10,18 @@
   <!-- gathers the items to be published -->
   <Target Name="GatherItemsForPattern">
     <Error Condition="'$(PublishPattern)' == ''" Text="Please specify a value for PublishPattern using standard msbuild 'include' syntax." />
+
+    <PropertyGroup>
+      <ReleativeBlobPathBase>$(BlobNamePrefix)</ReleativeBlobPathBase>
+      <ReleativeBlobPathBase Condition="'$(ReleativeBlobPathBase)' != '' and !HasTrailingSlash('$(ReleativeBlobPathBase)')">$(ReleativeBlobPathBase)</ReleativeBlobPathBase>
+    </PropertyGroup>
     <ItemGroup>
       <ForPublishing Include="$(PublishPattern)" />
     </ItemGroup>
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>
-        <RelativeBlobPath>$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath> 
+        <RelativeBlobPath>$(ReleativeBlobPathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
       </ForPublishing>
     </ItemGroup>
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/SyncCloudContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/SyncCloudContent.targets
@@ -25,7 +25,8 @@
     <DownloadFromAzure AccountName="$(CloudDropAccountName)"
                        AccountKey="$(CloudDropAccessToken)"
                        ContainerName="$(ContainerName)"
+                       BlobNamePrefix="$(BlobNamePrefix)"
                        DownloadDirectory="$(DownloadDirectory)" />
   </Target>
-  
+
 </Project>


### PR DESCRIPTION
This gets us into a place were we can start using the same
container with just different blob paths moving forward

cc @dagood @MattGal 

After this change we can start to move our build definitions to use the same container and just a different path.