### PR TITLE
Revert "change $* to "$@" to properly process arguments with spaces"

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.dll "$@"
+$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.dll $*
 exit $?


### PR DESCRIPTION
This reverts commit 2ec1ba86095671f13ddac5574ea5ba2a66d846fe.

Although this hasn't caused any problems in local builds, we are seeing some problems in our official builds, involving arguments being dropped from subsequent commands. We're not sure why exactly, it most likely has something to do with complicated quote escaping.

@MattGal @wfurt 