### PR TITLE
Make ExtractResWResourcesFromAssemblies derive from BuildTask

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
@@ -15,7 +15,7 @@ using System.Reflection.Metadata;
 
 namespace Microsoft.DotNet.Build.Tasks
 { 
-    public class ExtractResWResourcesFromAssemblies : Task
+    public class ExtractResWResourcesFromAssemblies : BuildTask
     {
         [Required]
         public ITaskItem[] InputAssemblies { get; set; }


### PR DESCRIPTION
This is necessary so that the AssemblyResolver unifies dependencies.

/cc @safern @weshaggard 