### PR TITLE
Add Mono to TargetFrameworkMonikers

### DIFF
--- a/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ActiveIssueDiscoverer.cs
@@ -51,6 +51,8 @@ namespace Xunit.NetCore.Extensions
             {
                 if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+                if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
+                    yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                     yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
                 if (frameworks.HasFlag(TargetFrameworkMonikers.UapNotUapAot))

--- a/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -47,6 +47,8 @@ namespace Xunit.NetCore.Extensions
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreapp1_1Test);
             if (platform.HasFlag(TargetFrameworkMonikers.NetFramework))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
+            if (platform.HasFlag(TargetFrameworkMonikers.Mono))
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
             if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
             if (platform.HasFlag(TargetFrameworkMonikers.UapNotUapAot))

--- a/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
+++ b/src/xunit.netcore.extensions/TargetFrameworkMonikers.cs
@@ -25,6 +25,7 @@ namespace Xunit
         UapNotUapAot = 0x2000,
         UapAot = 0x4000,
         Uap = UapAot | UapNotUapAot,
-        NetcoreCoreRT = 0x8000
+        NetcoreCoreRT = 0x8000,
+        Mono = 0x10000
     }
 }

--- a/src/xunit.netcore.extensions/XunitConstants.cs
+++ b/src/xunit.netcore.extensions/XunitConstants.cs
@@ -29,6 +29,7 @@ namespace Xunit.NetCore.Extensions
 
         //Non version framework constants
         internal static string NonNetfxTest = "nonnetfxtests";
+        internal static string NonMonoTest = "nonmonotests";
         internal static string NonUapTest = "nonuaptests";
         internal static string NonUapAotTest = "nonuapaottests";
         internal static string NonNetcoreappTest = "nonnetcoreapptests";


### PR DESCRIPTION
For several namespaces we try to reuse .NET Core sources including xunit tests and in most cases mono can pretend to be NetFramework
but in some places it completely uses .NET Core code and behaves more like .NET Core rather than .NET.

Example: https://github.com/dotnet/corefx/blob/master/src/System.Runtime.Numerics/tests/BigInteger/Comparison.cs#L369-L373 - we can't pretend to be NetFramework here as we also have that netcore fix for this case.

/cc: @marek-safar @akoeplinger 