### PR TITLE
Avoid linefeed in /proc/self/coredump_filter

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -64,7 +64,7 @@ elif [ "$(uname -s)" == "Linux" ]; then
       # Include memory in private and shared file-backed mappings in the dump.
       # This ensures that we can see disassembly from our shared libraries when
       # inspecting the contents of the dump. See 'man core' for details.
-      echo 0x3F > /proc/self/coredump_filter
+      echo -n 0x3F > /proc/self/coredump_filter
   fi
 
   ulimit -c unlimited


### PR DESCRIPTION
On Alpine Linux, the default shell is ash. To build .NET Core, we
explicitly install bash.

If we run the following command:

```sh
echo 0x3F > /proc/self/coredump_filter
```

in bash, it raises the exception:

> echo: write error: Invalid argument

while with ash, it works fine.

Problem is that, when `echo` is run from `bash`, it adds a trailing
linefeed which kernel seems to reject.

Adding `-n` avoids adding the linefeed.

Original exception while building CoreRT:

```sh
chmod +x /corert/Tools/dotnetcli//dotnet
/corert/bin/Linux.x64.Debug/ILCompiler.DependencyAnalysisFramework.Tests/RunTests.sh: line 67: echo: write error: Invalid argument
/corert/Tools/dotnetcli//dotnet xunit.console.netcore.exe ILCompiler.DependencyAnalysisFramework.Tests.dll  -xml testResults.xml -notrait Benchmark=true -notrait category=nontests -notrait category=nonlinuxtests  -notrait category=OuterLoop -notrait category=failing
```