### PR TITLE
Make all BuildTools tasks derive from BuildTask

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddDependenciesToProjectJson.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// 2. Provide a versions files, this becomes the source of package versions
     /// If both a package drop and a version file are provided, then the package drop takes precedent over the version file.
     /// </summary>
-    public class AddDependenciesToProjectJson : Microsoft.Build.Utilities.Task
+    public class AddDependenciesToProjectJson : BuildTask
     {
         // Additional Dependencies to add to the project.json. May Optionally contain a version.
         // Will Override dependencies present in the project if there is a conflict.

--- a/src/Microsoft.DotNet.Build.Tasks/AddItemIndices.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/AddItemIndices.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// <summary>
     /// Takes Input, adds Index metadata with each item's location in the array, and outputs them.
     /// </summary>
-    public class AddItemIndices : Task
+    public class AddItemIndices : BuildTask
     {
         [Required]
         public ITaskItem[] Input { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/CleanupVSTSAgent.cs
@@ -11,7 +11,7 @@ using System.Threading;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class CleanupVSTSAgent : Microsoft.Build.Utilities.Task
+    public class CleanupVSTSAgent : BuildTask
     {
         public bool Clean { get; set; }
 

--- a/src/Microsoft.DotNet.Build.Tasks/ComputeDestinationsForDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ComputeDestinationsForDependencies.cs
@@ -9,7 +9,7 @@ using System.IO;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class ComputeDestinationsForDependencies : Task
+    public class ComputeDestinationsForDependencies : BuildTask
     {
         [Required]
         public ITaskItem[] TestDependencies { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/EncryptedConfigNuGetRestore.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/EncryptedConfigNuGetRestore.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// An alternative is to acquire nuget.exe, but it's heavier than NuGet.Commands and is harder
     /// to use in the build.
     /// </summary>
-    public partial class EncryptedConfigNuGetRestore : Task
+    public partial class EncryptedConfigNuGetRestore : BuildTask
     {
         public ITaskItem[] Inputs { get; set; }
 

--- a/src/Microsoft.DotNet.Build.Tasks/ExecWithRetries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExecWithRetries.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// <summary>
     /// Run a command and retry if the exit code is not 0.
     /// </summary>
-    public class ExecWithRetries : Microsoft.Build.Utilities.Task, ICancelableTask
+    public class ExecWithRetries : BuildTask
     {
         [Required]
         public string Command { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/ExecWithRetriesForNuGetPush.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExecWithRetriesForNuGetPush.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// <summary>
     /// Run a command and retry if the exit code is not 0.
     /// </summary>
-    public class ExecWithRetriesForNuGetPush : Microsoft.Build.Utilities.Task, ICancelableTask
+    public class ExecWithRetriesForNuGetPush : BuildTask
     {
         [Required]
         public string Command { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GatherFoldersToRestore.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GatherFoldersToRestore.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GatherDirectoriesToRestore : Task
+    public class GatherDirectoriesToRestore : BuildTask
     {
         [Required]
         public string[] RootDirectories { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateAssemblyList.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateAssemblyList : Task
+    public class GenerateAssemblyList : BuildTask
     {
         [Required]
         public string InputListLocation { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateBindingRedirect.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateBindingRedirect.cs
@@ -10,7 +10,7 @@ using Task = Microsoft.Build.Utilities.Task;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateBindingRedirect : Task
+    public class GenerateBindingRedirect : BuildTask
     {
         [Required]
         public ITaskItem[] Assemblies { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateChecksums.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateChecksums.cs
@@ -10,7 +10,7 @@ using System.Security.Cryptography;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateChecksums : Task
+    public class GenerateChecksums : BuildTask
     {
         /// <summary>
         /// An item collection of files for which to generate checksums.  Each item must have metadata

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateCurrentVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateCurrentVersion.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public sealed class GenerateCurrentVersion : Task
+    public sealed class GenerateCurrentVersion : BuildTask
     {
         /// <summary>
         /// The passed in date that will be used to generate a version. (yyyy-MM-dd format)

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateEncodingTable.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateEncodingTable.cs
@@ -13,7 +13,7 @@ using System.Text;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateEncodingTable : Task
+    public class GenerateEncodingTable : BuildTask
     {
         private const string CommentIndicator = "#";
         private const char FieldDelimiter = ';';

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateEncryptedNuGetConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateEncryptedNuGetConfig.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateEncryptedNuGetConfig : Task
+    public class GenerateEncryptedNuGetConfig : BuildTask
     {
         [Required]
         public string ConfigPath { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -14,7 +14,7 @@ using System.Text;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateResourcesCode : Task
+    public class GenerateResourcesCode : BuildTask
     {
         private TargetLanguage _targetLanguage = TargetLanguage.CSharp;
         private StreamWriter _targetStream;

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateTestExecutionScripts : Task
+    public class GenerateTestExecutionScripts : BuildTask
     {
         [Required]
         public string[] TestCommands { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateUnencryptedNuGetConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateUnencryptedNuGetConfig.cs
@@ -11,7 +11,7 @@ using System.Xml;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GenerateUnencryptedNuGetConfig : Task
+    public class GenerateUnencryptedNuGetConfig : BuildTask
     {
         private const string NotImplementedMessage =
             "Unencrypted NuGet.Config functionality is unavailable. Use an encrypted " +

--- a/src/Microsoft.DotNet.Build.Tasks/GetDoItemsIntersect.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetDoItemsIntersect.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GetDoItemsIntersect : Task
+    public class GetDoItemsIntersect : BuildTask
     {
         [Required]
         public ITaskItem[] ItemGroup1 { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GetNetCoreAppVersionsFromFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetNetCoreAppVersionsFromFile.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GetNetCoreAppVersionsFromFile : Task
+    public class GetNetCoreAppVersionsFromFile : BuildTask
     {
         [Required]
         public string PathToVersionsFile { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GetNextRevisionNumber.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetNextRevisionNumber.cs
@@ -13,7 +13,7 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GetNextRevisionNumber : Task
+    public class GetNextRevisionNumber : BuildTask
     {
         [Required]
         public string VersionPropsFile { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GetPackageDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetPackageDependencies.cs
@@ -13,7 +13,7 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GetPackageDependencies : Task
+    public class GetPackageDependencies : BuildTask
     {
         /// <summary>
         /// An ItemGroup of full paths to packages.config NuGet files.

--- a/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetPackageVersion.cs
@@ -12,7 +12,7 @@ using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GetPackageVersion : Task
+    public class GetPackageVersion : BuildTask
     {
         [Required]
         public string RevisionNumber { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/GetTargetMachineInfo.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GetTargetMachineInfo.cs
@@ -9,7 +9,7 @@ using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class GetTargetMachineInfo : Task
+    public class GetTargetMachineInfo : BuildTask
     {
         [Output]
         public string TargetOS { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/InstallPackageFromFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/InstallPackageFromFile.cs
@@ -16,7 +16,7 @@ using ThreadingTask = System.Threading.Tasks.Task;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class InstallPackageFromFile : Task, ICancelableTask
+    public class InstallPackageFromFile : BuildTask, ICancelableTask
     {
         [Required]
         public string PackageFile { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/IsRestoreRequired.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/IsRestoreRequired.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public partial class IsRestoreRequired : Task
+    public partial class IsRestoreRequired : BuildTask
     {
         [Required]
         public ITaskItem[] ProjectJsons { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/LocatePreviousContract.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/LocatePreviousContract.cs
@@ -9,7 +9,7 @@ using System.IO;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class LocatePreviousContract : Task
+    public class LocatePreviousContract : BuildTask
     {
         [Required]
         public string CurrentContractProjectPath { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/NormalizePaths.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/NormalizePaths.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class NormalizePaths : Task
+    public class NormalizePaths : BuildTask
     {
         [Required]
         public ITaskItem[] InputPaths { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/OpenSourceSign.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/OpenSourceSign.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// without registering for verification skipping. The assembly cannot be installed to the
     /// GAC.
     /// </summary>
-    public sealed class OpenSourceSign : Task
+    public sealed class OpenSourceSign : BuildTask
     {
         /// <summary>
         /// The full path to the assembly to "Open Source Sign". The file will be modified in place.

--- a/src/Microsoft.DotNet.Build.Tasks/ParseTestCoverageInfo.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ParseTestCoverageInfo.cs
@@ -12,7 +12,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class ParseTestCoverageInfo : Task
+    public class ParseTestCoverageInfo : BuildTask
     {
         // Path to the directory that contains *.coverage.xml coverage info.
         [Required]

--- a/src/Microsoft.DotNet.Build.Tasks/PreprocessFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PreprocessFile.cs
@@ -11,7 +11,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class PreprocessFile : Task
+    public class PreprocessFile : BuildTask
     {
         [Required]
         public string SourceFile { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/PrereleaseResolveNuGetPackageAssets.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// <summary>
     /// Resolves the assets out of packages in the project.lock.json
     /// </summary>
-    public sealed class PrereleaseResolveNuGetPackageAssets : Task
+    public sealed class PrereleaseResolveNuGetPackageAssets : BuildTask
     {
         internal const string NuGetPackageIdMetadata = "NuGetPackageId";
         internal const string NuGetPackageVersionMetadata = "NuGetPackageVersion";

--- a/src/Microsoft.DotNet.Build.Tasks/ReadSigningRequired.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ReadSigningRequired.cs
@@ -11,7 +11,7 @@ using System.IO;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public sealed class ReadSigningRequired : Task
+    public sealed class ReadSigningRequired : BuildTask
     {
         /// <summary>
         /// Gets or sets the list of signing marker files.

--- a/src/Microsoft.DotNet.Build.Tasks/RemoveDuplicatesWithLastOneWinsPolicy.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/RemoveDuplicatesWithLastOneWinsPolicy.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Build.Tasks
     /// Unlike <see cref="RemoveDuplicates"/>, the last item in the list wins rather than the first.
     /// That distinction is important when the items have different metadata.
     /// </summary>
-    public class RemoveDuplicatesWithLastOneWinsPolicy : Task
+    public class RemoveDuplicatesWithLastOneWinsPolicy : BuildTask
     {
         /// <summary>
         /// The list of items from which to remove duplicates.

--- a/src/Microsoft.DotNet.Build.Tasks/ValidateExactRestore.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ValidateExactRestore.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class ValidateExactRestore : Task
+    public class ValidateExactRestore : BuildTask
     {
         [Required]
         public ITaskItem[] ProjectLockJsons { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -15,7 +15,7 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
-    public abstract class BaseDependenciesTask : Task
+    public abstract class BaseDependenciesTask : BuildTask
     {
         internal const string RawUrlMetadataName = "RawUrl";
         internal const string RawVersionsBaseUrlMetadataName = "RawVersionsBaseUrl";

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
-    public class LocalUpdatePublishedVersions : Task
+    public class LocalUpdatePublishedVersions : BuildTask
     {
         [Required]
         public ITaskItem[] ShippedNuGetPackage { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdatePublishedVersions.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
-    public class UpdatePublishedVersions : Task
+    public class UpdatePublishedVersions : BuildTask
     {
         [Required]
         public ITaskItem[] ShippedNuGetPackage { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VisitProjectDependencies.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public abstract class VisitProjectDependencies : Task
+    public abstract class VisitProjectDependencies : BuildTask
     {
         [Required]
         public ITaskItem[] ProjectJsons { get; set; }

--- a/src/Microsoft.DotNet.Build.Tasks/WriteSigningRequired.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/WriteSigningRequired.cs
@@ -9,7 +9,7 @@ using System.IO;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public sealed class WriteSigningRequired : Task
+    public sealed class WriteSigningRequired : BuildTask
     {
         /// <summary>
         /// Gets or sets the name of the Authenticode signature to apply.

--- a/src/Microsoft.DotNet.Build.Tasks/WriteVisualBasicDefineResponseFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/WriteVisualBasicDefineResponseFile.cs
@@ -16,7 +16,7 @@ using System.IO;
 /// </summary>
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public sealed class WriteVisualBasicDefineResponseFile : Task
+    public sealed class WriteVisualBasicDefineResponseFile : BuildTask
     {
         /// <summary>
         /// The set of DefineConstants that would be passed to the Vbc Task.

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileExtractToDirectory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileExtractToDirectory.cs
@@ -10,7 +10,7 @@ using System.IO.Compression;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public sealed class ZipFileExtractToDirectory : Task
+    public sealed class ZipFileExtractToDirectory : BuildTask
     {
         /// <summary>
         /// The path to the archive to be extracted.

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileGetEntries.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileGetEntries.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public sealed class ZipFileGetEntries : Task
+    public sealed class ZipFileGetEntries : BuildTask
     {
         /// <summary>
         /// The path to the archive.

--- a/src/Microsoft.DotNet.Build.Tasks/ZipFileInjectFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ZipFileInjectFile.cs
@@ -9,7 +9,7 @@ using System.IO.Compression;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public sealed class ZipFileInjectFile : Task
+    public sealed class ZipFileInjectFile : BuildTask
     {
         /// <summary>
         /// The path to the zip archive to be injected into.


### PR DESCRIPTION
BuildTask provides our common desktop support in a base class by
hooking AssemblyResolve and providing runtime unification for assemblies
referenced by the task.

/cc @jkotas @weshaggard 