### PR TITLE
Convert Portable to Windows PDBs during symbol archive targets

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -12,6 +12,11 @@
     <MicrosoftNETCorePlatformsVersion>1.1.0</MicrosoftNETCorePlatformsVersion>
   </PropertyGroup>
 
+  <!-- Package versions to validate, but not in a build-info file. -->
+  <PropertyGroup>
+    <MicrosoftDiaSymReaderConverterPackageVersion>1.0.0-beta1-61722-03</MicrosoftDiaSymReaderConverterPackageVersion>
+  </PropertyGroup>
+
   <!-- Package dependency verification/auto-upgrade configuration. -->
   <PropertyGroup>
     <BaseDotNetBuildInfo>build-info/dotnet/</BaseDotNetBuildInfo>
@@ -67,6 +72,15 @@
 
     <StaticDependency Include="System.Runtime.InteropServices.RuntimeInformation">
       <Version>4.4.0-beta-24813-03</Version>
+    </StaticDependency>
+
+    <!--
+      Microsoft.DiaSymReader.Converter and its dependencies are on these feeds:
+      https://dotnet.myget.org/gallery/symreader-converter
+      https://dotnet.myget.org/gallery/symreader-native
+    -->
+    <StaticDependency Include="Microsoft.DiaSymReader.Converter">
+      <Version>$(MicrosoftDiaSymReaderConverterPackageVersion)</Version>
     </StaticDependency>
 
     <NuGetDependency Include="NuGet.Client"/>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -39,4 +39,25 @@
     <TargetingPackReference Include="System.Xml" />
     <TargetingPackReference Include="System.Xml.Linq" />
   </ItemGroup>
+  <Target Name="AfterBuild">
+    <!-- Manually binplace DiaSymReader runtimes for win7-x86, which the official builds use. -->
+    <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
+                                         IncludeFrameworkReferences="false"
+                                         NuGetPackagesDirectory="$(PackagesDir)"
+                                         RuntimeIdentifier="win7-x86"
+                                         ProjectLanguage="$(Language)"
+                                         ProjectLockFile="project.lock.json"
+                                         TargetMonikers="$(NuGetTargetMoniker)">
+      <Output TaskParameter="ResolvedCopyLocalItems"
+              ItemName="_ReferenceCopyLocalPathsFromDependencies" />
+    </PrereleaseResolveNuGetPackageAssets>
+
+    <ItemGroup>
+      <_DiaSymReaderNativeCopyLocalItems Include='@(_ReferenceCopyLocalPathsFromDependencies)'
+                                         Condition="'%(NuGetPackageId)' == 'Microsoft.DiaSymReader.Native'" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_DiaSymReaderNativeCopyLocalItems)"
+          DestinationFolder="$(OutputPath)" />
+  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -40,7 +40,10 @@
     <TargetingPackReference Include="System.Xml.Linq" />
   </ItemGroup>
   <Target Name="AfterBuild">
-    <!-- Manually binplace DiaSymReader runtimes for win7-x86, which the official builds use. -->
+    <!--
+      Manually binplace DiaSymReader runtimes for win7-x86, which the official builds use.
+      This workaround should be removed, see https://github.com/dotnet/buildtools/issues/1608
+    -->
     <PrereleaseResolveNuGetPackageAssets AllowFallbackOnTargetSelection="true"
                                          IncludeFrameworkReferences="false"
                                          NuGetPackagesDirectory="$(PackagesDir)"

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
     "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",
@@ -7,8 +8,8 @@
     "NuGet.Packaging": "4.3.0-preview2-4095",
     "NuGet.ProjectModel": "4.3.0-preview2-4095",
     "NuGet.Versioning": "4.3.0-preview2-4095",
-    "System.Collections.Immutable": "1.2.0",
-    "System.Reflection.Metadata": "1.4.1",
+    "System.Collections.Immutable": "1.3.1",
+    "System.Reflection.Metadata": "1.4.2",
     "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },
   "frameworks": {
@@ -19,6 +20,7 @@
     }
   },
   "runtimes": {
-    "win7-x64": {}
+    "win7-x64": {},
+    "win7-x86": {}
   }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/ConvertPdbsToPortablePdbs.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ConvertPdbsToPortablePdbs.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DiaSymReader.Tools;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class ConvertPdbsToPortablePdbs : BuildTask
+    {
+        private const string PdbPathMetadata = "PdbPath";
+        private const string TargetPathMetadata = "TargetPath";
+
+        [Required]
+        public ITaskItem[] Files { get; set; }
+
+        public string[] ConversionOptions { get; set; }
+
+        public override bool Execute()
+        {
+            var parsedConversionOptions = PdbConversionOptions.Default;
+            foreach (string option in ConversionOptions ?? Enumerable.Empty<string>())
+            {
+                PdbConversionOptions parsedOption;
+                if (!Enum.TryParse(option, out parsedOption))
+                {
+                    throw new ArgumentException(
+                        $"Passed conversion option '{option}'" +
+                        $"is not a value of {nameof(PdbConversionOptions)}.");
+                }
+                parsedConversionOptions |= parsedOption;
+            }
+
+            var converter = new PdbConverter(
+                d => Log.LogError(d.ToString(CultureInfo.InvariantCulture)));
+
+            foreach (ITaskItem file in Files)
+            {
+                string pdbPath = file.GetMetadata(PdbPathMetadata);
+
+                if (string.IsNullOrEmpty(pdbPath))
+                {
+                    Log.LogError($"No '{PdbPathMetadata}' metadata found for '{file}'.");
+                    continue;
+                }
+
+                string targetPath = file.GetMetadata(TargetPathMetadata);
+
+                if (string.IsNullOrEmpty(targetPath))
+                {
+                    Log.LogError($"No '{TargetPathMetadata}' metadata found for '{file}'.");
+                    continue;
+                }
+
+                using (var sourcePdbStream = new FileStream(pdbPath, FileMode.Open, FileAccess.Read))
+                {
+                    if (PdbConverter.IsPortable(sourcePdbStream))
+                    {
+                        Log.LogMessage(
+                            MessageImportance.Low,
+                            $"Converting portable PDB '{file.ItemSpec}'...");
+
+                        Directory.CreateDirectory(Path.GetDirectoryName(targetPath));
+
+                        using (var peStream = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
+                        using (var peReader = new PEReader(peStream, PEStreamOptions.LeaveOpen))
+                        using (var outPdbStream = new FileStream(targetPath, FileMode.Create, FileAccess.Write))
+                        {
+                            converter.ConvertPortableToWindows(
+                                peReader,
+                                sourcePdbStream,
+                                outPdbStream,
+                                parsedConversionOptions);
+                        }
+
+                        Log.LogMessage(
+                            MessageImportance.Normal,
+                            $"Portable PDB '{file.ItemSpec}' -> '{targetPath}'");
+                    }
+                    else
+                    {
+                        Log.LogMessage(
+                            MessageImportance.Normal,
+                            $"PDB is not portable, skipping: '{file.ItemSpec}'");
+                    }
+                }
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -69,6 +69,7 @@
     <Compile Include="VersionTools\LocalUpdatePublishedVersions.cs" />
     <Compile Include="VersionTools\UpdatePublishedVersions.cs" />
     <Compile Include="VersionTools\VerifyDependencies.cs" />
+    <Compile Include="ConvertPdbsToPortablePdbs.cs" />
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="WriteSigningRequired.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="AddItemIndices" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ConvertPdbsToPortablePdbs" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileGetEntries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileInjectFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
@@ -119,6 +120,7 @@
   -->
   <Target Name="CreateSymbolsFileList"
           DependsOnTargets="UnzipSymbolPackagesForPublish;
+                            GenerateAdditionalSymbolsForArchive;
                             PublishSymbolFilesToFileShare">
     <PropertyGroup>
       <SymbolFileListPath>$(SymbolsRequestIntermediateDir)SymbolFileList.txt</SymbolFileListPath>
@@ -223,6 +225,43 @@
     <ItemGroup>
       <IndexedExtensions Include=".dll;.pdb;.exe" Condition="'@(IndexedExtensions)'==''" />
       <SymbolFileToPublish Include="$(SymbolPackageExtractDir)**\*%(IndexedExtensions.Identity)" />
+    </ItemGroup>
+  </Target>
+
+  <!-- Generate any extra symbols (e.g. Windows PDBs) that also need to be archived. -->
+  <Target Name="GenerateAdditionalSymbolsForArchive"
+          DependsOnTargets="SetArchivePropertiesCreateWindowsPdbsFromPortablePdbs;
+                            CreateWindowsPdbsFromPortablePdbs;
+                            AddConvertedWindowsPdbsToPublishList" />
+
+  <!--
+    Set up properties for CreateWindowsPdbsFromPortablePdbs that will generate Windows PDBs for
+    files in the unzipped symbol packages.
+  -->
+  <Target Name="SetArchivePropertiesCreateWindowsPdbsFromPortablePdbs">
+    <PropertyGroup>
+      <WindowsPdbConversionTargetPath>$(SymbolPackageExtractDir)WindowsPDB\</WindowsPdbConversionTargetPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <_ToPublishDllWithPdbCandidate Include="@(SymbolFileToPublish)"
+                            Condition="'%(Extension)'=='.dll'">
+        <PdbPath>%(RootDir)%(Directory)%(Filename).pdb</PdbPath>
+      </_ToPublishDllWithPdbCandidate>
+      <PortableFileToConvert Include="@(_ToPublishDllWithPdbCandidate)"
+                             Condition="Exists('%(PdbPath)')">
+        <TargetPath>$(WindowsPdbConversionTargetPath)%(RecursiveDir)%(Filename).pdb</TargetPath>
+      </PortableFileToConvert>
+    </ItemGroup>
+  </Target>
+
+  <!--
+    Add Windows PDBs created in CreateWindowsPdbsFromPortablePdbs to the list of symbol files to
+    publish. We need to wait until after the conversion: only Portable PDBs will be converted, and
+    we can't tell beforehand which PDBs are portable.
+  -->
+  <Target Name="AddConvertedWindowsPdbsToPublishList">
+    <ItemGroup>
+      <SymbolFileToPublish Include="$(WindowsPdbConversionTargetPath)**\*.pdb" />
     </ItemGroup>
   </Target>
 
@@ -401,6 +440,26 @@
     <ZipFileInjectFile TargetArchive="$(SymbolPackageFilePath)"
                        InjectFiles="@(CatalogFile);@(CatalogedFileManifest)"
                        Condition="'@(CatalogFile)'!=''" />
+  </Target>
+
+  <!--
+    Generates Windows PDBs from Portable PDBs.
+    
+    [In]
+    @(PortableFileToConvert)
+      * ItemSpec: The DLL file associated with a Portable PDB to convert.
+      * PdbPath: The path to the Portable PDB file to convert.
+      * TargetPath: The output path for the generated Windows PDB. Full filename.
+    @(ConversionOptions) [optional]
+      * ItemSpec: An entry in the Microsoft.DiaSymReader.Tools.PdbConversionOptions flags enum to
+        use for all conversions performed.
+  -->
+  <Target Name="CreateWindowsPdbsFromPortablePdbs">
+    <Error Text="BuildTools does not support Portable PDB conversion to Windows PDB in .NET Core. Run msbuild using the desktop framework."
+           Condition="'$(MSBuildRuntimeType)'=='core'" />
+
+    <ConvertPdbsToPortablePdbs Files="@(PortableFileToConvert)"
+                               ConversionOptions="@(ConversionOptions)" />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -119,8 +119,7 @@
         replaces 'PrefixToStrip' with 'UNCPath' when calculating the share location of each file.
   -->
   <Target Name="CreateSymbolsFileList"
-          DependsOnTargets="UnzipSymbolPackagesForPublish;
-                            GenerateAdditionalSymbolsForArchive;
+          DependsOnTargets="GetAllSymbolFilesToPublish;
                             PublishSymbolFilesToFileShare">
     <PropertyGroup>
       <SymbolFileListPath>$(SymbolsRequestIntermediateDir)SymbolFileList.txt</SymbolFileListPath>
@@ -138,6 +137,13 @@
                       Lines="@(SymbolFileToPublish -> '%(FullPath)')"
                       Overwrite="true" />
   </Target>
+
+  <!--
+    Gets every symbol file to publish onto disk and creates SymbolFileToPublish items.
+  -->
+  <Target Name="GetAllSymbolFilesToPublish"
+          DependsOnTargets="UnzipSymbolPackagesForPublish;
+                            GenerateAdditionalSymbolsForArchive" />
 
   <!--
     Copies symbols to a directory based on the given search glob path. The target should be a file

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -460,7 +460,10 @@
       * ItemSpec: An entry in the Microsoft.DiaSymReader.Tools.PdbConversionOptions flags enum to
         use for all conversions performed.
   -->
-  <Target Name="CreateWindowsPdbsFromPortablePdbs">
+  <Target Name="CreateWindowsPdbsFromPortablePdbs"
+          Condition="'$(SkipCreateWindowsPdbsFromPortablePdbs)'!='true'">
+
+    <!-- Early exit for unsupported scenario. See https://github.com/dotnet/buildtools/issues/1607 -->
     <Error Text="BuildTools does not support Portable PDB conversion to Windows PDB in .NET Core. Run msbuild using the desktop framework."
            Condition="'$(MSBuildRuntimeType)'=='core'" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -4,6 +4,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
     "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.Tpl.Dataflow": {
       "version": "4.5.24",
@@ -19,7 +20,7 @@
     "System.Dynamic.Runtime": "4.0.11",
     "System.Linq.Parallel": "4.0.1",
     "System.Net.Http": "4.1.0",
-    "System.Reflection.Metadata": "1.3.0",
+    "System.Reflection.Metadata": "1.4.2",
     "System.Xml.XPath.XmlDocument": "4.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
Adds a task and target that are used in the archive process to generate and then publish Windows PDBs for each Portable PDB. I've verified this locally, and I'm working on verifying it with a fake full symbol publish build def now.

I've already mirrored `Microsoft.DiaSymReader.Converter` and `Microsoft.DiaSymReader.Native` on the dotnet-buildtools feed.

There's a workaround in `Microsoft.DotNet.Build.Tasks.net45.csproj` to use `PrereleaseResolveNuGetPackageAssets` to grab the x86 natives. Without it, only the x64 natives end up in the buildtools package, but we run with x86 msbuild. I didn't want to just switch the project to x86 in case there's a compatibility reason for it being x64 now.

Currently I chose not to support this task on .NET Core. The task does compile and ship on Core, and when the dependencies are present, it works fine. But there was no clear way to gather and pack up all the dependencies needed, and full desktop framework is the only scenario. There isn't a whole lot to figure out (or work around) if it's useful to support Core in the future.

https://github.com/dotnet/core-eng/issues/698