### PR TITLE
Introduce mechanism to allow specifying environment to set before running test

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -423,8 +423,11 @@ robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
     </ItemGroup>
 
     <!-- If the PreExecutionTestScript property is set, then it should be set to the full path to a script that will be directly incorporated
-         into the generated runtests.cmd script, immediately before the test is run. This can be used to set a number of JIT stress modes,
-         for example.
+         into the generated runtests script, immediately before the test is run. This can be used to set a number of JIT stress modes,
+         for example. It is intended that this be as late as possible in the generated script, as close as possible to the running of the
+         test. That is why this doesn't appear higher in this file. The idea is that if the included script alters managed code behavior, such as
+         setting various JIT stress modes, we don't want those changes to affect any other managed code invocation (such as test infrastructure
+         written in managed code).
      -->
     <ItemGroup Condition="'$(PreExecutionTestScript)'!=''">
       <TestCommandLines Include="$([System.IO.File]::ReadAllText('$(PreExecutionTestScript)'))" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -422,6 +422,14 @@ robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
       <PostExecutionTestCommandLines Include="move $(UAP_Results_Path)$(XunitTestAssembly).xml .\$(XunitResultsFileName)" />
     </ItemGroup>
 
+    <!-- If the PreExecutionTestScript property is set, then it should be set to the full path to a script that will be directly incorporated
+         into the generated runtests.cmd script, immediately before the test is run. This can be used to set a number of JIT stress modes,
+         for example.
+     -->
+    <ItemGroup Condition="'$(PreExecutionTestScript)'!=''">
+      <TestCommandLines Include="$([System.IO.File]::ReadAllText('$(PreExecutionTestScript)'))" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(Performance)'!='true'">
       <!-- On Windows, call prevents the test command from making execution end prematurely -->
       <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(TestGCStressLevel)' != ''" Include="set COMPlus_GCStress=$(TestGCStressLevel)"/>


### PR DESCRIPTION
Introduce mechanism to allow specifying environment to set before running test

If the msbuild property `PreExecutionTestScript` is set, it must be
a set of script commands that will be incorporated into the generated
runtests script.

For example, this will be used to set JIT stress modes:
```
build-tests.cmd -Release -os:Windows_NT -buildArch:x86 -- /p:WithoutCategories=IgnoreForCI /p:PreExecutionTestScript=c:\SetStressModes.bat
```