### PR TITLE
Add necessary configurations in order to binplace the tests per buildconfiguration

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -345,7 +345,7 @@
     <ItemGroup>
       <_currentBinPlaceConfigurations Include="@(_bestBinlaceConfigurations)" Condition="'%(Identity)' == '$(Configuration)' OR '%(Identity)-$(ConfigurationGroup)' == '$(Configuration)'" />
 
-      <BinPlaceDir Condition="'$(BinPlaceTest)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(TestWorkingPath)')" />
+      <BinPlaceDir Condition="'$(BinPlaceTest)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(TestPath)')" />
       <BinPlaceDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(RuntimePath)')" />
       <BinPlaceDir Condition="'$(BinPlaceRef)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(RefPath)')" />
 
@@ -377,7 +377,7 @@
     <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(RuntimePath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(PackageFileRefPath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(PackageFileRuntimePath)')" />
-    <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(TestWorkingPath)')" />
+    <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(TestPath)')" />
   </ItemGroup>
 
   <Target Name="_CleanGetCurrentAdditionalFileWrites" BeforeTargets="_CleanGetCurrentAndPriorFileWrites" Condition="'@(AdditionalCleanDirectories)' != ''">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -232,7 +232,7 @@
   <!-- Binplacing targets and properties -->
   <PropertyGroup>
     <BinPlaceUseHardlinksIfPossible Condition="'$(BinPlaceUseHardlinksIfPossible)' == ''">true</BinPlaceUseHardlinksIfPossible>
-    <EnableBinPlacing Condition="'$(EnableBinPlacing)' == '' AND ('$(BinPlaceRef)' == 'true' OR '$(BinPlaceRuntime)' == 'true')">true</EnableBinPlacing>
+    <EnableBinPlacing Condition="'$(EnableBinPlacing)' == '' AND ('$(BinPlaceRef)' == 'true' OR '$(BinPlaceRuntime)' == 'true' OR '$(BinPlaceTest)' == 'true')">true</EnableBinPlacing>
   </PropertyGroup>
 
   <Target Name="BinPlace"
@@ -345,6 +345,7 @@
     <ItemGroup>
       <_currentBinPlaceConfigurations Include="@(_bestBinlaceConfigurations)" Condition="'%(Identity)' == '$(Configuration)' OR '%(Identity)-$(ConfigurationGroup)' == '$(Configuration)'" />
 
+      <BinPlaceDir Condition="'$(BinPlaceTest)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(TestWorkingPath)')" />
       <BinPlaceDir Condition="'$(BinPlaceRuntime)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(RuntimePath)')" />
       <BinPlaceDir Condition="'$(BinPlaceRef)' == 'true'" Include="@(_currentBinPlaceConfigurations->'%(RefPath)')" />
 
@@ -376,6 +377,7 @@
     <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(RuntimePath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(PackageFileRefPath)')" />
     <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(PackageFileRuntimePath)')" />
+    <AdditionalCleanDirectories Include="@(BinPlaceConfiguration->'%(TestWorkingPath)')" />
   </ItemGroup>
 
   <Target Name="_CleanGetCurrentAdditionalFileWrites" BeforeTargets="_CleanGetCurrentAndPriorFileWrites" Condition="'@(AdditionalCleanDirectories)' != ''">


### PR DESCRIPTION
This needs some changes in dir.targets in CoreFX to enable it. 

Contributes to: https://github.com/dotnet/buildtools/issues/1587

## Why is this necessary?

This is necessary in order to be able to have a test working directory different than the output directory. The output directory is shared across target groups if the test assemblies target netstandard or uap, but when running in different runtimes (uap, netcoreapp, etc.) dependencies in order to be able to run the tests change and we fill the directory with a bunch of items that are specific to that target framework. This causes to have some clashes in the bin when trying to run the same test assembly against different target frameworks without having a clean repo/output test directory. (i.e without this changes if I want to run a test project against both uap and uapaot, assuming I already built vertical for both, I would have to run tests against one TFM and then delete the test's output directory and rerun them against the other one).

This change will avoid that, and will allow to have a specific test working directory different than the output directory. This can be per tfm, pero build configuration or however the consuming repo sets this up. 

## New Behavior with this change

With this change we will have the next behavior when building/running tests:

- When building the tests we will still bin place the test assets to the `OutputDirectory` (`corefx\bin\OSGroup.Configuration\TestProject\TargetGroup/`)
- When running the tests we will bin place the tests assets to this new [`TestPath`](https://github.com/dotnet/corefx/pull/23633/files#diff-4de71e7a0fd952be821f8af2768281dcR34) which will be the `TestPath`. This new path will be the test's working directory where we will bin place the RunTests.cmd and necessary dependencies in tests.targets. Also the `testResults.xml` will be found here after the test execution.
- `TestPath` is set to be `bin/tests/<TestProject>/<BuildConfiguration>/` (i.e `corefx\bin\tests\System.Collections.Immutable.Tests`) in `dir.props`
- This `TestPath` will be added to the `BinPlaceDir` in `FrameworkTargeting.targets` when `BinPlaceTest` is set to true. 
- Then in the [`BinPlaceFiles`](https://github.com/safern/buildtools/blob/4d39247ff2c152ac50ade6128a44afc6f9993ca2/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets#L243) target the test assets will be hardlinked to the `TestPath`.

This will isolate every test execution per build configuration and will allow people to run the same test project for all of the supported configurations on the same repo without having to clean the repo.

cc: @weshaggard @ericstj