### PR TITLE
Allow projects to disable the Roslyn in BuildTools.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -52,7 +52,7 @@
 
   <Import Project="$(MSBuildThisFileDirectory)BuildVersion.targets" />
 
-  <Import Project="$(MSBuildThisFileDirectory)Roslyn.Common.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Roslyn.Common.props" Condition="'$(DisableBuildToolsRoslynVersion)' != 'true'" />
 
   <!-- Restore commands -->
   <PropertyGroup>


### PR DESCRIPTION
When using BuildTools in a repo like core-setup, where we want to use the dotnet-cli to build managed projects, we need to be able to not use the Roslyn properties that come in BuildTools.

For example, setting `<RoslynTargetsPath>$(ToolRuntimePath)</RoslynTargetsPath>` breaks any SDK project using the dotnet-cli.