### PR TITLE
Create Microsoft.DotNet.Build.Tasks.VersionTools package

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/Microsoft.DotNet.Build.Tasks.VersionTools.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/Microsoft.DotNet.Build.Tasks.VersionTools.net45.csproj
@@ -18,11 +18,13 @@
     <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Net.Http" />
+    <TargetingPackReference Include="System.Collections" />     
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.IO" />
     <TargetingPackReference Include="System.IO.Compression" />
     <TargetingPackReference Include="System.IO.Compression.FileSystem" />
     <TargetingPackReference Include="System.Runtime" />
+    <TargetingPackReference Include="System.Text.RegularExpressions" />     
     <TargetingPackReference Include="System.Threading.Tasks" />     
     <TargetingPackReference Include="System.Xml" />
     <TargetingPackReference Include="System.Xml.Linq" />

--- a/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/Microsoft.DotNet.Build.Tasks.VersionTools.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/Microsoft.DotNet.Build.Tasks.VersionTools.net45.csproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <NuGetRuntimeIdentifier>win7-x64</NuGetRuntimeIdentifier>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
+    <ImportedProjectRelativePath>..\Microsoft.DotNet.Build.Tasks.VersionTools\</ImportedProjectRelativePath>
+    <ProjectGuid>{17C66BCE-EB35-44CA-893C-8AAFB67708E9}</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.VersionTools.csproj" />
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <TargetingPackReference Include="Microsoft.Build.Tasks.v4.0" />
+    <TargetingPackReference Include="Microsoft.Build.Framework" />
+    <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Net.Http" />
+    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="System.IO" />
+    <TargetingPackReference Include="System.IO.Compression" />
+    <TargetingPackReference Include="System.IO.Compression.FileSystem" />
+    <TargetingPackReference Include="System.Runtime" />
+    <TargetingPackReference Include="System.Xml" />
+    <TargetingPackReference Include="System.Xml.Linq" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/Microsoft.DotNet.Build.Tasks.VersionTools.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/Microsoft.DotNet.Build.Tasks.VersionTools.net45.csproj
@@ -23,6 +23,7 @@
     <TargetingPackReference Include="System.IO.Compression" />
     <TargetingPackReference Include="System.IO.Compression.FileSystem" />
     <TargetingPackReference Include="System.Runtime" />
+    <TargetingPackReference Include="System.Threading.Tasks" />     
     <TargetingPackReference Include="System.Xml" />
     <TargetingPackReference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.VersionTools.net45/project.json
@@ -1,0 +1,15 @@
+{
+  "dependencies": {
+    "NuGet.Packaging": "4.3.0-preview2-4095"
+  },
+  "frameworks": {
+    "net45": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
+      }
+    }
+  },
+  "runtimes": {
+    "win7-x64": {}
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.VersionTools/Microsoft.DotNet.Build.Tasks.VersionTools.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.VersionTools/Microsoft.DotNet.Build.Tasks.VersionTools.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.DotNet.Build.Tasks.VersionTools</RootNamespace>
+    <AssemblyName>Microsoft.DotNet.Build.Tasks.VersionTools</AssemblyName>
+    <CLSCompliant>false</CLSCompliant>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <ProjectGuid>{D4D6ACB6-9D73-488E-B184-4A1C00D026D2}</ProjectGuid>
+    <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\BuildTask.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\BaseDependenciesTask.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\LocalUpdatePublishedVersions.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\MsBuildTraceListener.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\TraceListenerCollectionExtensions.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\UpdateDependencies.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\UpdateDependenciesAndSubmitPullRequest.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\UpdatePublishedVersions.cs" />
+    <Compile Include="..\Microsoft.DotNet.Build.Tasks\VersionTools\VerifyDependencies.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj">
+      <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
+      <Name>Microsoft.DotNet.VersionTools</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks.VersionTools/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.VersionTools/project.json
@@ -1,0 +1,19 @@
+﻿{
+  "dependencies": {
+    "Microsoft.Build": "0.1.0-preview-00022",
+    "Microsoft.Build.Framework": "0.1.0-preview-00022",
+    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
+    "Microsoft.Tpl.Dataflow": {
+      "version": "4.5.24",
+      "exclude": "all"
+    },
+    "NETStandard.Library": "1.6.0",
+    "NuGet.Packaging": "4.3.0-preview2-4095"
+  },
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <!-- Tasks to update the dotnet/versions repository. -->
-  <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-  <UsingTask TaskName="LocalUpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.VersionTools.dll" />
+  <UsingTask TaskName="LocalUpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.VersionTools.dll" />
 
   <ItemGroup Condition="'$(ShippedNuGetPackageGlobPath)'!=''">
     <ShippedNuGetPackage Include="$(ShippedNuGetPackageGlobPath)" />
@@ -38,7 +38,7 @@
   </Target>
 
   <!-- Task to update dependencies to expected values. -->
-  <UsingTask TaskName="UpdateDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdateDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.VersionTools.dll" />
 
   <ItemGroup Condition="'$(NotifyGitHubUsers)'!=''">
     <NotifyGitHubUsers Include="$(NotifyGitHubUsers)" />
@@ -52,7 +52,7 @@
   </Target>
 
   <!-- Task to perform dependency verification. -->
-  <UsingTask TaskName="VerifyDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="VerifyDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.VersionTools.dll" />
 
   <Target Name="VerifyDependencies" Condition="'$(SkipVerifyPackageVersions)'!='true'">
     <!-- Add message so it's clear what's happening when building with verbosity:minimal. For example, "sync -p". -->
@@ -67,7 +67,7 @@
   </Target>
 
   <!-- Task to create a dependency update pull request. -->
-  <UsingTask TaskName="UpdateDependenciesAndSubmitPullRequest" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdateDependenciesAndSubmitPullRequest" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.VersionTools.dll" />
 
   <Target Name="UpdateDependenciesAndSubmitPullRequest">
     <PropertyGroup>

--- a/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.Build.Tasks.VersionTools</id>
+    <version>1.0.0-prerelease</version>
+    <title>DotNet Build VersionTools</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>DotNet Build VersionTools</summary>
+    <description>This package provides support for updating the versions repo
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+     <!-- Do not add any dependencies to this package as we want to install it versionless (i.e. -ExcludeVersion) and we don't want the dependencies to be installed that way -->
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools\Microsoft.DotNet.Build.Tasks.VersionTools.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools.net45\*.dll" target="lib" Exclude="Microsoft.DotNet.Build.Tasks.VersionTools\Microsoft.DotNet.Build.Tasks.VersionTools.dll"/>
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools.net45\*.dll" target="lib\desktop" />
+    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
+    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\desktop" />
+    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="lib\desktop" />
+    <file src="..\obj\version.txt" target="" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
@@ -20,13 +20,13 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Microsoft.DotNet.Build.Tasks.VersionTools\Microsoft.DotNet.Build.Tasks.VersionTools.dll" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks.VersionTools.net45\*.dll" target="lib" Exclude="Microsoft.DotNet.Build.Tasks.VersionTools\Microsoft.DotNet.Build.Tasks.VersionTools.dll"/>
-    <file src="Microsoft.DotNet.Build.Tasks.VersionTools.net45\*.dll" target="lib\desktop" />
-    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
-    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\desktop" />
-    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="lib\desktop" />
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools\Microsoft.DotNet.Build.Tasks.VersionTools.dll" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools.net45\*.dll" target="lib\netstandard1.5" Exclude="Microsoft.DotNet.Build.Tasks.VersionTools\Microsoft.DotNet.Build.Tasks.VersionTools.dll"/>
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools.net45\*.dll" target="lib\net46" />
+    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
+    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="lib\net46" />
     <file src="..\obj\version.txt" target="" />
   </files>
 </package>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -26,6 +26,8 @@
     <file src="Microsoft.DotNet.Build.CloudTestTasks\RunnerScripts\**\*.*" target="lib\RunnerScripts" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools\Microsoft.DotNet.Build.Tasks.VersionTools.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks.VersionTools.net45\Microsoft.DotNet.Build.Tasks.VersionTools.dll" target="lib\net46" />
     <file src="Run\run.exe" target="lib" />
     <file src="Run\run.runtimeconfig.json" target="lib" />
     <file src="BclRewriter\BclRewriter.exe" target="lib" />


### PR DESCRIPTION
Create Microsoft.DotNet.Build.Tasks.VersionTools package which is repackaging the VersionTools tasks from Microsoft.DotNet.Build.Tasks.

This allows me to use the Microsoft.DotNet.Build.Tasks.VersionTools package for updating the dotnet/versions repo rather than the full Microsoft.DotNet.BuildTools package.

https://github.com/dotnet/core-eng/issues/1733