### PR TITLE
Enable configuration value to have any case

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Configuration/ConfigurationFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Configuration/ConfigurationFactory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             AllPropertyValues = propertyValueGrouping
-                .ToDictionary(g => g.Key, g => g.Single());
+                .ToDictionary(g => g.Key, g => g.Single(), StringComparer.OrdinalIgnoreCase);
 
             PropertyValues = AllPropertyValues.Values
                 .GroupBy(v => v.Property)


### PR DESCRIPTION
Fix this
```
"C:\git\corefx\src\System.Console\tests\System.Console.Tests.csproj" (default target) (1) ->
(AnnotateProjectReference target) ->
  C:\git\corefx\buildvertical.targets(155,5): error MSB4018: The "FindBestConfigurations" task failed unexpectedly.\r [C:\git\corefx\src\System.Console\tests\System.Console.Tests.csproj]
C:\git\corefx\buildvertical.targets(155,5): error MSB4018: System.ArgumentException: Unknown value 'release' found in configuration 'netstandard-Windows_NT-release'.  Expected property 'ConfigurationGroup' with one of values Debug, Release.\r [C:\git\corefx\src\System.Console\tests\System.Console.Tests.csproj]
C:\git\corefx\buildvertical.targets(155,5): error MSB4018:    at Microsoft.DotNet.Build.Tasks.ConfigurationFactory.ParseConfiguration(String configurationString, Boolean permitUnknownValues)\r 
```

There are other .ToDictionary() 's in there I didn't modify: this works.

