### PR TITLE
Trim only directory part of blobnameprefix when deriving local download directory

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -87,6 +87,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                         int dirIndex = blob.LastIndexOf("/");
                         string blobDirectory = string.Empty;
                         string blobFilename = string.Empty;
+
                         if (dirIndex == -1)
                         {
                             blobFilename = blob;
@@ -95,10 +96,16 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                         {
                             blobDirectory = blob.Substring(0, dirIndex);
                             blobFilename = blob.Substring(dirIndex + 1);
-                        }
-                        if(BlobNamePrefix != null)
-                        {
-                            blobDirectory = blobDirectory.Substring(BlobNamePrefix.Length);
+
+                            // Trim blob name prefix (directory part) from download to blob directory
+                            if(BlobNamePrefix != null)
+                            {
+                                if(BlobNamePrefix.Length > dirIndex)
+                                {
+                                    BlobNamePrefix = BlobNamePrefix.Substring(0, dirIndex);
+                                }
+                                blobDirectory = blobDirectory.Substring(BlobNamePrefix.Length);
+                            }
                         }
                         string downloadBlobDirectory = Path.Combine(DownloadDirectory, blobDirectory);
                         if (!Directory.Exists(downloadBlobDirectory))


### PR DESCRIPTION
Fixes 

```
2017-06-14T13:39:20.2232748Z E:\A\_work\416\s\Tools\SyncCloudContent.targets(25,5): error : startIndex cannot be larger than length of string. [E:\A\_work\416\s\src\syncAzure.proj]
2017-06-14T13:39:20.2232748Z E:\A\_work\416\s\Tools\SyncCloudContent.targets(25,5): error : Parameter name: startIndex [E:\A\_work\416\s\src\syncAzure.proj]
2017-06-14T13:39:20.2232748Z E:\A\_work\416\s\Tools\SyncCloudContent.targets(25,5): error :    at System.String.Substring(Int32 startIndex, Int32 length) [E:\A\_work\416\s\src\syncAzure.proj]
2017-06-14T13:39:20.2232748Z E:\A\_work\416\s\Tools\SyncCloudContent.targets(25,5): error :    at System.String.Substring(Int32 startIndex) [E:\A\_work\416\s\src\syncAzure.proj]
2017-06-14T13:39:20.2232748Z E:\A\_work\416\s\Tools\SyncCloudContent.targets(25,5): error :    at Microsoft.DotNet.Build.CloudTestTasks.DownloadFromAzure.<ExecuteAsync>d__17.MoveNext() [E:\A\_work\416\s\src\syncAzure.proj]
2017-06-14T13:39:20.2388700Z Command execution failed with exit code 1.
2017-06-14T13:39:20.2388700Z ##[error]Process completed with exit code 1.
2017-06-14T13:39:20.2544948Z ##[section]Finishing: Sync packages
```

/cc @mattgal @jcagme
