### PR TITLE
Preparing for serial ports in UAP

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/PinvokeAnalyzer_Win32UWPApis.txt
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/PinvokeAnalyzer_Win32UWPApis.txt
@@ -3134,7 +3134,6 @@ kernel32.dll!MoveFileExW
 kernel32.dll!MulDiv
 kernel32.dll!MultiByteToWideChar
 kernel32.dll!NormalizeString
-kernel32.dll!OpenCommPort
 kernel32.dll!OpenEventA
 kernel32.dll!OpenEventW
 kernel32.dll!OpenMutexA
@@ -3321,6 +3320,7 @@ kernel32.dll!WriteFile
 kernel32.dll!WriteFileEx
 kernel32legacy.dll!GetSystemPowerStatus
 kernelbase.dll!GetIntegratedDisplaySize
+kernelbase.dll!OpenCommPort
 kernelbase.dll!PathAllocCanonicalize
 kernelbase.dll!PathAllocCombine
 kernelbase.dll!PathCchAddBackslash

--- a/src/xunit.runner.uap/UpdateScript/AppxManifest_master.xml
+++ b/src/xunit.runner.uap/UpdateScript/AppxManifest_master.xml
@@ -72,6 +72,11 @@
     <uap:Capability Name="appointments" />
     <uap:Capability Name="contacts" />
     <uap:Capability Name="userAccountInformation" />
+    <DeviceCapability Name="serialcommunication">
+      <Device Id="any">
+        <Function Type="name:serialPort" />
+      </Device>
+    </DeviceCapability>
   </Capabilities>
   <build:Metadata>
     <build:Item Name="TargetFrameworkMoniker" Value=".NETCore,Version=v5.0" />


### PR DESCRIPTION
Eventually I will enable this API on UWP when I get a RS3 prerelease with it. This change is preparation for when that happens.