### PR TITLE
[release/2.0.0] Remove reference assembly attribute from partial ref facade when it is a full facade

### DIFF
--- a/src/GenFacades/GenFacades.Core/GenFacades.cs
+++ b/src/GenFacades/GenFacades.Core/GenFacades.cs
@@ -489,6 +489,15 @@ namespace GenFacades
                             return forwardedTypes.TryGetValue(oldType.DocId(), out newType) ? newType : oldType;
                         });
 
+                        var remainingTypes = assembly.AllTypes.Where(t => t.Name.Value != "<Module>");
+
+                        if (!remainingTypes.Any())
+                        {
+                            Trace.TraceInformation($"Removed all types from {contractAssembly.Name} thus will remove ReferenceAssemblyAttribute.");
+                            assembly.AssemblyAttributes.RemoveAll(ca => ca.FullName() == "System.Runtime.CompilerServices.ReferenceAssemblyAttribute");
+                            assembly.Flags &= ~ReferenceAssemblyFlag;
+                        }
+
                         typeRefRewriter.Rewrite(assembly);
                     }
                 }


### PR DESCRIPTION
Port of https://github.com/dotnet/buildtools/pull/1663 to release/2.0.0

/cc @weshaggard 