### PR TITLE
Updating Roslyn to version 2.6.0-rdonly-ref-62111-06

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynVersion>2.6.0-rdonly-ref-61915-01</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-62111-06</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.Compilers</RoslynPackageName>
     <RoslynTargetsPath>$(ToolRuntimePath)</RoslynTargetsPath>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -11,7 +11,7 @@ set PACKAGES_DIR=%PACKAGES_DIR:"=%
 set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
 set PORTABLETARGETS_VERSION=0.1.1-dev
-set ROSLYNCOMPILERS_VERSION=2.6.0-rdonly-ref-61915-01
+set ROSLYNCOMPILERS_VERSION=2.6.0-rdonly-ref-62111-06
 
 :: Determine if the CLI supports MSBuild projects. This controls whether csproj files are used for initialization and package restore.
 set CLI_VERSION=

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.3.409" />
     <PackageReference Include="Microsoft.Build" Version="15.3.409" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.6.0-rdonly-ref-61915-01" />
+    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="2.6.0-rdonly-ref-62111-06" />
     <PackageReference Include="Microsoft.Net.Compilers.Targets.NetCore" Version="0.1.5-dev" />
     <PackageReference Include="Microsoft.Cci" Version="4.0.0-rc4-24217-00" />
     <PackageReference Include="System.Composition" Version="1.1.0" />


### PR DESCRIPTION
FYI: @VSadov @weshaggard 

Needed for https://github.com/dotnet/corefx/pull/24076

Updating to a newer version of Roslyn that supports the compiler flag to disable validation generation.