### PR TITLE
Add an override so that packages can treat frameworks as out of box.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidatePackage.cs
@@ -226,7 +226,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     }
                     else
                     {
-                        if (validateFramework.IsInbox)
+                        if (validateFramework.IsInbox && !HasSuppression(Suppression.TreatAsOutOfBox, fx))
                         {
                             if (!hasCompileAsset && !hasCompilePlaceHolder)
                             {
@@ -251,7 +251,17 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                             Version referenceAssemblyVersion = null;
                             if (!hasCompileAsset)
                             {
-                                Log.LogError($"{ContractName} should be supported on {target} but has no compile assets.");
+                                if (hasCompilePlaceHolder)
+                                {
+                                    Log.LogError($"{ContractName} should be supported on {target} but has a compile placeholder.  You may need to remove InboxOnTargetFramework Include=\"{fx.GetShortFolderName()}\" /> from your project.");
+                                }
+                                else
+                                {
+                                    Log.LogError($"{ContractName} should be supported on {target} but has no compile assets.");
+                                }
+
+                                // skip the runtime checks
+                                continue;
                             }
                             else
                             {

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/ValidationTask.cs
@@ -85,6 +85,17 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             return false;
         }
 
+        protected bool HasSuppression(Suppression key, NuGetFramework framework)
+        {
+            HashSet<string> values;
+            if (_suppressions.TryGetValue(key, out values) && values != null)
+            {
+                var frameworkValues = new[] { framework.DotNetFrameworkName, framework.Framework, framework.GetShortFolderName() };
+                return frameworkValues.Any(fx => values.Contains(fx));
+            }
+            return false;
+        }
+
         private void LoadSuppressions()
         {
             _suppressions = new Dictionary<Suppression, HashSet<string>>();
@@ -174,6 +185,10 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
         /// <summary>
         /// Permits an inbox assembly to be missing from framework package.  This is used for cases where the assembly is part of the framework itself (eg: in desktop).
         /// </summary>
-        PermitMissingInbox
+        PermitMissingInbox,
+        /// <summary>
+        /// Treats an assembly as out of box on the given frameworks, but it must provide an assembly version that is compatible with the inbox version (>=)
+        /// </summary>
+        TreatAsOutOfBox
     }
 }


### PR DESCRIPTION
This allows us to opt out of using placeholders to model inbox state on a given framework.

/cc @weshaggard 