### PR TITLE
Pare down include lists for dump collection

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -5,10 +5,20 @@
     </Content>
     <DumplingIncPaths Include="$(RuntimePath)" />
     <DumplingIncPaths Include="$(TestPath)" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/" />
     <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="$HELIX_CORRELATION_PAYLOAD" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib64/" />
+    <!-- Only save off the files that we need.  This list was obatined by using ldd on libcoreclr.so -->
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libgcc_s.so.1" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libpthread.so.0" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/librt.so.1" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/libunwind.so.8" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libdl.so.2" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libuuid.so.1" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/libunwind-x86_64.so.8" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/libstdc++.so.6" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libm.so.6" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libc.so.6" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib64/ld-linux-x86-64.so.2" />
+    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/liblzma.so.5" />
   </ItemGroup>
   <Target Name="PreinstallDumpling"
           BeforeTargets="TestAllProjects">

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -7,18 +7,23 @@
     <DumplingIncPaths Include="$(TestPath)" />
     <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="$HELIX_CORRELATION_PAYLOAD" />
     <!-- Only save off the files that we need.  This list was obatined by using ldd on libcoreclr.so -->
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libgcc_s.so.1" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libpthread.so.0" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/librt.so.1" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/libunwind.so.8" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libdl.so.2" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libuuid.so.1" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/libunwind-x86_64.so.8" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/usr/lib/x86_64-linux-gnu/libstdc++.so.6" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libm.so.6" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/libc.so.6" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib64/ld-linux-x86-64.so.2" />
-    <DumplingIncPaths Condition="'$(TargetOS)'!='Windows_NT'" Include="/lib/x86_64-linux-gnu/liblzma.so.5" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/libgcc_s.so.1" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/libpthread.so.0" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/librt.so.1" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/usr/lib/x86_64-linux-gnu/libunwind.so.8" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/libdl.so.2" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/libuuid.so.1" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/usr/lib/x86_64-linux-gnu/libunwind-x86_64.so.8" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/usr/lib/x86_64-linux-gnu/libstdc++.so.6" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/libm.so.6" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/libc.so.6" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib64/ld-linux-x86-64.so.2" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='Linux'" Include="/lib/x86_64-linux-gnu/liblzma.so.5" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/System/Library/Frameworks/Security.framework/Versions/A/Security" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/usr/lib/libSystem.B.dylib" />
+    <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/usr/lib/libc++.1.dylib" />
   </ItemGroup>
   <Target Name="PreinstallDumpling"
           BeforeTargets="TestAllProjects">

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -73,7 +73,7 @@ def collect_dump(exitcodeStr, folder, startTimeStr, projectName, incpaths):
       sys.executable, dumplingPath, "upload",
       "--dumppath", file,
       "--noprompt",
-      "--triage", "full",
+      "--triage", "none",
       "--displayname", projectName,
       "--properties", "STRESS_TESTID="+projectName
       ], " ");


### PR DESCRIPTION
We started by just collecting all of the SOs in the lib and usr/lib
directories, but that proved to be too big.  This brings the list to
just the files that we need.  This also turns off dump triaging as it is
currently broken and blocking regular collection.