### PR TITLE
Add support for arch-specific `ActiveIssue`s.

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ActiveIssueAttribute.cs
@@ -18,7 +18,9 @@ namespace Xunit
         public ActiveIssueAttribute(string issue, TestPlatforms platforms) { }
         public ActiveIssueAttribute(int issueNumber, TargetFrameworkMonikers framework) { }
         public ActiveIssueAttribute(string issue, TargetFrameworkMonikers framework) { }
-        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0) { }
-        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0) { }
+        public ActiveIssueAttribute(int issueNumber, TestArchitectures architectures) { }
+        public ActiveIssueAttribute(string issueNumber, TestArchitectures architectures) { }
+        public ActiveIssueAttribute(int issueNumber, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0, TestArchitectures architectures = TestArchitectures.Any) { }
+        public ActiveIssueAttribute(string issue, TestPlatforms platforms = TestPlatforms.Any, TargetFrameworkMonikers framework = (TargetFrameworkMonikers)0, TestArchitectures architectures = TestArchitectures.Any) { }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -30,7 +30,8 @@ namespace Xunit.NetCore.Extensions
             string issue = ctorArgs.First().ToString();
             TestPlatforms platforms = TestPlatforms.Any;
             TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)0;
-            
+            TestArchitectures architectures = TestArchitectures.Any;
+
             foreach (object arg in ctorArgs.Skip(1)) // First argument is the issue number.
             {
                 if (arg is TestPlatforms)
@@ -41,13 +42,26 @@ namespace Xunit.NetCore.Extensions
                 {
                     frameworks = (TargetFrameworkMonikers)arg;
                 }
+                else if (arg is TestArchitectures)
+                {
+                    architectures = (TestArchitectures)arg;
+                }
             }
-        
-            if ((platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
+
+            bool appliesToPlatform =
+                (platforms.HasFlag(TestPlatforms.FreeBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.Linux) && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
                 (platforms.HasFlag(TestPlatforms.NetBSD) && RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"))) ||
                 (platforms.HasFlag(TestPlatforms.OSX) && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) ||
-                (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)))
+                (platforms.HasFlag(TestPlatforms.Windows) && RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+
+            bool appliesToArchitecture =
+                (architectures.HasFlag(TestArchitectures.X86) && RuntimeInformation.ProcessArchitecture == Architecture.X86) ||
+                (architectures.HasFlag(TestArchitectures.X64) && RuntimeInformation.ProcessArchitecture == Architecture.X64) ||
+                (architectures.HasFlag(TestArchitectures.Arm) && RuntimeInformation.ProcessArchitecture == Architecture.Arm) ||
+                (architectures.HasFlag(TestArchitectures.Arm64) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64);
+
+            if (appliesToPlatform && appliesToArchitecture)
             {
                 if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);

--- a/src/xunit.netcore.extensions/TestArchitectures.cs
+++ b/src/xunit.netcore.extensions/TestArchitectures.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Xunit
+{
+    [Flags]
+    public enum TestArchitectures
+    {
+        X86 = 1,
+        X64 = 2,
+        Arm = 4,
+        Arm64 = 8,
+        Any = ~0
+    }
+}

--- a/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
+++ b/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
@@ -30,6 +30,7 @@
     <Compile Include="Discoverers\SkipOnTargetFrameworkDiscoverer.cs" />
     <Compile Include="SkippedTestCase.cs" />
     <Compile Include="TargetFrameworkMonikers.cs" />
+    <Compile Include="TestArchitectures.cs" />
     <Compile Include="TestPlatforms.cs" />
     <Compile Include="XunitConstants.cs" />
   </ItemGroup>


### PR DESCRIPTION
This allows the user to disable a particular test when targeting a
specific platform without disabling the test for other platforms. We
intend to use this in CoreCLR to disable tests that e.g. fail on x86 or
ARM but not on other platforms.