### PR TITLE
Add TargetFrameworkMonikers.IsInAppContainer

### DIFF
--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -23,6 +23,7 @@ namespace Xunit
         NetFramework = 0x800,
         Netcoreapp = 0x1000,
         UapNotUapAot = 0x2000,
+        IsInAppContainer = UapNotUapAot, // If we begin to run AOT tests in AC, tests using IsInAppContainer need not change 
         UapAot = 0x4000,
         Uap = UapAot | UapNotUapAot,
         NetcoreCoreRT = 0x8000


### PR DESCRIPTION
Currently tests that require appcontainer filter with TFM.IsUapNotUapAot even though they may not care whether the configuration is Aot. Add TFM.IsInAppContainer so they can express this intent. If we later add support for AppContainer in Aot configuration runs, we don't need to update the tests, only the filtering.

relates to https://github.com/dotnet/corefx/issues/19931