### PR TITLE
Add Repo API common implementation

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -13,6 +13,8 @@
   -->
   <Import Project="$(MSBuildThisFileDirectory)ReferenceAssemblies.props" Condition="'$(ExcludeReferenceAssembliesImport)'!='true'" />
 
+  <Import Project="$(MSBuildThisFileDirectory)RepoAPI.Mapping.props" />
+
   <PropertyGroup>
     <CompilerResponseFile Condition="'$(CheckSumSHA256)'!='false'">$(MSBuildThisFileDirectory)checksum.rsp</CompilerResponseFile>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Provides a default API implementation where possible by setting BuildTools properties/items.
+
+    API documentation: https://github.com/dotnet/source-build/tree/dev/release/2.0/Documentation/auto-dependency-flow
+  -->
+
+  <!-- Produce packages into the specified blob feed. -->
+  <PropertyGroup Condition="'$(DotNetOutputBlobFeedDir)' != ''">
+    <PackageOutputPath>$(DotNetOutputBlobFeedDir)packages/</PackageOutputPath>
+    <SymbolPackageOutputPath>$(DotNetOutputBlobFeedDir)assets/</SymbolPackageOutputPath>
+  </PropertyGroup>
+
+  <!--
+    Import the restore source props file if passed to get "DotNetRestoreSources".
+
+    Note the "!= ''" check rather than Exists. If this API argument is passed but the file doesn't
+    exist, something is wrong and an error should be bubbled up as soon as we know about it.
+  -->
+  <Import Project="$(DotNetRestoreSourcePropsPath)"
+          Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <!-- Use passed NuGet restore sources, if any. -->
+  <PropertyGroup>
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+  </PropertyGroup>
+
+  <!--
+    Populate DotnetSourceList items based on NuGet restore sources from the Repo API plus any
+    additions the repo makes to the RestoreSources property.
+
+    This is used by the "dotnet restore" Exec that uses "source" args. When a repo uses msbuild
+    restore tooling, this ItemGroup is unnecessary.
+  -->
+  <ItemGroup>
+    <DotnetSourceList Include="$(RestoreSources)" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
@@ -23,7 +23,7 @@
 
   <!-- Use passed NuGet restore sources, if any. -->
   <PropertyGroup>
-    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources>$(RestoreSources);$(DotNetRestoreSources)</RestoreSources>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Takes APIs from https://github.com/dotnet/source-build/blob/dev/release/2.0/Documentation/auto-dependency-flow/api.md and sets BuildTools properties/items to implement them.

I used these branches in source-build submodules to try it out:

 * https://github.com/dotnet/standard/compare/dev/release/2.0.0...dagood:flow-api
 * https://github.com/dotnet/corefx/compare/dev/release/2.0.0...dagood:flow-api

I copied the props file directly below the `Build.Common.props` import in those branches to test this out quickly without updating the entire BuildTools package (which could have its own problems).

Confirmed that it works by checking the blob feed dir for the `nupkg`/`symbols.nupkg`s and using `strings` to peek at the DLLs that CoreFX binplaced to `bin/ref/netstandard`.