### PR TITLE
change $* to "$@" to properly process arguments with spaces on Unix

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.dll $*
+$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.dll "$@"
 exit $?


### PR DESCRIPTION
I bump into it while trying to pass multiple arguments to xunit:

/Tools/msbuild.sh ~/git/corefx/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj /t:build,test /p:xunitoptions='-showprogress -method System.Net.Security.Tests.SslStreamEKUTest.SslStream_NoEKUClientAuth_O'
Microsoft (R) Build Engine version 15.1.523.56541
Copyright (C) Microsoft Corporation. All rights reserved.
 
MSBUILD : error MSB1001: Unknown switch.
Switch: -method
 
For switch syntax, type "MSBuild /help"


The problem lives in msbuild.sh (I verified that by starting dotnet directly)
The script incorrectly uses $* to expand passed parameters and that will break if passed argument contains spaces. $@ and $* are almost similar any they work same way in most cases, but not in this one. As outlined bellow "$@" will preserve arguments as passed in.

Tomas 
 
 
 
P.S. here is test code to demonstrate the problem. I’m calling test with four parameters.
 
 
test.sh:
echo '$*'
./show.sh $*
echo '"$@"'
./show.sh "$@"



furt@Ubuntu:/tmp$ bash test.sh 1 2 "3 and 4" 5
$*
1: 1
2: 2
3: 3
4: and
5: 4
6: 5
"$@"
1: 1
2: 2
3: 3 and 4
4: 5
 
 
and
 
#!/bin/bash
 
I=1
while (( "$#" )); do
    echo $I: $1
    shift
    I=$(($I+1))
done
 

