### PR TITLE
Update PDB Conversion Task to fix random crash

### DIFF
--- a/dependencies.props
+++ b/dependencies.props
@@ -14,7 +14,7 @@
 
   <!-- Package versions to validate, but not in a build-info file. -->
   <PropertyGroup>
-    <MicrosoftDiaSymReaderConverterPackageVersion>1.0.0-beta1-61722-03</MicrosoftDiaSymReaderConverterPackageVersion>
+    <MicrosoftDiaSymReaderConverterPackageVersion>1.1.0-beta1-62225-01</MicrosoftDiaSymReaderConverterPackageVersion>
   </PropertyGroup>
 
   <!-- Package dependency verification/auto-upgrade configuration. -->

--- a/dir.props
+++ b/dir.props
@@ -86,6 +86,9 @@
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader/api/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader-native/api/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader-converter/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader" />
     <DnuSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" />

--- a/dir.props
+++ b/dir.props
@@ -87,6 +87,7 @@
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader" />
     <DnuSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" />
   </ItemGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -90,7 +90,6 @@
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader-native/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader-converter/api/v3/index.json" />
     <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/nuget-build/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader" />
     <DnuSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
+    "Microsoft.DiaSymReader": "1.3.0-beta-62225-02",
     "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
-    "Microsoft.DiaSymReader": "1.3.0-beta-62225-02",
+    "Microsoft.DiaSymReader.Converter": "1.1.0-beta1-62225-01",
     "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Newtonsoft.Json": "9.0.1",

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -4,8 +4,7 @@
     "Microsoft.Build.Framework": "0.1.0-preview-00022",
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
-    "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
-    "Microsoft.DiaSymReader": "1.3.0-beta-62225-02",
+    "Microsoft.DiaSymReader.Converter": "1.1.0-beta1-62225-01",
     "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.Tpl.Dataflow": {
       "version": "4.5.24",

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -5,6 +5,7 @@
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
     "Microsoft.DiaSymReader.Converter": "1.0.0-beta1-61722-03",
+    "Microsoft.DiaSymReader": "1.3.0-beta-62225-02",
     "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.Tpl.Dataflow": {
       "version": "4.5.24",


### PR DESCRIPTION
There was a COM bug in the PDB writing code used in the task that
converts portable PDBs to windows PDBs (see https://github.com/dotnet/symreader/pull/70)
This picks up a version with this fix in the build tools.

@tmat  @dagood 

I have confirmed that with this update the fix (which is in the SymUnmanagedWriterImpl.CloseSymWriter method), shows up in the Microsoft.DiaSymReader.dll placed in the bin directory.  