### PR TITLE
Create Microsoft.DotNet.Build.Tasks.Symbols package

### DIFF
--- a/src/BuildTools.sln
+++ b/src/BuildTools.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.0
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks", "Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.csproj", "{17C66BCE-EB35-44CA-893C-8AAFB67708E9}"
 EndProject
@@ -64,6 +64,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiCompat", "ApiCompat\ApiCompat.csproj", "{D0BA507E-778D-4BB3-9128-68177117E13C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks.Feed", "Microsoft.DotNet.Build.Tasks.Feed\Microsoft.DotNet.Build.Tasks.Feed.csproj", "{6623492E-9EAD-40F0-B8F4-AF0AFBF98890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Build.Tasks.Symbols", "Microsoft.DotNet.Build.Tasks.Symbols\Microsoft.DotNet.Build.Tasks.Symbols.csproj", "{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -465,6 +467,26 @@ Global
 		{6623492E-9EAD-40F0-B8F4-AF0AFBF98890}.Release|x64.Build.0 = Release|Any CPU
 		{6623492E-9EAD-40F0-B8F4-AF0AFBF98890}.Release|x86.ActiveCfg = Release|Any CPU
 		{6623492E-9EAD-40F0-B8F4-AF0AFBF98890}.Release|x86.Build.0 = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|ARM.Build.0 = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|ARM.ActiveCfg = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|ARM.Build.0 = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|x64.Build.0 = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.DotNet.Build.Tasks.Symbols.net45/Microsoft.DotNet.Build.Tasks.Symbols.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Symbols.net45/Microsoft.DotNet.Build.Tasks.Symbols.net45.csproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
+    <ImportedProjectRelativePath>..\Microsoft.DotNet.Build.Tasks.Symbols\</ImportedProjectRelativePath>
+    <ProjectGuid>{17C66BCE-EB35-44CA-893C-8AAFB67708E9}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.Symbols.csproj" />
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <TargetingPackReference Include="Microsoft.Build.Tasks.v4.0" />
+    <TargetingPackReference Include="Microsoft.Build.Framework" />
+    <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Net.Http" />
+    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="System.IO" />
+    <TargetingPackReference Include="System.IO.Compression" />
+    <TargetingPackReference Include="System.IO.Compression.FileSystem" />
+    <TargetingPackReference Include="System.Runtime" />
+    <TargetingPackReference Include="System.Xml" />
+    <TargetingPackReference Include="System.Xml.Linq" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Symbols.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Symbols.net45/project.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
+    "System.Reflection.Metadata": "1.4.1",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
+  },
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
+      }
+    }
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Symbols/Microsoft.DotNet.Build.Tasks.Symbols.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Symbols/Microsoft.DotNet.Build.Tasks.Symbols.csproj
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.DotNet.Build.Tasks.Symbols</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.Build.Tasks.Symbols</AssemblyName>
+    <CLSCompliant>false</CLSCompliant>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <ProjectGuid>{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}</ProjectGuid>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\AddItemIndices.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\BuildTask.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ConvertPdbsToPortablePdbs.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ExecWithRetries.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileExtractToDirectory.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileGetEntries.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileInjectFile.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="PackageFiles\**\*.*" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <PackageFiles Include="$(MSBuildThisProjectDirectory)PackageFiles\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(OutputPath)\PackageFiles\%(RecursiveDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Symbols/Microsoft.DotNet.Build.Tasks.Symbols.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Symbols/Microsoft.DotNet.Build.Tasks.Symbols.csproj
@@ -29,14 +29,7 @@
     <Compile Include="..\Microsoft.DotNet.Build.Tasks\ZipFileInjectFile.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="PackageFiles\**\*.*" />
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <Target Name="AfterBuild">
-    <ItemGroup>
-      <PackageFiles Include="$(MSBuildThisProjectDirectory)PackageFiles\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(PackageFiles)" DestinationFolder="$(OutputPath)\PackageFiles\%(RecursiveDir)" SkipUnchangedFiles="true" />
-  </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Symbols/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Symbols/project.json
@@ -1,0 +1,20 @@
+﻿{
+  "dependencies": {
+    "Microsoft.Build": "0.1.0-preview-00022",
+    "Microsoft.Build.Framework": "0.1.0-preview-00022",
+    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
+    "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
+    "Microsoft.Tpl.Dataflow": {
+      "version": "4.5.24",
+      "exclude": "all"
+    },
+    "System.Reflection.Metadata": "1.4.2",
+    "NETStandard.Library": "1.6.0"
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="AddItemIndices" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ConvertPdbsToPortablePdbs" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ExecWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ZipFileGetEntries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ZipFileInjectFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="AddItemIndices" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.Symbols.dll"/>
+  <UsingTask TaskName="ConvertPdbsToPortablePdbs" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.Symbols.dll"/>
+  <UsingTask TaskName="ExecWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.Symbols.dll"/>
+  <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.Symbols.dll"/>
+  <UsingTask TaskName="ZipFileGetEntries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.Symbols.dll"/>
+  <UsingTask TaskName="ZipFileInjectFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.Symbols.dll"/>
 
   <PropertyGroup>
     <SymbolsRequestIntermediateDir Condition="'$(SymbolsRequestIntermediateDir)'==''">$(BaseIntermediateOutputPath)SymbolsRequest\</SymbolsRequestIntermediateDir>

--- a/src/nuget/Microsoft.DotNet.Build.Tasks.Symbols.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.Symbols.nuspec
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.Build.Tasks.Symbols</id>
+    <version>1.0.0-prerelease</version>
+    <title>DotNet Build Symbols Tools</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>DotNet Build Feed Tools</summary>
+    <description>This package provides support for symbols related tasks such as archiving, publishing, indexing, etc...
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+     <!-- Do not add any dependencies to this package as we want to install it versionless (i.e. -ExcludeVersion) and we don't want the dependencies to be installed that way -->
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.DotNet.Build.Tasks.Symbols\Microsoft.DotNet.Build.Tasks.Symbols.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks.Symbols.net45\*.dll" target="lib" Exclude="Microsoft.DotNet.Build.Tasks.Symbols\Microsoft.DotNet.Build.Tasks.Symbols.dll"/>
+    <file src="Microsoft.DotNet.Build.Tasks.Symbols.net45\*.dll" target="lib\desktop" />
+    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\Symbols.targets" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\Symbols.targets" target="lib\desktop" />
+    <file src="..\obj\version.txt" target="" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -25,6 +25,7 @@
     <file src="Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\RunnerScripts\**\*.*" target="lib\RunnerScripts" />
     <file src="Microsoft.DotNet.Build.Tasks.Symbols\Microsoft.DotNet.Build.Tasks.Symbols.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks.Symbols.net45\*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
     <file src="Run\run.exe" target="lib" />
@@ -51,6 +52,7 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
+
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
     <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
 

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -24,6 +24,7 @@
     <file src="Microsoft.DotNet.Build.CloudTestTasks.net45\Microsoft.DotNet.Build.CloudTestTasks.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\RunnerScripts\**\*.*" target="lib\RunnerScripts" />
+    <file src="Microsoft.DotNet.Build.Tasks.Symbols\Microsoft.DotNet.Build.Tasks.Symbols.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
     <file src="Run\run.exe" target="lib" />

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -52,7 +52,6 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
-
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
     <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
 

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -25,7 +25,7 @@
     <file src="Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\RunnerScripts\**\*.*" target="lib\RunnerScripts" />
     <file src="Microsoft.DotNet.Build.Tasks.Symbols\Microsoft.DotNet.Build.Tasks.Symbols.dll" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks.Symbols.net45\*.dll" target="lib\net46" />
+    <file src="Microsoft.DotNet.Build.Tasks.Symbols.net45\Microsoft.DotNet.Build.Tasks.Symbols.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
     <file src="Run\run.exe" target="lib" />


### PR DESCRIPTION
This change repackages symbols related logic in a smaller package.  Microsoft.DotNet.BuildTools will still package sources for the symbols stuff, but this change produces a smaller package which we can use in builds to handle signed symbols catalog injection.

https://github.com/dotnet/core-eng/issues/1733
