### PR TITLE
Enabling the Feed task to copy nuget dependencies for net15

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -11,6 +11,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <ProjectGuid>{6623492E-9EAD-40F0-B8F4-AF0AFBF98890}</ProjectGuid>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>

--- a/src/nuget/Microsoft.DotNet.Build.Tasks.Feed.nuspec
+++ b/src/nuget/Microsoft.DotNet.Build.Tasks.Feed.nuspec
@@ -16,9 +16,7 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags></tags>
     <dependencies>
-     <group targetFramework=".NETStandard1.5">
-        <dependency id="SleetLib" version="2.2.9" exclude="Build,Analyzers" />
-      </group>
+       <!-- Do not add any dependencies to this package as we want to install it versionless (i.e. -ExcludeVersion) and we don't want the dependencies to be installed that way -->
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
We found that for net15 based builds there was an error about Sleet not being found since the dll was not being copied along with the Feed dll. This should fix this.