### PR TITLE
Enable to pass a TargetFrameworkMoniker to ActiveIssueAttribute

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -18,7 +18,7 @@ namespace Xunit
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
         public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
-        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)~0) { }
-        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)~0) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0) { }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -18,7 +18,7 @@ namespace Xunit
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
         public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
-        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.None) { }
-        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.None) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.All) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.All) { }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -18,7 +18,7 @@ namespace Xunit
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
         public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
-        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.All) { }
-        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.All) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)~0) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)~0) { }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -16,9 +16,7 @@ namespace Xunit
     {
         public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any) { }
         public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any) { }
-
         public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
-
         public ActiveIssueAttribute(string issueNumber, TargetFrameworkMonikers framework) { }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -14,9 +14,11 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class ActiveIssueAttribute : Attribute, ITraitAttribute
     {
-        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any) { }
-        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
-        public ActiveIssueAttribute(string issueNumber, TargetFrameworkMonikers framework) { }
+        public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.None) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = TargetFrameworkMonikers.None) { }
     }
 }

--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -16,5 +16,9 @@ namespace Xunit
     {
         public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any) { }
         public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any) { }
+
+        public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
+
+        public ActiveIssueAttribute(string issueNumber, TargetFrameworkMonikers framework) { }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -28,17 +28,36 @@ namespace Xunit.NetCore.Extensions
             Debug.Assert(ctorArgs.Count() >= 2);
 
             string issue = ctorArgs.First().ToString();
-            TestPlatforms platforms = (TestPlatforms)ctorArgs.Last();
-            if ((platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
-                (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
-                (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
-                (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
-                (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+            object lastArg = ctorArgs.Last();
+            if (lastArg is TestPlatforms)
             {
-                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
+                TestPlatforms platforms = (TestPlatforms)lastArg;
+                if ((platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
+                    (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+                    (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
+                    (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
+                    (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+                {
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
+                    yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
+                }
+            }
+            else
+            {
+                TargetFrameworkMonikers framework = (TargetFrameworkMonikers)lastArg;
+                if (framework.HasFlag(TargetFrameworkMonikers.NetFramework))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+                if (framework.HasFlag(TargetFrameworkMonikers.Netcoreapp))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
+                if (framework.HasFlag(TargetFrameworkMonikers.Uap))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
+                if (framework.HasFlag(TargetFrameworkMonikers.UapAot))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
+                if (framework.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
+                
                 yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
             }
-
         }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -29,7 +29,7 @@ namespace Xunit.NetCore.Extensions
 
             string issue = ctorArgs.First().ToString();
             TestPlatforms platforms = TestPlatforms.Any;
-            TargetFrameworkMonikers frameworks = TargetFrameworkMonikers.None;
+            TargetFrameworkMonikers frameworks = TargetFrameworkMonikers.All;
             
             if (ctorArgs.Count() > 2)
             {
@@ -65,8 +65,6 @@ namespace Xunit.NetCore.Extensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
-                if (frameworks == TargetFrameworkMonikers.None)
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
 
                 yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
             }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -29,16 +29,10 @@ namespace Xunit.NetCore.Extensions
 
             string issue = ctorArgs.First().ToString();
             TestPlatforms platforms = TestPlatforms.Any;
-            TargetFrameworkMonikers frameworks = TargetFrameworkMonikers.All;
+            TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)~0;
             
-            if (ctorArgs.Count() > 2)
+            foreach (object arg in ctorArgs.Skip(1)) // First argument is the issue number.
             {
-                platforms = (TestPlatforms)ctorArgs.ElementAt(1);
-                frameworks = (TargetFrameworkMonikers)ctorArgs.Last();
-            }
-            else
-            {
-                object arg = ctorArgs.Last();
                 if (arg is TestPlatforms)
                 {
                     platforms = (TestPlatforms)arg;

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -29,7 +29,7 @@ namespace Xunit.NetCore.Extensions
 
             string issue = ctorArgs.First().ToString();
             TestPlatforms platforms = TestPlatforms.Any;
-            TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)~0;
+            TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)0;
             
             foreach (object arg in ctorArgs.Skip(1)) // First argument is the issue number.
             {
@@ -37,7 +37,7 @@ namespace Xunit.NetCore.Extensions
                 {
                     platforms = (TestPlatforms)arg;
                 }
-                else
+                else if (arg is TargetFrameworkMonikers)
                 {
                     frameworks = (TargetFrameworkMonikers)arg;
                 }
@@ -59,6 +59,8 @@ namespace Xunit.NetCore.Extensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
+                if (frameworks == (TargetFrameworkMonikers)0)
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
 
                 yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
             }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -28,34 +28,48 @@ namespace Xunit.NetCore.Extensions
             Debug.Assert(ctorArgs.Count() >= 2);
 
             string issue = ctorArgs.First().ToString();
-            object lastArg = ctorArgs.Last();
-            if (lastArg is TestPlatforms)
+            TestPlatforms platforms = TestPlatforms.Any;
+            TargetFrameworkMonikers frameworks = TargetFrameworkMonikers.None;
+            
+            if (ctorArgs.Count() > 2)
             {
-                TestPlatforms platforms = (TestPlatforms)lastArg;
-                if ((platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
-                    (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
-                    (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
-                    (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
-                    (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
-                {
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
-                }
+                platforms = (TestPlatforms)ctorArgs.ElementAt(1);
+                frameworks = (TargetFrameworkMonikers)ctorArgs.Last();
             }
             else
             {
-                TargetFrameworkMonikers framework = (TargetFrameworkMonikers)lastArg;
-                if (framework.HasFlag(TargetFrameworkMonikers.NetFramework))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
-                if (framework.HasFlag(TargetFrameworkMonikers.Netcoreapp))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-                if (framework.HasFlag(TargetFrameworkMonikers.Uap))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
-                if (framework.HasFlag(TargetFrameworkMonikers.UapAot))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
-                if (framework.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
-                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
+                object arg = ctorArgs.Last();
+                if (arg is TestPlatforms)
+                {
+                    platforms = (TestPlatforms)arg;
+                }
+                else
+                {
+                    frameworks = (TargetFrameworkMonikers)arg;
+                }
             }
-            yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
+        
+            if ((platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
+                (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+                (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
+                (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
+                (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+            {
+                if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+                if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
+                if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
+                if (frameworks.HasFlag(TargetFrameworkMonikers.UapAot))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
+                if (frameworks.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
+                if (frameworks == TargetFrameworkMonikers.None)
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
+
+                yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
+            }
         }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -39,7 +39,6 @@ namespace Xunit.NetCore.Extensions
                     (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
                 {
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
-                    yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
                 }
             }
             else
@@ -55,9 +54,8 @@ namespace Xunit.NetCore.Extensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
                 if (framework.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
-                
-                yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
             }
+            yield return new KeyValuePair<string, string>(XunitConstants.ActiveIssue, issue);
         }
     }
 }

--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -9,7 +9,6 @@ namespace Xunit
     [Flags]
     public enum TargetFrameworkMonikers
     {
-        None = 0,
         Net45 = 0x1,
         Net451 = 0x2,
         Net452 = 0x4,
@@ -25,6 +24,7 @@ namespace Xunit
         Netcoreapp = 0x1000,
         Uap = 0x2000,
         UapAot = 0x4000,
-        NetcoreCoreRT = 0x8000
+        NetcoreCoreRT = 0x8000,
+        All = ~0
     }
 }

--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -9,6 +9,7 @@ namespace Xunit
     [Flags]
     public enum TargetFrameworkMonikers
     {
+        None = 0,
         Net45 = 0x1,
         Net451 = 0x2,
         Net452 = 0x4,

--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -24,7 +24,6 @@ namespace Xunit
         Netcoreapp = 0x1000,
         Uap = 0x2000,
         UapAot = 0x4000,
-        NetcoreCoreRT = 0x8000,
-        All = ~0
+        NetcoreCoreRT = 0x8000
     }
 }


### PR DESCRIPTION
With the desktop test effort we started disabling tests with an active issue on github by doing: 
```cs
[SkipOnTargetFramework(TagetFrameworkMonikers.NetFramework, "dotnet/corefx #issue")]
```
When that is not the intended usage of this attribute. We want to use this attribute when the test is specific to another framework or an intended difference on behavior. 

With this PR we allow to use `[ActiveIssue(1234, TargetFrameworkMonikers.NetFramework)]` in example to disable a test that has an issue open tracking the failure only on desktop, or if we find a failure only on uap or netcoreapp disable the test through ActiveIssueAttribute only for that target framework.

cc: @weshaggard @danmosemsft 

FYI: @stephentoub 