### PR TITLE
Tool-runtime should use MS.NETCore.App version built into CLI

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0-beta-001776-00</RuntimeFrameworkVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
/cc @mellinoe @weshaggard 

See https://github.com/dotnet/corefx/pull/23513#issuecomment-324726971