### PR TITLE
Updating the version of the roslyn compiler

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -40,8 +40,14 @@
     <OverrideToolHost Condition="'$(RunningOnUnix)' != 'true'">$(DotnetCliPath)dotnet.exe</OverrideToolHost>
     <BuildToolsTaskDir Condition="'$(RunningOnCore)'!='true'">$(ToolsDir)net46/</BuildToolsTaskDir>
     <BuildToolsTaskDir Condition="'$(RunningOnCore)'=='true'">$(ToolsDir)</BuildToolsTaskDir>
+    <RoslynIncompatibleMsbuildVersion Condition="'$(MSBuildToolsVersion)' == '2.0' OR
+                                                 '$(MSBuildToolsVersion)' == '3.5' OR
+                                                 '$(MSBuildToolsVersion)' == '4.0' OR
+                                                 '$(MSBuildToolsVersion)' == '12.0' OR
+                                                 '$(MSBuildToolsVersion)' == '14.0'">true</RoslynIncompatibleMsbuildVersion>
     <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(RunningOnUnix)'=='true'">false</UseRoslynCompilers>
-    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == '' and '$(RunningOnUnix)' != 'true' and '$(UseRoslynCompilers)' != 'false'">true</UseSharedCompilation>
+    <!-- UseSharedCompilation is not supported in MSBuild 14.0 with the new version of roslyn, so make sure we are not using that for building -->
+    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == '' and '$(RunningOnUnix)' != 'true' and '$(UseRoslynCompilers)' != 'false' and '$(RoslynIncompatibleMsbuildVersion)' != 'true'">true</UseSharedCompilation>
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynVersion>2.0.0-rc4</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-61915-01</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.Compilers</RoslynPackageName>
     <RoslynTargetsPath>$(ToolRuntimePath)</RoslynTargetsPath>
   </PropertyGroup>
 
   <PropertyGroup>
-    <RoslynPropsFile Condition="'$(RoslynPropsFile)' == '' and '$(RunningOnCore)' != 'true'">$(BuildToolsTaskDir)/roslyn/build/Microsoft.Net.Compilers.props</RoslynPropsFile>
+    <RoslynPropsFile Condition="'$(RoslynPropsFile)' == '' and '$(RunningOnCore)' != 'true'">$(BuildToolsTaskDir)roslyn/build/Microsoft.Net.Compilers.props</RoslynPropsFile>
   </PropertyGroup>
 
   <!--
@@ -22,4 +22,17 @@
     -->
     <DebugType>Portable</DebugType>
   </PropertyGroup>
+
+
+  <!-- If we're not using the compiler server, set ToolPath/Exe to direct to
+       the exes in this package -->
+  <PropertyGroup Condition="'$(UseRoslynCompilers)' != 'false' and '$(RoslynIncompatibleMsbuildVersion)' == 'true'">
+    <CscToolPath Condition="'$(RunningOnCore)' == 'true'">$(RoslynPackageDir)tools</CscToolPath>
+    <CscToolPath Condition="'$(RunningOnCore)' != 'true'">$(BuildToolsTaskDir)roslyn/tools</CscToolPath>
+    <CscToolExe>csc.exe</CscToolExe>
+    <VbcToolPath Condition="'$(RunningOnCore)' == 'true'">$(RoslynPackageDir)tools</VbcToolPath>
+    <VbcToolPath Condition="'$(RunningOnCore)' != 'true'">$(BuildToolsTaskDir)roslyn/tools</VbcToolPath>
+    <VbcToolExe>vbc.exe</VbcToolExe>
+  </PropertyGroup>
+
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -11,7 +11,7 @@ set PACKAGES_DIR=%PACKAGES_DIR:"=%
 set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
 set PORTABLETARGETS_VERSION=0.1.1-dev
-set ROSLYNCOMPILERS_VERSION=2.0.0-rc4
+set ROSLYNCOMPILERS_VERSION=2.6.0-rdonly-ref-61915-01
 
 :: Determine if the CLI supports MSBuild projects. This controls whether csproj files are used for initialization and package restore.
 set CLI_VERSION=

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -105,6 +105,10 @@ cp -R "${__PACKAGES_DIR}"/[Mm]icro[Bb]uild.[Cc]ore/"${__MICROBUILD_VERSION}/buil
 # Copy some roslyn files over
 cp $__TOOLRUNTIME_DIR/runtimes/any/native/* $__TOOLRUNTIME_DIR/
 
+#Temporarily rename roslyn compilers to have exe extension
+cp ${__TOOLRUNTIME_DIR}/csc.dll ${__TOOLRUNTIME_DIR}/csc.exe
+cp ${__TOOLRUNTIME_DIR}/vbc.dll ${__TOOLRUNTIME_DIR}/vbc.exe
+
 # Override versions in runtimeconfig.json files with highest available runtime version.
 __MNCA_FOLDER=$(dirname $__DOTNET_CMD)/shared/Microsoft.NETCore.App
 __HIGHEST_RUNTIME_VERSION=`ls $__MNCA_FOLDER | sed 'r/\([0-9]\+\).*/\1/g' | sort -n | tail -1`

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
     <PackageReference Include="Microsoft.Build" Version="15.3.409" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.0.0-rc4" />
+    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.6.0-rdonly-ref-61915-01" />
     <PackageReference Include="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
     <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc4-24217-00" />
     <PackageReference Include="System.Composition" Version="1.1.0" />


### PR DESCRIPTION
FYI: @weshaggard @ericstj 

These changes were already in buildtools but I reverted them temporarily so that @ericstj could ingest some other changes into corefx. Now I have the corefx changes in order to be able to build with the new compiler ready, so I'm re-applying this back in buildtools.