### PR TITLE
Two minor fixes in OSX Dumpling integration.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -15,11 +15,13 @@
           BeforeTargets="GenerateTestExecutionScripts">
     <PropertyGroup>
       <__DumplingIncPathsArg>@(DumplingIncPaths -> '%(Identity)', ',')</__DumplingIncPathsArg>
+      <CrashDumpFolder Condition="'$(CrashDumpFolder)' == '' and Exists('/cores/')">/cores/</CrashDumpFolder>
+      <CrashDumpFolder Condition="'$(CrashDumpFolder)' == '' and '$(OS)' == 'Unix'">`pwd`</CrashDumpFolder>
     </PropertyGroup>
     <ItemGroup Condition="'$(TargetOS)'!='Windows_NT'">
       <TestCommandLines Include="python DumplingHelper.py install_dumpling" />
       <TestCommandLines Include="__TIMESTAMP=`python DumplingHelper.py get_timestamp`" />
-      <PostExecutionTestCommandLines Include="python DumplingHelper.py collect_dump $%3F `pwd` $__TIMESTAMP $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
+      <PostExecutionTestCommandLines Include="python DumplingHelper.py collect_dump $%3F $(CrashDumpFolder) $__TIMESTAMP $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
     </ItemGroup>
     <Error Condition="'$(TargetOS)' == 'Windows_NT' And '$(CrashDumpFolder)' == ''" Text="CrashDumpFolder must be set to use Dumpling on Windows." />
     <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -17,7 +17,11 @@ def install_dumpling():
     downloadLocation = scriptPath + "/dumpling.py"
     urllib.urlretrieve(url, downloadLocation)
     subprocess.call([sys.executable, downloadLocation, "install", "--update"])
-  subprocess.call([sys.executable, dumplingPath, "install", "--full"])
+  # Dumpling installation crashes on OSX when "--full" is used. See: https://github.com/Microsoft/dumpling/issues/29
+  if (sys.platform == "darwin"):
+    subprocess.call([sys.executable, dumplingPath, "install"])
+  else:
+    subprocess.call([sys.executable, dumplingPath, "install", "--full"])
 
 def ensure_installed():
   if (not os.path.isfile(dumplingPath)):


### PR DESCRIPTION
* Don't use "install --full" on OSX because it crashes.
* Use `/cores/` as the default dump path on OSX.