### PR TITLE
Fix Unix folder permissions for deleting

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProcessNamesToKill Condition="'@(ProcessNamesToKill)' == ''" Include="git;vbcscompiler" />
+    <AdditionalCleanupDirectories Include="$(AdditionalCleanupDirectories)" />    
   </ItemGroup>
 
   <Target Name="Clean">
@@ -22,6 +23,7 @@
                       RetentionDays="$(RetentionDays)"
                       Clean="$(DoClean)"
                       Report="$(DoReport)"
-                      ProcessNamesToKill="@(ProcessNamesToKill)" />
+                      ProcessNamesToKill="@(ProcessNamesToKill)"
+                      AdditionalCleanupDirectories="@(AdditionalCleanupDirectories)" />
   </Target>
 </Project>


### PR DESCRIPTION
Change file / folder permissions if possible on Unix platforms so that we don't hit "Permission Denied" errors when trying to delete a folder.

Generalize the "additional cleanup directories" concept so it's slightly more extensible and has less hard-coded special knowledge for the temp folders (though still maintain an internal set of known temp locations).

This change is desired so that I can move corefx to use the `docker run with a volume` model which runs each docker command in a new container but using the same mounted volume.  The issue with this method is that it creates artifacts within the docker container with a different file permission set that doesn't allow the cleanup agent task (which runs outside of a docker container) to delete them.  I could specifically add a 'chmod' step to the corefx definition, or we could make cleanupagent a little smarter and let it handle the permissions where possible.

https://github.com/dotnet/core-eng/issues/707