### PR TITLE
Fixed GenerateDepsJson msbuild task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateDepsJson.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateDepsJson.cs
@@ -183,6 +183,10 @@ namespace Microsoft.DotNet.Build.Tasks
                 JObject platformRuntime = new JObject();
                 JObject platformNative = new JObject();
 
+                // Add mscorlib and System facades to platformRuntime
+                platformRuntime.Add($"runtimes/{rid}/lib/netcoreapp2.0/mscorlib.dll", new JObject());
+                platformRuntime.Add($"runtimes/{rid}/lib/netcoreapp2.0/System.dll", new JObject());
+
                 foreach (var assembly in assemblyNames)
                 {
                     try
@@ -194,9 +198,6 @@ namespace Microsoft.DotNet.Build.Tasks
 
                     }
                 }
-                // Add mscorlib and System facades to platformRuntime
-                platformRuntime.Add($"runtimes/{rid}/lib/netcoreapp2.0/mscorlib.dll", new JObject());
-                platformRuntime.Add($"runtimes/{rid}/lib/netcoreapp2.0/System.dll", new JObject());
 
                 foreach (var nativeAssembly in nonManagedAssemblyFilePaths)
                 {


### PR DESCRIPTION
Prevent failures like

```
C:\git\corefx\src\src.builds(32,5): error MSB4018: The "GenerateDepsJson" task failed unexpectedly.
C:\git\corefx\src\src.builds(32,5): error MSB4018: System.ArgumentException: Can not add property runtimes/win-x64/lib/netcoreapp2.0/mscorlib.dll to Newtonsoft.Json.Linq.JObject. Property with the same name already exists on object.
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Newtonsoft.Json.Linq.JObject.ValidateToken(JToken o, JToken existing)
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Newtonsoft.Json.Linq.JContainer.InsertItem(Int32 index, JToken item, Boolean skipParentCheck)
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Newtonsoft.Json.Linq.JObject.InsertItem(Int32 index, JToken item, Boolean skipParentCheck)
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Newtonsoft.Json.Linq.JContainer.AddInternal(Int32 index, Object content, Boolean skipParentCheck)
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Newtonsoft.Json.Linq.JContainer.Add(Object content)
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Newtonsoft.Json.Linq.JObject.Add(String propertyName, JToken value)
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Microsoft.DotNet.Build.Tasks.GenerateDepsJson.Execute()
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
C:\git\corefx\src\src.builds(32,5): error MSB4018:    at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()
```