### PR TITLE
Tool runtime improvements

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Restores crossgen and runs it on all tools components.
-
-__CoreClrVersion=2.0.0-preview1-25204-02
-__MyGetFeed=https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
-
 usage()
 {
     echo "crossgen.sh <directory>"
@@ -21,15 +18,13 @@ restore_crossgen()
 
     __pjDir=$__toolsDir/crossgen
     mkdir -p $__pjDir
-    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>netcoreapp2.0</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.Runtime.CoreCLR\" Version=\"$__CoreClrVersion\" /><PackageReference Include=\"Microsoft.NETCore.Platforms\" Version=\"1.1.0\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
+    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>netcoreapp2.0</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.App\" Version=\"$__sharedFxVersion\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
     $__dotnet restore $__pjDir/crossgen.csproj --packages $__packagesDir --source $__MyGetFeed
-    __crossgenInPackage=$__packagesDir/runtime.$__packageRid.microsoft.netcore.runtime.coreclr/$__CoreClrVersion/tools/crossgen
-    if [ ! -e $__crossgenInPackage ]; then
-        echo "The crossgen executable could not be found at "$__crossgenInPackage". Aborting crossgen.sh."
+    __crossgen=$__packagesDir/runtime.$__packageRid.microsoft.netcore.app/$__sharedFxVersion/tools/crossgen
+    if [ ! -e $__crossgen ]; then
+        echo "The crossgen executable could not be found at "$__crossgen". Aborting crossgen.sh."
         exit 1
     fi
-    cp $__crossgenInPackage $__sharedFxDir
-    __crossgen=$__sharedFxDir/crossgen
     # Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424
     chmod +x $__crossgen
 }
@@ -57,7 +52,8 @@ crossgen_single()
         if [[ ($__file == *.dll && -e ${__file/.dll/.ni.dll}) || ($__file == *.exe && -e ${__file/.exe/.ni.exe}) ]]; then
             echo "$__file has already been crossgen'd.  Skipping."
         else
-            $__crossgen /Platform_Assemblies_Paths $__sharedFxDir:$__toolsDir /nologo /MissingDependenciesOK /ReadyToRun $__file > /dev/null
+            set +e
+            $__crossgen /Platform_Assemblies_Paths $__sharedFxDir:$__toolsDir /JitPath $__sharedFxDir/libclrjit.$__libraryExtension /nologo /MissingDependenciesOK /ReadyToRun $__file > /dev/null
             if [ $? -eq 0 ]; then
                 __outname="${__file/.dll/.ni.dll}"
                 __outname="${__outname/.exe/.ni.exe}"
@@ -65,19 +61,21 @@ crossgen_single()
             else
                 echo "Unable to successfully compile $__file"
             fi
+            set -e
         fi
     fi
 }
 
-if [ ! -z $BUILDTOOLS_SKIP_CROSSGEN ]; then
+if [ ! -z ${BUILDTOOLS_SKIP_CROSSGEN:-} ]; then
     echo "BUILDTOOLS_SKIP_CROSSGEN is set. Skipping crossgen step."
     exit 0
 fi
 
-if [[ -z "$1" || "$1" == "-?" || "$1" == "--help" || "$1" == "-h" ]]; then
+if [[ -z "${1:-}" || "$1" == "-?" || "$1" == "--help" || "$1" == "-h" ]]; then
     usage
 fi
 
+__MyGetFeed=${BUILDTOOLS_CROSSGEN_FEED:-https://dotnet.myget.org/F/dotnet-core/api/v3/index.json}
 __targetDir=$1
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __toolsDir=$__scriptpath/../Tools
@@ -90,9 +88,11 @@ __sharedFxDir=$__toolsDir/dotnetcli/shared/Microsoft.NETCore.App/$__sharedFxVers
 case $(uname -s) in
     Darwin)
         __packageRid=osx-x64
+        __libraryExtension=dylib
         ;;
     Linux)
         __packageRid=linux-x64
+        __libraryExtension=so
         ;;
     *)
         echo "Unsupported OS $(uname -s) detected. Skipping crossgen of the toolset."

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -8,8 +8,6 @@ set PACKAGES_DIR=%4
 if [%PACKAGES_DIR%] == [] set PACKAGES_DIR=%TOOLRUNTIME_DIR%
 :: Remove quotes to the packages directory
 set PACKAGES_DIR=%PACKAGES_DIR:"=%
-IF [%BUILDTOOLS_TARGET_RUNTIME%]==[] set BUILDTOOLS_TARGET_RUNTIME=win7-x64
-IF [%BUILDTOOLS_NET46_TARGET_RUNTIME%]==[] set BUILDTOOLS_NET46_TARGET_RUNTIME=win7-x86
 set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
 set PORTABLETARGETS_VERSION=0.1.1-dev
@@ -80,7 +78,7 @@ if not [%RESTORE_ERROR_LEVEL%]==[0] (
   exit /b %RESTORE_ERROR_LEVEL%
 )
 @echo on
-call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECT%" -f %PUBLISH_TFM% -r %BUILDTOOLS_TARGET_RUNTIME% -o "%TOOLRUNTIME_DIR%"
+call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECT%" -f %PUBLISH_TFM% -o "%TOOLRUNTIME_DIR%"
 set TOOLRUNTIME_PUBLISH_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%TOOLRUNTIME_PUBLISH_ERROR_LEVEL%]==[0] (
@@ -88,13 +86,16 @@ if not [%TOOLRUNTIME_PUBLISH_ERROR_LEVEL%]==[0] (
   exit /b %TOOLRUNTIME_PUBLISH_ERROR_LEVEL%
 )
 @echo on
-call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECT%" -f net46 -r %BUILDTOOLS_NET46_TARGET_RUNTIME% -o "%TOOLRUNTIME_DIR%\net46"
+call "%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECT%" -f net46 -o "%TOOLRUNTIME_DIR%\net46"
 set NET46_PUBLISH_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%NET46_PUBLISH_ERROR_LEVEL%]==[0] (
   echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" publish "%TOOLRUNTIME_PROJECT%" -f net46'. Please check above for more details.
   exit /b %NET46_PUBLISH_ERROR_LEVEL%
 )
+
+:: Copy some roslyn files which are published into runtimes\any\native to the root
+Robocopy "%TOOLRUNTIME_DIR%\runtimes\any\native" "%TOOLRUNTIME_DIR%\."
 
 :: Microsoft.Build.Runtime dependency is causing the MSBuild.runtimeconfig.json buildtools copy to be overwritten - re-copy the buildtools version.
 Robocopy "%BUILDTOOLS_PACKAGE_DIR%\." "%TOOLRUNTIME_DIR%\." "MSBuild.runtimeconfig.json"
@@ -118,6 +119,6 @@ Robocopy "%PACKAGES_DIR%\MicroBuild.Core\%MICROBUILD_VERSION%\build\." "%TOOLRUN
 Robocopy "%PACKAGES_DIR%\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%TOOLRUNTIME_DIR%\net46\roslyn\." /E
 
 echo "Calling powershell initialization script."
-powershell %BUILDTOOLS_PACKAGE_DIR%\init-tools.ps1 -ToolRuntimePath %TOOLRUNTIME_DIR% -DotnetCmd %DOTNET_CMD%
+powershell %BUILDTOOLS_PACKAGE_DIR%\init-tools.ps1 -ToolRuntimePath %TOOLRUNTIME_DIR% -DotnetCmd %DOTNET_CMD% -BuildToolsPackageDir %BUILDTOOLS_PACKAGE_DIR%
 
 exit /b 0

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.ps1
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.ps1
@@ -1,6 +1,7 @@
  param (
     [Parameter(Mandatory=$true)][string]$ToolRuntimePath,
-    [Parameter(Mandatory=$true)][string]$DotnetCmd
+    [Parameter(Mandatory=$true)][string]$DotnetCmd,
+    [Parameter(Mandatory=$true)][string]$BuildToolsPackageDir
  )
 
 # Override versions in runtimeconfig.json files with highest available runtime version.
@@ -13,3 +14,8 @@ foreach ($file in Get-ChildItem $ToolRuntimePath *.runtimeconfig.json)
     $text = (Get-Content $file.FullName) -replace "1.1.0","$highestVersion"
     Set-Content $file.FullName $text
 }
+
+# Make a directory in the root of the tools folder that matches the buildtools version, this is done so
+# the init-tools.cmd (that is checked into each repository that uses buildtools) can write the semaphore
+# marker into this file once tool initialization is complete.
+New-Item -Type Directory (Join-Path $ToolRuntimePath (Split-Path -Leaf (Split-Path $BuildToolsPackageDir)))

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -75,42 +75,6 @@ if [ ! -d "$__TOOLRUNTIME_DIR" ]; then
     mkdir $__TOOLRUNTIME_DIR
 fi
 
-if [ -z "${__PUBLISH_RID:-}" ]; then
-    OSName=$(uname -s)
-    case $OSName in
-        Darwin)
-            __PUBLISH_RID=osx.10.10-x64
-            ;;
-
-        Linux)
-            if [ ! -e /etc/os-release ]; then
-                echo "Can not determine distribution, assuming Ubuntu 14.04"
-                __PUBLISH_RID=ubuntu.14.04-x64
-            else
-                source /etc/os-release
-                if [[ "$ID" == "ubuntu" && "$VERSION_ID" != "14.04" && "$VERSION_ID" != "16.04" ]]; then
-                echo "Unsupported Ubuntu version, falling back to Ubuntu 14.04"
-                __PUBLISH_RID=ubuntu.14.04-x64
-                else
-                __PUBLISH_RID=$ID.$VERSION_ID-x64
-                fi
-            fi
-
-            # RHEL bumps their OS Version with minor releases, but we only put the "rhel.7-x64" RID in our
-            # tool runtime, since there's binary compatibility between minor versions.
-
-            if [[ $__PUBLISH_RID == rhel.7*-x64 ]]; then
-                __PUBLISH_RID=rhel.7-x64
-            fi
-            ;;
-
-        *)
-            echo "Unsupported OS '$OSName' detected. Downloading ubuntu-x64 tools."
-            __PUBLISH_RID=ubuntu.14.04-x64
-            ;;
-    esac
-fi
-
 cp -R $__TOOLS_DIR/* $__TOOLRUNTIME_DIR
 
 __TOOLRUNTIME_PROJECT=$__TOOLS_DIR/tool-runtime/project.$__PROJECT_EXTENSION
@@ -118,16 +82,8 @@ __TOOLRUNTIME_PROJECT=$__TOOLS_DIR/tool-runtime/project.$__PROJECT_EXTENSION
 echo "Running: $__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_RESTORE_ARGS"
 $__DOTNET_CMD restore "${__TOOLRUNTIME_PROJECT}" $__TOOLRUNTIME_RESTORE_ARGS
 
-echo "Running: $__DOTNET_CMD publish \"${__TOOLRUNTIME_PROJECT}\" -f ${__PUBLISH_TFM} -r ${__PUBLISH_RID} -o $__TOOLRUNTIME_DIR"
-$__DOTNET_CMD publish "${__TOOLRUNTIME_PROJECT}" -f ${__PUBLISH_TFM} -r ${__PUBLISH_RID} -o $__TOOLRUNTIME_DIR
-
-# Microsoft.Build.Runtime dependency is causing the MSBuild.runtimeconfig.json buildtools copy to be overwritten - re-copy the buildtools version.
-cp -f "$__TOOLS_DIR/MSBuild.runtimeconfig.json" "$__TOOLRUNTIME_DIR/."
-
-if [ -n "${BUILDTOOLS_OVERRIDE_RUNTIME:-}" ]; then
-    find $__TOOLRUNTIME_DIR -name *.ni.* | xargs rm 2>/dev/null
-    cp -R $BUILDTOOLS_OVERRIDE_RUNTIME/* $__TOOLRUNTIME_DIR
-fi
+echo "Running: $__DOTNET_CMD publish \"${__TOOLRUNTIME_PROJECT}\" -f ${__PUBLISH_TFM} -o $__TOOLRUNTIME_DIR"
+$__DOTNET_CMD publish "${__TOOLRUNTIME_PROJECT}" -f ${__PUBLISH_TFM} -o $__TOOLRUNTIME_DIR
 
 # Copy Portable Targets Over to ToolRuntime
 if [ ! -d "${__PACKAGES_DIR}/generated" ]; then mkdir "${__PACKAGES_DIR}/generated"; fi
@@ -145,6 +101,9 @@ cp -R "${__PACKAGES_DIR}"/[Mm]icro[Bb]uild.[Cc]ore/"${__MICROBUILD_VERSION}/buil
 # Temporary Hacks to fix couple of issues in the msbuild and roslyn nuget packages
 # https://github.com/dotnet/buildtools/issues/1464
 [ -e "$__TOOLRUNTIME_DIR/Microsoft.CSharp.Targets" ] || mv "$__TOOLRUNTIME_DIR/Microsoft.CSharp.targets" "$__TOOLRUNTIME_DIR/Microsoft.CSharp.Targets"
+
+# Copy some roslyn files over
+cp $__TOOLRUNTIME_DIR/runtimes/any/native/* $__TOOLRUNTIME_DIR/
 
 # Override versions in runtimeconfig.json files with highest available runtime version.
 __MNCA_FOLDER=$(dirname $__DOTNET_CMD)/shared/Microsoft.NETCore.App


### PR DESCRIPTION
Two major changes here:
- Stop publishing the tool runtime standalone.
- Clean up crossgen.sh to pull crossgen from the Microsoft.NETCore.App package, using the version that matches whatever is in the shared folder of the dotnet cli we're using.

I hit these issues while locally tying to move the version of the CLI that CoreFX uses forward to a preview2 build, which lead to these changes.