### PR TITLE
Release/2.0.0 Create Microsoft.DotNet.Build.Tasks.VersionTools package

### DIFF
--- a/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
@@ -15,21 +15,11 @@
     </description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags></tags>
-    <dependencies>
-      <group targetFramework="netstandard1.5">
-        <dependency id="NETStandard.Library" version="1.6.0" />
-        <dependency id="Newtonsoft.Json" version="9.0.1" />
-        <dependency id="NuGet.Packaging" version="4.3.0-preview2-4095" />
-        <dependency id="NuGet.Versioning" version="4.3.0-preview2-4095" />
-        <dependency id="System.Diagnostics.Process" version="4.1.0" />
-        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
-      </group>
-    </dependencies>  </metadata>
+  </metadata>
   <files>
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib\netstandard1.5" />
-    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.VersionTools\*.dll" target="lib\netstandard1.5" />
     <file src="Microsoft.DotNet.Build.Tasks.net45\Microsoft.DotNet.Build.Tasks.dll" target="lib\net46" />
-    <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.VersionTools.net45\*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="build" />
     <file src="..\obj\version.txt" target="" />

--- a/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata minClientVersion="2.8.1">
+    <id>Microsoft.DotNet.Build.Tasks.VersionTools</id>
+    <version>2.0.0-servicing</version>
+    <title>DotNet Build VersionTools</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <summary>DotNet Build VersionTools</summary>
+    <description>This package provides support for updating the versions repo
+    </description>
+    <copyright>Copyright © Microsoft Corporation</copyright>
+    <tags></tags>
+    <dependencies>
+      <group targetFramework="netstandard1.5">
+        <dependency id="NETStandard.Library" version="1.6.0" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="NuGet.Packaging" version="4.3.0-preview2-4095" />
+        <dependency id="NuGet.Versioning" version="4.3.0-preview2-4095" />
+        <dependency id="System.Diagnostics.Process" version="4.1.0" />
+        <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
+      </group>
+    </dependencies>  </metadata>
+  <files>
+    <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.Build.Tasks.net45\Microsoft.DotNet.Build.Tasks.dll" target="lib\net46" />
+    <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
+    <file src="Microsoft.DotNet.VersionTools.net45\*.dll" target="lib\net46" />
+    <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="build" />
+    <file src="..\obj\version.txt" target="" />
+  </files>
+</package>

--- a/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.VersionTools.nuspec
@@ -11,14 +11,13 @@
     <projectUrl>http://go.microsoft.com/fwlink/?LinkId=518631</projectUrl>
     <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <summary>DotNet Build VersionTools</summary>
-    <description>This package provides support for updating the versions repo
-    </description>
+    <description>This package provides support for updating the versions repo</description>
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags></tags>
   </metadata>
   <files>
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib\netstandard1.5" />
-    <file src="Microsoft.DotNet.VersionTools\*.dll" target="lib\netstandard1.5" />
+    <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />
     <file src="Microsoft.DotNet.Build.Tasks.net45\Microsoft.DotNet.Build.Tasks.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.VersionTools.net45\*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\VersionTools.targets" target="build" />


### PR DESCRIPTION
Moving PR from https://github.com/dotnet/buildtools/pull/1702 to target release/2.0.0

This addresses feedback in that PR, except for changing BuildTask and the open question of how to handle versioning.