### PR TITLE
Initial set of changes to use msbuild that comes with the CLI on Windows

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -106,10 +106,13 @@
   <Import Project="IL.targets"
            Condition="'$(MSBuildProjectExtension)' == '.ilproj' AND '$(SkipImportILTargets)'!='true'" />
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'">
+  <PropertyGroup Condition="'$(RunningOnCore)' == 'true'">
     <CSharpCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     <VisualBasicCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>
+
+<!--   <Import Project="$(MSBuildThisFileDirectory)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' And '$(_IsDesktop)' != 'true'" /> -->
 
   <!--
       workaround file casing issue where it has different casing in different places which fails on linux builds
@@ -121,13 +124,19 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft.CSharp.targets"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' and '$(RunningOnCore)' == 'true'" />
+
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' and '$(RunningOnCore)' != 'true'" />
 
   <Import Project="$(CSharpTargetsFile)"
           Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
 
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft.VisualBasic.targets"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj'" />
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj' and '$(RunningOnCore)' == 'true'" />
+
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.VisualBasic.targets"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj' and '$(RunningOnCore)' != 'true'" />
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets"
           Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj'" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -106,8 +106,10 @@
   <Import Project="IL.targets"
            Condition="'$(MSBuildProjectExtension)' == '.ilproj' AND '$(SkipImportILTargets)'!='true'" />
 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable'">
+    <CSharpCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
+    <VisualBasicCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
+  </PropertyGroup>
 
   <!--
       workaround file casing issue where it has different casing in different places which fails on linux builds
@@ -118,10 +120,13 @@
     <CSharpTargetsFile Condition="!Exists('$(CSharpTargetsFile)')">$(MSBuildToolsPath)\Microsoft.CSharp.Targets</CSharpTargetsFile>
   </PropertyGroup>
 
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft.CSharp.targets"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
+
   <Import Project="$(CSharpTargetsFile)"
           Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.VisualBasic.targets"
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft.VisualBasic.targets"
           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj'" />
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -10,6 +10,7 @@ if [%PACKAGES_DIR%] == [] set PACKAGES_DIR=%TOOLRUNTIME_DIR%
 set PACKAGES_DIR=%PACKAGES_DIR:"=%
 set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
+set ROSLYNCOMPILERS_VERSION=2.0.0-rc
 
 :: Determine if the CLI supports MSBuild projects. This controls whether csproj files are used for initialization and package restore.
 set CLI_VERSION=
@@ -26,7 +27,8 @@ if [%BUILDTOOLS_USE_CSPROJ%]==[] (
 { ^
   "dependencies": ^
     { ^
-      "MicroBuild.Core": "%MICROBUILD_VERSION%" ^
+      "MicroBuild.Core": "%MICROBUILD_VERSION%", ^
+      "Microsoft.Net.Compilers": "%ROSLYNCOMPILERS_VERSION%" ^
     }, ^
   "frameworks": {"netcoreapp1.0": {},"net46": {}} ^
 }
@@ -41,6 +43,7 @@ if [%BUILDTOOLS_USE_CSPROJ%]==[] (
   ^^^</PropertyGroup^^^> ^
   ^^^<ItemGroup^^^> ^
     ^^^<PackageReference Include=^"MicroBuild.Core^" Version=^"%MICROBUILD_VERSION%^" /^^^> ^
+    ^^^<PackageReference Include=^"Microsoft.Net.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
   ^^^</ItemGroup^^^> ^
  ^^^</Project^^^>
   set PROJECT_EXTENSION=csproj
@@ -88,6 +91,8 @@ if not [%NET46_PUBLISH_ERROR_LEVEL%]==[0] (
   exit /b %NET46_PUBLISH_ERROR_LEVEL%
 )
 
+Robocopy "%TOOLRUNTIME_DIR%\runtimes\any\native" "%TOOLRUNTIME_DIR%\."
+
 :: Copy Portable Targets Over to ToolRuntime
 if not exist "%PACKAGES_DIR%\generated" mkdir "%PACKAGES_DIR%\generated"
 set PORTABLETARGETS_PROJECT=%PACKAGES_DIR%\generated\project.%PROJECT_EXTENSION%
@@ -101,6 +106,7 @@ if not [%RESTORE_PORTABLETARGETS_ERROR_LEVEL%]==[0] (
   exit /b %RESTORE_PORTABLETARGETS_ERROR_LEVEL%
 )
 Robocopy "%PACKAGES_DIR%\MicroBuild.Core\%MICROBUILD_VERSION%\build\." "%TOOLRUNTIME_DIR%\." /E
+Robocopy "%PACKAGES_DIR%\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%TOOLRUNTIME_DIR%\net46\roslyn\." /E
 
 @echo on
 powershell -NoProfile -ExecutionPolicy unrestricted %BUILDTOOLS_PACKAGE_DIR%\init-tools.ps1 -ToolRuntimePath %TOOLRUNTIME_DIR% -DotnetCmd %DOTNET_CMD% -BuildToolsPackageDir %BUILDTOOLS_PACKAGE_DIR%

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.cmd
@@ -1,2 +1,2 @@
-@call msbuild.exe %*
+@call %~dp0dotnetcli\dotnet.exe msbuild %*
 @exit /b %ERRORLEVEL%

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001776-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
@@ -13,16 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.Build" Version="15.1.0-preview-000523-01" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.2.0-beta-001090" />
-    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.0.0-rc" />
-    <PackageReference Include="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
-    <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc4-24217-00" />
     <PackageReference Include="System.Composition" Version="1.1.0-preview1-25204-02" />
+    <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc4-24217-00" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
cc: @weshaggard 

This are only the changes required to build on Windows, we still need to do some work for Linux side. Also, in here we will always be using .NET Core MSBuild on Windows, the right approach to me would be to be able to choose which one, but throwing this out just to get initial feedback.