### PR TITLE
Don't use "install --full" in DumplingHelper. Ignore install errors.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -11,17 +11,17 @@ def get_timestamp():
   print(time.time())
 
 def install_dumpling():
-  if (not os.path.isfile(dumplingPath)):
-    url = "https://dumpling.azurewebsites.net/api/client/dumpling.py"
-    scriptPath = os.path.dirname(os.path.realpath(__file__))
-    downloadLocation = scriptPath + "/dumpling.py"
-    urllib.urlretrieve(url, downloadLocation)
-    subprocess.call([sys.executable, downloadLocation, "install", "--update"])
-  # Dumpling installation crashes on OSX when "--full" is used. See: https://github.com/Microsoft/dumpling/issues/29
-  if (sys.platform == "darwin"):
+  try:
+    if (not os.path.isfile(dumplingPath)):
+      url = "https://dumpling.azurewebsites.net/api/client/dumpling.py"
+      scriptPath = os.path.dirname(os.path.realpath(__file__))
+      downloadLocation = scriptPath + "/dumpling.py"
+      urllib.urlretrieve(url, downloadLocation)
+      subprocess.call([sys.executable, downloadLocation, "install", "--update"])
+
     subprocess.call([sys.executable, dumplingPath, "install"])
-  else:
-    subprocess.call([sys.executable, dumplingPath, "install", "--full"])
+  except:
+    print("An unexpected error was encountered while installing dumpling.py: " + sys.exc_info()[0])
 
 def ensure_installed():
   if (not os.path.isfile(dumplingPath)):


### PR DESCRIPTION
`dumpling install --full` has proven to be pretty unreliable. I'm not longer using it here. Additionally, installation errors of any sort (internet connection problems, timeouts, etc) are ignored. Things should just "move along" if dumpling fails to work for whatever reason. We don't want spurious failures because this script couldn't download some file or upload some blob to Azure.