### PR TITLE
Make public the default SignType

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <BuildToolsTaskDir Condition="'$(BuildToolsTaskDir)' == ''">$(ToolsDir)</BuildToolsTaskDir>
-    
+
     <!-- For UAP, we need to bin place the resources as resw files to create the runner's pri file. -->
     <ResourcesFolderPath Condition="'$(ResourcesFolderPath)' == ''">$(RuntimePath)resw</ResourcesFolderPath>
 
@@ -295,7 +295,7 @@
     import the MicroBuild boot-strapper project (only relevant for shipping binaries)
     NOTE: we import this at the end as it will override some dummy targets (e.g. SignFiles)
   -->
-  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.targets" Condition="'$(IsTestProject)'!='true' and '$(SignType)' != 'oss'" />
+  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.targets" Condition="Exists('$(MSBuildThisFileDirectory)MicroBuild.Core.targets') and $(IsTestProject)' != 'true'" />
 
   <!--
     Providing a definition for __BlockReflectionAttribute in an assembly is a signal to the .NET Native toolchain

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -45,13 +45,16 @@
 
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
 
-    <!-- applicable values for SignType are oss, test or real -->
-    <SignType Condition="'$(SignType)' == ''">oss</SignType>
+    <!-- applicable values for SignType are public, test or real -->
+    <SignType Condition="'$(SignType)' == ''">public</SignType>
 
     <ShouldWriteSigningRequired Condition="'$(IsTestProject)' == 'true'">false</ShouldWriteSigningRequired>
     <ShouldWriteSigningRequired Condition="'$(SkipSigning)' == 'true'">false</ShouldWriteSigningRequired>
-    <ShouldWriteSigningRequired Condition="'$(SignType)' == 'oss'">false</ShouldWriteSigningRequired>
+    <ShouldWriteSigningRequired Condition="$(SignType)' == 'public' or '$(SignType)' == 'oss'">false</ShouldWriteSigningRequired>
     <ShouldWriteSigningRequired Condition="'$(ShouldWriteSigningRequired)'==''">true</ShouldWriteSigningRequired>
+
+    <ShouldOpenSourceSign Condition="$(SignType)' == 'public' or '$(SignType)' == 'oss'">$(DelaySign)</ShouldOpenSourceSign>
+    <ShouldOpenSourceSign Condition="'$(SkipSigning)' == 'true'">false</ShouldOpenSourceSign>
   </PropertyGroup>
 
   <!-- stub for signing.  for official builds this is replaced with the real one -->
@@ -103,7 +106,7 @@
   </PropertyGroup>
 
   <Target Name="OpenSourceSign"
-          Condition="'$(DelaySign)' == 'true' and '@(IntermediateAssembly)' != '' and '$(SkipSigning)' != 'true' and '$(SignType)' == 'oss'"
+          Condition="'$(ShouldOpenSourceSign)' == 'true' and '@(IntermediateAssembly)' != ''"
           Inputs="@(IntermediateAssembly)"
           Outputs="%(IntermediateAssembly.Identity).oss_signed"
           >


### PR DESCRIPTION
As part of our repo API we are using 'public' as the signtype to
indicate what we formally referred to as oss signing. We still work
if oss is specified for back-compat but we now default to public
if it isn't set.

cc @dagood @mmitche 