### PR TITLE
Remove unnecessary RuntimeIdentifiers from tool-runtime project

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -2,11 +2,15 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <EnableDefaultItems>false</EnableDefaultItems>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001776-00</RuntimeFrameworkVersion>
-    <RuntimeIdentifiers>centos.7-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;opensuse.13.2-x64;opensuse.42.1-x64;osx.10.10-x64;rhel.7-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;win7-x64;win7-x86</RuntimeIdentifiers>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-preview-000523-01" />


### PR DESCRIPTION
@mellinoe @ellismg @danmosemsft PTAL

While investigating why init-tools takes 15-20mins on a fresh CI machine I found that we restored a lot of runtime specific packages that we never actually use. We never publish for a given RID after https://github.com/dotnet/buildtools/pull/1536 so we can remove these RuntimeIdentifiers and reduce the cost of this restore by a lot (my local tests go from 12 mins to 1 min on a machine with no packages already). 