### PR TITLE
Add feed package to buildtools init

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,3 +1,4 @@
 Microsoft.DotNet.BuildTools=1.0.27-prerelease-01205-03
 Microsoft.DotNet.BuildTools.Run=1.0.1-prerelease-01205-03
+Microsoft.DotNet.Build.Tasks.Feed=1.0.0-prerelease-02119-02
 NuGet.CommandLine=3.4.3

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Publish.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Publish.targets
@@ -1,6 +1,10 @@
 <Project ToolsVersion="12.0" DefaultTargets="PublishOutputLeg" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="PushToBlobFeed" AssemblyFile="$(MSBuildThisFileDirectory)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   
+    <ItemGroup Condition="'$(ItemsToPushGlobPattern)' != ''">
+      <ItemsToPush Include="$(ItemsToPushGlobPattern)" />
+    </ItemGroup>
+
     <!-- This is the standard publish target. It can be used to publish assets for the intermediate output of individual build legs and
          the finalized output of an official build. 
          ExpectedFeedUrl - The url of the nuget feed you would like to generate (should contain the storage account, container and relative path) and end with index.json
@@ -21,7 +25,7 @@
       <Error Text="The AccountKey property must be set on the command line."  
             Condition="'$(AccountKey)' == ''" />
       
-      <Message Importance="High" Text="Publish to $(ContainerName) started" />
+      <Message Importance="High" Text="Publish to container started" />
       <PushToBlobFeed ExpectedFeedUrl="$(ExpectedFeedUrl)"
                       AccountKey="$(AccountKey)"
                       ItemsToPush="@(ItemsToPush)"


### PR DESCRIPTION
1. Adds the feed package to .toolsversions so that we can publish in the official build def and not have a chicken-egg problem which may occur if we used the version of feeds from the current build

2. ie, it'd be nice if there was a way to use this package without having to always define a wrapper project in the repo which is used simply to define itemstopush and to pass through the rest of the variables..  