### PR TITLE
Add conditions for DownloadFilesTask and DownloadSymbolPackages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/DownloadFilesFromUrl.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/DownloadFilesFromUrl.cs
@@ -38,6 +38,11 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public override bool Execute()
         {
+            if (Items == null || Items.Length <= 0)
+            {
+                return true;
+            }
+
             var filesCreated = new List<ITaskItem>();
             using (HttpClient client = new HttpClient(GetHttpHandler()))
             {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -528,7 +528,8 @@
       Includes the same metadata that was passed in @(SymbolPackagesToDownload)
       If this itemgroup is empty the task failed to download the files.
   -->
-  <Target Name="DownloadAndUnzipSymbolPackage">
+  <Target Name="DownloadAndUnzipSymbolPackage"
+          Condition="'@(SymbolPackagesToDownload)' != ''">
 
       <DownloadFilesFromUrl Items="@(SymbolPackagesToDownload)"
                            DestinationDir="$(SymbolPackagesDir)"
@@ -539,7 +540,7 @@
       <ZipFileExtractToDirectory SourceArchive="%(SymbolPackagesDownloaded.Identity)"
                                  DestinationDirectory="%(SymbolPackagesDownloaded.UnzipDestinationDir)"
                                  OverwriteDestination="true"
-                                 Condition="@(SymbolPackagesDownloaded) != ''" />
+                                 Condition="'@(SymbolPackagesDownloaded)' != ''" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Do nothing when SymbolPackagesToDownload is empty.

cc: @weshaggard 