### PR TITLE
Enable ignore condition for timeout followed by forbidden 

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExecWithRetriesForNuGetPush.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExecWithRetriesForNuGetPush.cs
@@ -33,6 +33,7 @@ namespace Microsoft.DotNet.Build.Tasks
         /// The default is -1 to make the first retry instant, because ((base^0)-1) == 0.
         /// </summary>
         public double RetryDelayConstant { get; set; } = -1;
+
         /// <summary>
         /// The "IgnoredErrorMessagesWithConditional" item collection
         /// allows you to specify error messages which you want to ignore.  If you
@@ -40,13 +41,13 @@ namespace Microsoft.DotNet.Build.Tasks
         /// only ignored if the "conditional" error message was detected in a previous (or current)
         /// Exec attempt.
         /// 
-        /// Example: <IgnoredErrorMessagesWithConditional>publish failed</IgnoredErrorMessagesWithConditional>
+        /// Example: <IgnoredErrorMessagesWithConditional Include="publish failed" />
         ///            Specifying this item would tell the task to report success, even if "publish failed" is detected
         ///            in the Exec output
         ///
-        ///            <IgnorableErrorMessages Include="Overwriting existing packages is forbidden according to the package retention settings for this feed.">
+        ///            <IgnoredErrorMessagesWithConditional Include="Overwriting existing packages is forbidden according to the package retention settings for this feed.">
         ///               <ConditionalErrorMessage>Pushing took too long</ConditionalErrorMessage>
-        ///            </IgnorableErrorMessages>
+        ///            </IgnoredErrorMessagesWithConditional>
         ///            This tells the task to report success if "Overwriting existing packages is forbidden..." is detected
         ///            in the Exec output, but only if a previous Exec attempt failed and reported "Pushing took too long".
         /// </summary>

--- a/src/Microsoft.DotNet.Build.Tasks/ExecWithRetriesForNuGetPush.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExecWithRetriesForNuGetPush.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Tasks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    /// <summary>
+    /// Run a command and retry if the exit code is not 0.
+    /// </summary>
+    public class ExecWithRetriesForNuGetPush : ExecWithRetries
+    {
+        /// <summary>
+        /// There's a very special failure scenario that we want to ignore.  That scenario is
+        /// when NuGet hits a timeout on one "push" attempt, and then gets a "Forbidden" response
+        /// because the package "already exists" on the next response.  This indicates that the
+        /// timeout occurred, but the push was actually successful.
+        ///
+        /// To address the condition, I'm implementing a special "IgnoredErrorMessagesWithConditional"
+        /// property that allows you to specify error messages which you want to ignore.  If you
+        /// specify the "ConditionalErrorMessage" metadata on the Item, then the error message is
+        /// only ignored if the "conditional" error message was detected in a previous (or current)
+        /// Exec attempt.
+        /// </summary>
+        public ITaskItem[] IgnoredErrorMessagesWithConditional { get; set; }
+
+        private CancellationTokenSource _cancelTokenSource = new CancellationTokenSource();
+
+        private Exec _runningExec;
+
+        public override bool Execute()
+        {
+            HashSet<string> activeIgnorableErrorMessages = new HashSet<string>();
+            // Add any "Ignore" messages that don't have conditionals to our active list.
+            if (IgnoredErrorMessagesWithConditional != null)
+            {
+                foreach(var message in IgnoredErrorMessagesWithConditional)
+                {
+                    string conditional = message.GetMetadata("ConditionalErrorMessage");
+                    if (string.IsNullOrEmpty(conditional))
+                    {
+                        activeIgnorableErrorMessages.Add(message.ItemSpec);
+                    }
+                }
+            }
+            for (int i = 0; i < MaxAttempts; i++)
+            {
+                string attemptMessage = $"(attempt {i + 1}/{MaxAttempts})";
+                _runningExec = new Exec
+                {
+                    BuildEngine = BuildEngine,
+                    Command = Command,
+                    LogStandardErrorAsError = false,
+                    IgnoreExitCode = true,
+                    ConsoleToMSBuild = true
+                };
+                if (!_runningExec.Execute())
+                {
+                    Log.LogError("Child Exec task failed to execute.");
+                    break;
+                }
+
+                int exitCode = _runningExec.ExitCode;
+                if (exitCode == 0)
+                {
+                    return true;
+                }
+
+                if (_runningExec.ConsoleOutput != null &&
+                    IgnoredErrorMessagesWithConditional != null &&
+                    _runningExec.ConsoleOutput.Length > 0)
+                {
+                    var consoleOutput = _runningExec.ConsoleOutput.Select(c => c.ItemSpec);
+                    // If the console output contains a "conditional" message, add the item to the active list.
+                    var conditionMessages = IgnoredErrorMessagesWithConditional.Where(m => consoleOutput.Any(n => n.Contains(m.GetMetadata("ConditionalErrorMessage"))));
+                    foreach(var condition in conditionMessages)
+                    {
+                        activeIgnorableErrorMessages.Add(condition.ItemSpec);
+                    }
+                    // If an active "ignore" message is present in the console output, then return true instead of retrying.
+                    foreach (var ignoreMessage in activeIgnorableErrorMessages)
+                    {
+                        if (consoleOutput.Any(c => c.Contains(ignoreMessage)))
+                        {
+                            Log.LogMessage(MessageImportance.High, $"Error detected, but error condition is valid, ignoring error \"{ignoreMessage}\"");
+                            return true;
+                        }
+                    }
+                }
+                string message = $"Exec FAILED: exit code {exitCode} {attemptMessage}";
+
+                if (i + 1 == MaxAttempts || _cancelTokenSource.IsCancellationRequested)
+                {
+                    Log.LogError(message);
+                    break;
+                }
+
+                Log.LogMessage(MessageImportance.High, message);
+
+                TimeSpan delay = TimeSpan.FromSeconds(
+                    Math.Pow(RetryDelayBase, i) + RetryDelayConstant);
+
+                Log.LogMessage(MessageImportance.High, $"Retrying after {delay}...");
+
+                try
+                {
+                    Task.Delay(delay, _cancelTokenSource.Token).Wait();
+                }
+                catch (AggregateException e) when (e.InnerException is TaskCanceledException)
+                {
+                    break;
+                }
+            }
+            return false;
+        }
+    }
+}
+

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -50,6 +50,7 @@
     <Compile Include="NugetMsBuildLogger.cs" />
     <Compile Include="NuGetPackageObject.cs" />
     <Compile Include="ExecWithRetries.cs" />
+    <Compile Include="ExecWithRetriesForNuGetPush.cs" />
     <Compile Include="OpenSourceSign.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="PreprocessFile.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="NuGetPushWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="ExecWithRetriesForNuGetPush" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <!--
     Utility target for pushing a set of packages using the ExecWithRetriesForNuGetPush task.

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
@@ -31,6 +31,11 @@
     <ItemGroup>
       <NuGetPushCommand Include="@(PackagesToPush -> '$(NuGetExePath) $(NuGetPushArgsBase) %(Identity)')" />
 
+      <!-- There's a very special failure scenario that we want to ignore.  That scenario is
+           when NuGet hits a timeout on one "push" attempt, and then gets a "Forbidden" response
+           because the package "already exists" on the next response.  This indicates that the
+           timeout occurred, but the push was actually successful.
+      -->
       <IgnorableErrorMessages Include="Overwriting existing packages is forbidden according to the package retention settings for this feed.">
         <ConditionalErrorMessage>Pushing took too long</ConditionalErrorMessage>
       </IgnorableErrorMessages>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="ExecWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="NuGetPushWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <!--
-    Utility target for pushing a set of packages using the ExecWithRetries task.
+    Utility target for pushing a set of packages using the ExecWithRetriesForNuGetPush task.
     The per-package retries make this target more reliable than using NuGet.exe
     when there is a hang.
   -->
@@ -30,13 +30,18 @@
 
     <ItemGroup>
       <NuGetPushCommand Include="@(PackagesToPush -> '$(NuGetExePath) $(NuGetPushArgsBase) %(Identity)')" />
+
+      <IgnorableErrorMessages Include="Overwriting existing packages is forbidden according to the package retention settings for this feed.">
+        <ConditionalErrorMessage>Pushing took too long</ConditionalErrorMessage>
+      </IgnorableErrorMessages>
     </ItemGroup>
 
-    <ExecWithRetries
+    <ExecWithRetriesForNuGetPush
       Command="%(NuGetPushCommand.Identity)"
       MaxAttempts="$(MaxAttempts)"
       RetryDelayBase="$(RetryDelayBase)"
-      RetryDelayConstant="$(RetryDelayConstant)" />
+      RetryDelayConstant="$(RetryDelayConstant)"
+      IgnoredErrorMessagesWithConditional="@(IgnorableErrorMessages)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/1375

There's a very special failure scenario that we want to ignore.  That scenario is when NuGet hits a timeout on one "push" attempt, and then gets a "Forbidden" response because the package "already exists" on the next response.  This indicates that the timeout occurred, but the push was actually successful. 

To address the condition, I'm implementing a special "IgnoredErrorMessagesWithConditional" property that allows you to specify error messages which you want to ignore.  If you specify the "ConditionalErrorMessage" metadata on the Item, then the error message is only ignored if the "conditional" error message was detected in a previous (or current) Exec attempt.

It's a bit of an odd feature, but it causes enough failures in our builds, that I'm creating the special case task for NuGet push to handle it.

/cc @dagood 

The diff isn't super useful, but if you compare the `Execute` method for `ExecWithRetries` with the `Execute` method in `ExecuteWithRetriesForNuGetPush`, you can see how this method differs.