### PR TITLE
Add new job to test the reproBuild parameter in Jenkins

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -37,9 +37,9 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         
-        def zipWorkspace = "'C:\\Program Files\\7-Zip\\7z.exe' a -t7z workspace.7z -mx9"
+        def zipWorkspace = "\"C:\\Program Files\\7-Zip\\7z.exe\" a -t7z workspace.7z -mx9"
         def workspaceDestination = "https://cisnapshot.blob.core.windows.net/workspace"
-        def uploadToAzure = "'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe' /Source:. /Pattern:workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
+        def uploadToAzure = "\"C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe\" /Source:. /Pattern:workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
         def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/75d89d44-c3a0-44da-958a-b63d4132ca8e/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/workspace.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
 
         batchFile("echo Renaming launch.cmd")

--- a/netci.groovy
+++ b/netci.groovy
@@ -36,7 +36,8 @@ def branch = GithubBranchName
 // Generate a fake job to test ReproBuild functionality
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
-        
+        batchFile('''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd''')
+
         def zipWorkspace = "\"C:\\Program Files\\7-Zip\\7z.exe\" a -t7z %COMPUTERNAME%-Workspace.7z -mx9"
         def workspaceDestination = "https://dotnetci1vmstorage2.blob.core.windows.net/workspace"
         def uploadToAzure = "\"C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe\" /Source:. /Pattern:%COMPUTERNAME%-Workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"

--- a/netci.groovy
+++ b/netci.groovy
@@ -31,4 +31,14 @@ def branch = GithubBranchName
     }
 }
 
+// Generate a fake job to test ReproBuild functionality
+def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
+    steps {
+        batchFile('''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd''')
+    }
+}
+Utilities.setMachineAffinity(reproJob, 'Windows_NT', 'latest-or-auto')
+Utilities.standardJobSetup(reproJob, project, true, "*/${branch}")
+Utilities.addGithubPushTrigger(reproJob)
+
 Utilities.addCROSSCheck(this, project, branch)

--- a/netci.groovy
+++ b/netci.groovy
@@ -1,5 +1,6 @@
 // Import the utility functionality.
 
+import jobs.generation.ArchivalSettings
 import jobs.generation.Utilities;
 
 def project = GithubProject
@@ -42,6 +43,10 @@ Utilities.standardJobSetup(reproJob, project, true, "*/${branch}")
 Utilities.addGithubPushTrigger(reproJob)
 
 //Process the msbuild log
-Utilities.addReproBuild (reproJob, "msbuild.log")
+def archiveSettings = new ArchivalSettings()
+archiveSettings.addFiles("msbuild.log")
+archiveSettings.setFailIfNothingArchived()
+archiveSettings.setArchiveOnFailure()
+Utilities.addReproBuild (reproJob, archiveSettings)
 
 Utilities.addCROSSCheck(this, project, branch)

--- a/netci.groovy
+++ b/netci.groovy
@@ -37,10 +37,9 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json' -ErrorAction Continue"""
-        batchFile("dir C:\\Jenkins")
-        batchFile("ren C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmddisabled")
+        powerShell("Rename-Item C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmd.disabled")
         powerShell("${curlCommand}")
-        batchFile("ren C:\\Jenkins\\launch.cmddisabled C:\\Jenkins\\launch.cmd")
+        powerShell("Rename-Item C:\\Jenkins\\launch.cmd.disabled C:\\Jenkins\\launch.cmd")
     }
     // Ensure credentials are bound
     wrappers {

--- a/netci.groovy
+++ b/netci.groovy
@@ -38,6 +38,7 @@ def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', tr
     steps {
         def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json' -ErrorAction Continue"""
         powerShell("Rename-Item C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmd.disabled")
+        powerShell("echo ${curlCommand}")
         powerShell("${curlCommand}")
         powerShell("Rename-Item C:\\Jenkins\\launch.cmd.disabled C:\\Jenkins\\launch.cmd")
     }

--- a/netci.groovy
+++ b/netci.groovy
@@ -36,9 +36,9 @@ def branch = GithubBranchName
 // Generate a fake job to test ReproBuild functionality
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
-        def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=%SNAPSHOT_TOKEN% -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '%COMPUTERNAME%', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json'"""
+        def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json' -ErrorAction Continue"""
         batchFile("ren 'C:\\Jenkins\\launch.cmd' 'C:\\Jenkins\\launch.cmd.disabled'")
-        powerShell("${curlCommand} || exit 0")
+        powerShell("${curlCommand}")
         batchFile("ren 'C:\\Jenkins\\launch.cmd.disabled' 'C:\\Jenkins\\launch.cmd'")
     }
     // Ensure credentials are bound

--- a/netci.groovy
+++ b/netci.groovy
@@ -37,10 +37,10 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         
-        def zipWorkspace = "'C:\\Program Files\\7-Zip\\7z.exe' a -t7z ${GitBranchOrCommit}.7z -mx9"
+        def zipWorkspace = "'C:\\Program Files\\7-Zip\\7z.exe' a -t7z \${GitBranchOrCommit}.7z -mx9"
         def workspaceDestination = "https://cisnapshot.blob.core.windows.net/workspace"
-        def uploadToAzure = "'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe' /Source:. /Pattern:${GitBranchOrCommit}.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
-        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/75d89d44-c3a0-44da-958a-b63d4132ca8e/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/${GitBranchOrCommit}.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
+        def uploadToAzure = "'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe' /Source:. /Pattern:\${GitBranchOrCommit}.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
+        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/75d89d44-c3a0-44da-958a-b63d4132ca8e/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/\${GitBranchOrCommit}.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
 
         batchFile("echo Renaming launch.cmd")
         powerShell("Rename-Item C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmd.disabled")

--- a/netci.groovy
+++ b/netci.groovy
@@ -40,7 +40,7 @@ def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', tr
         def zipWorkspace = "\"C:\\Program Files\\7-Zip\\7z.exe\" a -t7z %COMPUTERNAME%-Workspace.7z -mx9"
         def workspaceDestination = "https://dotnetci1vmstorage2.blob.core.windows.net/workspace"
         def uploadToAzure = "\"C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe\" /Source:. /Pattern:%COMPUTERNAME%-Workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
-        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/7c8473db-c6cf-4be2-a0e7-680429fc0c99/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/%COMPUTERNAME%-Workspace.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
+        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/7c8473db-c6cf-4be2-a0e7-680429fc0c99/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/\$env:computername-Workspace.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
 
         batchFile("echo Renaming launch.cmd")
         powerShell("Rename-Item C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmd.disabled")

--- a/netci.groovy
+++ b/netci.groovy
@@ -37,10 +37,10 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         
-        def zipWorkspace = "\"C:\\Program Files\\7-Zip\\7z.exe\" a -t7z workspace.7z -mx9"
+        def zipWorkspace = "\"C:\\Program Files\\7-Zip\\7z.exe\" a -t7z %COMPUTERNAME%-Workspace.7z -mx9"
         def workspaceDestination = "https://cisnapshot.blob.core.windows.net/workspace"
-        def uploadToAzure = "\"C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe\" /Source:. /Pattern:workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
-        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/75d89d44-c3a0-44da-958a-b63d4132ca8e/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/workspace.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
+        def uploadToAzure = "\"C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe\" /Source:. /Pattern:%COMPUTERNAME%-Workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
+        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/7c8473db-c6cf-4be2-a0e7-680429fc0c99/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/%COMPUTERNAME%-Workspace.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
 
         batchFile("echo Renaming launch.cmd")
         powerShell("Rename-Item C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmd.disabled")

--- a/netci.groovy
+++ b/netci.groovy
@@ -32,21 +32,29 @@ def branch = GithubBranchName
     }
 }
 
-// Generate a fake job to test ReproBuild functionality
-def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
-    steps {
-        batchFile('''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd''')
+// Generate fake jobs to test ReproBuild functionality
+["Windows_NT", "Ubuntu14.04"].each { os ->
+    def reproJob = job(Utilities.getFullJobName(project, "${os}_ReproBuild", true)) {
+        steps {
+            if (os == 'Windows_NT') {
+                batchFile('''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd''')
+            }
+            else {
+                shell('''./build.sh''')
+            }
+        }
     }
-}
-Utilities.setMachineAffinity(reproJob, 'Windows_NT', 'latest-or-auto')
-Utilities.standardJobSetup(reproJob, project, true, "*/${branch}")
-Utilities.addGithubPushTrigger(reproJob)
 
-//Process the msbuild log
-def archiveSettings = new ArchivalSettings()
-archiveSettings.addFiles("msbuild.log")
-archiveSettings.setFailIfNothingArchived()
-archiveSettings.setArchiveOnFailure()
-Utilities.addReproBuild (reproJob, archiveSettings)
+    Utilities.setMachineAffinity(reproJob, os, 'latest-or-auto')
+    Utilities.standardJobSetup(reproJob, project, true, "*/${branch}")
+    Utilities.addGithubPushTrigger(reproJob)
+
+    //Process the msbuild log
+    def archiveSettings = new ArchivalSettings()
+    archiveSettings.addFiles("msbuild.log")
+    archiveSettings.setFailIfNothingArchived()
+    archiveSettings.setArchiveOnFailure()
+    Utilities.addReproBuild (reproJob, archiveSettings)
+}
 
 Utilities.addCROSSCheck(this, project, branch)

--- a/netci.groovy
+++ b/netci.groovy
@@ -41,4 +41,7 @@ Utilities.setMachineAffinity(reproJob, 'Windows_NT', 'latest-or-auto')
 Utilities.standardJobSetup(reproJob, project, true, "*/${branch}")
 Utilities.addGithubPushTrigger(reproJob)
 
+//Process the msbuild log
+Utilities.addReproBuild (reproJob, "msbuild.log")
+
 Utilities.addCROSSCheck(this, project, branch)

--- a/netci.groovy
+++ b/netci.groovy
@@ -37,10 +37,10 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         
-        def zipWorkspace = "'C:\\Program Files\\7-Zip\\7z.exe' a -t7z \${GitBranchOrCommit}.7z -mx9"
+        def zipWorkspace = "'C:\\Program Files\\7-Zip\\7z.exe' a -t7z workspace.7z -mx9"
         def workspaceDestination = "https://cisnapshot.blob.core.windows.net/workspace"
-        def uploadToAzure = "'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe' /Source:. /Pattern:\${GitBranchOrCommit}.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
-        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/75d89d44-c3a0-44da-958a-b63d4132ca8e/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/\${GitBranchOrCommit}.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
+        def uploadToAzure = "'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe' /Source:. /Pattern:workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
+        def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/75d89d44-c3a0-44da-958a-b63d4132ca8e/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/workspace.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
 
         batchFile("echo Renaming launch.cmd")
         powerShell("Rename-Item C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmd.disabled")

--- a/netci.groovy
+++ b/netci.groovy
@@ -36,7 +36,7 @@ def branch = GithubBranchName
 // Generate a fake job to test ReproBuild functionality
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
-        def curlCommand = "Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=%SNAPSHOT_TOKEN% -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '%COMPUTERNAME%', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json'"
+        def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=%SNAPSHOT_TOKEN% -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '%COMPUTERNAME%', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json'"""
         batchFile("ren 'C:\Jenkins\launch.cmd' 'C:\Jenkins\launch.cmd.disabled'")
         powerShell("${curlCommand} || exit 0")
         batchFile("ren 'C:\Jenkins\launch.cmd.disabled' 'C:\Jenkins\launch.cmd'")

--- a/netci.groovy
+++ b/netci.groovy
@@ -49,10 +49,9 @@ def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', tr
     }
 }
 
-
-// Utilities.setMachineAffinity(reproJob, 'Windows_NT', 'latest-or-auto')
-// Utilities.standardJobSetup(reproJob, project, true, "*/${branch}")
-// Utilities.addGithubPushTrigger(reproJob)
+Utilities.setMachineAffinity(reproJob, 'Windows_NT', 'latest-or-auto')
+Utilities.standardJobSetup(reproJob, project, true, "*/${branch}")
+Utilities.addGithubPushTrigger(reproJob)
 
 //Process the msbuild log
 /*def archiveSettings = new ArchivalSettings()

--- a/netci.groovy
+++ b/netci.groovy
@@ -37,9 +37,10 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json' -ErrorAction Continue"""
-        batchFile("ren 'C:\\Jenkins\\launch.cmd' 'C:\\Jenkins\\launch.cmd.disabled'")
+        batchFile("dir C:\\Jenkins")
+        batchFile("ren C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmddisabled")
         powerShell("${curlCommand}")
-        batchFile("ren 'C:\\Jenkins\\launch.cmd.disabled' 'C:\\Jenkins\\launch.cmd'")
+        batchFile("ren C:\\Jenkins\\launch.cmddisabled C:\\Jenkins\\launch.cmd")
     }
     // Ensure credentials are bound
     wrappers {

--- a/netci.groovy
+++ b/netci.groovy
@@ -37,15 +37,17 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         //def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json' -ErrorAction Continue"""
-        def zipWorkspace = '''"C:\Program Files\7-Zip\7z.exe" a -t7z ${GitBranchOrCommit}.7z -mx9 '''
-        def uploadToAzure = '''"C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe" /Source:. /Pattern:${GitBranchOrCommit}.7z /Dest:https://cisnapshot.blob.core.windows.net/workspace /DestKey:%SNAPSHOT_STORAGE_KEY% /Y'''
+        def zipWorkspace = '''"C:\\Program Files\\7-Zip\\7z.exe" a -t7z ${GitBranchOrCommit}.7z -mx9 '''
+        def uploadToAzure = '''"C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe" /Source:. /Pattern:${GitBranchOrCommit}.7z /Dest:https://cisnapshot.blob.core.windows.net/workspace /DestKey:%SNAPSHOT_STORAGE_KEY% /Y'''
                 
         batchFile("echo Renaming launch.cmd")
         powerShell("Rename-Item C:\\Jenkins\\launch.cmd C:\\Jenkins\\launch.cmd.disabled")
         
+        batchFile("dir")
         batchFile("echo zip the workspace with ${zipWorkspace}")
         batchFile("${zipWorkspace}")
         
+        batchFile("dir")
         batchFile("echo upload to Azure with ${uploadToAzure}")
         batchFile("${uploadToAzure}")
         

--- a/netci.groovy
+++ b/netci.groovy
@@ -38,7 +38,7 @@ def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', tr
     steps {
         
         def zipWorkspace = "\"C:\\Program Files\\7-Zip\\7z.exe\" a -t7z %COMPUTERNAME%-Workspace.7z -mx9"
-        def workspaceDestination = "https://cisnapshot.blob.core.windows.net/workspace"
+        def workspaceDestination = "https://dotnetci1vmstorage2.blob.core.windows.net/workspace"
         def uploadToAzure = "\"C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\AzCopy\\AzCopy.exe\" /Source:. /Pattern:%COMPUTERNAME%-Workspace.7z /Dest:${workspaceDestination} /DestKey:%SNAPSHOT_STORAGE_KEY% /Y"
         def createSnapshot = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/7c8473db-c6cf-4be2-a0e7-680429fc0c99/snapshot?code=\$env:SNAPSHOT_TOKEN -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '\$env:computername', 'payload': \'${workspaceDestination}/%COMPUTERNAME%-Workspace.7z\', 'targetContainer': 'snapshots' }" -ContentType 'application/json' -ErrorAction Continue"""
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -37,9 +37,9 @@ def branch = GithubBranchName
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
         def curlCommand = """Invoke-RestMethod https://snapshotter.azurewebsites.net/api/snapshot/vm?code=%SNAPSHOT_TOKEN% -Method Post -Body "{ 'group': 'dotnet-ci1-vms', 'name': '%COMPUTERNAME%', 'targetGroup': 'snapshot-test' }" -ContentType 'application/json'"""
-        batchFile("ren 'C:\Jenkins\launch.cmd' 'C:\Jenkins\launch.cmd.disabled'")
+        batchFile("ren 'C:\\Jenkins\\launch.cmd' 'C:\\Jenkins\\launch.cmd.disabled'")
         powerShell("${curlCommand} || exit 0")
-        batchFile("ren 'C:\Jenkins\launch.cmd.disabled' 'C:\Jenkins\launch.cmd'")
+        batchFile("ren 'C:\\Jenkins\\launch.cmd.disabled' 'C:\\Jenkins\\launch.cmd'")
     }
     // Ensure credentials are bound
     wrappers {

--- a/netci.groovy
+++ b/netci.groovy
@@ -36,7 +36,7 @@ def branch = GithubBranchName
 // Generate a fake job to test ReproBuild functionality
 def reproJob = job(Utilities.getFullJobName(project, 'Windows_NT_ReproBuild', true)) {
     steps {
-        batchFile('''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd''')
+        batchFile('''call "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\VsDevCmd.bat" && build.cmd && exit 0''')
 
         def zipWorkspace = "\"C:\\Program Files\\7-Zip\\7z.exe\" a -t7z %COMPUTERNAME%-Workspace.7z -mx9"
         def workspaceDestination = "https://dotnetci1vmstorage2.blob.core.windows.net/workspace"


### PR DESCRIPTION
This is part of the first proof of concept that we are doing to enable a Repro Environment functionality when a job fails. For it, we are enabling a new parameter in Jenkins that is called `ReproBuild`. When it is set to `true` and the build fails, we want to trigger some behaviors.
To avoid disruptions with the functionality of the repository, I'm creating a new job that only runs when it is called and that is affected by the parameter `ReproBuild`.

cc: @mmitche @alexperovich 