### PR TITLE
Enabling build of UAP Launcher and Runner on Windows

### DIFF
--- a/src/WindowsStoreAppLauncher/WindowsStoreAppLauncher.vcxproj
+++ b/src/WindowsStoreAppLauncher/WindowsStoreAppLauncher.vcxproj
@@ -2,7 +2,6 @@
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration>Release</Configuration>
-    <Platform>x64</Platform>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup Label="ProjectConfigurations">
@@ -12,6 +11,8 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
     <ProjectGuid>{177AA879-D233-4A16-8398-8BDF5D5E1ED8}</ProjectGuid>
     <Keyword>ManagedCProj</Keyword>
     <RootNamespace>WindowsStoreAppLauncher</RootNamespace>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <!-- Exclude the UAP runner from the build as it depends on Win10 SDKs -->
-    <ProjectsToExclude Include="xunit.runner.uap\XUnit.Runner.Uap.csproj" />
+    <ProjectsToExclude Include="xunit.runner.uap\XUnit.Runner.Uap.csproj" Condition="'$(OSEnvironment)' != 'Windows_NT'" />
     <ProjectsToExclude Include="xunit.runner.uap\RunnerRemoteExecutionServiceUAP\RunnerRemoteExecutionServiceUAP.csproj" />
     <!-- tool-runtime\project.csproj is not a real project to build, it's part of the buildtools package for initialization. -->
     <ProjectsToExclude Include="Microsoft.DotNet.Build.Tasks\PackageFiles\tool-runtime\project.csproj" />
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Project Include="*\**\*.csproj" Exclude="@(ProjectsToExclude)" />
     <Project Include="*\**\*.depproj" />
+    <Project Include="WindowsStoreAppLauncher\WindowsStoreAppLauncher.vcxproj" Condition="'$(OSEnvironment)' == 'Windows_NT'" />
   </ItemGroup>
 
   <Import Project="..\dir.targets" />


### PR DESCRIPTION
cc: @weshaggard @tarekgh 

We want to start building both the launcher and the Runner for our F5 uap tests on our official builds so that the binaries are signed. These changes will enable the build for both of them on Windows. I added the NO MERGE label for now since I suspect Jenkins machines won't be able to build the Runner, but if it does succeed then this would be ready for merging.