### PR TITLE
Retry PDB conversion in a new msbuild process

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExecWithRetries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExecWithRetries.cs
@@ -18,6 +18,8 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string Command { get; set; }
 
+        public bool IgnoreStandardErrorWarningFormat { get; set; }
+
         public int MaxAttempts { get; set; } = 5;
 
         /// <summary>
@@ -52,6 +54,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 {
                     BuildEngine = BuildEngine,
                     Command = Command,
+                    IgnoreStandardErrorWarningFormat = IgnoreStandardErrorWarningFormat,
                     LogStandardErrorAsError = false,
                     IgnoreExitCode = true
                 };

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="AddItemIndices" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ConvertPdbsToPortablePdbs" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ExecWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileGetEntries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileInjectFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
@@ -236,28 +237,38 @@
 
   <!-- Generate any extra symbols (e.g. Windows PDBs) that also need to be archived. -->
   <Target Name="GenerateAdditionalSymbolsForArchive"
-          DependsOnTargets="SetArchivePropertiesCreateWindowsPdbsFromPortablePdbs;
-                            CreateWindowsPdbsFromPortablePdbs;
+          DependsOnTargets="ExecCreateWindowsPdbsFromPortablePdbs;
                             AddConvertedWindowsPdbsToPublishList" />
 
   <!--
     Set up properties for CreateWindowsPdbsFromPortablePdbs that will generate Windows PDBs for
     files in the unzipped symbol packages.
   -->
-  <Target Name="SetArchivePropertiesCreateWindowsPdbsFromPortablePdbs">
+  <Target Name="ExecCreateWindowsPdbsFromPortablePdbs">
     <PropertyGroup>
-      <WindowsPdbConversionTargetPath>$(SymbolPackageExtractDir)WindowsPDB\</WindowsPdbConversionTargetPath>
+      <PortablePdbToConvertGlob>$(SymbolPackageExtractDir)**\*.pdb</PortablePdbToConvertGlob>
+
+      <!-- Note: uses / instead of \ to avoid escaping &quot; in the command. -->
+      <WindowsPdbConversionTargetPath>$(SymbolPackageExtractDir)WindowsPDB/</WindowsPdbConversionTargetPath>
+
+      <!--
+        Run symbol conversion in a new process so that we can safely retry when PDB conversion hits
+        an AccessViolation exception.
+      -->
+      <_ConvertPdbCommand>&quot;$(MSBuildBinPath)\msbuild.exe&quot;</_ConvertPdbCommand>
+      <_ConvertPdbCommand>$(_ConvertPdbCommand) /v:Detailed</_ConvertPdbCommand>
+      <_ConvertPdbCommand>$(_ConvertPdbCommand) &quot;$(MSBuildProjectFullPath)&quot;</_ConvertPdbCommand>
+      <_ConvertPdbCommand>$(_ConvertPdbCommand) /t:CreateWindowsPdbsFromPortablePdbs</_ConvertPdbCommand>
+      <_ConvertPdbCommand>$(_ConvertPdbCommand) &quot;/p:PortablePdbToConvertGlob=$(PortablePdbToConvertGlob)&quot;</_ConvertPdbCommand>
+      <_ConvertPdbCommand>$(_ConvertPdbCommand) &quot;/p:WindowsPdbConversionTargetPath=$(WindowsPdbConversionTargetPath)&quot;</_ConvertPdbCommand>
     </PropertyGroup>
-    <ItemGroup>
-      <_ToPublishDllWithPdbCandidate Include="@(SymbolFileToPublish)"
-                            Condition="'%(Extension)'=='.dll'">
-        <PdbPath>%(RootDir)%(Directory)%(Filename).pdb</PdbPath>
-      </_ToPublishDllWithPdbCandidate>
-      <PortableFileToConvert Include="@(_ToPublishDllWithPdbCandidate)"
-                             Condition="Exists('%(PdbPath)')">
-        <TargetPath>$(WindowsPdbConversionTargetPath)%(RecursiveDir)%(Filename).pdb</TargetPath>
-      </PortableFileToConvert>
-    </ItemGroup>
+
+    <!-- Only retry once, and don't delay. Failure hasn't been observed twice in a row yet. -->
+    <ExecWithRetries Command="$(_ConvertPdbCommand)"
+                     IgnoreStandardErrorWarningFormat="true"
+                     MaxAttempts="2"
+                     RetryDelayBase="0"
+                     RetryDelayConstant="0"/>
   </Target>
 
   <!--
@@ -449,13 +460,15 @@
   </Target>
 
   <!--
-    Generates Windows PDBs from Portable PDBs.
+    Generates Windows PDBs from Portable PDBs. PDBs passed that are not Portable are skipped.
     
     [In]
-    @(PortableFileToConvert)
-      * ItemSpec: The DLL file associated with a Portable PDB to convert.
-      * PdbPath: The path to the Portable PDB file to convert.
-      * TargetPath: The output path for the generated Windows PDB. Full filename.
+    $(PortablePdbToConvertGlob)
+      * A path glob that matches all portable PDBs to convert. Conversion requires the DLL, and this
+        option assumes that the DLL is in the same directory with the same filename.
+    $(WindowsPdbConversionTargetPath)
+      * Location to place converted PDBs when using PortablePdbToConvertGlob. Recursive directory
+        is preserved, if one is present in the glob.
     @(ConversionOptions) [optional]
       * ItemSpec: An entry in the Microsoft.DiaSymReader.Tools.PdbConversionOptions flags enum to
         use for all conversions performed.
@@ -466,6 +479,30 @@
     <!-- Early exit for unsupported scenario. See https://github.com/dotnet/buildtools/issues/1607 -->
     <Error Text="BuildTools does not support Portable PDB conversion to Windows PDB in .NET Core. Run msbuild using the desktop framework."
            Condition="'$(MSBuildRuntimeType)'=='core'" />
+
+    <!-- Find DLL/PDB pairs based on the optional path glob given. -->
+    <ItemGroup Condition="'$(PortablePdbToConvertGlob)'!=''">
+      <_PdbCandidate Include="$(PortablePdbToConvertGlob)" />
+
+      <_ToPublishDllCandidate Include="@(_PdbCandidate -> '%(RootDir)%(Directory)%(Filename).dll')">
+        <PdbPath>%(Identity)</PdbPath>
+        <PdbRecursiveDir>%(RecursiveDir)</PdbRecursiveDir>
+      </_ToPublishDllCandidate>
+
+      <!--
+        If this target becomes reliable, we could start calling directly in msbuild and define these
+        items as parameters:
+        
+        @(PortableFileToConvert)
+          * ItemSpec: The DLL file associated with a Portable PDB to convert.
+          * PdbPath: The path to the Portable PDB file to convert.
+          * TargetPath: The output path for the generated Windows PDB. Full filename.
+      -->
+      <PortableFileToConvert Include="@(_ToPublishDllCandidate)"
+                             Condition="Exists('%(Identity)')">
+        <TargetPath>$(WindowsPdbConversionTargetPath)%(PdbRecursiveDir)%(Filename).pdb</TargetPath>
+      </PortableFileToConvert>
+    </ItemGroup>
 
     <ConvertPdbsToPortablePdbs Files="@(PortableFileToConvert)"
                                ConversionOptions="@(ConversionOptions)" />


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/1273

This works around a `System.AccessViolationException` that can happen inside `Microsoft.DiaSymReader.ISymUnmanagedWriter5.Close()`:

```
Converting portable PDB '[...]System.Private.Xml.dll'...
##[error]Unhandled Exception: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at Microsoft.DiaSymReader.ISymUnmanagedWriter5.Close()
   at Microsoft.DiaSymReader.SymUnmanagedWriter.WriteTo(Stream stream)
   at Microsoft.DiaSymReader.Tools.PdbConverter.ConvertPortableToWindows(PEReader peReader, MetadataReader pdbReader, Stream targetPdbStream, PdbConversionOptions options)
   at Microsoft.DiaSymReader.Tools.PdbConverter.ConvertPortableToWindows(PEReader peReader, Stream sourcePdbStream, Stream targetPdbStream, PdbConversionOptions options)
   at Microsoft.DotNet.Build.Tasks.ConvertPdbsToPortablePdbs.Execute()
```

I have tested this in VSTS by cloning the symbol publish leg (which does this conversion) and running it with a dev build of buildtools. Creating a new process seems to have made the access violations go away for now, but the conversion does still work and it will now be more robust if AVs continue to happen.

I simulated failures on my dev machine to confirm that the retry logic will work and that the build succeeds if the retry succeeds.