### PR TITLE
Update links for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # .NET Core Build Tools
 
-[![Build status](https://ci.dot.net/job/dotnet_buildtools/job/master/job/innerloop/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/innerloop/)
+[![Build Status Windows_NT](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/)
+
+[![Build Status Ubuntu14.04](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/)
 
 [![Packages](https://img.shields.io/dotnet.myget/dotnet-buildtools/v/Microsoft.DotNet.BuildTools.svg?label=Packages)](https://dotnet.myget.org/gallery/dotnet-buildtools/)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # .NET Core Build Tools
 
-###Windows
+### Windows
 [![Build Status](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/)
 
-###Ubuntu 14.04
+### Ubuntu 14.04
 [![Build Status](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/)
 
 [![Packages](https://img.shields.io/dotnet.myget/dotnet-buildtools/v/Microsoft.DotNet.BuildTools.svg?label=Packages)](https://dotnet.myget.org/gallery/dotnet-buildtools/)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # .NET Core Build Tools
 
-[![Build Status Windows_NT](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/)
+###Windows
+[![Build Status](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/)
 
-[![Build Status Ubuntu14.04](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/)
+###Ubuntu 14.04
+[![Build Status](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/)
 
 [![Packages](https://img.shields.io/dotnet.myget/dotnet-buildtools/v/Microsoft.DotNet.BuildTools.svg?label=Packages)](https://dotnet.myget.org/gallery/dotnet-buildtools/)
 


### PR DESCRIPTION
The links in the README.md file were out of date.  I have updated them
to inlcude the proper links to the actual jobs that live in Jenkins.