### PR TITLE
Rename ConvertPdbsToPortablePdbs to ConvertPortablePdbsToWindowsPdbs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ConvertPortablePdbsToWindowsPdbs.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ConvertPortablePdbsToWindowsPdbs.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using Microsoft.DiaSymReader.Tools;
 using System;
 using System.Globalization;
@@ -13,7 +12,7 @@ using System.Reflection.PortableExecutable;
 
 namespace Microsoft.DotNet.Build.Tasks
 {
-    public class ConvertPdbsToPortablePdbs : BuildTask
+    public class ConvertPortablePdbsToWindowsPdbs : BuildTask
     {
         private const string PdbPathMetadata = "PdbPath";
         private const string TargetPathMetadata = "TargetPath";

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -75,7 +75,7 @@
     <Compile Include="VersionTools\LocalUpdatePublishedVersions.cs" />
     <Compile Include="VersionTools\UpdatePublishedVersions.cs" />
     <Compile Include="VersionTools\VerifyDependencies.cs" />
-    <Compile Include="ConvertPdbsToPortablePdbs.cs" />
+    <Compile Include="ConvertPortablePdbsToWindowsPdbs.cs" />
     <Compile Include="VisitProjectDependencies.cs" />
     <Compile Include="ValidateProjectDependencyVersions.cs" />
     <Compile Include="WriteSigningRequired.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Symbols.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="AddItemIndices" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ConvertPdbsToPortablePdbs" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ConvertPortablePdbsToWindowsPdbs" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="DownloadFilesFromUrl" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ExecWithRetries" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
@@ -505,8 +505,8 @@
       </PortableFileToConvert>
     </ItemGroup>
 
-    <ConvertPdbsToPortablePdbs Files="@(PortableFileToConvert)"
-                               ConversionOptions="@(ConversionOptions)" />
+    <ConvertPortablePdbsToWindowsPdbs Files="@(PortableFileToConvert)"
+                                      ConversionOptions="@(ConversionOptions)" />
   </Target>
 
   <!--


### PR DESCRIPTION
Fixes https://github.com/dotnet/buildtools/issues/1735. I want to fix this before someone gets a chance to start relying on this build task's name outside of the BuildTools targets.

Thanks for spotting this, @vancem!