### PR TITLE
Add bininspect package to optional tooling

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/optional-tool-runtime/optional.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/optional-tool-runtime/optional.json
@@ -2,6 +2,7 @@
   "frameworks": {
     "net45": {
       "dependencies": {
+        "Microsoft.DotNet.BinInspector": "1.0.0-alpha-00001",
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
         "Microsoft.DotNet.UAP.TestTools" : "1.0.2"
        }


### PR DESCRIPTION
I've created a package for the bininspect tool and uploaded it to our optional tooling feed. This change just adds the package to the optional tool runtime so that it can be consumed via BuildTools mechanisms in the Core-Setup build.  

I'll be making a change to this PR, https://github.com/dotnet/core-setup/pull/2561, to use BinInspector via the package feed instead of a separate azure storage download.

I made a couple minor edits to the documentation as some of the property name / values have changed - https://github.com/dotnet/core-eng/blob/master/Documentation/Project-Docs/fetch-internal-tooling.md