### PR TITLE
Allow maintainers to modify auto PRs by default.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -70,6 +70,10 @@
   <UsingTask TaskName="UpdateDependenciesAndSubmitPullRequest" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <Target Name="UpdateDependenciesAndSubmitPullRequest">
+    <PropertyGroup>
+      <MaintainersCanModifyPullRequest Condition="'$(MaintainersCanModifyPullRequest)' == ''">true</MaintainersCanModifyPullRequest>
+    </PropertyGroup>
+
     <UpdateDependenciesAndSubmitPullRequest DependencyBuildInfo="@(DependencyBuildInfo)"
                                             ProjectJsonFiles="@(ProjectJsonFiles)"
                                             UpdateStep="@(UpdateStep)"
@@ -82,6 +86,7 @@
                                             GitHubAuthor="$(GitHubAuthor)"
                                             NotifyGitHubUsers="@(NotifyGitHubUsers)"
                                             CurrentRefXmlPath="$(CurrentRefXmlPath)"
-                                            AlwaysCreateNewPullRequest="$(AlwaysCreateNewPullRequest)" />
+                                            AlwaysCreateNewPullRequest="$(AlwaysCreateNewPullRequest)"
+                                            MaintainersCanModifyPullRequest="$(MaintainersCanModifyPullRequest)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependenciesAndSubmitPullRequest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependenciesAndSubmitPullRequest.cs
@@ -38,6 +38,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
 
         public bool AlwaysCreateNewPullRequest { get; set; }
 
+        public bool MaintainersCanModifyPullRequest { get; set; }
+
         protected override void TraceListenedExecute()
         {
             // Use the commit sha of versions repo master (not just "master") for stable upgrade.
@@ -110,7 +112,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                     suggestedMessage,
                     suggestedMessage + $" ({ProjectRepoBranch})",
                     body,
-                    forceCreate: AlwaysCreateNewPullRequest).Wait();
+                    forceCreate: AlwaysCreateNewPullRequest,
+                    maintainersCanModify: MaintainersCanModifyPullRequest).Wait();
             }
             else
             {

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -112,14 +112,16 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             string title,
             string description,
             GitHubBranch headBranch,
-            GitHubBranch baseBranch)
+            GitHubBranch baseBranch,
+            bool maintainersCanModify)
         {
             string createPrBody = JsonConvert.SerializeObject(new
             {
                 title = title,
                 body = description,
                 head = $"{headBranch.Project.Owner}:{headBranch.Name}",
-                @base = baseBranch.Name
+                @base = baseBranch.Name,
+                maintainer_can_modify = maintainersCanModify
             }, Formatting.Indented);
 
             string pullUrl = $"https://api.github.com/repos/{baseBranch.Project.Segments}/pulls";
@@ -139,7 +141,8 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             int number,
             string title = null,
             string body = null,
-            string state = null)
+            string state = null,
+            bool? maintainersCanModify = null)
         {
             var updatePrBody = new JObject();
 
@@ -154,6 +157,10 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             if (state != null)
             {
                 updatePrBody.Add(new JProperty("state", state));
+            }
+            if (maintainersCanModify != null)
+            {
+                updatePrBody.Add(new JProperty("maintainer_can_modify", maintainersCanModify.Value));
             }
 
             string url = $"https://api.github.com/repos/{project.Segments}/pulls/{number}";

--- a/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
@@ -56,7 +56,8 @@ namespace Microsoft.DotNet.VersionTools.Automation
             string commitMessage,
             string title,
             string description,
-            bool forceCreate = false)
+            bool forceCreate = false,
+            bool maintainersCanModify = true)
         {
             var upstream = UpstreamBranch.Project;
 
@@ -118,11 +119,21 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
                 if (pullRequestToUpdate != null)
                 {
-                    await client.UpdateGitHubPullRequestAsync(upstream, pullRequestToUpdate.Number, title, description);
+                    await client.UpdateGitHubPullRequestAsync(
+                        upstream,
+                        pullRequestToUpdate.Number,
+                        title,
+                        description,
+                        maintainersCanModify: maintainersCanModify);
                 }
                 else
                 {
-                    await client.PostGitHubPullRequestAsync(title, description, originBranch, UpstreamBranch);
+                    await client.PostGitHubPullRequestAsync(
+                        title,
+                        description,
+                        originBranch,
+                        UpstreamBranch,
+                        maintainersCanModify);
                 }
             }
         }


### PR DESCRIPTION
This change checks this box by default when auto-PRs are created.

![image](https://user-images.githubusercontent.com/8291187/30668737-55bbd386-9e21-11e7-9ec4-394aa55693ba.png)

That way people don't need access to `dotnet-maestro-bot`'s fork to update the auto-PR.