### PR TITLE
Add signed filename attribute to symbol files.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -356,7 +356,7 @@
     <ItemGroup>
       <CatalogFile Include="$(ExtractBaseDir)signatures.cat.cdf"
                    Condition="'@(SymbolFileToCatalog)'!=''">
-        <ContentLines>$(CatalogFileHeaderLines);@(SymbolFileToCatalog -> '&lt;HASH&gt;%(Identity)=%(Identity);')</ContentLines>
+        <ContentLines>$(CatalogFileHeaderLines);@(SymbolFileToCatalog -> '&lt;HASH&gt;%(Identity)=%(Identity);&lt;HASH&gt;%(Identity)ATTR1=0x11010001:Filename:%(Identity);')</ContentLines>
       </CatalogFile>
     </ItemGroup>
 


### PR DESCRIPTION
This adds an additional line with `<Filename>ATTR1=0x11010001:Filename:<Filename>`.
0x11010001 = signed, do not replicate to compatibility entries (we don't use these), plaintext, name-value pair