### PR TITLE
Fix the success code returned from remote execution

### DIFF
--- a/src/xunit.runner.uap/RunnerRemoteExecutionServiceUAP/RunnerRemoteExecutionServiceUAP.cs
+++ b/src/xunit.runner.uap/RunnerRemoteExecutionServiceUAP/RunnerRemoteExecutionServiceUAP.cs
@@ -16,6 +16,7 @@ namespace RunnerRemoteExecutionService
     {
         private BackgroundTaskDeferral backgroundTaskDeferral;
         private AppServiceConnection appServiceconnection;
+        internal const int SuccessExitCode = 42;
 
         public void Run(IBackgroundTaskInstance taskInstance)
         {
@@ -61,8 +62,8 @@ namespace RunnerRemoteExecutionService
             string methodName;
             string[] additionalArgs;
 
-            // default the results to 0 as success. We override it at failures.
-            returnData["Results"] = 0;
+            // default the results to SuccessExitCode as success. We override it at failures.
+            returnData["Results"] = SuccessExitCode;
 
             // The message expects to be passed the target assembly name to load, the type
             // from that assembly to find, and the method from that assembly to invoke.


### PR DESCRIPTION
Currently the remote execution returning 0 as success code but in corefx repo we use the value 42 as the success code. changing the success code to 42 so corefx tests work seamlessly with the uap runner 