### PR TITLE
Fix Uap TFM to include Aot

### DIFF
--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -22,7 +22,7 @@ namespace Xunit
         Netcoreapp1_1 = 0x400,
         NetFramework = 0x800,
         Netcoreapp = 0x1000,
-        Uap = 0x2000,
+        Uap = UapAot | 0x2000,
         UapAot = 0x4000,
         NetcoreCoreRT = 0x8000
     }


### PR DESCRIPTION
When I did the refactoring for TFM incorrectly refactored NetcoreUWP (which included both Uap and UapAot) to be Uap only. https://github.com/dotnet/buildtools/pull/1355

cc: @danmosemsft @weshaggard 