### PR TITLE
Fix race associted with SourceLink

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -294,8 +294,10 @@
 
     <!-- Generate the SourceLink file that will be passed to the C# compiler (using ProjectDir and GitHubRepositoryUrl as data) -->
     <MakeDir Directories="$(BaseIntermediateOutputPath)" />
-    <WriteLinesToFile Condition="'$(UseSourceLink)' == 'true' AND '$(GitHubRepositoryUrl)' != '' AND '$(LatestCommit)' != 'N/A'"
-      File="$(BaseIntermediateOutputPath)source_link.json" 
+    <WriteLinesToFile 
+      Condition="'$(UseSourceLink)' == 'true' AND '$(GitHubRepositoryUrl)' != '' AND '$(LatestCommit)' != 'N/A' AND !Exists('$(SourceLinkFilePath)')"
+      ContinueOnError="WarnAndContinue"
+      File="$(SourceLinkFilePath)" 
       Overwrite="true" 
       Lines='{"documents": { "$(ProjectDir.Replace("\", "\\"))*" : "$(GitHubRepositoryUrl.Replace("github.com", "raw.githubusercontent.com"))/$(LatestCommit)/*" }}' />
 


### PR DESCRIPTION
The sourcelink file is generated one for the whole repo so it is possible that
differnet parts of the build will race to write it.   We have seen this show up as a file
access error in builds.

It is already the case that there is logic that avoids running the code most of the time
(see VersionPropsImported).  but races are still possible.  They are avoided in that
scheme by testing for the file existing and simply warning if there is a error trying to
write the file.   We follow suit here.

As a unrelated change there was already a variable SourceLinkFilePath, for the source
link file so I use it instead of building it out of more primitive variable.

@dagood 