### PR TITLE
Increase timeout in DownloadFromAzure task

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 int failureCount = 0;
                 using (HttpClient client = new HttpClient())
                 {
+                    client.Timeout = TimeSpan.FromMinutes(10);
                     foreach (string blob in blobNames)
                     {
                         Log.LogMessage(MessageImportance.Low, "Downloading BLOB - {0}", blob);


### PR DESCRIPTION
Builds are failing because Downloading large payloads in parallel is causing timeouts. Increase the timeout to 10 minutes.