### PR TITLE
Ensure deps file contains correct extension

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateDepsJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateDepsJson.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 AssemblyName result;
                 if (TryGetManagedAssemblyName(file, out result))
                 {
-                    assemblyNames.Add(new FileNameAssemblyPair(result, Path.GetFileNameWithoutExtension(file)));
+                    assemblyNames.Add(new FileNameAssemblyPair(result, Path.GetFileName(file)));
                 }
                 else
                 {
@@ -116,8 +116,8 @@ namespace Microsoft.DotNet.Build.Tasks
             {
                 JObject runtimes = new JObject();
                 JObject runtimeLocation = new JObject();
-                string key = $"{assembly.FileName}/{assembly.AssemblyName.Version.Major}.{assembly.AssemblyName.Version.Minor}.{assembly.AssemblyName.Version.Build}";
-                runtimeLocation.Add(assembly.FileName + ".dll", new JObject());
+                string key = $"{assembly.AssemblyName.Name}/{assembly.AssemblyName.Version.Major}.{assembly.AssemblyName.Version.Minor}.{assembly.AssemblyName.Version.Build}";
+                runtimeLocation.Add(assembly.FileName, new JObject());
                 runtimes.Add("runtime", runtimeLocation);
                 try
                 {


### PR DESCRIPTION
Previously the GenerateDepsJson task was assuming all assemblies were
dlls, however that is not the case; xunit.console.netcore.exe is an exe.

This didn't seem to cause an issue if the file existed in the
application folder.  If xunit.console.netcore.exe existed in the app folder, the host would
ignore the incorrect entry in the framework deps file.

If, however, the file was missing from the app folder and had incorrect
extension, the host would fail at startup.

This change fixes the deps file to have the correct extension.

The only diff after making this fix can be seen here: https://gist.github.com/ericstj/abdd9ba519dff947c3ac8910c9f37324/revisions#diff-4ed1ec087ae487fff3bdda792419a18e