### PR TITLE
Fix GenApi so that when creating a PNSE Assembly Deconstructors throw as well

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Cci.Writers.CSharp
             WriteIdentifier(((INamedEntity)method.ContainingTypeDefinition).Name);
             WriteSymbol("(");
             WriteSymbol(")", false);
-            WriteEmptyBody();
+            WriteMethodBody(method);
         }
 
         private void WriteTypeName(ITypeReference type, ITypeReference containingType, bool isDynamic = false)


### PR DESCRIPTION
Currently for deconstructors we're just producing an empty body and this causes the build to fail if we are generating a PNSE Assembly because in implementation deconstroctors must have a body. This doesn't hurt the regular GenApi scenario of creating an AssemblyReference since `_platformNotSupportedExceptionMessage` will be null and it will produce an empty body. I've tested both scenarios locally and they work fine. 

cc: @weshaggard 

FYI: @pjanotti 