### PR TITLE
Adding SourceLink Support (source code from GitHub) for dotnet builds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
@@ -8,5 +8,13 @@
     <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(AssemblyFileVersion)$(BuiltByString). $(SrcCodeRef)</InformationalVersion>
     <Product Condition="'$(Product)' == ''">Microsoft%AE .NET Framework</Product>
     <AssemblyTitle Condition="'$(AssemblyTitle)' == ''">$(AssemblyName)</AssemblyTitle>
+	<!-- File passed to C# compiler that defines the mapping from source to GIT URL.  Created in versioning.targets --> 
+    <SourceLinkFilePath>$(BaseIntermediateOutputPath)source_link.json</SourceLinkFilePath>
   </PropertyGroup>
+
+  <PropertyGroup Condition="Exists('$(SourceLinkFilePath)')">
+    <!-- Defining this variable tells the C# compiler to use this as the /sourcelink option value. -->
+    <SourceLink>$(SourceLinkFilePath)</SourceLink>
+  </PropertyGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
@@ -8,11 +8,12 @@
     <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(AssemblyFileVersion)$(BuiltByString). $(SrcCodeRef)</InformationalVersion>
     <Product Condition="'$(Product)' == ''">Microsoft%AE .NET Framework</Product>
     <AssemblyTitle Condition="'$(AssemblyTitle)' == ''">$(AssemblyName)</AssemblyTitle>
+    
 	<!-- File passed to C# compiler that defines the mapping from source to GIT URL.  Created in versioning.targets --> 
     <SourceLinkFilePath>$(BaseIntermediateOutputPath)source_link.json</SourceLinkFilePath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="Exists('$(SourceLinkFilePath)')">
+  <PropertyGroup Condition="'$(UseSourceLink)' == 'true' AND Exists('$(SourceLinkFilePath)')">
     <!-- Defining this variable tells the C# compiler to use this as the /sourcelink option value. -->
     <SourceLink>$(SourceLinkFilePath)</SourceLink>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -290,6 +290,15 @@
       <GitHubRepositoryUrl>https://github.com/$(GitHubOwnerName)/$(GitHubRepositoryName)</GitHubRepositoryUrl>
     </PropertyGroup>
     
+    <!-- ******* SourceLink Support, activated by setting $(UseSourceLink) ********* -->
+
+    <!-- Generate the SourceLink file that will be passed to the C# compiler (using ProjectDir and GitHubRepositoryUrl as data) -->
+    <MakeDir Directories="$(BaseIntermediateOutputPath)" />
+    <WriteLinesToFile Condition="'$(UseSourceLink)' == 'true' AND '$(GitHubRepositoryUrl)' != '' AND '$(LatestCommit)' != 'N/A'"
+      File="$(BaseIntermediateOutputPath)source_link.json" 
+      Overwrite="true" 
+      Lines='{"documents": { "$(ProjectDir.Replace("\", "\\"))*" : "$(GitHubRepositoryUrl.Replace("github.com", "raw.githubusercontent.com"))/$(LatestCommit)/*" }}' />
+
     <!-- ************************* -->
 
     <!-- SrcCodeRef is something that identifies the source code along with at tag (e.g. SrcCode: https://.....) -->


### PR DESCRIPTION
You have to set the variable UseSourceLink to activate it.  Thus this change has no effect unless you opt in.   

Also older C# compilers this will fail unless you generate portable PDBs (later C# compilers support MSPDB).  This may limit when you can turn this on.  

There are additional issues getting this working end-to-end but I think this is all we need in build-tools.

I have been testing this on the corefx and coreclr repo.  I need a build of build-tools however before those repos can be updated.   

@dagood, @tmat, @mikem8361 
