### PR TITLE
Copy resx files in resources.targets to AssemblyName.resw file

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -11,7 +11,6 @@
     
     <!-- For UAP, we need to bin place the resources as resw files to create the runner's pri file. -->
     <ResourcesFolderPath Condition="'$(ResourcesFolderPath)' == ''">$(RuntimePath)resw</ResourcesFolderPath>
-    <CommonPriFile Condition="'$(CommonPriFile)' == ''">$(ResourcesFolderPath)/resources.pri</CommonPriFile>
 
     <!-- A number of the imports below depend on these default properties -->
     <AssemblyVersion Condition="'$(AssemblyVersion)'==''">999.999.999.999</AssemblyVersion>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -8,6 +8,9 @@
 
   <PropertyGroup>
     <BuildToolsTaskDir Condition="'$(BuildToolsTaskDir)' == ''">$(ToolsDir)</BuildToolsTaskDir>
+    
+    <!-- For UAP, we need to bin place the resources as resw files to create the runner's pri file. -->
+    <ResourcesFolderPath Condition="'$(ResourcesFolderPath)' == ''">$(RuntimePath)resw</ResourcesFolderPath>
 
     <!-- A number of the imports below depend on these default properties -->
     <AssemblyVersion Condition="'$(AssemblyVersion)'==''">999.999.999.999</AssemblyVersion>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -11,7 +11,7 @@
     
     <!-- For UAP, we need to bin place the resources as resw files to create the runner's pri file. -->
     <ResourcesFolderPath Condition="'$(ResourcesFolderPath)' == ''">$(RuntimePath)resw</ResourcesFolderPath>
-    <CommonPriFile Condition="'$(CommonPriFile)' == ''">$(RuntimePath)resources.pri</CommonPriFile>
+    <CommonPriFile Condition="'$(CommonPriFile)' == ''">$(ResourcesFolderPath)/resources.pri</CommonPriFile>
 
     <!-- A number of the imports below depend on these default properties -->
     <AssemblyVersion Condition="'$(AssemblyVersion)'==''">999.999.999.999</AssemblyVersion>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -11,6 +11,7 @@
     
     <!-- For UAP, we need to bin place the resources as resw files to create the runner's pri file. -->
     <ResourcesFolderPath Condition="'$(ResourcesFolderPath)' == ''">$(RuntimePath)resw</ResourcesFolderPath>
+    <CommonPriFile Condition="'$(CommonPriFile)' == ''">$(RuntimePath)resources.pri</CommonPriFile>
 
     <!-- A number of the imports below depend on these default properties -->
     <AssemblyVersion Condition="'$(AssemblyVersion)'==''">999.999.999.999</AssemblyVersion>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -20,19 +20,24 @@
           GenerateResourcesSource;
           $(CompileDependsOn);
       </CompileDependsOn>
+      <ResourcesFolderPath Condition="'$(BuildingUAPVertical)' == 'true'">$(RuntimePath)resw</ResourcesFolderPath>
   </PropertyGroup>
 
   <Target Name="GenerateResourcesSource"
           Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'"
           Inputs="$(StringResourcesPath)"
           Outputs="$(IntermediateResOutputFileFullPath)">
-    
-    
 
     <GenerateResourcesCode
         ResxFilePath="$(StringResourcesPath)" 
         OutputSourceFilePath="$(IntermediateResOutputFileFullPath)" 
         AssemblyName="$(AssemblyName)" />
+
+    <Copy Condition="'$(BuildingUAPVertical)' == 'true'"
+          SourceFiles="$(StringResourcesPath)"
+          DestinationFiles="$(ResourcesFolderPath)\$(AssemblyName).resw"
+          SkipUnchangedFiles="true"
+          />
 
     <ItemGroup>
       <!-- The following Compile element has to be included dynamically inside the Target otherwise intellisense will not work -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -37,10 +37,6 @@
           DestinationFiles="$(ResourcesFolderPath)\FxResources.$(AssemblyName).SR.resw"
           SkipUnchangedFiles="true" />
 
-    <Delete Condition="'$(BuildingUAPVertical)' == 'true' AND Exists('$(CommonPriFile)')"
-            Files="$(CommonPriFile)"
-            ContinueOnError="true" />
-
     <ItemGroup>
       <!-- The following Compile element has to be included dynamically inside the Target otherwise intellisense will not work -->
       <Compile Include="$(IntermediateResOutputFileFullPath)" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -34,7 +34,7 @@
 
     <Copy Condition="'$(BuildingUAPVertical)' == 'true'"
           SourceFiles="$(StringResourcesPath)"
-          DestinationFiles="$(ResourcesFolderPath)\$(AssemblyName).resw"
+          DestinationFiles="$(ResourcesFolderPath)\FxResources.$(AssemblyName).SR.resw"
           SkipUnchangedFiles="true"
           />
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -20,7 +20,6 @@
           GenerateResourcesSource;
           $(CompileDependsOn);
       </CompileDependsOn>
-      <ResourcesFolderPath Condition="'$(BuildingUAPVertical)' == 'true'">$(RuntimePath)resw</ResourcesFolderPath>
   </PropertyGroup>
 
   <Target Name="GenerateResourcesSource"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -35,8 +35,11 @@
     <Copy Condition="'$(BuildingUAPVertical)' == 'true'"
           SourceFiles="$(StringResourcesPath)"
           DestinationFiles="$(ResourcesFolderPath)\FxResources.$(AssemblyName).SR.resw"
-          SkipUnchangedFiles="true"
-          />
+          SkipUnchangedFiles="true" />
+
+    <Delete Condition="'$(BuildingUAPVertical)' == 'true' AND Exists('$(CommonPriFile)')"
+            Files="$(CommonPriFile)"
+            ContinueOnError="true" />
 
     <ItemGroup>
       <!-- The following Compile element has to be included dynamically inside the Target otherwise intellisense will not work -->


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/corefx/issues/21692

This is needed as MakePri.exe doesn't support .resx files. Also they have to be called as the assembly so that when we create the .pri file the resources are mapped correctly.

cc: @tarekgh @weshaggard @joperezr 