### PR TITLE
Update the include list for dumpling

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -5,6 +5,10 @@
     </Content>
     <DumplingIncPaths Include="$(RuntimePath)" />
     <DumplingIncPaths Include="$(TestPath)" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="$HELIX_CORRELATION_PAYLOAD" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib64/" />
   </ItemGroup>
   <Target Name="PreinstallDumpling"
           BeforeTargets="TestAllProjects">


### PR DESCRIPTION
This adds saving off the full runtime that we unpack as part of running
the tests as well as the system libs that live in lib and usr/lib.