### PR TITLE
Adding option to enable  using shared assemblies for multi-file tests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -224,6 +224,7 @@
             ====================================================== -->
     <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
       <ILCBuildType Condition="'$(ILCBuildType)' == ''">ret</ILCBuildType>
+      <_UseSharedAssemblies Condition="'$(EnableMultiFileILCTests)' == 'true'">-useSharedAssemblies</_UseSharedAssemblies>
       <_TestILCFolder>%RUNTIME_PATH%\TestILC</_TestILCFolder>
       <_Runtime_Path>%RUNTIME_PATH%\ILCInputFolder\</_Runtime_Path>
       <!-- Currently (and probably forever) we can't build UAPAOT on ARM,
@@ -241,7 +242,7 @@
       <TestCommandLines Include="rmdir /S /Q %EXECUTION_DIR%int" />
       <TestCommandLines Include="rmdir /S /Q %EXECUTION_DIR%native" />
       <TestCommandLines Include="@(TargetExecutableNames -> '
-call %RUNTIME_PATH%\TestILC\ilc.exe -ExeName %(Identity) -in %EXECUTION_DIR% -out %EXECUTION_DIR%int\%(Identity)\ -usedefaultpinvoke -buildtype $(ILCBuildType) -v diag
+call %RUNTIME_PATH%\TestILC\ilc.exe -ExeName %(Identity) -in %EXECUTION_DIR% -out %EXECUTION_DIR%int\%(Identity)\ -usedefaultpinvoke -buildtype $(ILCBuildType) -v diag $(_UseSharedAssemblies)
 set ILCERRORLEVEL=%ERRORLEVEL%
 if NOT [%ILCERRORLEVEL%] == [0] exit /b %ILCERRORLEVEL%
 robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\


### PR DESCRIPTION
cc: @danmosemsft @safern @tijoytom 