### PR TITLE
Revert "Merge pull request #1699 from joperezr/1.0Branch"

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal EnableDelayedExpansion 
+setlocal
 
 :: Note: We've disabled node reuse because it causes file locking issues.
 ::       The issue is that we extend the build with our own targets which
@@ -22,29 +22,6 @@ if not defined VisualStudioVersion (
     exit /b 1
 )
 
-REM Process arguments passed in to build.cmd
-set "__args= %*"
-set __ConfigurationGroup=Debug
-set processedArgs=
-set __Platform=AnyCPU
-:Arg_Loop
-if "%1" == "" goto ArgsDone
-
-if /i "%1" == "-release"                 (set __ConfigurationGroup=Release&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "-debug"                 (set __ConfigurationGroup=Debug&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "-platform"                 (set __Platform=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
-if /i "%1" == "--"                 (set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-
-if [!processedArgs!]==[] (
-  set __UnprocessedBuildArgs=%__args%
-) else (
-  set __UnprocessedBuildArgs=%__args%
-  for %%t in (!processedArgs!) do (
-    set __UnprocessedBuildArgs=!__UnprocessedBuildArgs:*%%t=!
-  )
-)
-:ArgsDone
-
 :EnvSet
 
 call %~dp0init-tools.cmd
@@ -64,7 +41,7 @@ call :build %*
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%_buildlog%";Append /p:ConfigurationGroup=%__ConfigurationGroup% /p:Platform=%__Platform% !__UnprocessedBuildArgs! %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%_buildlog%";Append %* %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 


### PR DESCRIPTION
This reverts commit 470ebf035b93d9ea41821e87d9291897a0e151d1, reversing
changes made to 95cebe4159ac5fb3c4d23918242137950202dae7.

There was some confusion here because there are unfortunately too many build tools definitions. I reverted @joperezr's change and proved this works with build:

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/index?buildId=1024262&_a=summary

... a successful build with the commit from before Joe's change.

I've made the relevant updates to the correct definition as well to support oss signing.