### PR TITLE
Add Full GIT URL to version info.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
@@ -5,7 +5,7 @@
     <Copyright Condition="'$(Copyright)' == ''">%A9 Microsoft Corporation.  All rights reserved.</Copyright>
     <Description Condition="'$(Description)' == ''">$(AssemblyName)</Description>
     <FileVersion Condition="'$(FileVersion)' == '' and '$(AssemblyFileVersion)' != ''">$(AssemblyFileVersion)</FileVersion>
-    <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(AssemblyFileVersion)$(BuiltByString). Commit Hash%3A $(LatestCommit)</InformationalVersion>
+    <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(AssemblyFileVersion)$(BuiltByString). $(SrcCodeRef)</InformationalVersion>
     <Product Condition="'$(Product)' == ''">Microsoft%AE .NET Framework</Product>
     <AssemblyTitle Condition="'$(AssemblyTitle)' == ''">$(AssemblyName)</AssemblyTitle>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -292,7 +292,7 @@
     
     <!-- ************************* -->
 
-    <!-- SrcCodeRef is something that identifies the source code along with at tag (e.g. SrcCode: http//.....) -->
+    <!-- SrcCodeRef is something that identifies the source code along with at tag (e.g. SrcCode: https://.....) -->
     <!-- We do the best we can, and fall back as necessary -->
     <PropertyGroup Condition="'$(GitHubRepositoryUrl)' != '' AND '$(LatestCommit)' != 'N/A'">
       <SrcCodeRef>SrcCode%3A $(GitHubRepositoryUrl)/tree/$(LatestCommit)</SrcCodeRef>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -286,7 +286,7 @@
     </PropertyGroup>
 
     <!-- The GitHubRepositoryUrl is formed out of the simple GitHubRepositoryName (e.g. coreclr or corefx) -->
-    <PropertyGroup Condition="'$(GitHubOwnerName)' != '' AND '$(GitHubRepositoryName)' != ''" AND '$(GitHubRepositoryUrl)' == ''">
+    <PropertyGroup Condition="'$(GitHubOwnerName)' != '' AND '$(GitHubRepositoryName)' != '' AND '$(GitHubRepositoryUrl)' == ''">
       <GitHubRepositoryUrl>https:/github.com/$(GitHubOwnerName)/$(GitHubRepositoryName)</GitHubRepositoryUrl>
     </PropertyGroup>
     

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -294,11 +294,11 @@
 
     <!-- SrcCodeRef is something that identifies the source code along with at tag (e.g. SrcCode: http//.....) -->
     <!-- We do the best we can, and fall back as necessary -->
-    <PropertyGroup Condition="'$(GitHubRepositoryUrl)' != ''">
+    <PropertyGroup Condition="'$(GitHubRepositoryUrl)' != '' AND '$(LatestCommit)' != 'N/A'">
       <SrcCodeRef>SrcCode%3A $(GitHubRepositoryUrl)/tree/$(LatestCommit)</SrcCodeRef>
     </PropertyGroup>
     <!-- If we dont have the GitHubRepositoryUrl at least put the commit ID (which is N/A if that does not exist) -->
-    <PropertyGroup Condition="'$(GitHubRepositoryUrl)' == ''">
+    <PropertyGroup Condition="'$(GitHubRepositoryUrl)' == '' OR '$(LatestCommit)' == 'N/A'">
       <SrcCodeRef>Commit%3A $(LatestCommit)</SrcCodeRef>
     </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -167,11 +167,11 @@
       <NativeVersionLines Include="#undef VER_PRODUCTVERSION" />
       <NativeVersionLines Include="#define VER_PRODUCTVERSION          $(MajorVersion),$(MinorVersion),$(BuildNumberMajor),$(BuildNumberMinor)" />
       <NativeVersionLines Include="#undef VER_PRODUCTVERSION_STR" />
-      <NativeVersionLines Include="#define VER_PRODUCTVERSION_STR      &quot;$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)$(BuiltByString). Commit Hash%3A $(LatestCommit)&quot;" />
+      <NativeVersionLines Include="#define VER_PRODUCTVERSION_STR      &quot;$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)$(BuiltByString). $(SrcCodeRef)&quot;" />
       <NativeVersionLines Include="#undef VER_FILEVERSION" />
       <NativeVersionLines Include="#define VER_FILEVERSION             $(MajorVersion),$(MinorVersion),$(BuildNumberMajor),$(BuildNumberMinor)" />
       <NativeVersionLines Include="#undef VER_FILEVERSION_STR" />
-      <NativeVersionLines Include="#define VER_FILEVERSION_STR         &quot;$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)$(BuiltByString). Commit Hash%3A $(LatestCommit)&quot;" />
+      <NativeVersionLines Include="#define VER_FILEVERSION_STR         &quot;$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)$(BuiltByString). $(SrcCodeRef)&quot;" />
       <NativeVersionLines Include="#ifndef VER_LEGALCOPYRIGHT_STR" />
       <NativeVersionLines Include="#define VER_LEGALCOPYRIGHT_STR      &quot;\xa9 Microsoft Corporation.  All rights reserved.&quot;" />
       <NativeVersionLines Include="#endif" />
@@ -207,7 +207,7 @@
 
     <ItemGroup>
       <SourceFileLines />
-      <SourceFileLines Include="static char sccsid%5B%5D %5F%5Fattribute%5F%5F%28%28used%29%29 %3D %22%40%28%23%29Version $(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)$(BuiltByString). Commit Hash%3A $(LatestCommit)%22%3B" />
+      <SourceFileLines Include="static char sccsid%5B%5D %5F%5Fattribute%5F%5F%28%28used%29%29 %3D %22%40%28%23%29Version $(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)$(BuiltByString). $(SrcCodeRef)%22%3B" />
       <!-- Since this is a source file, compiler will complain if there is no new line at end of file, so adding one bellow. -->
       <SourceFileLines Include=" " />
     </ItemGroup>
@@ -278,6 +278,30 @@
     <PropertyGroup Condition="'$(LatestCommitExitCode)'!='0'">
       <LatestCommit>N/A</LatestCommit>
     </PropertyGroup>
+
+    <!-- The GitHubOwnerName is the name of the entity that 'owns' a particular github repository (e.g the 'dotnet in https://github/dotnet/coreclr) -->
+    <!-- we assume by default that these build tools are used by the 'dotnet' group.  This can be overridden. -->
+    <PropertyGroup Condition="'$(GitHubOwnerName)' == ''">
+      <GitHubOwnerName>dotnet</GitHubOwnerName>
+    </PropertyGroup>
+
+    <!-- The GitHubRepositoryUrl is formed out of the simple GitHubRepositoryName (e.g. coreclr or corefx) -->
+    <PropertyGroup Condition="'$(GitHubOwnerName)' != '' AND '$(GitHubRepositoryName)' != ''" AND '$(GitHubRepositoryUrl)' == ''">
+      <GitHubRepositoryUrl>https:/github.com/$(GitHubOwnerName)/$(GitHubRepositoryName)</GitHubRepositoryUrl>
+    </PropertyGroup>
+    
+    <!-- ************************* -->
+
+    <!-- SrcCodeRef is something that identifies the source code along with at tag (e.g. SrcCode: http//.....) -->
+    <!-- We do the best we can, and fall back as necessary -->
+    <PropertyGroup Condition="'$(GitHubRepositoryUrl)' != ''">
+      <SrcCodeRef>SrcCode%3A $(GitHubRepositoryUrl)/tree/$(LatestCommit)</SrcCodeRef>
+    </PropertyGroup>
+    <!-- If we dont have the GitHubRepositoryUrl at least put the commit ID (which is N/A if that does not exist) -->
+    <PropertyGroup Condition="'$(GitHubRepositoryUrl)' == ''">
+      <SrcCodeRef>Commit%3A $(LatestCommit)</SrcCodeRef>
+    </PropertyGroup>
+
     <PropertyGroup>
       <LatestCommitExitCode/>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -287,7 +287,7 @@
 
     <!-- The GitHubRepositoryUrl is formed out of the simple GitHubRepositoryName (e.g. coreclr or corefx) -->
     <PropertyGroup Condition="'$(GitHubOwnerName)' != '' AND '$(GitHubRepositoryName)' != '' AND '$(GitHubRepositoryUrl)' == ''">
-      <GitHubRepositoryUrl>https:/github.com/$(GitHubOwnerName)/$(GitHubRepositoryName)</GitHubRepositoryUrl>
+      <GitHubRepositoryUrl>https://github.com/$(GitHubOwnerName)/$(GitHubRepositoryName)</GitHubRepositoryUrl>
     </PropertyGroup>
     
     <!-- ************************* -->


### PR DESCRIPTION
Previously we had the commit ID in the file version information.  However we have
several Repos so this is needlessly ambigous.  Add the full url.   Now when you do a
filever -v you get something like ths

ProductVersion   4.6.25511.0 built by: vancem-VANCEM1. SrcCode: https://github.com/dotnet/coreclr/tree/de5f92822dbac17160da9e796e21918d2b812e38

Which unambiguously identifies vi the source code.  

@ericstj @dagood  

I have tested this by getting the coreclr repo to use the new build tools and seen that it 
produces the above URL.  