### PR TITLE
two updates to pinvoke whitelist

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/PinvokeAnalyzer_Win32UWPApis.txt
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/PinvokeAnalyzer_Win32UWPApis.txt
@@ -3136,7 +3136,6 @@ kernel32.dll!OpenMutexW
 kernel32.dll!OpenPrivateNamespaceA
 kernel32.dll!OpenPrivateNamespaceW
 kernel32.dll!OpenProcess
-kernel32.dll!OpenProcessToken
 kernel32.dll!OpenSemaphoreW
 kernel32.dll!OpenThread
 kernel32.dll!OpenWaitableTimerA
@@ -4791,6 +4790,7 @@ shcore.dll!CreateRandomAccessStreamOnFile
 shcore.dll!CreateRandomAccessStreamOverStream
 shcore.dll!CreateStreamOverRandomAccessStream
 shcore.dll!IsProcessInIsolatedContainer
+shell32.dll!SHGetKnownFolderPath
 shlwapi.dll!GetAcceptLanguagesA
 shlwapi.dll!GetAcceptLanguagesW
 srpapi.dll!SrpDoesPolicyAllowAppExecution


### PR DESCRIPTION
1. Remove kernel32.dll!OpenProcessToken since it caused problems to
DllImport using advapi32.dll
2. Add shell32.dll!SHGetKnownFolderPath that per conversation is already
being tracked to be added UAP (it will allow complete deletion of custom whitelists for src/System.Runtime.Extensions)