### PR TITLE
Fix exit code handling in DumplingHelper.py

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -47,8 +47,10 @@ def find_latest_dump(folder, startTimeStr):
       return latestFile
   return None
 
-def collect_dump(exitcode, folder, startTimeStr, projectName, incpaths):
-  if (exitcode == "0"):
+def collect_dump(exitcodeStr, folder, startTimeStr, projectName, incpaths):
+  exitcode = int(exitcodeStr)
+
+  if (exitcode == 0):
     sys.exit(exitcode)
 
   if not ensure_installed():


### PR DESCRIPTION
This variable is actually a string passed from the command line. it needs to be an actual integer to be used in the way that we want.