### PR TITLE
Enable XUnit conditional filtering uses other assemblies

### DIFF
--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
@@ -48,16 +48,36 @@ namespace Xunit.NetCore.Extensions
                     continue;
                 }
 
-                string[] symbols = conditionMemberName.Split('.');
                 Type declaringType = testMethodDeclaringType;
 
-                if (symbols.Length == 2)
+                // We have qualified type name with the assembly name, something like
+                // [ConditionalFact("System.PlatformDetection, CoreFx.Private.TestUtilities!" + nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]
+                // We don't use '.' as separator in such case and use '!' because the qualified type name can have '.' to include the type namespace.
+                if (conditionMemberName.IndexOf('!') > 0)
                 {
-                    conditionMemberName = symbols[1];
-                    ITypeInfo type = testMethod.TestClass.Class.Assembly.GetTypes(false).Where(t => t.Name.Contains(symbols[0])).FirstOrDefault();
-                    if (type != null)
+                    // get the method name
+                    string[] symbols = conditionMemberName.Split('!');
+                    if (symbols.Length == 2)
                     {
-                        declaringType = type.ToRuntimeType();
+                        conditionMemberName = symbols[1];
+                        Type requestedType = Type.GetType(symbols[0]);
+                        if (requestedType != null)
+                        {
+                            declaringType = requestedType;
+                        }
+                    }
+                }
+                else
+                {
+                    string[] symbols = conditionMemberName.Split('.');
+                    if (symbols.Length == 2)
+                    {
+                        conditionMemberName = symbols[1];
+                        ITypeInfo type = testMethod.TestClass.Class.Assembly.GetTypes(false).Where(t => t.Name.Contains(symbols[0])).FirstOrDefault();
+                        if (type != null)
+                        {
+                            declaringType = type.ToRuntimeType();
+                        }
                     }
                 }
 


### PR DESCRIPTION
Conditional Fact and Theory in our xunit filtering is always used types from the test assembly that currently running. We are working on moving PlatformDetection code to CoreFx.Private.TestUtilities assembly as it is naturally fit there and avoid including the cs files in every test project need to use it. We have many tests using Conditional Fact/Theory which calls PlatformDetection methods. The way we apply this filtering is we create the PlatformDetection type from the running test assembly. After we move PlatformDetection to CoreFx.Private.TestUtilities, this mechanism will not work. To make it work, we adding the way to allow specify the assembly containing the type through providing the qualified type name which include the assembly name.