### PR TITLE
GenAPI: Add global prefix to explicit interface method and property

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -72,6 +72,19 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteTypeName(method.Type, method.ContainingType, isDynamic: IsDynamic(method.ReturnValueAttributes));
             }
 
+
+            if (_forCompilationIncludeGlobalprefix && method.IsExplicitInterfaceMethod())
+            {
+                if (!name.StartsWith("global::"))
+                    name = "global::" + name;
+
+                var pos = name.IndexOf('<');
+                if (pos > -1)
+                {
+                    name = name.Substring(0, pos + 1) + "global::" + name.Substring(pos + 1, name.Length - pos - 1);
+                }
+            }
+
             WriteIdentifier(name);
 
             if (isOperator)
@@ -149,7 +162,7 @@ namespace Microsoft.Cci.Writers.CSharp
 
         private void WriteInterfaceMethodModifiers(IMethodDefinition method)
         {
-            if (method.GetHiddenBaseMethod(_filter) != Dummy.Method)
+            if (method.GetHiddenBaseMethod(_filter) != Dummy.Method && !method.IsConversionOperator())
                 WriteKeyword("new");
         }
 
@@ -206,9 +219,9 @@ namespace Microsoft.Cci.Writers.CSharp
                 Write("throw new ");
                 if (_forCompilationIncludeGlobalprefix)
                     Write("global::");
-                if(_platformNotSupportedExceptionMessage.Length == 0)
+                if (_platformNotSupportedExceptionMessage.Length == 0)
                     Write("System.PlatformNotSupportedException();");
-                else if(_platformNotSupportedExceptionMessage.StartsWith("SR."))
+                else if (_platformNotSupportedExceptionMessage.StartsWith("SR."))
                     Write($"System.PlatformNotSupportedException(System.{_platformNotSupportedExceptionMessage}); ");
                 else
                     Write($"System.PlatformNotSupportedException(\"{_platformNotSupportedExceptionMessage}\"); ");

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -83,7 +83,20 @@ namespace Microsoft.Cci.Writers.CSharp
             }
             else
             {
-                WriteIdentifier(property.Name);
+                var name = property.Name.Value;
+                if (_forCompilationIncludeGlobalprefix && property.IsExplicitInterfaceProperty())
+                {
+                    if (!name.StartsWith("global::"))
+                        name = "global::" + name;
+
+                    var pos = name.IndexOf('<');
+                    if (pos > -1)
+                    {
+                        name = name.Substring(0, pos + 1) + "global::" + name.Substring(pos + 1, name.Length - pos - 1);
+                    }
+                }
+
+                WriteIdentifier(name);
             }
             WriteSpace();
             WriteSymbol("{");

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -44,23 +44,12 @@
       Manually binplace DiaSymReader runtimes for win7-x86, which the official builds use.
       This workaround should be removed, see https://github.com/dotnet/buildtools/issues/1608
     -->
-    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
-                                         IncludeFrameworkReferences="false"
-                                         NuGetPackagesDirectory="$(PackagesDir)"
-                                         RuntimeIdentifier="win7-x86"
-                                         ProjectLanguage="$(Language)"
-                                         ProjectLockFile="project.lock.json"
-                                         TargetMonikers="$(NuGetTargetMoniker)">
-      <Output TaskParameter="ResolvedCopyLocalItems"
-              ItemName="_ReferenceCopyLocalPathsFromDependencies" />
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true" IncludeFrameworkReferences="false" NuGetPackagesDirectory="$(PackagesDir)" RuntimeIdentifier="win7-x86" ProjectLanguage="$(Language)" ProjectLockFile="project.lock.json" TargetMonikers="$(NuGetTargetMoniker)">
+      <Output TaskParameter="ResolvedCopyLocalItems" ItemName="_ReferenceCopyLocalPathsFromDependencies" />
     </PrereleaseResolveNuGetPackageAssets>
-
     <ItemGroup>
-      <_DiaSymReaderNativeCopyLocalItems Include='@(_ReferenceCopyLocalPathsFromDependencies)'
-                                         Condition="'%(NuGetPackageId)' == 'Microsoft.DiaSymReader.Native'" />
+      <_DiaSymReaderNativeCopyLocalItems Include="@(_ReferenceCopyLocalPathsFromDependencies)" Condition="'%(NuGetPackageId)' == 'Microsoft.DiaSymReader.Native'" />
     </ItemGroup>
-
-    <Copy SourceFiles="@(_DiaSymReaderNativeCopyLocalItems)"
-          DestinationFolder="$(OutputPath)" />
+    <Copy SourceFiles="@(_DiaSymReaderNativeCopyLocalItems)" DestinationFolder="$(OutputPath)" />
   </Target>
 </Project>


### PR DESCRIPTION
When use "-global" option, the global prefix "global::" should be added to name of explicit interface methods and properties as follows.

```
object global::System.Collections.IEnumerator.Current { get { throw new global::System.PlatformNotSupportedException("Not Supported Feature"); } }
```