### PR TITLE
Always overwrite IntermediateOutputPath when signing catalogs.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -292,7 +292,9 @@
         signs files that are under these paths.
       -->
       <OutDir Condition="'$(OutDir)'==''">$(BinDir)</OutDir>
-      <IntermediateOutputPath Condition="'$(IntermediateOutputPath)'==''">$(SymbolCatalogIntermediateDir)</IntermediateOutputPath>
+      <!-- always overwrite IntermediateOutputPath so we know we can sign the catalogs.
+           some repos do weird things with BaseIntermediateOutputPath -->
+      <IntermediateOutputPath>$(SymbolCatalogIntermediateDir)</IntermediateOutputPath>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
This makes sure we always have our catalogs in a path MicroBuild is willing to sign.