### PR TITLE
Move core-setup tasks into BuildTools

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureBlobLease.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureBlobLease.cs
@@ -1,0 +1,185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public partial class AzureBlobLease
+    {
+        private string _containerName;
+        private string _blobName;
+        private TimeSpan _maxWait;
+        private TimeSpan _delay;
+        private const int s_MaxWaitDefault = 60; // seconds
+        private const int s_DelayDefault = 500; // milliseconds
+        private CancellationTokenSource _cancellationTokenSource;
+        private Task _leaseRenewalTask;
+        private string _connectionString;
+        private string _accountName;
+        private string _accountKey;
+        private Microsoft.Build.Utilities.TaskLoggingHelper _log;
+        private string _leaseId;
+        private string _leaseUrl;
+
+        public AzureBlobLease(string accountName, string accountKey, string connectionString, string containerName, string blobName, Microsoft.Build.Utilities.TaskLoggingHelper log, string maxWait = null, string delay=null)
+        {
+            _accountName = accountName;
+            _accountKey = accountKey;
+            _connectionString = connectionString;
+            _containerName = containerName;
+            _blobName = blobName;
+            _maxWait = !string.IsNullOrWhiteSpace(maxWait) ? TimeSpan.Parse(maxWait) : TimeSpan.FromSeconds(s_MaxWaitDefault);
+            _delay = !string.IsNullOrWhiteSpace(delay) ? TimeSpan.Parse(delay) : TimeSpan.FromMilliseconds(s_DelayDefault);
+            _log = log;
+            _leaseUrl = $"{AzureHelper.GetBlobRestUrl(_accountName, _containerName, _blobName)}?comp=lease";
+        }
+
+        public void Acquire()
+        {
+            Stopwatch stopWatch = new Stopwatch();
+            stopWatch.Start();
+
+            while (stopWatch.ElapsedMilliseconds < _maxWait.TotalMilliseconds)
+            {
+                try
+                {
+                    string leaseId = AcquireLeaseOnBlobAsync().GetAwaiter().GetResult();
+                    _cancellationTokenSource = new CancellationTokenSource();
+                    _leaseRenewalTask = Task.Run(() =>
+                    { AutoRenewLeaseOnBlob(this, _accountName, _accountKey, _containerName, _blobName, leaseId, _leaseUrl, _log); },
+                      _cancellationTokenSource.Token);
+                    _leaseId = leaseId;
+                    return;
+                }
+                catch (Exception e)
+                {
+                    _log.LogMessage($"Retrying lease acquisition on {_blobName}, {e.Message}");
+                    Thread.Sleep(_delay);
+                }
+            }
+            ResetLeaseRenewalTaskState();
+            throw new Exception($"Unable to acquire lease on {_blobName}");
+
+        }
+
+        public void Release()
+        {
+            // Cancel the lease renewal task since we are about to release the lease.
+            ResetLeaseRenewalTaskState();
+
+            using (HttpClient client = new HttpClient())
+            {
+                Tuple<string, string> leaseAction = new Tuple<string, string>("x-ms-lease-action", "release");
+                Tuple<string, string> headerLeaseId = new Tuple<string, string>("x-ms-lease-id", _leaseId);
+                List<Tuple<string, string>> additionalHeaders = new List<Tuple<string, string>>() { leaseAction, headerLeaseId };
+                var request = AzureHelper.RequestMessage("PUT", _leaseUrl, _accountName, _accountKey, additionalHeaders);
+                using (HttpResponseMessage response = AzureHelper.RequestWithRetry(_log, client, request).GetAwaiter().GetResult())
+                {
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        _log.LogMessage($"Unable to release lease on container/blob {_containerName}/{_blobName}.");
+                    }
+                }
+            }
+        }
+
+        private async Task<string> AcquireLeaseOnBlobAsync()
+        {
+            _log.LogMessage(MessageImportance.Low, $"Requesting lease for container/blob '{_containerName}/{_blobName}'.");
+            string leaseId = string.Empty;
+            using (HttpClient client = new HttpClient())
+            {
+                try
+                {
+                    Tuple<string, string> leaseAction = new Tuple<string, string>("x-ms-lease-action", "acquire");
+                    Tuple<string, string> leaseDuration = new Tuple<string, string>("x-ms-lease-duration", "60" /* seconds */);
+                    List<Tuple<string, string>> additionalHeaders = new List<Tuple<string, string>>() { leaseAction, leaseDuration };
+                    var request = AzureHelper.RequestMessage("PUT", _leaseUrl, _accountName, _accountKey, additionalHeaders);
+                    using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(_log, client, request))
+                    {
+                        leaseId = response.Headers.GetValues("x-ms-lease-id").FirstOrDefault();
+                    }
+                }
+                catch (Exception e)
+                {
+                    _log.LogErrorFromException(e, true);
+                }
+            }
+
+            return leaseId;
+        }
+        private static void AutoRenewLeaseOnBlob(AzureBlobLease instance, string accountName, string accountKey, string containerName, string blob, string leaseId, string leaseUrl, Microsoft.Build.Utilities.TaskLoggingHelper log)
+        {
+            TimeSpan maxWait = TimeSpan.FromSeconds(s_MaxWaitDefault);
+            TimeSpan delay = TimeSpan.FromMilliseconds(s_DelayDefault);
+            TimeSpan waitFor = maxWait;
+            CancellationToken token = instance._cancellationTokenSource.Token;
+
+            while (true)
+            {
+                token.ThrowIfCancellationRequested();
+
+                try
+                {
+                    log.LogMessage(MessageImportance.Low, $"Requesting lease for container/blob '{containerName}/{blob}'.");
+                    using (HttpClient client = new HttpClient())
+                    {
+                        Tuple<string, string> leaseAction = new Tuple<string, string>("x-ms-lease-action", "renew");
+                        Tuple<string, string> headerLeaseId = new Tuple<string, string>("x-ms-lease-id", leaseId);
+                        List<Tuple<string, string>> additionalHeaders = new List<Tuple<string, string>>() { leaseAction, headerLeaseId };
+                        var request = AzureHelper.RequestMessage("PUT", leaseUrl, accountName, accountKey, additionalHeaders);
+                        using (HttpResponseMessage response = AzureHelper.RequestWithRetry(log, client, request).GetAwaiter().GetResult())
+                        {
+                            if (!response.IsSuccessStatusCode)
+                            {
+                                throw new Exception("Unable to acquire lease.");
+                            }
+                        }
+                    }
+                    waitFor = maxWait;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Rerying lease renewal on {containerName}, {e.Message}");
+                    waitFor = delay;
+                }
+                token.ThrowIfCancellationRequested();
+
+                Thread.Sleep(waitFor);
+            }
+        }
+
+        private void ResetLeaseRenewalTaskState()
+        {
+            // Cancel the lease renewal task if it was created
+            if (_leaseRenewalTask != null)
+            {
+                _cancellationTokenSource.Cancel();
+
+                // Block until the task ends. It can throw if we cancelled it before it completed.
+                try
+                {
+                    _leaseRenewalTask.Wait();
+                }
+                catch (Exception)
+                {
+                    // Ignore the caught exception as it will be expected.
+                }
+
+                _leaseRenewalTask = null;
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -19,7 +19,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
-    // This is grabbed directly from buildtools and we should not duplicate this when we move ListAzureBlobs back to buildtools
     public static class AzureHelper
     {
         /// <summary>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -18,6 +19,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
+    // This is grabbed directly from buildtools and we should not duplicate this when we move ListAzureBlobs back to buildtools
     public static class AzureHelper
     {
         /// <summary>
@@ -27,34 +29,35 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         public const string DateHeaderString = "x-ms-date";
         public const string VersionHeaderString = "x-ms-version";
         public const string AuthorizationHeaderString = "Authorization";
+        public const string CacheControlString = "x-ms-blob-cache-control";
+        public const string ContentTypeString = "x-ms-blob-content-type";
 
         public enum SasAccessType
         {
-            Read, 
+            Read,
             Write,
         };
 
         public static string AuthorizationHeader(
-            string storageAccount, 
-            string storageKey, 
-            string method, 
+            string storageAccount,
+            string storageKey,
+            string method,
             DateTime now,
-            HttpRequestMessage request, 
-            string ifMatch = "", 
-            string contentMD5 = "", 
-            string size = "", 
+            HttpRequestMessage request,
+            string ifMatch = "",
+            string contentMD5 = "",
+            string size = "",
             string contentType = "")
         {
             string stringToSign = string.Format(
-                "{0}\n\n\n{1}\n{5}\n{6}\n\n\n{2}\n\n\n\n{3}{4}", 
-                method, 
-                (size == string.Empty) ? string.Empty : size, 
-                ifMatch, 
-                GetCanonicalizedHeaders(request), 
-                GetCanonicalizedResource(request.RequestUri, storageAccount), 
-                contentMD5, 
+                "{0}\n\n\n{1}\n{5}\n{6}\n\n\n{2}\n\n\n\n{3}{4}",
+                method,
+                (size == string.Empty) ? string.Empty : size,
+                ifMatch,
+                GetCanonicalizedHeaders(request),
+                GetCanonicalizedResource(request.RequestUri, storageAccount),
+                contentMD5,
                 contentType);
-
             byte[] signatureBytes = Encoding.UTF8.GetBytes(stringToSign);
             string authorizationHeader;
             using (HMACSHA256 hmacsha256 = new HMACSHA256(Convert.FromBase64String(storageKey)))
@@ -67,10 +70,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         }
 
         public static string CreateContainerSasToken(
-            string accountName, 
-            string containerName, 
-            string key, 
-            SasAccessType accessType, 
+            string accountName,
+            string containerName,
+            string key,
+            SasAccessType accessType,
             int validityTimeInDays)
         {
             string signedPermissions = string.Empty;
@@ -93,11 +96,11 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             string signedVersion = StorageApiVersion;
 
             string stringToSign = ConstructServiceStringToSign(
-                signedPermissions, 
-                signedVersion, 
-                signedExpiry, 
-                canonicalizedResource, 
-                signedIdentifier, 
+                signedPermissions,
+                signedVersion,
+                signedExpiry,
+                canonicalizedResource,
+                signedIdentifier,
                 signedStart);
 
             byte[] signatureBytes = Encoding.UTF8.GetBytes(stringToSign);
@@ -108,12 +111,12 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
 
             string sasToken = string.Format(
-                "?sv={0}&sr={1}&sig={2}&st={3}&se={4}&sp={5}", 
-                WebUtility.UrlEncode(signedVersion), 
-                WebUtility.UrlEncode("c"), 
-                WebUtility.UrlEncode(signature), 
-                WebUtility.UrlEncode(signedStart), 
-                WebUtility.UrlEncode(signedExpiry), 
+                "?sv={0}&sr={1}&sig={2}&st={3}&se={4}&sp={5}",
+                WebUtility.UrlEncode(signedVersion),
+                WebUtility.UrlEncode("c"),
+                WebUtility.UrlEncode(signature),
+                WebUtility.UrlEncode(signedStart),
+                WebUtility.UrlEncode(signedExpiry),
                 WebUtility.UrlEncode(signedPermissions));
 
             return sasToken;
@@ -252,13 +255,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     if (validationCallback == null)
                     {
                         // check if the response code is within the range of failures
-                        if (IsWithinRetryRange(response.StatusCode))
+                        if (!IsWithinRetryRange(response.StatusCode))
                         {
-                            loggingHelper.LogWarning("Request failed with status code {0}", response.StatusCode);
-                        }
-                        else
-                        {
-                            loggingHelper.LogMessage(MessageImportance.Low, "Response completed with status code {0}", response.StatusCode);
                             return response;
                         }
                     }
@@ -297,35 +295,35 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         }
 
         private static string ConstructServiceStringToSign(
-            string signedPermissions, 
-            string signedVersion, 
-            string signedExpiry, 
-            string canonicalizedResource, 
-            string signedIdentifier, 
-            string signedStart, 
-            string signedIP = "", 
-            string signedProtocol = "", 
-            string rscc = "", 
-            string rscd = "", 
-            string rsce = "", 
-            string rscl = "", 
+            string signedPermissions,
+            string signedVersion,
+            string signedExpiry,
+            string canonicalizedResource,
+            string signedIdentifier,
+            string signedStart,
+            string signedIP = "",
+            string signedProtocol = "",
+            string rscc = "",
+            string rscd = "",
+            string rsce = "",
+            string rscl = "",
             string rsct = "")
         {
             // constructing string to sign based on spec in https://msdn.microsoft.com/en-us/library/azure/dn140255.aspx
             var stringToSign = string.Join(
-                "\n", 
-                signedPermissions, 
-                signedStart, 
-                signedExpiry, 
-                canonicalizedResource, 
-                signedIdentifier, 
-                signedIP, 
-                signedProtocol, 
-                signedVersion, 
-                rscc, 
-                rscd, 
-                rsce, 
-                rscl, 
+                "\n",
+                signedPermissions,
+                signedStart,
+                signedExpiry,
+                canonicalizedResource,
+                signedIdentifier,
+                signedIP,
+                signedProtocol,
+                signedVersion,
+                rscc,
+                rscd,
+                rsce,
+                rscl,
                 rsct);
             return stringToSign;
         }
@@ -393,6 +391,73 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
 
             return dictionary;
+        }
+
+        public static Func<HttpRequestMessage> RequestMessage(string method, string url, string accountName, string accountKey, List<Tuple<string, string>> additionalHeaders = null, string body = null)
+        {
+            Func<HttpRequestMessage> requestFunc = () =>
+            {
+                HttpMethod httpMethod = HttpMethod.Get;
+                if(method == "PUT")
+                {
+                    httpMethod = HttpMethod.Put;
+                }
+                else if (method == "DELETE")
+                {
+                    httpMethod = HttpMethod.Delete;
+                }
+                DateTime dateTime = DateTime.UtcNow;
+                var request = new HttpRequestMessage(httpMethod, url);
+                request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
+                request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
+                if (additionalHeaders != null)
+                {
+                    foreach (Tuple<string, string> additionalHeader in additionalHeaders)
+                    {
+                        request.Headers.Add(additionalHeader.Item1, additionalHeader.Item2);
+                    }
+                }
+                if (body != null)
+                {
+                    request.Content = new StringContent(body);
+                    request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
+                        accountName,
+                        accountKey,
+                        method,
+                        dateTime,
+                        request,
+                        "",
+                        "",
+                        request.Content.Headers.ContentLength.ToString(),
+                        request.Content.Headers.ContentType.ToString()));
+                }
+                else
+                {
+                    request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
+                        accountName,
+                        accountKey,
+                        method,
+                        dateTime,
+                        request));
+                }
+                return request;
+            };
+            return requestFunc;
+        }
+
+        public static string GetRootRestUrl(string accountName)
+        {
+            return $"https://{accountName}.blob.core.windows.net";
+        } 
+       
+        public static string GetContainerRestUrl(string accountName, string containerName)
+        {
+            return $"{GetRootRestUrl(accountName)}/{containerName}";
+        }
+
+        public static string GetBlobRestUrl(string accountName, string containerName, string blob)
+        {
+            return $"{GetContainerRestUrl(accountName, containerName)}/{blob}";
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CopyAzureBlobToBlob.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CopyAzureBlobToBlob.cs
@@ -1,0 +1,100 @@
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public partial class CopyAzureBlobToBlob : AzureConnectionStringBuildTask
+    {
+        [Required]
+        public string ContainerName { get; set; }
+        [Required]
+        public string SourceBlobName { get; set; }
+        [Required]
+        public string DestinationBlobName { get; set; }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task<bool> ExecuteAsync()
+        {
+            ParseConnectionString();
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
+            string sourceUrl = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, SourceBlobName);
+            string destinationUrl = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, DestinationBlobName);
+            using (HttpClient client = new HttpClient())
+            {
+                try
+                {
+                    Tuple<string, string> leaseAction = new Tuple<string, string>("x-ms-lease-action", "acquire");
+                    Tuple<string, string> leaseDuration = new Tuple<string, string>("x-ms-lease-duration", "60" /* seconds */);
+                    Tuple<string, string> headerSource = new Tuple<string, string>("x-ms-copy-source", sourceUrl);
+                    List<Tuple<string, string>> additionalHeaders = new List<Tuple<string, string>>() { leaseAction, leaseDuration, headerSource };
+                    var request = AzureHelper.RequestMessage("PUT", destinationUrl, AccountName, AccountKey, additionalHeaders);
+                    using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, request))
+                    {
+                        if (response.IsSuccessStatusCode)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.LogErrorFromException(e, true);
+                }
+            }
+            return false;
+        }
+        public static bool Execute(string accountName,
+                                       string accountKey,
+                                       string connectionString,
+                                       string containerName,
+                                       string sourceBlobName,
+                                       string destinationBlobName,
+                                       IBuildEngine buildengine,
+                                       ITaskHost taskHost)
+        {
+            CopyAzureBlobToBlob copyAzureBlobToBlob = new CopyAzureBlobToBlob()
+            {
+                AccountName = accountName,
+                AccountKey = accountKey,
+                ContainerName = containerName,
+                SourceBlobName = sourceBlobName,
+                DestinationBlobName = destinationBlobName,
+                BuildEngine = buildengine,
+                HostObject = taskHost
+            };
+            return copyAzureBlobToBlob.Execute();
+        }
+        public static Task<bool> ExecuteAsync(string accountName,
+                                              string accountKey,
+                                              string connectionString,
+                                              string containerName,
+                                              string sourceBlobName,
+                                              string destinationBlobName,
+                                              IBuildEngine buildengine,
+                                              ITaskHost taskHost)
+        {
+            CopyAzureBlobToBlob copyAzureBlobToBlob = new CopyAzureBlobToBlob()
+            {
+                AccountName = accountName,
+                AccountKey = accountKey,
+                ContainerName = containerName,
+                SourceBlobName = sourceBlobName,
+                DestinationBlobName = destinationBlobName,
+                BuildEngine = buildengine,
+                HostObject = taskHost
+            };
+            return copyAzureBlobToBlob.ExecuteAsync();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CreateAzureContainer.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CreateAzureContainer.cs
@@ -87,27 +87,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Log.LogMessage(MessageImportance.Low, "Sending request to create Container");
             using (HttpClient client = new HttpClient())
             {
-                Func<HttpRequestMessage> createRequest = () =>
-                {
-                    DateTime dt = DateTime.UtcNow;
-                    var req = new HttpRequestMessage(HttpMethod.Put, url);
-                    req.Headers.Add(AzureHelper.DateHeaderString, dt.ToString("R", CultureInfo.InvariantCulture));
-                    req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                    req.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
-                            AccountName,
-                            AccountKey,
-                            "PUT",
-                            dt,
-                            req));
-                    byte[] bytestoWrite = new byte[0];
-                    int bytesToWriteLength = 0;
-
-                    Stream postStream = new MemoryStream();
-                    postStream.Write(bytestoWrite, 0, bytesToWriteLength);
-                    req.Content = new StreamContent(postStream);
-
-                    return req;
-                };
+                var createRequest = AzureHelper.RequestMessage("PUT", url, AccountName, AccountKey);
 
                 Func<HttpResponseMessage, bool> validate = (HttpResponseMessage response) =>
                 {

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DeleteAzureBlob.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DeleteAzureBlob.cs
@@ -1,0 +1,66 @@
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public partial class DeleteAzureBlob: AzureConnectionStringBuildTask
+    {
+        [Required]
+        public string ContainerName { get; set; }
+        [Required]
+        public string BlobName { get; set; }
+
+        public override bool Execute()
+        {
+            ParseConnectionString();
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
+            string deleteUrl = $"https://{AccountName}.blob.core.windows.net/{ContainerName}/{BlobName}";
+
+            using (HttpClient client = new HttpClient())
+            {
+                try
+                {
+                    Tuple<string, string> snapshots = new Tuple<string, string>("x-ms-lease-delete-snapshots", "include");
+                    List<Tuple<string, string>> additionalHeaders = new List<Tuple<string, string>>() { snapshots };
+                    var request = AzureHelper.RequestMessage("DELETE", deleteUrl, AccountName, AccountKey, additionalHeaders);
+                    using (HttpResponseMessage response = AzureHelper.RequestWithRetry(Log, client, request).GetAwaiter().GetResult())
+                    {
+                        return response.IsSuccessStatusCode;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.LogErrorFromException(e, true);
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        public static bool Execute(string accountName,
+                                       string accountKey,
+                                       string connectionString,
+                                       string containerName,
+                                       string blobName,
+                                       IBuildEngine buildengine,
+                                       ITaskHost taskHost)
+            {
+            DeleteAzureBlob deleteAzureoBlob = new DeleteAzureBlob()
+            {
+                AccountName = accountName,
+                AccountKey = accountKey,
+                ContainerName = containerName,
+                BlobName = blobName,
+                BuildEngine = buildengine,
+                HostObject = taskHost
+            };
+            return deleteAzureoBlob.Execute();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -31,6 +31,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
         public string BlobNamePrefix { get; set; }
 
+        public ITaskItem[] BlobNames { get; set; }
+        
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -48,96 +50,64 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Log.LogMessage(MessageImportance.Normal, "Downloading contents of container {0} from storage account '{1}' to directory {2}.",
                 ContainerName, AccountName, DownloadDirectory);
 
-            string optionalBlobPrefixForQuery = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
-
-            List<string> blobsNames = new List<string>();
-            string urlListBlobs = $"https://{AccountName}.blob.core.windows.net/{ContainerName}?restype=container&comp=list{optionalBlobPrefixForQuery}";
-
-            Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
-
-            using (HttpClient client = new HttpClient())
+            try
             {
-                try
+                List<string> blobNames = new List<string>();
+                if (BlobNames == null)
                 {
-                    Func<HttpRequestMessage> createRequest = () =>
+                    ListAzureBlobs listAzureBlobs = new ListAzureBlobs()
                     {
-                        DateTime dateTime = DateTime.UtcNow;
-                        var request = new HttpRequestMessage(HttpMethod.Get, urlListBlobs);
-                        request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
-                        request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                        request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
-                                AccountName,
-                                AccountKey,
-                                "GET",
-                                dateTime,
-                                request));
-                        return request;
-                    };
-
-                    XmlDocument responseFile;
-                    string nextMarker = string.Empty;
-                    using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
+                        AccountName = AccountName,
+                        AccountKey = AccountKey,
+                        ContainerName = ContainerName,
+                        FilterBlobNames = BlobNamePrefix,
+                        BuildEngine = this.BuildEngine,
+                        HostObject = this.HostObject
+                    };                    
+                    listAzureBlobs.Execute();
+                    blobNames = listAzureBlobs.BlobNames.ToList();
+                }
+                else
+                {
+                    blobNames = BlobNames.Select(b => b.ItemSpec).ToList<string>();
+                    if (BlobNamePrefix != null)
                     {
-                        responseFile = new XmlDocument();
-                        responseFile.LoadXml(await response.Content.ReadAsStringAsync());
-                        XmlNodeList elemList = responseFile.GetElementsByTagName("Name");
-
-                        blobsNames.AddRange(elemList.Cast<XmlNode>()
-                                                    .Select(x => x.InnerText)
-                                                    .ToList());
-                        nextMarker = responseFile.GetElementsByTagName("NextMarker").Cast<XmlNode>().FirstOrDefault()?.InnerText;
+                        blobNames = blobNames.Where(b => b.StartsWith(BlobNamePrefix)).ToList<string>();
                     }
-                    while (!string.IsNullOrEmpty(nextMarker))
-                    {
-                        urlListBlobs = string.Format($"https://{AccountName}.blob.core.windows.net/{ContainerName}?restype=container&comp=list&marker={nextMarker}");
-                        using (HttpResponseMessage response = AzureHelper.RequestWithRetry(Log, client, createRequest).GetAwaiter().GetResult())
-                        {
-                            responseFile = new XmlDocument();
-                            responseFile.LoadXml(response.Content.ReadAsStringAsync().GetAwaiter().GetResult());
-                            XmlNodeList elemList = responseFile.GetElementsByTagName("Name");
-
-                            blobsNames.AddRange(elemList.Cast<XmlNode>()
-                                                        .Select(x => x.InnerText)
-                                                        .ToList());
-
-                            nextMarker = responseFile.GetElementsByTagName("NextMarker").Cast<XmlNode>().FirstOrDefault()?.InnerText;
-                        }
-                    }
-
-                    // track the number of blobs that fail to download
-                    int failureCount = 0;
-                    if (blobsNames.Count == 0)
-                        Log.LogWarning("No blobs were found.");
-                    else
-                        Log.LogMessage(MessageImportance.Low, $"{blobsNames.Count} blobs found.");
-
-                    foreach (string blob in blobsNames)
+                }
+                // track the number of blobs that fail to download
+                int failureCount = 0;
+                using (HttpClient client = new HttpClient())
+                {
+                    foreach (string blob in blobNames)
                     {
                         Log.LogMessage(MessageImportance.Low, "Downloading BLOB - {0}", blob);
-                        string urlGetBlob = string.Format("https://{0}.blob.core.windows.net/{1}/{2}", AccountName, ContainerName, blob);
+                        string urlGetBlob = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, blob);
 
-                        string filename = Path.Combine(DownloadDirectory, blob);
-                        string blobDirectory = blob.Substring(0, blob.LastIndexOf("/"));
+                        int dirIndex = blob.LastIndexOf("/");
+                        string blobDirectory = string.Empty;
+                        string blobFilename = string.Empty;
+                        if (dirIndex == -1)
+                        {
+                            blobFilename = blob;
+                        }
+                        else
+                        {
+                            blobDirectory = blob.Substring(0, dirIndex);
+                            blobFilename = blob.Substring(dirIndex + 1);
+                        }
+                        if(BlobNamePrefix != null)
+                        {
+                            blobDirectory = blobDirectory.Substring(BlobNamePrefix.Length);
+                        }
                         string downloadBlobDirectory = Path.Combine(DownloadDirectory, blobDirectory);
                         if (!Directory.Exists(downloadBlobDirectory))
                         {
                             Directory.CreateDirectory(downloadBlobDirectory);
                         }
+                        string filename = Path.Combine(downloadBlobDirectory, blobFilename);
 
-                        createRequest = () =>
-                        {
-                            DateTime dateTime = DateTime.UtcNow;
-                            var request = new HttpRequestMessage(HttpMethod.Get, urlGetBlob);
-                            request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
-                            request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                            request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
-                                    AccountName,
-                                    AccountKey,
-                                    "GET",
-                                    dateTime,
-                                    request));
-                            return request;
-                        };
+                        var createRequest = AzureHelper.RequestMessage("GET", urlGetBlob, AccountName, AccountKey);
 
                         using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
                         {
@@ -165,14 +135,14 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                             }
                         }
                     }
-                    Log.LogMessage($"{failureCount} errors seen downloading blobs.");
                 }
-                catch (Exception e)
-                {
-                    Log.LogErrorFromException(e, true);
-                }
-                return !Log.HasLoggedErrors;
+                Log.LogMessage($"{failureCount} errors seen downloading blobs.");
             }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureBlobs.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureBlobs.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Xml;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public partial class ListAzureBlobs : AzureConnectionStringBuildTask
+    {
+
+        /// <summary>
+        /// The name of the container to access.  The specified name must be in the correct format, see the
+        /// following page for more info.  https://msdn.microsoft.com/en-us/library/azure/dd135715.aspx
+        /// </summary>
+        [Required]
+        public string ContainerName { get; set; }
+
+        [Output]
+        public string[] BlobNames { get; set; }
+
+        public string FilterBlobNames { get; set; }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        public static string [] Execute(string accountName,
+                                   string accountKey,
+                                   string connectionString,
+                                   string containerName,
+                                   string filterBlobNames,
+                                   IBuildEngine buildengine,
+                                   ITaskHost taskHost)
+        {
+            ListAzureBlobs getAzureBlobList = new ListAzureBlobs()
+            {
+                AccountName = accountName,
+                AccountKey = accountKey,
+                ContainerName = containerName,
+                FilterBlobNames = filterBlobNames,
+                BuildEngine = buildengine,
+                HostObject = taskHost
+            };
+            getAzureBlobList.Execute();
+            return getAzureBlobList.BlobNames;
+        }
+
+        // This code is duplicated in BuildTools task DownloadFromAzure, and that code should be refactored to permit blob listing.
+        public async Task<bool> ExecuteAsync()
+        {
+            ParseConnectionString();
+
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
+            List<string> blobsNames = new List<string>();
+            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list", AccountName, ContainerName);
+            if (!string.IsNullOrWhiteSpace(FilterBlobNames))
+            {
+                urlListBlobs += $"&prefix={FilterBlobNames}";
+            }
+            Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
+
+            using (HttpClient client = new HttpClient())
+            {
+                try
+                {
+                    var createRequest = AzureHelper.RequestMessage("GET", urlListBlobs, AccountName, AccountKey);
+
+                    XmlDocument responseFile;
+                    string nextMarker = string.Empty;
+                    using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
+                    {
+                        responseFile = new XmlDocument();
+                        responseFile.LoadXml(await response.Content.ReadAsStringAsync());
+                        XmlNodeList elemList = responseFile.GetElementsByTagName("Name");
+
+                        blobsNames.AddRange(elemList.Cast<XmlNode>()
+                                                    .Select(x => x.InnerText)
+                                                    .ToList());
+
+                        nextMarker = responseFile.GetElementsByTagName("NextMarker").Cast<XmlNode>().FirstOrDefault()?.InnerText;
+                    }
+                    while (!string.IsNullOrEmpty(nextMarker))
+                    {
+                        urlListBlobs = string.Format($"https://{AccountName}.blob.core.windows.net/{ContainerName}?restype=container&comp=list&marker={nextMarker}");
+                        var nextRequest = AzureHelper.RequestMessage("GET", urlListBlobs, AccountName, AccountKey);
+                        using (HttpResponseMessage nextResponse = AzureHelper.RequestWithRetry(Log, client, nextRequest).GetAwaiter().GetResult())
+                        {
+                            responseFile = new XmlDocument();
+                            responseFile.LoadXml(await nextResponse.Content.ReadAsStringAsync());
+                            XmlNodeList elemList = responseFile.GetElementsByTagName("Name");
+
+                            blobsNames.AddRange(elemList.Cast<XmlNode>()
+                                                        .Select(x => x.InnerText)
+                                                        .ToList());
+
+                            nextMarker = responseFile.GetElementsByTagName("NextMarker").Cast<XmlNode>().FirstOrDefault()?.InnerText;
+                        }
+                    }
+                    BlobNames = blobsNames.ToArray();
+                }
+                catch (Exception e)
+                {
+                    Log.LogErrorFromException(e, true);
+                }
+                return !Log.HasLoggedErrors;
+            }
+        }
+    }
+
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureContainers.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureContainers.cs
@@ -49,20 +49,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             {
                 try
                 {
-                    Func<HttpRequestMessage> createRequest = () =>
-                    {
-                        DateTime dateTime = DateTime.UtcNow;
-                        var request = new HttpRequestMessage(HttpMethod.Get, url);
-                        request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
-                        request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                        request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
-                                AccountName,
-                                AccountKey,
-                                "GET",
-                                dateTime,
-                                request));
-                        return request;
-                    };
+                    var createRequest = AzureHelper.RequestMessage("GET", url, AccountName, AccountKey);
 
                     // TODO:  This task has a bug, it needs to continue when there are > 5000 containers in a storage acccount.
                     //        Fix is something like the one made to DownloadFromAzure, but not pressing since it looks like GetLatestContainerNameFromAzure is rarely / not used.

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -26,22 +26,7 @@
     <Compile Include="$(CommonPath)\ZipFileCreateFromDirectory.cs">
       <Link>ZipFileCreateFromDirectory.cs</Link>
     </Compile>
-    <Compile Include="SendJobsToHelix.cs" />
-    <Compile Include="SimulateHelixExecution.cs" />
-    <Compile Include="ValidateWorkItems.cs" />
-    <Compile Include="AzureConnectionStringBuildTask.cs" />
-    <Compile Include="AzureHelper.cs" />
-    <Compile Include="CreateAzureContainer.cs" />
-    <Compile Include="DownloadFromAzure.cs" />
-    <Compile Include="FilterForUpload.cs" />
-    <Compile Include="GetPerfTestAssemblies.cs" />
-    <Compile Include="ListAzureContainers.cs" />
-    <Compile Include="SendToHelix.cs" />
-    <Compile Include="UploadClient.cs" />
-    <Compile Include="UploadToAzure.cs" />
-    <Compile Include="WriteBuildStatsJson.cs" />
-    <Compile Include="RemoveItemMetadata.cs" />
-    <Compile Include="WriteItemsToJson.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)*.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="RunnerScripts\**\*.*" />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -26,7 +26,27 @@
     <Compile Include="$(CommonPath)\ZipFileCreateFromDirectory.cs">
       <Link>ZipFileCreateFromDirectory.cs</Link>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)*.cs" />
+    <Compile Include="AzureConnectionStringBuildTask.cs" />
+    <Compile Include="AzureBlobLease.cs" />
+    <Compile Include="AzureHelper.cs" />
+    <Compile Include="CopyAzureBlobToBlob.cs" />
+    <Compile Include="CreateAzureContainer.cs" />
+    <Compile Include="DeleteAzureBlob.cs" />
+    <Compile Include="DownloadFromAzure.cs" />
+    <Compile Include="FilterForUpload.cs" />
+    <Compile Include="GetPerfTestAssemblies.cs" />
+    <Compile Include="ListAzureBlobs.cs" />
+    <Compile Include="ListAzureContainers.cs" />
+    <Compile Include="PublishStringToAzureBlob.cs" />
+    <Compile Include="RemoveItemMetadata.cs" />
+    <Compile Include="SendJobsToHelix.cs" />
+    <Compile Include="SendToHelix.cs" />
+    <Compile Include="SimulateHelixExecution.cs" />
+    <Compile Include="UploadClient.cs" />
+    <Compile Include="UploadToAzure.cs" />
+    <Compile Include="ValidateWorkItems.cs" />
+    <Compile Include="WriteBuildStatsJson.cs" />
+    <Compile Include="WriteItemsToJson.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="RunnerScripts\**\*.*" />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PublishStringToAzureBlob.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PublishStringToAzureBlob.cs
@@ -1,0 +1,72 @@
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public partial class PublishStringToAzureBlob : AzureConnectionStringBuildTask
+    {
+        [Required]
+        public string BlobName { get; set; }
+        [Required]
+        public string ContainerName { get; set; }
+        [Required]
+        public string Content { get; set; }
+        public string ContentType { get; set; }
+
+        public override bool Execute()
+        {
+            ParseConnectionString();
+
+            string blobUrl = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, BlobName);
+            using (HttpClient client = new HttpClient())
+            {
+                try
+                {
+                    Tuple<string, string> headerBlobType = new Tuple<string, string>("x-ms-blob-type", "BlockBlob");
+                    List<Tuple<string, string>> additionalHeaders = new List<Tuple<string, string>>() { headerBlobType };
+
+                    if (!string.IsNullOrEmpty(ContentType))
+                    {
+                        additionalHeaders.Add(new Tuple<string, string>(AzureHelper.ContentTypeString, ContentType));
+                    }
+
+                    var request = AzureHelper.RequestMessage("PUT", blobUrl, AccountName, AccountKey, additionalHeaders, Content);
+
+                    AzureHelper.RequestWithRetry(Log, client, request).GetAwaiter().GetResult();
+                }
+                catch (Exception e)
+                {
+                    Log.LogErrorFromException(e, true);
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        public static bool Execute(string accountName,
+                                   string accountKey,
+                                   string connectionString,
+                                   string containerName,
+                                   string blobName,
+                                   string content,
+                                   string contentType,
+                                   IBuildEngine buildengine,
+                                   ITaskHost taskHost)
+        {
+            PublishStringToAzureBlob publishStringToBlob = new PublishStringToAzureBlob()
+            {
+                AccountName = accountName,
+                AccountKey = accountKey,
+                ContainerName = containerName,
+                BlobName = blobName,
+                Content = content,
+                ContentType = contentType,
+                BuildEngine = buildengine,
+                HostObject = taskHost
+            };
+            return publishStringToBlob.Execute();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateChecksums.cs
@@ -1,0 +1,68 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class GenerateChecksums : Task
+    {
+        /// <summary>
+        /// An item collection of files for which to generate checksums.  Each item must have metadata
+        /// 'DestinationPath' that specifies the path of the checksum file to create.
+        /// </summary>
+        [Required]
+        public ITaskItem[] Items { get; set; }
+
+        public override bool Execute()
+        {
+            foreach (ITaskItem item in Items)
+            {
+                try
+                {
+                    string destinationPath = item.GetMetadata("DestinationPath");
+                    if (string.IsNullOrEmpty(destinationPath))
+                    {
+                        throw new Exception($"Metadata 'DestinationPath' is missing for item '{item.ItemSpec}'.");
+                    }
+
+                    if (!File.Exists(item.ItemSpec))
+                    {
+                        throw new Exception($"The file '{item.ItemSpec}' does not exist.");
+                    }
+
+                    Log.LogMessage(
+                        MessageImportance.High,
+                        "Generating checksum for '{0}' into '{1}'...",
+                        item.ItemSpec,
+                        destinationPath);
+
+                    using (FileStream stream = File.OpenRead(item.ItemSpec))
+                    {
+                        using(HashAlgorithm hashAlgorithm = SHA512.Create())
+                        {
+                            byte[] hash = hashAlgorithm.ComputeHash(stream);
+                            string checksum = BitConverter.ToString(hash).Replace("-", string.Empty);
+                            File.WriteAllText(destinationPath, checksum);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    // We have 2 log calls because we want a nice error message but we also want to capture the
+                    // callstack in the log.
+                    Log.LogError("An exception occurred while trying to generate a checksum for '{0}'.", item.ItemSpec);
+                    Log.LogMessage(MessageImportance.Low, e.ToString());
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -29,6 +29,7 @@
     <Compile Include="AddDependenciesToProjectJson.cs" />
     <Compile Include="FilterRuntimesFromSupports.cs" />
     <Compile Include="GenerateBindingRedirect.cs" />
+    <Compile Include="GenerateChecksums.cs" />
     <Compile Include="GenerateEncryptedNuGetConfig.cs" />
     <Compile Include="GenerateTestExecutionScripts.cs" />
     <Compile Include="GenerateCurrentVersion.cs" />


### PR DESCRIPTION
This change is moving the tasks from https://github.com/dotnet/core-setup/tree/master/tools-local/Microsoft.DotNet.Build.Tasks.Local into BuildTools.  

The files which are modified (not new additions), *should* be non-breaking in repos which utilize these tasks though I will have to make some small modifications to core-setup when I update that repo to consume these changes.

https://github.com/dotnet/core-setup/blob/master/tools-local/Microsoft.DotNet.Build.Tasks.Local/DownloadBlobFromAzure.cs and https://github.com/dotnet/core-setup/blob/master/tools-local/Microsoft.DotNet.Build.Tasks.Local/DownloadBlobsFromAzure.cs have been collapsed into the DownloadFromAzure task.  I've validated previous behavior for DownloadFromAzure task in CoreFx repo.

I'm not porting https://github.com/dotnet/core-setup/blob/master/tools-local/Microsoft.DotNet.Build.Tasks.Local/GetHostInformation.cs because I think we can replace that task with BuildTools pre-existing https://github.com/dotnet/buildtools/blob/master/src/Microsoft.DotNet.Build.Tasks/GetTargetMachineInfo.cs task.

All tasks are moving into CloudTestTasks except for GenerateChecksums.cs which is moving into Microsoft.DotNet.Build.Tools.