### PR TITLE
Allow generate resources with assembly name has dashes

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     continue; // we don't want to extract the resources from Private CoreLib since this resources are managed by the legacy ResourceManager which gets them from the embedded and not from PRI. 
                 }
 
-                if (!ShouldExtractResources($"FxResources.{assemblyName}.SR.resw", assemblyPath))
+                if (!ShouldExtractResources($"FxResources.{Helper.NormalizeAssemblyName(assemblyName)}.SR.resw", assemblyPath))
                 {
                     continue; // we skip framework assemblies that resources already exist and don't need to be extracted to avoid reading dll metadata.
                 }

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -31,13 +31,17 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string AssemblyName { get; set; }
 
+        [Output]
+        public string NormalizedAssemblyName { get; set; }
+
         public bool DebugOnly { get; set; }
 
         public override bool Execute()
         {
             try
             {
-                _resourcesName = "FxResources." + AssemblyName;
+                NormalizedAssemblyName = Helper.NormalizeAssemblyName(AssemblyName);
+                _resourcesName = "FxResources." + NormalizedAssemblyName;
 
                 using (_targetStream = File.CreateText(OutputSourceFilePath))
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/Helper.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Helper.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    internal static class Helper
+    {
+        // normalize the passed name so it can be used as namespace name inside the code
+        internal static string NormalizeAssemblyName(string name)
+        {
+            if (String.IsNullOrEmpty(name))
+                return name;
+
+            bool insertUnderscore = Char.IsNumber(name[0]) ? true : false;
+            int i = 0;
+
+            while (i < name.Length)
+            {
+                char c = name[i];
+                if (!Char.IsLetter(c) && c != '.' && c != '_' && !Char.IsNumber(c))
+                    break;
+                i++;
+            }
+
+            if (i >= name.Length)
+                return insertUnderscore ? "_" + name : name;
+
+            StringBuilder sb = new StringBuilder();
+            if (insertUnderscore)
+            {
+                sb.Append('_');
+            }
+
+            for (int j = 0; j < i; j++)
+            {
+                sb.Append(name[j]);
+            }
+
+            sb.Append('_');
+            i++;
+
+            while (i < name.Length)
+            {
+                char c = name[i];
+                if (Char.IsLetter(c) || c == '.' || c == '_' || Char.IsNumber(c))
+                    sb.Append(c);
+                else
+                    sb.Append('_');
+                i++;
+            }
+
+            return sb.ToString();
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Helper.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Helper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Build.Tasks
             if (String.IsNullOrEmpty(name))
                 return name;
 
-            bool insertUnderscore = Char.IsNumber(name[0]) ? true : false;
+            bool insertUnderscore = Char.IsNumber(name[0]);
             int i = 0;
 
             while (i < name.Length)

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -37,6 +37,7 @@
     <Compile Include="GenerateCurrentVersion.cs" />
     <Compile Include="GenerateResourcesCode.cs" />
     <Compile Include="GenerateEncodingTable.cs" />
+    <Compile Include="Helper.cs" />
     <Compile Include="EncryptedConfigNuGetRestore.cs" />
     <Compile Include="GenerateUnencryptedNuGetConfig.cs" />
     <Compile Include="GenFacadesTask.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -75,7 +75,21 @@
     <GenerateResourcesCode
         ResxFilePath="$(StringResourcesPath)" 
         OutputSourceFilePath="$(IntermediateResOutputFileFullPath)" 
-        AssemblyName="$(AssemblyName)" />
+        AssemblyName="$(AssemblyName)" >
+
+        <Output TaskParameter="NormalizedAssemblyName" PropertyName="_NormalizedAssemblyName" />
+    </GenerateResourcesCode>
+
+    <ItemGroup>
+      <!-- 
+         EmbeddedResource is defined outside the target and cannot be defined inside this target 
+         we need to update logical name and ReswName after we normalize the assembly name.
+      -->
+      <EmbeddedResource Condition="'%(EmbeddedResource.LogicalName)'=='FxResources.$(AssemblyName).SR.resources'">
+        <LogicalName>FxResources.$(_NormalizedAssemblyName).SR.resources</LogicalName>
+        <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(_NormalizedAssemblyName).SR</ReswName>
+      </EmbeddedResource>
+    </ItemGroup>    
 
     <ItemGroup>
       <!-- The following Compile element has to be included dynamically inside the Target otherwise intellisense will not work -->
@@ -94,7 +108,7 @@
       <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(AssemblyName).SR</ReswName>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <Choose>
     <When Condition="Exists('$(StringResourcesPath)') And '$(SkipCommonResourcesIncludes)'=='' AND '$(OmitResources)'!='true'">
       <Choose>


### PR DESCRIPTION
As we generate cs code for accessing the embedded resources. The generated type will be named as FxResources.AsemblyName.SR. if the AssemblyName has characters not allowed in the namespace names (e.g. dashes), this will cause compilation errors. The fix here is we normalize the assembly name before we use it.