### PR TITLE
WCF does not necessarily run tests on the same OS as it built on.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -26,7 +26,7 @@
     <DefaultOSGroup Condition="'$(OS)'=='Unix' AND Exists('/Applications')">OSX</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'=='' AND '$(OS)'=='Unix'">Linux</DefaultOSGroup>
     <DefaultOSGroup Condition="'$(DefaultOSGroup)'==''">$(OS)</DefaultOSGroup>
-    <RunningOnUnix Condition="'$(OS)'!='Windows_NT'">true</RunningOnUnix>
+    <RunningOnUnix Condition="'$(RunningOnUnix)'=='' AND '$(OS)'!='Windows_NT'">true</RunningOnUnix>
 
     <RunningOnCore Condition="'$(MSBuildRuntimeType)' == 'core'">true</RunningOnCore>
   </PropertyGroup>


### PR DESCRIPTION
* In the case of our OSX and Linux tests, we build the projects on Windows and then in Helix run the tests on Linux or OSX.
* We need to be able to override this property so it does the correct thing further down the line for when tests are run in Helix.
* One specific issue this should fix...
https://github.com/dotnet/buildtools/blob/c45406f85a56c903d02eab582db455afa98dce3d/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets#L34
causing error...

> 2017-08-08 00:31:43,688: INFO: proc(54): run_and_log_output: Output: chmod: cannot access '%RUNTIME_PATH%dotnet.exe': No such file or directory

In: https://mc.dot.net/#/product/components/master/source/official~2Fwcf~2Fmaster~2F/type/test~2Fscenario~2Fiishosted~2F/build/20170808.03/workItem/Binding.Custom.Tests/wilogs