### PR TITLE
Fix duplicate file keys when creating catalogs.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -354,7 +354,7 @@
     <ItemGroup>
       <CatalogFile Include="$(ExtractBaseDir)signatures.cat.cdf"
                    Condition="'@(SymbolFileToCatalog)'!=''">
-        <ContentLines>$(CatalogFileHeaderLines);@(SymbolFileToCatalog -> '&lt;HASH&gt;%(Filename)%(Extension)=%(Identity);')</ContentLines>
+        <ContentLines>$(CatalogFileHeaderLines);@(SymbolFileToCatalog -> '&lt;HASH&gt;%(Identity)=%(Identity);')</ContentLines>
       </CatalogFile>
     </ItemGroup>
 


### PR DESCRIPTION
MakeCat apparently does not handle duplicate keys well even though we are supposed to be using the `<HASH>` as the key.  This change makes us use the full file path for the key so there are no duplicates.