### PR TITLE
Change Microsoft.xunit.extensibility.execution.netcore redist package links to BuildTools ones

### DIFF
--- a/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
+++ b/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
@@ -11,8 +11,8 @@
         in the xunit-perfomance library (github.com/Microsoft/xunit-performance)
     </description>
     <language>en-US</language>
-    <projectUrl>https://github.com/Microsoft/xunit-performance</projectUrl>
-    <licenseUrl>https://raw.githubusercontent.com/Microsoft/xunit-performance/master/LICENSE</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>


### PR DESCRIPTION
Copy license and project urls from `Microsoft.xunit.netcore.extensions.nuspec` to `Microsoft.xunit.extensibility.execution.netcore.nuspec`. This should avoid some confusion when seeing the package without context.

@brianrob @karajas 