### PR TITLE
Fix race condition because of assembly name normalization

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -31,17 +31,13 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string AssemblyName { get; set; }
 
-        [Output]
-        public string NormalizedAssemblyName { get; set; }
-
         public bool DebugOnly { get; set; }
 
         public override bool Execute()
         {
             try
             {
-                NormalizedAssemblyName = Helper.NormalizeAssemblyName(AssemblyName);
-                _resourcesName = "FxResources." + NormalizedAssemblyName;
+                _resourcesName = "FxResources." + AssemblyName;
 
                 using (_targetStream = File.CreateText(OutputSourceFilePath))
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -49,6 +49,7 @@
     <Compile Include="InstallPackageFromFile.cs" />
     <Compile Include="LocatePreviousContract.cs" />
     <Compile Include="NormalizePaths.cs" />
+    <Compile Include="NormalizeAssemblyName.cs" />
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="NugetMsBuildLogger.cs" />
     <Compile Include="NuGetPackageObject.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/NormalizeAssemblyName.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/NormalizeAssemblyName.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class NormalizeAssemblyName : Task
+    public class NormalizeAssemblyName : BuildTask
     {
         [Required]
         public string AssemblyName { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/NormalizeAssemblyName.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/NormalizeAssemblyName.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class NormalizeAssemblyName : Task
+    {
+        [Required]
+        public string AssemblyName { get; set; }
+
+        [Output]
+        public string NormalizedAssemblyName { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                NormalizedAssemblyName = Helper.NormalizeAssemblyName(AssemblyName);
+            }
+            catch (Exception e)
+            {
+                Log.LogError($"Failed to normalize the assembly name {AssemblyName} with error:\n{e.Message}");
+                return false; // fail the task
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="GenerateResourcesCode" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="NormalizeAssemblyName" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <GenerateResourceMSBuildRuntime>CurrentRuntime</GenerateResourceMSBuildRuntime>
@@ -62,10 +63,29 @@
   
   <PropertyGroup Condition="'$(StringResourcesPath)'!=''">
       <CompileDependsOn>
+          AssemblyNameNormalization;
           GenerateResourcesSource;
           $(CompileDependsOn);
       </CompileDependsOn>
   </PropertyGroup>
+
+  <Target Name="AssemblyNameNormalization" Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'">
+    <NormalizeAssemblyName
+        AssemblyName="$(AssemblyName)" >
+        <Output TaskParameter="NormalizedAssemblyName" PropertyName="_NormalizedAssemblyName" />
+    </NormalizeAssemblyName>
+
+    <ItemGroup>
+      <!--
+         EmbeddedResource is defined outside the target and cannot be defined inside this target
+         we need to update logical name and ReswName after we normalize the assembly name.
+      -->
+      <EmbeddedResource Condition="'%(EmbeddedResource.LogicalName)'=='FxResources.$(AssemblyName).SR.resources'">
+        <LogicalName>FxResources.$(_NormalizedAssemblyName).SR.resources</LogicalName>
+        <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(_NormalizedAssemblyName).SR</ReswName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
 
   <Target Name="GenerateResourcesSource"
           Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'"
@@ -73,23 +93,10 @@
           Outputs="$(IntermediateResOutputFileFullPath)">
 
     <GenerateResourcesCode
-        ResxFilePath="$(StringResourcesPath)" 
-        OutputSourceFilePath="$(IntermediateResOutputFileFullPath)" 
-        AssemblyName="$(AssemblyName)" >
-
-        <Output TaskParameter="NormalizedAssemblyName" PropertyName="_NormalizedAssemblyName" />
+        ResxFilePath="$(StringResourcesPath)"
+        OutputSourceFilePath="$(IntermediateResOutputFileFullPath)"
+        AssemblyName="$(_NormalizedAssemblyName)" >
     </GenerateResourcesCode>
-
-    <ItemGroup>
-      <!-- 
-         EmbeddedResource is defined outside the target and cannot be defined inside this target 
-         we need to update logical name and ReswName after we normalize the assembly name.
-      -->
-      <EmbeddedResource Condition="'%(EmbeddedResource.LogicalName)'=='FxResources.$(AssemblyName).SR.resources'">
-        <LogicalName>FxResources.$(_NormalizedAssemblyName).SR.resources</LogicalName>
-        <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(_NormalizedAssemblyName).SR</ReswName>
-      </EmbeddedResource>
-    </ItemGroup>    
 
     <ItemGroup>
       <!-- The following Compile element has to be included dynamically inside the Target otherwise intellisense will not work -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -63,13 +63,13 @@
   
   <PropertyGroup Condition="'$(StringResourcesPath)'!=''">
       <CompileDependsOn>
-          AssemblyNameNormalization;
+          NormalizeAssemblyName;
           GenerateResourcesSource;
           $(CompileDependsOn);
       </CompileDependsOn>
   </PropertyGroup>
 
-  <Target Name="AssemblyNameNormalization" Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'">
+  <Target Name="NormalizeAssemblyName" Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'">
     <NormalizeAssemblyName
         AssemblyName="$(AssemblyName)" >
         <Output TaskParameter="NormalizedAssemblyName" PropertyName="_NormalizedAssemblyName" />


### PR DESCRIPTION
We used to generate the normalized assembly name in the target GenerateResourcesSource and we override the resw name of the resource file there too. In the incremental build the target GenerateResourcesSource will get skipped but overriding the resw item name still be done as it is used outside the target in other places. This will cause the normalized name property not initialized but it is used in setting the resw name. and that will cause a race condition because many projects will try to access the exact same resw file name while building.
The fix is to move the assembly name normalization outside GenerateResourcesSource so we’ll be sure we always initialize the normalized assembly name property.

Fixes #23618