### PR TITLE
[release/2.0.0] Only set [Symbol]PackageOutputPath if empty

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
@@ -8,8 +8,8 @@
 
   <!-- Produce packages into the specified blob feed. -->
   <PropertyGroup Condition="'$(DotNetOutputBlobFeedDir)' != ''">
-    <PackageOutputPath>$(DotNetOutputBlobFeedDir)packages/</PackageOutputPath>
-    <SymbolPackageOutputPath>$(DotNetOutputBlobFeedDir)assets/</SymbolPackageOutputPath>
+    <PackageOutputPath Condition="'$(PackageOutputPath)' == ''">$(DotNetOutputBlobFeedDir)packages/</PackageOutputPath>
+    <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(DotNetOutputBlobFeedDir)assets/</SymbolPackageOutputPath>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This is generally friendlier in the MSBuild ecosystem. It allows the repo to provide a PackageOutputProps in dir.props if it knows better.

I checked to make sure CoreCLR, CoreFX, and Standard set [Symbol]PackageOutputPath after the `Build.Common.props` import, so this won't break them.

Small change that @eerhardt mentioned when he hit a hard `<PackageOutputPath>foo</PackageOutputPath>` in Core-Setup.