### PR TITLE
Make VerifyClosure handle an assembly referencing itself

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/VerifyClosure.cs
@@ -302,7 +302,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                     var cycle = depStack.Reverse().ToArray();
                     Log.LogMessage($"Cycle detected for {depAssm.Path} : {PrintCycle(cycle)}.");
 
-                    var suspectAssembly = cycle.First(a => a != root);
+                    var suspectAssembly = cycle.FirstOrDefault(a => a != root) ?? root;
 
                     AssemblyInfo[] existingCycle;
                     if (!suspectCycles.TryGetValue(suspectAssembly, out existingCycle) ||


### PR DESCRIPTION
Don't crash on an assembly with a reference to itself, instead treat it like any other cycle.

This is a busted assembly and we're not going out of our way to special case it, but it will fail the build.

I had seen this before when I passed in an assembly with the same name as a candidate seed to GenFacades and hadn't bothered to fix it since it was user error, but it never hurts to avoid a crash.

Fixes #1712

/cc @danmosemsft 