### PR TITLE
Add symbol signing targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -77,6 +77,8 @@
     <Compile Include="$(CommonPath)\ZipFileCreateFromDirectory.cs">
       <Link>ZipFileCreateFromDirectory.cs</Link>
     </Compile>
+    <Compile Include="ZipFileGetEntries.cs" />
+    <Compile Include="ZipFileInjectFile.cs" />
     <Compile Include="ZipFileExtractToDirectory.cs" />
     <Compile Include="Strings.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -2,6 +2,8 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="AddItemIndices" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ZipFileGetEntries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ZipFileInjectFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
   <PropertyGroup>
     <SymbolsRequestIntermediateDir Condition="'$(SymbolsRequestIntermediateDir)'==''">$(BaseIntermediateOutputPath)SymbolsRequest\</SymbolsRequestIntermediateDir>
@@ -222,6 +224,163 @@
       <IndexedExtensions Include=".dll;.pdb;.exe" Condition="'@(IndexedExtensions)'==''" />
       <SymbolFileToPublish Include="$(SymbolPackageExtractDir)**\*%(IndexedExtensions.Identity)" />
     </ItemGroup>
+  </Target>
+
+  <!-- This will be overridden if we're building with MicroBuild. -->
+  <Target Name="SignFiles">
+    <Message Text="Fake sign target.  Would sign: @(FilesToSign)" />
+  </Target>
+
+  <!--
+    Entry point: inject signed symbol catalogs into all specified symbol packages.
+  -->
+  <Target Name="InjectSignedSymbolCatalogIntoSymbolPackages"
+          DependsOnTargets="GenerateSymbolCatalogs;
+                            SignFiles">
+    <MSBuild Targets="InjectSignedSymbolCatalogsForPackage"
+             Projects="$(MSBuildProjectFile)"
+             Properties="SymbolPackageFilePath=%(SymbolPackageFileWithIndex.Identity);
+                         SymbolPackageIndex=%(SymbolPackageFileWithIndex.Index);
+                         SymbolCatalogIntermediateDir=$(SymbolCatalogIntermediateDir);"
+             Condition="'@(SymbolPackageFileWithIndex)'!=''" />
+  </Target>
+
+  <!--
+    Generate symbol catalogs for all symbol packages specified. Creates FilesToSign items for each
+    catalog so they can be sigend.
+  -->
+  <Target Name="GenerateSymbolCatalogs">
+    <PropertyGroup>
+      <SymbolCatalogIntermediateDir Condition="'$(SymbolCatalogIntermediateDir)' == ''">$(BaseIntermediateOutputPath)SymbolsCatalog\</SymbolCatalogIntermediateDir>
+      <ExtensionsToCatalog Condition="'$(ExtensionsToCatalog)'==''">.dll;.pdb;.a;.so;.dbg;.dylib;.dwarf</ExtensionsToCatalog>
+      <MakeCatCommand Condition="'$(MakeCatCommand)'==''">makecat -v</MakeCatCommand>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SymbolPackageFile Include="$(SymbolPackagesToPublishGlob)" />
+    </ItemGroup>
+
+    <!-- Extract to the index of the symbol package, not file name, to avoid exceeding max path. -->
+    <AddItemIndices Input="@(SymbolPackageFile)">
+      <Output TaskParameter="Output" ItemName="SymbolPackageFileWithIndex" />
+    </AddItemIndices>
+
+    <RemoveDir Directories="$(SymbolCatalogIntermediateDir)"
+               Condition="Exists('$(SymbolCatalogIntermediateDir)')" />
+
+    <MSBuild Targets="GenerateSymbolCatalogsForPackage"
+             Projects="$(MSBuildProjectFile)"
+             Properties="SymbolPackageFilePath=%(SymbolPackageFileWithIndex.Identity);
+                         SymbolPackageIndex=%(SymbolPackageFileWithIndex.Index);
+                         ExtensionsToCatalog=$(ExtensionsToCatalog);
+                         SymbolCatalogIntermediateDir=$(SymbolCatalogIntermediateDir);
+                         MakeCatCommand=$(MakeCatCommand)" />
+
+    <!-- Find the catalogs to sign them. -->
+    <ItemGroup>
+      <FilesToSign Include="$(SymbolCatalogIntermediateDir)**\*.cat">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <!--
+        The OutDir and IntermediateOutputPath properties are required by MicroBuild. MicroBuild only
+        signs files that are under these paths.
+      -->
+      <OutDir Condition="'$(OutDir)'==''">$(BinDir)</OutDir>
+      <IntermediateOutputPath Condition="'$(IntermediateOutputPath)'==''">$(SymbolCatalogIntermediateDir)</IntermediateOutputPath>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    Generates any catalogs needed to sign a specific symbol package.
+  -->
+  <Target Name="GenerateSymbolCatalogsForPackage">
+    <ItemGroup>
+      <!-- Create a single item for the symbol package to get metadata about it. -->
+      <SymbolPackageFile Include="$(SymbolPackageFilePath)" />
+      <ExtensionToCatalog Include="$(ExtensionsToCatalog)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <ExtractBaseDir>$(SymbolCatalogIntermediateDir)$(SymbolPackageIndex)\</ExtractBaseDir>
+    </PropertyGroup>
+
+    <ZipFileGetEntries TargetArchive="$(SymbolPackageFilePath)">
+      <Output TaskParameter="Entries" ItemName="SymbolPackageEntry" />
+    </ZipFileGetEntries>
+
+    <ItemGroup>
+      <SymbolPackageEntryCrossExtensionsToCatalog Include="@(SymbolPackageEntry)">
+        <AttemptMatchExtension>%(ExtensionToCatalog.Identity)</AttemptMatchExtension>
+      </SymbolPackageEntryCrossExtensionsToCatalog>
+
+      <SymbolFileToCatalog Include="@(SymbolPackageEntryCrossExtensionsToCatalog)"
+                           Condition="'%(Extension)'=='%(AttemptMatchExtension)'" />
+    </ItemGroup>
+
+
+    <ZipFileExtractToDirectory SourceArchive="$(SymbolPackageFilePath)"
+                               Include="@(SymbolFileToCatalog)"
+                               DestinationDirectory="$(ExtractBaseDir)"
+                               Condition="'@(SymbolFileToCatalog)'!=''" />
+
+    <!-- Leave a marker so a package can be associated with its numbered dir. -->
+    <WriteLinesToFile File="$(SymbolCatalogIntermediateDir)%(SymbolPackageFile.Filename)"
+                      Lines="$(SymbolPackageIndex)"
+                      Overwrite="true"
+                      Condition="'@(SymbolFileToCatalog)'!=''" />
+
+    <!-- Create the catalog file to feed into makecat. -->
+    <ItemGroup>
+      <CatalogFile Include="@(SymbolFileToCatalog -> '$(ExtractBaseDir)%(Identity).cat.cdf')">
+        <Contents>
+[CatalogHeader]
+Name=%(Filename)%(Extension).cat
+ResultDir=.\
+PublicVersion=2
+CatalogVersion=2
+HashAlgorithms=SHA256
+PageHashes=true
+EncodingType=0x00010001
+CATATTR1=0x10010001:OSAttr:2:6.4
+[CatalogFiles]
+&lt;HASH&gt;%(Filename)%(Extension)=%(Filename)%(Extension)
+        </Contents>
+      </CatalogFile>
+    </ItemGroup>
+
+    <Message Text="@(CatalogFile)" />
+
+    <WriteLinesToFile File="%(CatalogFile.FullPath)"
+                      Lines="%(Contents)"
+                      Condition="'@(CatalogFile)'!=''" />
+
+    <!--
+      Don't include cdf path because it may be too long for makecat.
+      See https://stackoverflow.com/a/18682676
+    -->
+    <Exec Command="$(MakeCatCommand) %(CatalogFile.Filename)%(CatalogFile.Extension)"
+          WorkingDirectory="%(CatalogFile.RootDir)%(CatalogFile.Directory)"
+          Condition="'@(CatalogFile)'!=''" />
+  </Target>
+
+  <!--
+    Inject all symbol catalogs found in the extracted symbol package dir into a new copy of the
+    symbol package in the intermediate dir.
+  -->
+  <Target Name="InjectSignedSymbolCatalogsForPackage">
+    <ItemGroup>
+      <CatalogFile Include="$(SymbolCatalogIntermediateDir)$(SymbolPackageIndex)\**\*.cat" />
+      <CatalogFile>
+        <ArchivePath>%(RecursiveDir)%(Filename)%(Extension)</ArchivePath>
+      </CatalogFile>
+    </ItemGroup>
+
+    <ZipFileInjectFile TargetArchive="$(SymbolPackageFilePath)"
+                       InjectFiles="@(CatalogFile)"
+                       Condition="'@(CatalogFile)'!=''" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -333,28 +333,37 @@
                       Condition="'@(SymbolFileToCatalog)'!=''" />
 
     <!-- Create the catalog file to feed into makecat. -->
+    <PropertyGroup>
+      <CatalogFileHeaderLines>
+        [CatalogHeader];
+        Name=signatures.cat;
+        ResultDir=.\;
+        PublicVersion=2;
+        CatalogVersion=2;
+        HashAlgorithms=SHA256;
+        PageHashes=true;
+        EncodingType=0x00010001;
+        CATATTR1=0x10010001:OSAttr:2:6.4;
+        [CatalogFiles]
+      </CatalogFileHeaderLines>
+    </PropertyGroup>
+
     <ItemGroup>
-      <CatalogFile Include="@(SymbolFileToCatalog -> '$(ExtractBaseDir)%(Identity).cat.cdf')">
-        <Contents>
-[CatalogHeader]
-Name=%(Filename)%(Extension).cat
-ResultDir=.\
-PublicVersion=2
-CatalogVersion=2
-HashAlgorithms=SHA256
-PageHashes=true
-EncodingType=0x00010001
-CATATTR1=0x10010001:OSAttr:2:6.4
-[CatalogFiles]
-&lt;HASH&gt;%(Filename)%(Extension)=%(Filename)%(Extension)
-        </Contents>
+      <CatalogFile Include="$(ExtractBaseDir)signatures.cat.cdf"
+                   Condition="'@(SymbolFileToCatalog)'!=''">
+        <ContentLines>$(CatalogFileHeaderLines);@(SymbolFileToCatalog -> '&lt;HASH&gt;%(Filename)%(Extension)=%(Identity);')</ContentLines>
       </CatalogFile>
     </ItemGroup>
 
     <Message Text="@(CatalogFile)" />
 
-    <WriteLinesToFile File="%(CatalogFile.FullPath)"
-                      Lines="%(Contents)"
+    <WriteLinesToFile File="@(CatalogFile)"
+                      Lines="%(ContentLines)"
+                      Condition="'@(CatalogFile)'!=''" />
+
+    <!-- Create an easily readable list of files that were cataloged. -->
+    <WriteLinesToFile File="$(ExtractBaseDir)cataloged.txt"
+                      Lines="@(SymbolFileToCatalog)"
                       Condition="'@(CatalogFile)'!=''" />
 
     <!--
@@ -376,10 +385,14 @@ CATATTR1=0x10010001:OSAttr:2:6.4
       <CatalogFile>
         <ArchivePath>%(RecursiveDir)%(Filename)%(Extension)</ArchivePath>
       </CatalogFile>
+
+      <CatalogedFileManifest Include="$(SymbolCatalogIntermediateDir)$(SymbolPackageIndex)\cataloged.txt">
+        <ArchivePath>cataloged.txt</ArchivePath>
+      </CatalogedFileManifest>
     </ItemGroup>
 
     <ZipFileInjectFile TargetArchive="$(SymbolPackageFilePath)"
-                       InjectFiles="@(CatalogFile)"
+                       InjectFiles="@(CatalogFile);@(CatalogedFileManifest)"
                        Condition="'@(CatalogFile)'!=''" />
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -277,9 +277,12 @@
                          MakeCatCommand=$(MakeCatCommand)" />
 
     <!-- Find the catalogs to sign them. -->
+    <Error Text="'SymbolCatalogCertificateId' must be defined."
+           Condition="'$(SymbolCatalogCertificateId)'==''" />
+
     <ItemGroup>
       <FilesToSign Include="$(SymbolCatalogIntermediateDir)**\*.cat">
-        <Authenticode>$(InternalCertificateId)</Authenticode>
+        <Authenticode>$(SymbolCatalogCertificateId)</Authenticode>
       </FilesToSign>
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileExtractToDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileExtractToDirectory.cs
@@ -30,8 +30,8 @@ namespace Microsoft.DotNet.Build.Tasks
         public bool OverwriteDestination { get; set; }
 
         /// <summary>
-        /// The paths to include in the extraction, relative to root. If null,
-        /// all files are extracted.
+        /// File entries to include in the extraction. Entries are relative
+        /// paths inside the archive. If null or empty, all files are extracted.
         /// </summary>
         public ITaskItem[] Include { get; set; }
 
@@ -41,20 +41,19 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 if (Directory.Exists(DestinationDirectory))
                 {
-                    if (OverwriteDestination == true)
+                    if (OverwriteDestination)
                     {
-                        Log.LogMessage(MessageImportance.Low, "'{0}' already exists, trying to delete before unzipping...", DestinationDirectory);
+                        Log.LogMessage(MessageImportance.Low, $"'{DestinationDirectory}' already exists, trying to delete before unzipping...");
                         Directory.Delete(DestinationDirectory, recursive: true);
                     }
                     else
                     {
-                        Log.LogWarning("'{0}' already exists. Did you forget to set '{1}' to true?", DestinationDirectory, nameof(OverwriteDestination));
+                        Log.LogWarning($"'{DestinationDirectory}' already exists. Did you forget to set '{nameof(OverwriteDestination)}' to true?");
                     }
                 }
 
                 Log.LogMessage(MessageImportance.High, "Decompressing '{0}' into '{1}'...", SourceArchive, DestinationDirectory);
-                if (!Directory.Exists(Path.GetDirectoryName(DestinationDirectory)))
-                    Directory.CreateDirectory(Path.GetDirectoryName(DestinationDirectory));
+                Directory.CreateDirectory(Path.GetDirectoryName(DestinationDirectory));
 
                 using (ZipArchive archive = ZipFile.OpenRead(SourceArchive))
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileGetEntries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileGetEntries.cs
@@ -19,8 +19,8 @@ namespace Microsoft.DotNet.Build.Tasks
         public string TargetArchive { get; set; }
 
         /// <summary>
-        /// Generated items where each ItemSpec is the relative location of an
-        /// entry in the zip archive.
+        /// Generated items where each ItemSpec is the relative location of a
+        /// file entry in the zip archive.
         /// </summary>
         [Output]
         public ITaskItem[] Entries { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileGetEntries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileGetEntries.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class ZipFileGetEntries : Task
+    {
+        /// <summary>
+        /// The path to the archive.
+        /// </summary>
+        [Required]
+        public string TargetArchive { get; set; }
+
+        /// <summary>
+        /// Generated items where each ItemSpec is the relative location of an
+        /// entry in the zip archive.
+        /// </summary>
+        [Output]
+        public ITaskItem[] Entries { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                using (ZipArchive archive = ZipFile.OpenRead(TargetArchive))
+                {
+                    Entries = archive.Entries
+                        // Escape '%' so encoded '+' in the nupkg stays encoded through MSBuild.
+                        .Select(e => new TaskItem(e.FullName.Replace("%", "%25")))
+                        .ToArray();
+                }
+            }
+            catch (Exception e)
+            {
+                // We have 2 log calls because we want a nice error message but we also want to capture the callstack in the log.
+                Log.LogError($"An exception has occurred while trying to read entries from '{TargetArchive}'.");
+                Log.LogErrorFromException(e, /*show stack=*/ true, /*show detail=*/ true, TargetArchive);
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileInjectFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileInjectFile.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO.Compression;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public sealed class ZipFileInjectFile : Task
+    {
+        /// <summary>
+        /// The path to the zip archive to be injected into.
+        /// </summary>
+        [Required]
+        public string TargetArchive { get; set; }
+
+        /// <summary>
+        /// Files to inject into the zip archive. "ArchivePath" metadata is used
+        /// as the relative path from the root of the archive to place the file.
+        /// </summary>
+        public ITaskItem[] InjectFiles { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                Log.LogMessage(
+                    MessageImportance.High,
+                    $"Injecting files into '{TargetArchive}'...");
+
+                using (ZipArchive archive = ZipFile.Open(TargetArchive, ZipArchiveMode.Update))
+                {
+                    foreach (ITaskItem file in InjectFiles)
+                    {
+                        string archivePath = file.GetMetadata("ArchivePath");
+                        if (string.IsNullOrEmpty(archivePath))
+                        {
+                            throw new ArgumentException($"Item '{file.ItemSpec}' does not have a value for required metadata 'ArchivePath'.");
+                        }
+
+                        ZipArchiveEntry newEntry = archive.CreateEntryFromFile(
+                            file.ItemSpec,
+                            archivePath);
+
+                        Log.LogMessage(
+                            MessageImportance.Low,
+                            $"Injected into '{TargetArchive}': '{file.ItemSpec}' as '{newEntry.FullName}'");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                // We have 2 log calls because we want a nice error message but we also want to capture the callstack in the log.
+                Log.LogError($"An exception has occurred while trying to inject into '{TargetArchive}'.");
+                Log.LogErrorFromException(e, /*show stack=*/ true, /*show detail=*/ true, TargetArchive);
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Adds targets and new utility tasks to create signed catalog files and inject them into symbol packages for upload to MyGet. Uses `makecat` to create the catalogs and MicroBuild to sign them.

 1. Reads the entries in the symbol package zips
 2. Finds ones that have an extension we want to sign
 3. Extracts those entries into an intermediate directory
 4. Creates one catalog file per package
 5. Signs the catalog files
 6. Injects the signed catalog files
 7. Injects a list of cataloged files into each symbol package (for EmbedIndex)

The first commit is from when we were going to have one catalog file per signed file for simplicity, but that ended up being extremely slow: ~1 hour (which would be part of the package publish leg). A single catalog per package takes ~5 minutes total.

I don't like the `MSBuild` tasks, but so far they seem like the clearest way to make the per-package ops work.