### PR TITLE
Add NuGetPush task/target with retry logic that handles hangs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExecWithRetries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExecWithRetries.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Run a command and retry if the exit code is not 0.
+    /// </summary>
+    public class ExecWithRetries : Microsoft.Build.Utilities.Task, ICancelableTask
+    {
+        [Required]
+        public string Command { get; set; }
+
+        public int MaxAttempts { get; set; } = 5;
+
+        /// <summary>
+        /// Base, in seconds, raised to the power of the number of retries so far.
+        /// </summary>
+        public double RetryDelayBase { get; set; } = 6;
+
+        /// <summary>
+        /// A constant, in seconds, added to (base^retries) to find the delay before retrying.
+        /// 
+        /// The default is -1 to make the first retry instant, because ((base^0)-1) == 0.
+        /// </summary>
+        public double RetryDelayConstant { get; set; } = -1;
+
+        private CancellationTokenSource _cancelTokenSource = new CancellationTokenSource();
+
+        private Exec _runningExec;
+
+        public void Cancel()
+        {
+            _runningExec?.Cancel();
+            _cancelTokenSource.Cancel();
+        }
+
+        public override bool Execute()
+        {
+            for (int i = 0; i < MaxAttempts; i++)
+            {
+                string attemptMessage = $"(attempt {i + 1}/{MaxAttempts})";
+
+                _runningExec = new Exec
+                {
+                    BuildEngine = BuildEngine,
+                    Command = Command,
+                    LogStandardErrorAsError = false,
+                    IgnoreExitCode = true
+                };
+
+                if (!_runningExec.Execute())
+                {
+                    Log.LogError("Child Exec task failed to execute.");
+                    break;
+                }
+
+                int exitCode = _runningExec.ExitCode;
+                if (exitCode == 0)
+                {
+                    return true;
+                }
+
+                string message = $"Exec FAILED: exit code {exitCode} {attemptMessage}";
+
+                if (i + 1 == MaxAttempts || _cancelTokenSource.IsCancellationRequested)
+                {
+                    Log.LogError(message);
+                    break;
+                }
+
+                Log.LogMessage(MessageImportance.High, message);
+
+                TimeSpan delay = TimeSpan.FromSeconds(
+                    Math.Pow(RetryDelayBase, i) + RetryDelayConstant);
+
+                Log.LogMessage(MessageImportance.High, $"Retrying after {delay}...");
+
+                try
+                {
+                    Task.Delay(delay, _cancelTokenSource.Token).Wait();
+                }
+                catch (AggregateException e) when (e.InnerException is TaskCanceledException)
+                {
+                    break;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -48,6 +48,7 @@
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="NugetMsBuildLogger.cs" />
     <Compile Include="NuGetPackageObject.cs" />
+    <Compile Include="ExecWithRetries.cs" />
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="PreprocessFile.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -83,6 +83,11 @@
   <Import Project="$(MSBuildThisFileDirectory)Symbols.targets" />
 
   <!--
+    Import the PublishProduct.targets file for publish tooling like NuGetPush.
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)PublishProduct.targets" />
+
+  <!--
     Import the default target framework targets.
 
     Inputs:

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask TaskName="ExecWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
+  <!--
+    Utility target for pushing a set of packages using the ExecWithRetries task.
+    The per-package retries make this target more reliable than using NuGet.exe
+    when there is a hang.
+  -->
+  <Target Name="NuGetPush">
+    <!-- Interpret an input glob for easy direct usage from command line. -->
+    <ItemGroup Condition="'$(PackagesGlob)'!=''">
+      <PackagesToPush Include="$(PackagesGlob)" />
+    </ItemGroup>
+
+    <Error Text="NuGetSource property is not defined."
+           Condition="'$(NuGetSource)'==''" />
+
+    <PropertyGroup>
+      <NuGetTimeout Condition="'$(NuGetTimeout)'==''">600</NuGetTimeout>
+      <NuGetVerbosity Condition="'$(NuGetVerbosity)'==''">Detailed</NuGetVerbosity>
+
+      <NuGetPushArgsBase>$(NuGetPushArgsBase) push</NuGetPushArgsBase>
+      <NuGetPushArgsBase>$(NuGetPushArgsBase) -Source $(NuGetSource)</NuGetPushArgsBase>
+      <NuGetPushArgsBase>$(NuGetPushArgsBase) -Timeout $(NuGetTimeout)</NuGetPushArgsBase>
+      <NuGetPushArgsBase>$(NuGetPushArgsBase) -Verbosity $(NuGetVerbosity)</NuGetPushArgsBase>
+      <NuGetPushArgsBase Condition="'$(NuGetApiKey)'!=''">$(NuGetPushArgsBase) -ApiKey $(NuGetApiKey)</NuGetPushArgsBase>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <NuGetPushCommand Include="@(PackagesToPush -> '$(NuGetExePath) $(NuGetPushArgsBase) %(Identity)')" />
+    </ItemGroup>
+
+    <ExecWithRetries
+      Command="%(NuGetPushCommand.Identity)"
+      MaxAttempts="$(MaxAttempts)"
+      RetryDelayBase="$(RetryDelayBase)"
+      RetryDelayConstant="$(RetryDelayConstant)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
This is the workaround for https://github.com/dotnet/core-eng/issues/434.

When running `nuget.exe push foo\*.nupkg -Timeout 3600`, like we do in official build publish legs, if any HTTP call hangs, the entire push times out and the build fails. With this target, each package has a timeout, so a single HTTP hang will not fail the build.

It's preferable in general to use `Exec` to run commands, but here I used `Process` because doing the retry logic in MSBuild isn't reasonable.

An alternative to `Process` is to call into the NuGet methods directly from the task. I think it's better to keep the BuildTools NuGet package version separate, because we can be sure we're using what other MyGet customers are using and can be more flexible when asked to upgrade NuGet.exe as a potential way to fix a problem.

I tested this with Fiddler by breaking connections, exceeding timeouts, etc. and it behaved as expected. To use it, the publish def needs these changes: https://github.com/dagood/corefx/commit/e907c35e4f9215c9913657e1c0b64b9e34ff3921. (I tested that on a CoreFX package set in VSTS.)