### PR TITLE
move CheckTokenMembershipEx to kernel32.dll

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/PinvokeAnalyzer_Win32UWPApis.txt
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/PinvokeAnalyzer_Win32UWPApis.txt
@@ -7,7 +7,6 @@ advapi32.dll!AdjustTokenPrivileges
 advapi32.dll!AllocateAndInitializeSid
 advapi32.dll!AllocateLocallyUniqueId
 advapi32.dll!CheckTokenMembership
-advapi32.dll!CheckTokenMembershipEx
 advapi32.dll!CloseTrace
 advapi32.dll!ControlTraceW
 advapi32.dll!ConvertSecurityDescriptorToStringSecurityDescriptorW
@@ -2802,6 +2801,7 @@ kernel32.dll!CancelIoEx
 kernel32.dll!CancelThreadpoolIo
 kernel32.dll!CancelWaitableTimer
 kernel32.dll!CeipIsOptedIn
+kernel32.dll!CheckTokenMembershipEx
 kernel32.dll!ClearCommBreak
 kernel32.dll!ClearCommError
 kernel32.dll!CloseHandle


### PR DESCRIPTION
Moving CheckTokenMembershipEx to kernel32.dll per https://github.com/dotnet/corefx/issues/22128 /cc @CIPop - after a new nuget is published with this change we can make the change on corefx.