### PR TITLE
(Port to master) Add "UpdateToRemote" concept for better submodule update

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -69,7 +69,9 @@
     <Compile Include="ValidateExactRestore.cs" />
     <Compile Include="VersionTools\BaseDependenciesTask.cs" />
     <Compile Include="VersionTools\MsBuildTraceListener.cs" />
+    <Compile Include="VersionTools\TaskItemBuildDependencyInfo.cs" />
     <Compile Include="VersionTools\UpdateDependenciesAndSubmitPullRequest.cs" />
+    <Compile Include="VersionTools\UpdateToRemoteDependencies.cs" />
     <Compile Include="VersionTools\TraceListenerCollectionExtensions.cs" />
     <Compile Include="VersionTools\UpdateDependencies.cs" />
     <Compile Include="VersionTools\LocalUpdatePublishedVersions.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -1,25 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <UsingTask TaskName="LocalUpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdateDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdateDependenciesAndSubmitPullRequest" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="UpdateToRemoteDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="VerifyDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
   <PropertyGroup>
     <!-- Cache of build info files retrieved from versions repository. -->
     <BuildInfoCacheDir>$(ToolsDir)BuildInfoCache/</BuildInfoCacheDir>
   </PropertyGroup>
 
-  <!-- For backward compatibility, Include XmlUpdateSteps as Xml-type updaters. -->
-  <ItemGroup>
-    <UpdateStep Include="@(XmlUpdateStep)">
-      <UpdaterType>Xml</UpdaterType>
-    </UpdateStep>
-  </ItemGroup>
-
-  <!-- Tasks to update the dotnet/versions repository. -->
-  <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-  <UsingTask TaskName="LocalUpdatePublishedVersions" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
   <ItemGroup Condition="'$(ShippedNuGetPackageGlobPath)'!=''">
     <ShippedNuGetPackage Include="$(ShippedNuGetPackageGlobPath)" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(NotifyGitHubUsers)'!=''">
+    <NotifyGitHubUsers Include="$(NotifyGitHubUsers)" />
+  </ItemGroup>
+
+  <Target Name="CreateDefaultDependencyInfos">
+    <ItemGroup>
+      <!-- For backward compatibility, Include XmlUpdateSteps as Xml-type updaters. -->
+      <UpdateStep Include="@(XmlUpdateStep)">
+        <UpdaterType>Xml</UpdaterType>
+      </UpdateStep>
+
+      <!-- For backward compatibility, create DependencyInfos for DependencyBuildInfos. -->
+      <DependencyInfo Include="@(DependencyBuildInfo)">
+        <DependencyType>Build</DependencyType>
+      </DependencyInfo>
+
+      <!--
+        For submodule updaters with no matching custom DependencyInfo, create default ones.
+        The metadata names match up.
+      -->
+      <DependencyInfo Include="@(UpdateStep)"
+                      Condition="'%(UpdateStep.UpdaterType)' == 'Submodule from latest'">
+        <DependencyType>Submodule</DependencyType>
+      </DependencyInfo>
+    </ItemGroup>
+  </Target>
 
   <Target Name="UpdatePublishedVersions">
     <UpdatePublishedVersions ShippedNuGetPackage="@(ShippedNuGetPackage)"
@@ -37,28 +60,21 @@
                                   VersionsRepoPath="$(VersionsRepoPath)" />
   </Target>
 
-  <!-- Task to update dependencies to expected values. -->
-  <UsingTask TaskName="UpdateDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
-  <ItemGroup Condition="'$(NotifyGitHubUsers)'!=''">
-    <NotifyGitHubUsers Include="$(NotifyGitHubUsers)" />
-  </ItemGroup>
-
-  <Target Name="UpdateDependencies">
-    <UpdateDependencies DependencyBuildInfo="@(DependencyBuildInfo)"
+  <Target Name="UpdateDependencies"
+          DependsOnTargets="CreateDefaultDependencyInfos">
+    <UpdateDependencies DependencyInfo="@(DependencyInfo)"
                         ProjectJsonFiles="@(ProjectJsonFiles)"
                         UpdateStep="@(UpdateStep)"
                         BuildInfoCacheDir="$(BuildInfoCacheDir)" />
   </Target>
 
-  <!-- Task to perform dependency verification. -->
-  <UsingTask TaskName="VerifyDependencies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
-
-  <Target Name="VerifyDependencies" Condition="'$(SkipVerifyPackageVersions)'!='true'">
+  <Target Name="VerifyDependencies"
+          DependsOnTargets="CreateDefaultDependencyInfos"
+          Condition="'$(SkipVerifyPackageVersions)'!='true'">
     <!-- Add message so it's clear what's happening when building with verbosity:minimal. For example, "sync -p". -->
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Verifying all auto-upgradeable dependencies..." />
 
-    <VerifyDependencies DependencyBuildInfo="@(DependencyBuildInfo)"
+    <VerifyDependencies DependencyInfo="@(DependencyInfo)"
                         ProjectJsonFiles="@(ProjectJsonFiles)"
                         UpdateStep="@(UpdateStep)"
                         BuildInfoCacheDir="$(BuildInfoCacheDir)" />
@@ -66,15 +82,32 @@
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Verifying all auto-upgradeable dependencies... Done." />
   </Target>
 
-  <!-- Task to create a dependency update pull request. -->
-  <UsingTask TaskName="UpdateDependenciesAndSubmitPullRequest" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <!--
+    Update to the latest dependencies available remotely. A "UpdateDependencies" call uses the local
+    source of truth, but this looks up the latest truth on the remote. For example, this uses the
+    latest dotnet/versions remote commit for build-infos, and it uses the project's GitHub
+    repository to find the latest commit for a submodule.
 
-  <Target Name="UpdateDependenciesAndSubmitPullRequest">
+    If using the remote causes any updates, the local source of truth is modified to match it.
+  -->
+  <Target Name="UpdateToRemoteDependencies"
+          DependsOnTargets="CreateDefaultDependencyInfos">
+    <UpdateToRemoteDependencies DependencyInfo="@(DependencyInfo)"
+                                ProjectJsonFiles="@(ProjectJsonFiles)"
+                                UpdateStep="@(UpdateStep)"
+                                CurrentRefXmlPath="$(CurrentRefXmlPath)" />
+  </Target>
+
+  <!--
+    Update to the latest dependencies available remotely, then submit a pull request.
+  -->
+  <Target Name="UpdateDependenciesAndSubmitPullRequest"
+          DependsOnTargets="CreateDefaultDependencyInfos">
     <PropertyGroup>
       <MaintainersCanModifyPullRequest Condition="'$(MaintainersCanModifyPullRequest)' == ''">true</MaintainersCanModifyPullRequest>
     </PropertyGroup>
 
-    <UpdateDependenciesAndSubmitPullRequest DependencyBuildInfo="@(DependencyBuildInfo)"
+    <UpdateDependenciesAndSubmitPullRequest DependencyInfo="@(DependencyInfo)"
                                             ProjectJsonFiles="@(ProjectJsonFiles)"
                                             UpdateStep="@(UpdateStep)"
                                             ProjectRepoName="$(ProjectRepoName)"
@@ -87,6 +120,7 @@
                                             NotifyGitHubUsers="@(NotifyGitHubUsers)"
                                             CurrentRefXmlPath="$(CurrentRefXmlPath)"
                                             AlwaysCreateNewPullRequest="$(AlwaysCreateNewPullRequest)"
-                                            MaintainersCanModifyPullRequest="$(MaintainersCanModifyPullRequest)" />
+                                            MaintainersCanModifyPullRequest="$(MaintainersCanModifyPullRequest)"
+                                            CommitMessage="$(CommitMessage)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using Microsoft.DotNet.VersionTools;
 using Microsoft.DotNet.VersionTools.Dependencies;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using Microsoft.DotNet.VersionTools.Dependencies.Submodule;
 using System;
 using System.Collections.Generic;
@@ -22,14 +22,12 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
         internal const string VersionsRepoDirMetadataName = "VersionsRepoDir";
         internal const string BuildInfoPathMetadataName = "BuildInfoPath";
         internal const string CurrentRefMetadataName = "CurrentRef";
-        internal const string CurrentBranchMetadataName = "CurrentBranch";
         internal const string PackageIdMetadataName = "PackageId";
         internal const string VersionMetadataName = "Version";
-
-        internal const string AutoUpgradeBranchMetadataName = "Version";
+        internal const string DependencyTypeMetadataName = "DependencyType";
 
         [Required]
-        public ITaskItem[] DependencyBuildInfo { get; set; }
+        public ITaskItem[] DependencyInfo { get; set; }
 
         public ITaskItem[] ProjectJsonFiles { get; set; }
 
@@ -112,11 +110,41 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
             }
         }
 
-        protected IEnumerable<DependencyBuildInfo> CreateBuildInfoDependencies()
+        protected IEnumerable<IDependencyInfo> CreateLocalDependencyInfos()
         {
-            return DependencyBuildInfo
-                ?.Select(item => CreateBuildInfoDependency(item, BuildInfoCacheDir))
-                ?? Enumerable.Empty<DependencyBuildInfo>();
+            return CreateDependencyInfos(false, null);
+        }
+
+        protected IEnumerable<IDependencyInfo> CreateDependencyInfos(
+            bool remote,
+            string versionsCommit)
+        {
+            foreach (ITaskItem info in DependencyInfo ?? Enumerable.Empty<ITaskItem>())
+            {
+                string type = info.GetMetadata("DependencyType");
+                switch (type)
+                {
+                    case "Build":
+                        if (versionsCommit != null)
+                        {
+                            ReplaceExistingMetadata(info, CurrentRefMetadataName, versionsCommit);
+                        }
+                        yield return CreateBuildInfoDependency(info, BuildInfoCacheDir);
+                        break;
+
+                    case "Submodule":
+                        yield return SubmoduleDependencyInfo.Create(
+                            GetRequiredMetadata(info, "Repository"),
+                            GetRequiredMetadata(info, "Ref"),
+                            GetRequiredMetadata(info, "Path"),
+                            remote);
+                        break;
+
+                    default:
+                        throw new NotSupportedException(
+                            $"Unsupported DependencyInfo '{info.ItemSpec}': DependencyType '{type}'.");
+                }
+            }
         }
 
         private FileRegexUpdater CreateXmlUpdater(ITaskItem step)
@@ -146,7 +174,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
             return updater;
         }
 
-        private static DependencyBuildInfo CreateBuildInfoDependency(ITaskItem item, string cacheDir)
+        private static TaskItemBuildDependencyInfo CreateBuildInfoDependency(ITaskItem item, string cacheDir)
         {
             BuildInfo info = CreateBuildInfo(item, cacheDir);
 
@@ -158,7 +186,11 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                 .GetMetadata("DisabledPackages")
                 .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
-            return new DependencyBuildInfo(info, updateStaticDependencies, disabledPackages);
+            return new TaskItemBuildDependencyInfo(
+                info,
+                updateStaticDependencies,
+                disabledPackages,
+                item);
         }
 
         private static BuildInfo CreateBuildInfo(ITaskItem item, string cacheDir)
@@ -173,12 +205,6 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
             string rawVersionsBaseUrl = item.GetMetadata(RawVersionsBaseUrlMetadataName);
             string buildInfoPath = item.GetMetadata(BuildInfoPathMetadataName);
             string currentRef = item.GetMetadata(CurrentRefMetadataName);
-            // Optional
-            string currentBranch = item.GetMetadata(CurrentBranchMetadataName);
-            if (!string.IsNullOrEmpty(currentBranch) && !string.IsNullOrEmpty(buildInfoPath))
-            {
-                buildInfoPath = $"{buildInfoPath}/{currentBranch}";
-            }
 
             // Optional: override base url with a local directory.
             string versionsRepoDir = item.GetMetadata(VersionsRepoDirMetadataName);
@@ -234,6 +260,14 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                     $"On '{item.ItemSpec}', did not find required '{name}' metadata.");
             }
             return metadata;
+        }
+
+        private static void ReplaceExistingMetadata(ITaskItem item, string name, string value)
+        {
+            if (!string.IsNullOrEmpty(item.GetMetadata(name)))
+            {
+                item.SetMetadata(name, value);
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/TaskItemBuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/TaskItemBuildDependencyInfo.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.VersionTools;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Build.Tasks.VersionTools
+{
+    public class TaskItemBuildDependencyInfo : BuildDependencyInfo
+    {
+        /// <summary>
+        /// MSBuild item used to create this DependencyInfo.
+        /// </summary>
+        public ITaskItem SourceItem { get; }
+
+        public TaskItemBuildDependencyInfo(
+            BuildInfo buildInfo,
+            bool upgradeStableVersions,
+            IEnumerable<string> disabledPackages,
+            ITaskItem sourceItem)
+            : base(buildInfo, upgradeStableVersions, disabledPackages)
+        {
+            SourceItem = sourceItem;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateDependencies.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
         {
             DependencyUpdateUtils.Update(
                 CreateUpdaters().ToArray(),
-                CreateBuildInfoDependencies().ToArray());
+                CreateLocalDependencyInfos().ToArray());
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateToRemoteDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateToRemoteDependencies.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.VersionTools;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Build.Tasks.VersionTools
+{
+    public class UpdateToRemoteDependencies : BaseDependenciesTask
+    {
+        public string CurrentRefXmlPath { get; set; }
+
+        /// <summary>
+        /// If provided, GitHub authentication info is used to fetch the remote dotnet/versions
+        /// commit. The anonymous user rate limit is small, and this can be used to use an account's
+        /// quota instead. The "...AndSubmitPullRequest" subclass also uses this to create the PR.
+        /// </summary>
+        public string GitHubAuthToken { get; set; }
+        public string GitHubUser { get; set; }
+        public string GitHubEmail { get; set; }
+
+        protected override void TraceListenedExecute()
+        {
+            using (GitHubClient client = CreateClient(allowAnonymous: true))
+            {
+                DependencyUpdateResults updateResults = UpdateToRemote(client);
+
+                Log.LogMessage(
+                    MessageImportance.Low,
+                    $"Suggested commit message: '{updateResults.GetSuggestedCommitMessage()}'");
+            }
+        }
+
+        protected GitHubClient CreateClient(bool allowAnonymous)
+        {
+            GitHubAuth gitHubAuth = null;
+            if (string.IsNullOrEmpty(GitHubAuthToken))
+            {
+                if (allowAnonymous)
+                {
+                    Log.LogMessage(
+                        MessageImportance.Low,
+                        $"No value for '{nameof(GitHubAuthToken)}'. " +
+                        "Accessing GitHub API anonymously.");
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"Required argument '{nameof(GitHubAuthToken)}' is null or empty.");
+                }
+            }
+            else
+            {
+                gitHubAuth = new GitHubAuth(GitHubAuthToken, GitHubUser, GitHubEmail);
+            }
+
+            return new GitHubClient(gitHubAuth);
+        }
+
+        protected DependencyUpdateResults UpdateToRemote(GitHubClient client)
+        {
+            // Use the commit hash of the remote dotnet/versions repo master branch.
+            string versionsCommitHash = client
+                .GetReferenceAsync(new GitHubProject("versions", "dotnet"), "heads/master")
+                .Result.Object.Sha;
+
+            DependencyUpdateResults updateResults = DependencyUpdateUtils.Update(
+                CreateUpdaters().ToArray(),
+                CreateDependencyInfos(true, versionsCommitHash).ToArray());
+
+            // Update CurrentRef for each applicable build info used.
+            if (!string.IsNullOrEmpty(CurrentRefXmlPath))
+            {
+                foreach (ITaskItem item in updateResults.UsedInfos
+                    .OfType<TaskItemBuildDependencyInfo>()
+                    .Distinct()
+                    .Select(info => info.SourceItem)
+                    .Where(item => !string.IsNullOrEmpty(item.GetMetadata(CurrentRefMetadataName))))
+                {
+                    UpdateProperty(
+                        CurrentRefXmlPath,
+                        $"{item.ItemSpec}{CurrentRefMetadataName}",
+                        versionsCommitHash);
+                }
+            }
+
+            return updateResults;
+        }
+
+        private void UpdateProperty(string path, string elementName, string newValue)
+        {
+            const string valueGroup = "valueGroup";
+            Action updateAction = FileUtils.GetUpdateFileContentsTask(
+                path,
+                contents =>
+                {
+                    Group g = CreateXmlUpdateRegex(elementName, valueGroup)
+                        .Match(contents)
+                        .Groups[valueGroup];
+
+                    return contents
+                        .Remove(g.Index, g.Length)
+                        .Insert(g.Index, newValue);
+                });
+            // There may not be an task to perform for the value to be up to date: allow null.
+            updateAction?.Invoke();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/VerifyDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/VerifyDependencies.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
             IEnumerable<DependencyUpdateTask> updateTasks = DependencyUpdateUtils
                 .GetUpdateTasks(
                     CreateUpdaters().ToArray(),
-                    CreateBuildInfoDependencies().ToArray())
+                    CreateLocalDependencyInfos().ToArray())
                 .ToArray();
 
             if (updateTasks.Any())

--- a/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdateUtils.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/DependencyUpdateUtils.cs
@@ -11,24 +11,28 @@ namespace Microsoft.DotNet.VersionTools.Automation
     public static class DependencyUpdateUtils
     {
         /// <summary>
-        /// Runs the updaters given using buildInfo sources, and returns information about the
-        /// updates performed, such as a recommended commit name based on the BuildInfos used.
+        /// Runs the updaters given using given dependency info sources. Returns information about
+        /// the updates performed, such as a recommended commit name.
         /// </summary>
         public static DependencyUpdateResults Update(
             IEnumerable<IDependencyUpdater> updaters,
-            IEnumerable<DependencyBuildInfo> buildInfoDependencies)
+            IEnumerable<IDependencyInfo> dependencyInfos)
         {
-            IEnumerable<BuildInfo> distinctUsedBuildInfos = GetUpdateTasks(updaters, buildInfoDependencies)
+            IEnumerable<DependencyUpdateTask> updateTasks = GetUpdateTasks(
+                updaters,
+                dependencyInfos);
+
+            IDependencyInfo[] distinctUsedDependencyInfos = updateTasks
                 .Select(task =>
                 {
                     task.Start();
                     return task.Result;
                 })
-                .SelectMany(results => results.UsedBuildInfos)
+                .SelectMany(results => results.UsedInfos)
                 .Distinct()
                 .ToArray();
 
-            return new DependencyUpdateResults(distinctUsedBuildInfos);
+            return new DependencyUpdateResults(distinctUsedDependencyInfos);
         }
 
         /// <summary>
@@ -36,9 +40,9 @@ namespace Microsoft.DotNet.VersionTools.Automation
         /// </summary>
         public static IEnumerable<DependencyUpdateTask> GetUpdateTasks(
             IEnumerable<IDependencyUpdater> updaters,
-            IEnumerable<DependencyBuildInfo> buildInfoDependencies)
+            IEnumerable<IDependencyInfo> dependencyInfos)
         {
-            return updaters.SelectMany(updater => updater.GetUpdateTasks(buildInfoDependencies));
+            return updaters.SelectMany(updater => updater.GetUpdateTasks(dependencyInfos));
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/BuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/BuildDependencyInfo.cs
@@ -7,9 +7,9 @@ using NuGet.Versioning;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.DotNet.VersionTools.Dependencies
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput
 {
-    public class DependencyBuildInfo
+    public class BuildDependencyInfo : IDependencyInfo
     {
         public BuildInfo BuildInfo { get; }
 
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
         /// </summary>
         public IEnumerable<PackageIdentity> Packages { get; }
 
-        public DependencyBuildInfo(
+        public BuildDependencyInfo(
             BuildInfo buildInfo,
             bool upgradeStableVersions,
             IEnumerable<string> disabledPackages)
@@ -47,5 +47,9 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
                 .Select(pair => new PackageIdentity(pair.Key, new NuGetVersion(pair.Value)))
                 .ToArray();
         }
+
+        public string SimpleName => BuildInfo.Name;
+
+        public string SimpleVersion => BuildInfo.LatestReleaseVersion;
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FilePackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FilePackageUpdater.cs
@@ -6,8 +6,9 @@ using Microsoft.DotNet.VersionTools.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
-namespace Microsoft.DotNet.VersionTools.Dependencies
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput
 {
     public class FilePackageUpdater : IDependencyUpdater
     {
@@ -16,9 +17,9 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
         public string PackageId { get; set; }
 
         public IEnumerable<DependencyUpdateTask> GetUpdateTasks(
-            IEnumerable<DependencyBuildInfo> dependencyBuildInfos)
+            IEnumerable<IDependencyInfo> dependencyInfos)
         {
-            foreach (var info in dependencyBuildInfos)
+            foreach (BuildDependencyInfo info in dependencyInfos.OfType<BuildDependencyInfo>())
             {
                 string version;
                 if (info.RawPackages.TryGetValue(PackageId, out version))
@@ -46,7 +47,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
                     {
                         yield return new DependencyUpdateTask(
                             updateTask,
-                            new[] { info.BuildInfo },
+                            new[] { info },
                             new[] { $"In '{Path}', '{originalValue}' must be '{version}'." });
                     }
                     yield break;

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FileRegexPackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FileRegexPackageUpdater.cs
@@ -6,28 +6,29 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace Microsoft.DotNet.VersionTools.Dependencies
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput
 {
     public class FileRegexPackageUpdater : FileRegexUpdater
     {
         public string PackageId { get; set; }
 
         protected override string TryGetDesiredValue(
-            IEnumerable<DependencyBuildInfo> dependencyBuildInfos,
-            out IEnumerable<BuildInfo> usedBuildInfos)
+            IEnumerable<IDependencyInfo> dependencyInfos,
+            out IEnumerable<IDependencyInfo> usedDependencyInfos)
         {
-            var matchingBuildInfo = dependencyBuildInfos
+            var matchingBuildInfo = dependencyInfos
+                .OfType<BuildDependencyInfo>()
                 .FirstOrDefault(d => d.RawPackages.ContainsKey(PackageId));
 
             if (matchingBuildInfo == null)
             {
-                usedBuildInfos = Enumerable.Empty<BuildInfo>();
+                usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
 
                 Trace.TraceError($"Could not find package version information for '{PackageId}'");
                 return $"DEPENDENCY '{PackageId}' NOT FOUND";
             }
 
-            usedBuildInfos = new[] { matchingBuildInfo.BuildInfo };
+            usedDependencyInfos = new[] { matchingBuildInfo };
 
             return matchingBuildInfo.RawPackages[PackageId];
         }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FileRegexReleaseUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FileRegexReleaseUpdater.cs
@@ -6,31 +6,31 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace Microsoft.DotNet.VersionTools.Dependencies
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput
 {
     public class FileRegexReleaseUpdater : FileRegexUpdater
     {
         public string BuildInfoName { get; set; }
 
         protected override string TryGetDesiredValue(
-            IEnumerable<DependencyBuildInfo> dependencyBuildInfos,
-            out IEnumerable<BuildInfo> usedBuildInfos)
+            IEnumerable<IDependencyInfo> dependencyInfos,
+            out IEnumerable<IDependencyInfo> usedDependencyInfos)
         {
-            BuildInfo project = dependencyBuildInfos
-                .Select(d => d.BuildInfo)
-                .SingleOrDefault(d => d.Name == BuildInfoName);
+            BuildDependencyInfo project = dependencyInfos
+                .OfType<BuildDependencyInfo>()
+                .SingleOrDefault(d => d.BuildInfo.Name == BuildInfoName);
 
             if (project == null)
             {
-                usedBuildInfos = Enumerable.Empty<BuildInfo>();
+                usedDependencyInfos = Enumerable.Empty<IDependencyInfo>();
 
                 Trace.TraceError($"Could not find build info for project named {BuildInfoName}");
                 return $"PROJECT '{BuildInfoName}' NOT FOUND";
             }
 
-            usedBuildInfos = new[] { project };
+            usedDependencyInfos = new[] { project };
 
-            return project.LatestReleaseVersion;
+            return project.BuildInfo.LatestReleaseVersion;
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/DependencyUpdateTask.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/DependencyUpdateTask.cs
@@ -16,23 +16,23 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
     public class DependencyUpdateTask : Task<DependencyUpdateResults>
     {
         /// <summary>
-        /// The build infos that would be used during this update.
+        /// The dependency infos that were used to create this update task.
         /// </summary>
-        public IEnumerable<BuildInfo> UsedBuildInfos { get; }
+        public IEnumerable<IDependencyInfo> UsedInfos { get; }
 
         public IEnumerable<string> ReadableDescriptionLines { get; }
 
         public DependencyUpdateTask(
             Action updateAction,
-            IEnumerable<BuildInfo> usedBuildInfos,
+            IEnumerable<IDependencyInfo> usedInfos,
             IEnumerable<string> readableDescriptionLines)
             : base(() =>
             {
                 updateAction();
-                return new DependencyUpdateResults(usedBuildInfos);
+                return new DependencyUpdateResults(usedInfos);
             })
         {
-            UsedBuildInfos = usedBuildInfos;
+            UsedInfos = usedInfos;
             ReadableDescriptionLines = readableDescriptionLines;
         }
     }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using Microsoft.DotNet.VersionTools.Util;
 using System;
 using System.Collections.Generic;
@@ -17,10 +18,10 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
         public Regex Regex { get; set; }
         public string VersionGroupName { get; set; }
 
-        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<DependencyBuildInfo> dependencyBuildInfos)
+        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos)
         {
-            IEnumerable<BuildInfo> usedBuildInfos;
-            string newValue = TryGetDesiredValue(dependencyBuildInfos, out usedBuildInfos);
+            IEnumerable<IDependencyInfo> usedInfos;
+            string newValue = TryGetDesiredValue(dependencyInfos, out usedInfos);
 
             if (newValue == null)
             {
@@ -44,16 +45,16 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
                     var messageLines = new[]
                     {
                         $"In '{Path}', '{originalValue}' must be '{newValue}' based on build info " +
-                            $"'{string.Join(", ", usedBuildInfos.Select(info => info.Name))}'"
+                            $"'{string.Join(", ", usedInfos.Select(info => info.SimpleName))}'"
                     };
-                    yield return new DependencyUpdateTask(update, usedBuildInfos, messageLines);
+                    yield return new DependencyUpdateTask(update, usedInfos, messageLines);
                 }
             }
         }
 
         protected abstract string TryGetDesiredValue(
-            IEnumerable<DependencyBuildInfo> dependencyBuildInfos,
-            out IEnumerable<BuildInfo> usedBuildInfos);
+            IEnumerable<IDependencyInfo> dependencyInfos,
+            out IEnumerable<IDependencyInfo> usedDependencyInfos);
 
         private static string ReplaceGroupValue(
             Regex regex,

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/IDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/IDependencyInfo.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    /// <summary>
+    /// Information about the current state of a dependency. This information is at some point in
+    /// time, not necessarily the latest state available.
+    /// </summary>
+    public interface IDependencyInfo
+    {
+        /// <summary>
+        /// A simple, short name for this dependency info. Used in the suggested commit message.
+        /// </summary>
+        string SimpleName { get; }
+
+        /// <summary>
+        /// A simple, short name for the overall version of this dependency info. Used in the
+        /// suggested commit message.
+        /// </summary>
+        string SimpleVersion { get; }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/IDependencyUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/IDependencyUpdater.cs
@@ -7,13 +7,13 @@ using System.Collections.Generic;
 namespace Microsoft.DotNet.VersionTools.Dependencies
 {
     /// <summary>
-    /// A tool that uses buildInfos to perform an update.
+    /// A tool that uses dependency infos to perform an update.
     /// </summary>
     public interface IDependencyUpdater
     {
         /// <summary>
-        /// Updates based on the given build infos and returns build infos used during update.
+        /// Returns update tasks based on the dependency infos passed.
         /// </summary>
-        IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<DependencyBuildInfo> dependencyBuildInfos);
+        IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos);
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/IndicatorPackageSubmoduleUpdater.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using NuGet.Packaging.Core;
 using System;
 using System.Collections.Generic;
@@ -40,10 +41,10 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
         }
 
         protected override string GetDesiredCommitHash(
-            IEnumerable<DependencyBuildInfo> dependencyBuildInfos,
-            out IEnumerable<DependencyBuildInfo> usedBuildInfos)
+            IEnumerable<IDependencyInfo> dependencyInfos,
+            out IEnumerable<IDependencyInfo> usedDependencyInfos)
         {
-            foreach (var info in dependencyBuildInfos)
+            foreach (var info in dependencyInfos.OfType<BuildDependencyInfo>())
             {
                 PackageIdentity package = info.Packages
                     .FirstOrDefault(p => p.Id == IndicatorPackageId);
@@ -69,18 +70,18 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
                         string packageCommitHash = versionTxtReader.ReadLine();
                         Trace.TraceInformation($"Found commit '{packageCommitHash}' in versions.txt.");
 
-                        usedBuildInfos = new[] { info };
+                        usedDependencyInfos = new[] { info };
                         return packageCommitHash;
                     }
                 }
             }
 
             Trace.TraceError($"Failed to find '{IndicatorPackageId}' specifying a commit in any build-info.");
-            usedBuildInfos = Enumerable.Empty<DependencyBuildInfo>();
+            usedDependencyInfos = Enumerable.Empty<BuildDependencyInfo>();
             return null;
         }
 
-        protected async Task<ZipArchive> DownloadPackageAsync(DependencyBuildInfo info, PackageIdentity package)
+        protected async Task<ZipArchive> DownloadPackageAsync(BuildDependencyInfo info, PackageIdentity package)
         {
             if (PackageDownloadBaseUrl == null)
             {

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/SubmoduleDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/SubmoduleDependencyInfo.cs
@@ -1,0 +1,100 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using Microsoft.DotNet.VersionTools.Util;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
+{
+    public class SubmoduleDependencyInfo : IDependencyInfo
+    {
+        public static SubmoduleDependencyInfo Create(
+            string repository,
+            string @ref,
+            string path,
+            bool remote)
+        {
+            string commit;
+
+            if (remote)
+            {
+                string remoteRefOutput = GitCommand.LsRemoteHeads(path, repository, @ref);
+
+                string[] remoteRefLines = remoteRefOutput
+                    .Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(line => !string.IsNullOrWhiteSpace(line))
+                    .ToArray();
+
+                if (remoteRefLines.Length != 1)
+                {
+                    string allRefs = "";
+                    if (remoteRefLines.Length > 1)
+                    {
+                        allRefs = $" ({string.Join(", ", remoteRefLines)})";
+                    }
+
+                    throw new NotSupportedException(
+                        $"The configured Ref '{@ref}' for '{path}' " +
+                        $"must match exactly one ref on the remote, '{repository}'. " +
+                        $"Matched {remoteRefLines.Length}{allRefs}. ");
+                }
+
+                commit = remoteRefLines.Single().Split('\t').First();
+            }
+            else
+            {
+                // Get the current commit of the submodule as tracked by the containing repo. This
+                // ensures local changes don't interfere.
+                // https://git-scm.com/docs/git-submodule/1.8.2#git-submodule---cached
+                commit = GitCommand.SubmoduleStatusCached(path)
+                    .Substring(1, 40);
+            }
+
+            return new SubmoduleDependencyInfo(repository, @ref, commit);
+        }
+
+        /// <summary>
+        /// The target repository, in a format that works with commands like "git fetch".
+        /// 
+        /// For example: https://github.com/dotnet/buildtools
+        /// </summary>
+        public string Repository { get; }
+
+        /// <summary>
+        /// The Git reference/ref (branch or tag) this dependency info tracks.
+        /// </summary>
+        public string Ref { get; }
+
+        /// <summary>
+        /// The commit that Ref points to in Repository.
+        /// </summary>
+        public string Commit { get; }
+
+        public SubmoduleDependencyInfo(string repository, string @ref, string commit)
+        {
+            if (repository == null)
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+            if (@ref == null)
+            {
+                throw new ArgumentNullException(nameof(@ref));
+            }
+            if (commit == null)
+            {
+                throw new ArgumentNullException(nameof(commit));
+            }
+            Repository = repository;
+            Ref = @ref;
+            Commit = commit;
+        }
+
+        public override string ToString() => $"{SimpleName}:{Ref} ({Commit})";
+
+        public string SimpleName => Repository.Split('/').Last();
+
+        public string SimpleVersion => Commit?.Substring(0, Math.Min(7, Commit.Length)) ?? "latest";
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -24,7 +24,8 @@
     <Compile Include="Automation\GitHubApi\HttpFailureResponseException.cs" />
     <Compile Include="Automation\LocalVersionsRepoUpdater.cs" />
     <Compile Include="Automation\GitHubVersionsRepoUpdater.cs" />
-    <Compile Include="Dependencies\DependencyBuildInfo.cs" />
+    <Compile Include="Dependencies\BuildOutput\BuildDependencyInfo.cs" />
+    <Compile Include="Dependencies\IDependencyInfo.cs" />
     <Compile Include="Dependencies\DependencyUpdateTask.cs" />
     <Compile Include="Automation\GitHubApi\GitHubClient.cs" />
     <Compile Include="Automation\DependencyUpdateUtils.cs" />
@@ -32,10 +33,11 @@
     <Compile Include="Automation\GitHubProject.cs" />
     <Compile Include="Automation\PullRequestCreator.cs" />
     <Compile Include="Automation\GitHubApi\GitHubApiModel.cs" />
-    <Compile Include="Dependencies\ToolVersionsUpdater.cs" />
-    <Compile Include="Dependencies\FilePackageUpdater.cs" />
-    <Compile Include="Dependencies\FileRegexPackageUpdater.cs" />
-    <Compile Include="Dependencies\FileRegexReleaseUpdater.cs" />
+    <Compile Include="Dependencies\Submodule\SubmoduleDependencyInfo.cs" />
+    <Compile Include="Dependencies\BuildOutput\ToolVersionsUpdater.cs" />
+    <Compile Include="Dependencies\BuildOutput\FilePackageUpdater.cs" />
+    <Compile Include="Dependencies\BuildOutput\FileRegexPackageUpdater.cs" />
+    <Compile Include="Dependencies\BuildOutput\FileRegexReleaseUpdater.cs" />
     <Compile Include="Automation\IUpdateBranchNamingStrategy.cs" />
     <Compile Include="Automation\SingleBranchNamingStrategy.cs" />
     <Compile Include="Dependencies\Submodule\LatestCommitSubmoduleUpdater.cs" />
@@ -50,8 +52,9 @@
     <Compile Include="Dependencies\FileRegexUpdater.cs" />
     <Compile Include="Dependencies\IDependencyUpdater.cs" />
     <Compile Include="BuildInfo.cs" />
-    <Compile Include="Dependencies\ProjectJsonUpdater.cs" />
+    <Compile Include="Dependencies\BuildOutput\ProjectJsonUpdater.cs" />
     <Compile Include="Automation\VersionsRepoUpdater.cs" />
+    <Compile Include="Util\GitCommand.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">

--- a/src/Microsoft.DotNet.VersionTools/Util/Command.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/Command.cs
@@ -14,8 +14,6 @@ namespace Microsoft.DotNet.VersionTools.Util
 {
     internal class Command
     {
-        public static Command Git(params string[] args) => Create("git", args);
-
         public static readonly string[] RunnableSuffixes = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? new string[] { ".exe", ".cmd", ".bat" }
             : new string[] { string.Empty };

--- a/src/Microsoft.DotNet.VersionTools/Util/GitCommand.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/GitCommand.cs
@@ -1,0 +1,122 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Util
+{
+    internal static class GitCommand
+    {
+        internal static Command Create(params string[] args) => Command.Create("git", args);
+
+        internal static string PorcelainStatus()
+        {
+            CommandResult result = Create("status", "--porcelain")
+                .CaptureStdOut()
+                .Execute();
+            result.EnsureSuccessful();
+            return result.StdOut;
+        }
+
+        internal static void Commit(string message, string authorName, string authorEmail, bool all)
+        {
+            string allFlag = all ? "--all" : "";
+
+            Create("commit", allFlag, "-m", message, "--author", $"{authorName} <{authorEmail}>")
+                .EnvironmentVariable("GIT_COMMITTER_NAME", authorName)
+                .EnvironmentVariable("GIT_COMMITTER_EMAIL", authorEmail)
+                .Execute()
+                .EnsureSuccessful();
+        }
+
+        internal static void Push(string repository, string redactedRepository, string refSpec, bool force)
+        {
+            string forceFlag = force ? "--force" : "";
+
+            string[] args =
+            {
+                "push", forceFlag, repository, refSpec
+            };
+            var logArgs = args.Select(arg => arg == repository ? redactedRepository : arg);
+
+            string logMessage = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(logArgs);
+
+            Trace.TraceInformation($"EXEC {logMessage}");
+
+            CommandResult pushResult =
+                Create(args)
+                    .QuietBuildReporter()  // we don't want secrets showing up in our logs
+                    .CaptureStdErr() // git push will write to StdErr upon success, disable that
+                    .CaptureStdOut()
+                    .Execute();
+
+            var message = $"{logMessage} exited with exit code {pushResult.ExitCode}";
+            if (pushResult.ExitCode == 0)
+            {
+                Trace.TraceInformation($"EXEC success: {message}");
+            }
+            else
+            {
+                Trace.TraceError($"EXEC failure: {message}");
+            }
+
+            pushResult.EnsureSuccessful(suppressOutput: true);
+        }
+
+        internal static void Checkout(string path, string hash)
+        {
+            Trace.TraceInformation($"In '{path}', checking out '{hash}'.");
+            Create("-C", path, "checkout", hash)
+                .Execute()
+                .EnsureSuccessful();
+        }
+
+        internal static void Fetch(
+            string path,
+            string repository = "",
+            string refspec = "")
+        {
+            Create("-C", path, "fetch", repository, refspec)
+                .Execute()
+                .EnsureSuccessful();
+        }
+
+        internal static void FetchAll(
+            string path,
+            string repository = "")
+        {
+            Create("-C", path, "fetch", "--all", repository)
+                .Execute()
+                .EnsureSuccessful();
+        }
+
+        internal static string LsRemoteHeads(string path, string repository, string @ref)
+        {
+            CommandResult result = Create("-C", path, "ls-remote", "--heads", repository, @ref)
+                .CaptureStdOut()
+                .Execute();
+            result.EnsureSuccessful();
+            return result.StdOut;
+        }
+
+        internal static string RevParse(string path, params string[] args)
+        {
+            CommandResult result = Create(new[] { "-C", path, "rev-parse" }.Concat(args).ToArray())
+                .CaptureStdOut()
+                .Execute();
+            result.EnsureSuccessful();
+            return result.StdOut;
+        }
+
+        internal static string SubmoduleStatusCached(string submodulePath)
+        {
+            CommandResult result = Create("submodule", "status", "--cached", submodulePath)
+                .CaptureStdOut()
+                .Execute();
+            result.EnsureSuccessful();
+            return result.StdOut;
+        }
+    }
+}


### PR DESCRIPTION
Port https://github.com/dotnet/buildtools/pull/1741 to master.

I squashed https://github.com/dotnet/buildtools/pull/1752 into the cherry-pick to avoid any merge conflicts.

I haven't tested this yet against CoreFX master and friends. No breaking changes expected for BuildTools MSBuild users. There are some for VersionTools .NET lib users.