### PR TITLE
Disable UI Logging in Xunit.Runner.Uap to avoid crashes when the log is super long

### DIFF
--- a/src/xunit.runner.uap/MainPage.xaml
+++ b/src/xunit.runner.uap/MainPage.xaml
@@ -11,7 +11,7 @@
         <Ellipse Fill="Yellow" ></Ellipse>
         <TextBlock FontFamily="Verdana" FontSize="50" VerticalAlignment="Center" HorizontalAlignment="Center" > Xunit UAP Runner</TextBlock>
         <TextBox Margin="20" ScrollViewer.VerticalScrollBarVisibility="Visible" ScrollViewer.HorizontalScrollBarVisibility="Auto" x:Name="outputTextBox" TextWrapping="Wrap"
-                  IsTextPredictionEnabled="False" IsReadOnly="True"
+                  IsTextPredictionEnabled="False" IsReadOnly="True" Text="Starting..."
                   >
             
             

--- a/src/xunit.runner.uap/MainPage.xaml.cs
+++ b/src/xunit.runner.uap/MainPage.xaml.cs
@@ -20,24 +20,17 @@ namespace XUnit.Runner.Uap
 
         internal static StringBuilder log;
 
-        public async void UpdateTextBox(string text)
+        public void UpdateLog(string text)
         {
-            await CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(
-                Windows.UI.Core.CoreDispatcherPriority.Normal,
-            () =>
-            {
-                log.AppendLine(text);
-                outputTextBox.Text += $"{text}\r\n";
-            });
+            log.AppendLine(text);
         }
 
         private void RunXunitTestsInDirectory(object sender, RoutedEventArgs e)
         {
             // Run tests for assemblies in current directory
             XunitTestRunner runner = new XunitTestRunner();
-            UpdateTextBox("Starting...");
 
-            Task.Run(() => runner.RunTests(App.LaunchArgs.Arguments, log, UpdateTextBox));
+            Task.Run(() => runner.RunTests(App.LaunchArgs.Arguments, log, UpdateLog));
         }
     }
 }


### PR DESCRIPTION
When there is a lot of failures and we try to dump everything to the UI it slows the test execution and it crashes it so we get no testResults.xml

With this change we will see the output in the console at the end of the execution which is usually fast without the UI logging. 

cc: @danmosemsft @tarekgh @joperezr 