### PR TITLE
Ensure we get correct last stable version when building stable

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GetLastStablePackage.cs
@@ -96,6 +96,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     Log.LogError($"Could not parse version {versionString} for StablePackage {packageId}");
                     continue;
                 }
+                stableVersion = VersionUtility.As4PartVersion(stableVersion);
 
                 // only consider a stable version less or equal to than current version
                 if (latestVersion != null && stableVersion >= latestVersion)
@@ -135,7 +136,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 PackageInfo info;
                 if (index.Packages.TryGetValue(packageId, out info))
                 {
-                    var candidateVersions = (latestVersion == null) ? info.StableVersions : info.StableVersions.Where(sv => sv < latestVersion);
+                    var candidateVersions = (latestVersion == null) ? info.StableVersions : info.StableVersions.Where(sv => VersionUtility.As4PartVersion(sv) < latestVersion);
 
                     if (candidateVersions.Any())
                     {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/GetLastStablePackageTests.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/GetLastStablePackageTests.cs
@@ -1,0 +1,132 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Build.Tasks.Packaging.Tests
+{
+    public class GetLastStablePackageTests
+    {
+        private Log _log;
+        private TestBuildEngine _engine;
+        private ITaskItem[] _packageIndexes;
+
+        public GetLastStablePackageTests(ITestOutputHelper output)
+        {
+            _log = new Log(output);
+            _engine = new TestBuildEngine(_log);
+            _packageIndexes = new[] { new TaskItem("packageIndex.json") };
+        }
+
+        [Fact]
+        public void LaterPreReleaseGetsStable()
+        {
+            ITaskItem[] latestPackages = new[]
+            {
+                CreateItem("StableVersionTest", "1.2.0-pre")
+            };
+
+            GetLastStablePackage task = new GetLastStablePackage()
+            {
+                BuildEngine = _engine,
+                PackageIndexes = _packageIndexes,
+                LatestPackages = latestPackages
+            };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+            Assert.Equal(task.LatestPackages.Length, task.LastStablePackages.Length);
+            Assert.Equal("StableVersionTest", task.LastStablePackages[0].ItemSpec);
+            Assert.Equal("1.1.0", task.LastStablePackages[0].GetMetadata("Version"));
+        }
+
+
+        [Fact]
+        public void StableGetsPreviousStable()
+        {
+            ITaskItem[] latestPackages = new[]
+            {
+                CreateItem("StableVersionTest", "1.1.0")
+            };
+
+            GetLastStablePackage task = new GetLastStablePackage()
+            {
+                BuildEngine = _engine,
+                PackageIndexes = _packageIndexes,
+                LatestPackages = latestPackages
+            };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+            Assert.Equal(task.LatestPackages.Length, task.LastStablePackages.Length);
+            Assert.Equal("StableVersionTest", task.LastStablePackages[0].ItemSpec);
+            Assert.Equal("1.0.0", task.LastStablePackages[0].GetMetadata("Version"));
+        }
+
+        [Fact]
+        public void PreGetsPreviousStable()
+        {
+            ITaskItem[] latestPackages = new[]
+            {
+                CreateItem("StableVersionTest", "1.1.0-pre")
+            };
+
+            GetLastStablePackage task = new GetLastStablePackage()
+            {
+                BuildEngine = _engine,
+                PackageIndexes = _packageIndexes,
+                LatestPackages = latestPackages
+            };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+            Assert.Equal(task.LatestPackages.Length, task.LastStablePackages.Length);
+            Assert.Equal("StableVersionTest", task.LastStablePackages[0].ItemSpec);
+            Assert.Equal("1.0.0", task.LastStablePackages[0].GetMetadata("Version"));
+        }
+
+        [Fact]
+        public void PriorToStableGetsNothing()
+        {
+            ITaskItem[] latestPackages = new[]
+            {
+                CreateItem("StableVersionTest", "1.0.0-pre")
+            };
+
+            GetLastStablePackage task = new GetLastStablePackage()
+            {
+                BuildEngine = _engine,
+                PackageIndexes = _packageIndexes,
+                LatestPackages = latestPackages
+            };
+
+            _log.Reset();
+            task.Execute();
+            Assert.Equal(0, _log.ErrorsLogged);
+            Assert.Equal(0, _log.WarningsLogged);
+            Assert.Equal(0, task.LastStablePackages.Length);
+        }
+
+        private static ITaskItem CreateItem(string name, string version)
+        {
+            TaskItem item = new TaskItem(name);
+
+            if (version != null)
+            {
+                item.SetMetadata("Version", version);
+            }
+
+            return item;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/Microsoft.DotNet.Build.Tasks.Packaging.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Compile Include="CreateTrimDependencyGroupsTests.cs" />
     <Compile Include="ApplyBaseLineTests.cs" />
+    <Compile Include="GetLastStablePackageTests.cs" />
     <Compile Include="HarvestPackageTests.cs" />
     <Compile Include="NugetPropertyStringProviderTests.cs" />
     <Compile Include="NuGetAssetResolverTests.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/packageIndex.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/packageIndex.json
@@ -2,6 +2,12 @@
   "Packages": {
     "System.Runtime": {
       "BaselineVersion": "4.0.21"
+    },
+    "StableVersionTest": {
+      "StableVersions": [
+        "1.0.0",
+        "1.1.0"
+      ]
     }
   }
 }


### PR DESCRIPTION
Fixes #1529

/cc @weshaggard 

We'll need this in order to correctly harvest packages once moving to stable.