### PR TITLE
add UapNotUapAot to TFM enum

### DIFF
--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -53,7 +53,7 @@ namespace Xunit.NetCore.Extensions
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-                if (frameworks.HasFlag(TargetFrameworkMonikers.Uap))
+                if (frameworks.HasFlag(TargetFrameworkMonikers.UapNotUapAot))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.UapAot))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);

--- a/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -49,7 +49,7 @@ namespace Xunit.NetCore.Extensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
             if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.Uap))
+            if (platform.HasFlag(TargetFrameworkMonikers.UapNotUapAot))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
             if (platform.HasFlag(TargetFrameworkMonikers.UapAot))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);

--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -22,8 +22,9 @@ namespace Xunit
         Netcoreapp1_1 = 0x400,
         NetFramework = 0x800,
         Netcoreapp = 0x1000,
-        Uap = UapAot | 0x2000,
+        UapNotUapAot = 0x2000,
         UapAot = 0x4000,
+        Uap = UapAot | UapNotUapAot,
         NetcoreCoreRT = 0x8000
     }
 }


### PR DESCRIPTION
three problems to solve:

1) Making this work ` [SkipOnTargetFramework(~TargetFrameworkMonikers.UapAot)]`

- `SkipOnTargetFrameworkDiscoverer` determines the test has traits `nonXXXXtests` where XXX is every TFM for which `(~TargetFrameworkMonikers.UapAot).HasFlag(TFM)` is true.
- Because `TFM.Uap = TFM.UapAot | 0x2000`, this is NOT true for TFM.Uap (the negated mask of UapAot does not HasFlag of TFM.Uap because it's missing the UapAot bit out of TFM.Uap). So this test is determined to have all nonXXXtests traits except `nonUapaottests` and `nonUaptests`.
- When running tests, `tests.targets` passes `-notrait nonTARGETGROUPtests` to xunit. In the case of a UAP test run, this would be `-notrait nonuaptests`. This does not exclude the test marked with the attribute above, because the test is NOT considered to have trait `nonuaptests`.

2) Making tihs work `[SkipOnTargetFramework(TargetFrameworkMonikers.UapNotUapAot)]` .. should skip specifically Uap and not Uapaot.

3) Making this work  `[SkipOnTargetFramework(~TargetFrameworkMonikers.Uap)]` .. should skip everything except uap, including skipping uapaot.

Proposal: Add `UapNotUapAot = 0x2000,` and special case that bit so it yields `nonUapTests`. This should fix both problems (I think? my head hurts.)

This is also a lesson in why one should never use negated constants or flags in any situation ever. 