### PR TITLE
GenAPI: Write security attributes in property accessors too

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Cci.Writers.CSharp
         {
             WriteSpace();
             WriteAttributes(accessor.Attributes, writeInline: true);
+            WriteAttributes(accessor.SecurityAttributes, writeInline: true);
             // If the accessor is an internal call (or a PInvoke) we should put those attributes here as well
 
             WriteMethodPseudoCustomAttributes(accessor);


### PR DESCRIPTION
Like it's done e.g. for methods: https://github.com/mono/buildtools/blob/14a12e45dd954bfd6e98aecc366e8742aeaa6590/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs#L32