### PR TITLE
Update all package outputs to 2.1.0-prerelease

### DIFF
--- a/src/nuget/Microsoft.DotNet.Build.CloudTest.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.CloudTest.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.Build.CloudTest</id>
-    <version>1.0.0-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Microsoft DotNet Build cloud test tools </title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.Build.Tasks.Feed.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.Feed.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.Build.Tasks.Feed</id>
-    <version>1.0.0-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>DotNet Build Feed Tools</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.ApiCompat.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.ApiCompat.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.ApiCompat</id>
-    <version>1.0.0-beta3</version>
+    <version>$PackageVersion$</version>
     <title>API Compatibility Checker (ApiCompat)</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.Cci.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.Cci.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.Cci</id>
-    <version>1.0.0-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Microsoft DotNet BuildTools CCI</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.GenAPI.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.GenAPI.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.GenAPI</id>
-    <version>1.0.0-beta3</version>
+    <version>$PackageVersion$</version>
     <title>Reference Assembly Source Generator (GenAPI)</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.GenFacades.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.GenFacades.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.GenFacades</id>
-    <version>1.0.0-beta3</version>
+    <version>$PackageVersion$</version>
     <title>Facade Generator (GenFacade)</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.RepoUtils.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.RepoUtils</id>
-    <version>1.0.1-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Repository Produces/Consumes Utilities</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.Run.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.Run.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.Run</id>
-    <version>1.0.1-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Microsoft DotNet Run Tool</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.TestSuite.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.TestSuite</id>
-    <version>1.0.1-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>xUnit suite of .NET Core test projects</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.VstsBuildsApi.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools.VstsBuildsApi</id>
-    <version>1.0.27-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Microsoft DotNet VSTS Builds REST APIs</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.BuildTools</id>
-    <version>2.0.0-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Microsoft DotNet BuildTools</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.DotNet.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.VersionTools.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.DotNet.VersionTools</id>
-    <version>1.0.27-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Microsoft DotNet VersionTools</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
+++ b/src/nuget/Microsoft.xunit.extensibility.execution.netcore.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.5">
     <id>Microsoft.xunit.extensibility.execution.netcore</id>
-    <version>1.0.1-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>Redist of xunit.execution.execution to target netstandard1.0</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
+++ b/src/nuget/Microsoft.xunit.netcore.extensions.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>Microsoft.xunit.netcore.extensions</id>
-    <version>1.0.1-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>xUnit extensions of .NET Core test projects</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/nuget/xunit.console.netcore.nuspec
+++ b/src/nuget/xunit.console.netcore.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="2.8.1">
     <id>xunit.console.netcore</id>
-    <version>1.0.4-prerelease</version>
+    <version>$PackageVersion$</version>
     <title>xUnit.net [Runners - .NET Core]</title>
     <authors>James Newkirk, Brad Wilson (.NET Core package by Matt Cohn)</authors>
     <owners>Microsoft</owners>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -10,7 +10,15 @@
          https://github.com/dotnet/buildtools/issues/780 -->
     <PackagingTaskDir Condition="'$(BuildToolsTargets45)' != 'true'">$(BinDir)AnyOS.AnyCPU.$(ConfigurationGroup)/Microsoft.DotNet.Build.Tasks.Packaging/</PackagingTaskDir>
     <PackagingTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(BinDir)AnyOS.AnyCPU.$(ConfigurationGroup)/Microsoft.DotNet.Build.Tasks.Packaging.Desktop/</PackagingTaskDir>
+
+    <!-- Use the same package version for all output packages. -->
+    <DoNotGeneratePackageVersion>true</DoNotGeneratePackageVersion>
+    <PackageVersion>2.1.0-prerelease-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <NuspecProperties Include="PackageVersion=$(PackageVersion)" />
+  </ItemGroup>
 
   <Import Project="Microsoft.DotNet.Build.Tasks\PackageFiles\packages.targets" Condition="'$(ImportGetNuGetPackageVersions)' != 'false'" />
   


### PR DESCRIPTION
This allows us to avoid conflicts between BuildTools branches in the most straightforward way. See https://github.com/dotnet/buildtools/issues/1489.

I noticed this was still out of date when reviewing https://github.com/dotnet/corefx/pull/24784.