### PR TITLE
Mark SkippedTestCase as serializable for Full Framework

### DIFF
--- a/src/xunit.netcore.extensions.46/xunit.netcore.extensions.net46.csproj
+++ b/src/xunit.netcore.extensions.46/xunit.netcore.extensions.net46.csproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <DefineConstants>FULL_FRAMEWORK</DefineConstants>
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>

--- a/src/xunit.netcore.extensions.46/xunit.netcore.extensions.net46.csproj
+++ b/src/xunit.netcore.extensions.46/xunit.netcore.extensions.net46.csproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <DefineConstants>FULL_FRAMEWORK</DefineConstants>
     <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>

--- a/src/xunit.netcore.extensions/SkippedTestCase.cs
+++ b/src/xunit.netcore.extensions/SkippedTestCase.cs
@@ -6,16 +6,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Xunit.NetCore.Extensions
 {
-#if FULL_FRAMEWORK
-    [Serializable]
-#endif
     /// <summary>Wraps another test case that should be skipped.</summary>
-    internal sealed class SkippedTestCase : IXunitTestCase
+    internal sealed class SkippedTestCase : LongLivedMarshalByRefObject, IXunitTestCase
     {
         private readonly IXunitTestCase _testCase;
         private readonly string _skippedReason;

--- a/src/xunit.netcore.extensions/SkippedTestCase.cs
+++ b/src/xunit.netcore.extensions/SkippedTestCase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,9 @@ using Xunit.Sdk;
 
 namespace Xunit.NetCore.Extensions
 {
+#if FULL_FRAMEWORK
+    [Serializable]
+#endif
     /// <summary>Wraps another test case that should be skipped.</summary>
     internal sealed class SkippedTestCase : IXunitTestCase
     {


### PR DESCRIPTION
This is needed because xunit creates different AppDomains, so if it not serializable when the condition in ConditionalFact/Theory attributes is not met the test will be marked as not discovered instead of skipped. So the test summary will not be correct and we will never catch when the tests are skipped for desktop.

cc: @weshaggard 