### PR TITLE
[release/2.0.0] Allow maintainers to modify auto PRs by default.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -103,6 +103,10 @@
   -->
   <Target Name="UpdateDependenciesAndSubmitPullRequest"
           DependsOnTargets="CreateDefaultDependencyInfos">
+    <PropertyGroup>
+      <MaintainersCanModifyPullRequest Condition="'$(MaintainersCanModifyPullRequest)' == ''">true</MaintainersCanModifyPullRequest>
+    </PropertyGroup>
+
     <UpdateDependenciesAndSubmitPullRequest DependencyInfo="@(DependencyInfo)"
                                             ProjectJsonFiles="@(ProjectJsonFiles)"
                                             UpdateStep="@(UpdateStep)"
@@ -116,6 +120,7 @@
                                             NotifyGitHubUsers="@(NotifyGitHubUsers)"
                                             CurrentRefXmlPath="$(CurrentRefXmlPath)"
                                             AlwaysCreateNewPullRequest="$(AlwaysCreateNewPullRequest)"
+                                            MaintainersCanModifyPullRequest="$(MaintainersCanModifyPullRequest)"
                                             CommitMessage="$(CommitMessage)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependenciesAndSubmitPullRequest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependenciesAndSubmitPullRequest.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
 
         public bool AlwaysCreateNewPullRequest { get; set; }
 
+        public bool MaintainersCanModifyPullRequest { get; set; }
+
         /// <summary>
         /// A commit message to use instead of the default generated message.
         /// </summary>
@@ -62,7 +64,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                         CommitMessage,
                         CommitMessage + $" ({ProjectRepoBranch})",
                         body,
-                        forceCreate: AlwaysCreateNewPullRequest).Wait();
+                        forceCreate: AlwaysCreateNewPullRequest,
+                        maintainersCanModify: MaintainersCanModifyPullRequest).Wait();
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -123,7 +123,8 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             string title,
             string description,
             GitHubBranch headBranch,
-            GitHubBranch baseBranch)
+            GitHubBranch baseBranch,
+            bool maintainersCanModify)
         {
             EnsureAuthenticated();
 
@@ -132,7 +133,8 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
                 title = title,
                 body = description,
                 head = $"{headBranch.Project.Owner}:{headBranch.Name}",
-                @base = baseBranch.Name
+                @base = baseBranch.Name,
+                maintainer_can_modify = maintainersCanModify
             }, Formatting.Indented);
 
             string pullUrl = $"https://api.github.com/repos/{baseBranch.Project.Segments}/pulls";
@@ -152,7 +154,8 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             int number,
             string title = null,
             string body = null,
-            string state = null)
+            string state = null,
+            bool? maintainersCanModify = null)
         {
             EnsureAuthenticated();
 
@@ -169,6 +172,10 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             if (state != null)
             {
                 updatePrBody.Add(new JProperty("state", state));
+            }
+            if (maintainersCanModify != null)
+            {
+                updatePrBody.Add(new JProperty("maintainer_can_modify", maintainersCanModify.Value));
             }
 
             string url = $"https://api.github.com/repos/{project.Segments}/pulls/{number}";

--- a/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
@@ -48,7 +48,8 @@ namespace Microsoft.DotNet.VersionTools.Automation
             string commitMessage,
             string title,
             string description,
-            bool forceCreate = false)
+            bool forceCreate = false,
+            bool maintainersCanModify = true)
         {
             var upstream = UpstreamBranch.Project;
 
@@ -110,11 +111,21 @@ namespace Microsoft.DotNet.VersionTools.Automation
 
                 if (pullRequestToUpdate != null)
                 {
-                    await client.UpdateGitHubPullRequestAsync(upstream, pullRequestToUpdate.Number, title, description);
+                    await client.UpdateGitHubPullRequestAsync(
+                        upstream,
+                        pullRequestToUpdate.Number,
+                        title,
+                        description,
+                        maintainersCanModify: maintainersCanModify);
                 }
                 else
                 {
-                    await client.PostGitHubPullRequestAsync(title, description, originBranch, UpstreamBranch);
+                    await client.PostGitHubPullRequestAsync(
+                        title,
+                        description,
+                        originBranch,
+                        UpstreamBranch,
+                        maintainersCanModify);
                 }
             }
         }


### PR DESCRIPTION
Port https://github.com/dotnet/buildtools/pull/1686 to `release/2.0.0`. Porting this will help with merge conflicts vs. `master` when forward-porting VersionTools features. (It's also a very useful feature.)