### PR TITLE
Fix failure on Unix associate with converting PDBs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -50,10 +50,13 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="GenerateWindowsPdbsForAssemblyBeingTested" BeforeTargets="GenerateTestExecutionScripts">
+  <!-- *********************************************************************************************** -->
     <!-- As of 10/2017 OpenCover does not support portable PDBs, but we want the builds to generate
          portable PDBs.  Thus we generate windows PDBs from portable PDBs here.   Can be removed
          when OpenCover directly supports Portable PDBs (probably by early 2018) -->
+
+  <Target Name="GenerateWindowsPdbsForAssemblyBeingTested" BeforeTargets="GenerateTestExecutionScripts"
+    Condition="$(CodeCoverageEnabled) == 'true' and '$(TargetOS)'=='Windows_NT'">
 
     <!-- We look for the DLL being tested for coverage and its PDB create a WindowsPDB\*.pdb which has
          the windows PDB.  -->
@@ -80,8 +83,8 @@
          portable PDBs directly  -->
     <Message Importance="high" Text="Replacing Portable PDB with Windows Pdb in place!" />
     <Copy SourceFiles="%(ExistingPortableDllsToConvert.TargetPath)" DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)" Condition="Exists('%(ExistingPortableDllsToConvert.TargetPath)')"/>
-
   </Target>
+  <!-- *********************************************************************************************** -->
 
   <!-- xUnit command line with coverage enabled -->
   <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true'">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -55,8 +55,9 @@
          portable PDBs.  Thus we generate windows PDBs from portable PDBs here.   Can be removed
          when OpenCover directly supports Portable PDBs (probably by early 2018) -->
 
-  <Target Name="GenerateWindowsPdbsForAssemblyBeingTested" BeforeTargets="GenerateTestExecutionScripts"
-    Condition="$(CodeCoverageEnabled) == 'true' and '$(TargetOS)'=='Windows_NT'">
+  <Target Name="GenerateWindowsPdbsForAssemblyBeingTested" 
+    BeforeTargets="GenerateTestExecutionScripts"
+    Condition="'$(CodeCoverageEnabled)' == 'true' and '$(TargetOS)'=='Windows_NT'">
 
     <!-- We look for the DLL being tested for coverage and its PDB create a WindowsPDB\*.pdb which has
          the windows PDB.  -->


### PR DESCRIPTION
Code to convert portable pdbs to windows pdbs was being run on UNIX machines.
This is clearly not needed and was causing failures.   Fix it to only run on non Windows
and only for coverage (which is the only thing we know that needs the Windows  PDBs).

Basically just make the conversion condition stricter.  

See also  https://github.com/dotnet/corefx/issues/24807.