### PR TITLE
Remove deprecated PackageTargetFallback

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -12,16 +12,16 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.0-preview-000388-1" />
-    <PackageReference Include="Microsoft.Build.Runtime" Version="15.3.0-preview-000388-1" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.0-preview-000388-1" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.0-preview-000388-1" />
-    <PackageReference Include="Microsoft.Build" Version="15.3.0-preview-000388-1" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0-preview2-25407-01" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Runtime" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build" Version="15.3.409" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.0.0-rc4" />
     <PackageReference Include="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
     <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc4-24217-00" />
-    <PackageReference Include="System.Composition" Version="1.1.0-preview2-25405-01" />
+    <PackageReference Include="System.Composition" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001776-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
@@ -13,25 +12,25 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.2.0-beta-001090" />
-    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.0.0-rc" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.0-preview-000388-1" />
+    <PackageReference Include="Microsoft.Build.Runtime" Version="15.3.0-preview-000388-1" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.0-preview-000388-1" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.0-preview-000388-1" />
+    <PackageReference Include="Microsoft.Build" Version="15.3.0-preview-000388-1" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0-preview2-25407-01" />
+    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.0.0-rc4" />
     <PackageReference Include="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
     <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc4-24217-00" />
-    <PackageReference Include="System.Composition" Version="1.1.0-preview1-25204-02" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="System.Composition" Version="1.1.0-preview2-25405-01" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc4-24217-00" />
     <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.0.1" />
-    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.0.0" />
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolves https://github.com/dotnet/buildtools/issues/1617

Gets fresh coreclr builds working again if you've installed 2.1.0 preview; else its very broken

Not sure if it will break 2.0.0 builds?

/cc @weshaggard @mellinoe @ellismg @danmosemsft PTAL