### PR TITLE
Add init-tools PackageVersionProps download

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RepoAPI.Mapping.props
@@ -12,6 +12,14 @@
     <SymbolPackageOutputPath Condition="'$(SymbolPackageOutputPath)' == ''">$(DotNetOutputBlobFeedDir)assets/</SymbolPackageOutputPath>
   </PropertyGroup>
 
+  <!-- If init-tools downloaded a package version props file, use it. -->
+  <PropertyGroup>
+    <DownloadedPackageVersionPropsPath>$(ToolsDir)DownloadedPackageVersions.props</DownloadedPackageVersionPropsPath>
+
+    <DotNetPackageVersionPropsPath Condition="'$(DotNetPackageVersionPropsPath)' == '' and 
+                                               Exists('$(DownloadedPackageVersionPropsPath)')">$(DownloadedPackageVersionPropsPath)</DotNetPackageVersionPropsPath>
+  </PropertyGroup>
+
   <!--
     Import the restore source props file if passed to get "DotNetRestoreSources".
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.ps1
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.ps1
@@ -21,22 +21,11 @@ foreach ($file in Get-ChildItem $ToolRuntimePath *.runtimeconfig.json)
 New-Item -Force -Type Directory (Join-Path $ToolRuntimePath (Split-Path -Leaf (Split-Path $BuildToolsPackageDir)))
 
 # Download the package version props file, if  was passed in the environment.
-$packageVersionPropsUrl = $env:PB_PACKAGEVERSIONPROPSURL
-$packageVersionPropsPath = $env:PackageVersionPropsDownloadPath
+$packageVersionPropsUrl = $env:PACKAGEVERSIONPROPSURL
+$packageVersionPropsPath = Join-Path $ToolRuntimePath "DownloadedPackageVersions.props"
 
 if ($packageVersionPropsUrl)
 {
-    if (-not $packageVersionPropsPath)
-    {
-        throw "Url '$packageVersionPropsUrl' (PB_PACKAGEVERSIONPROPSURL) specified, but no download path (PackageVersionPropsDownloadPath)."
-    }
-
-    $dir = Split-Path -Parent $packageVersionPropsPath
-    if (-not (Test-Path $dir))
-    {
-        mkdir $dir
-    }
-
     Write-Host "Downloading package version props from '$packageVersionPropsUrl' to '$packageVersionPropsPath'..."
 
     # Copied from init-tools.cmd in CoreFX
@@ -71,5 +60,6 @@ if ($packageVersionPropsUrl)
         }
     } while ($success -eq $false);
 
-    Write-Host "Downloaded package version props."
+    Write-Host "Downloaded package version props:"
+    Get-Content $packageVersionPropsPath
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.ps1
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.ps1
@@ -19,3 +19,57 @@ foreach ($file in Get-ChildItem $ToolRuntimePath *.runtimeconfig.json)
 # the init-tools.cmd (that is checked into each repository that uses buildtools) can write the semaphore
 # marker into this file once tool initialization is complete.
 New-Item -Force -Type Directory (Join-Path $ToolRuntimePath (Split-Path -Leaf (Split-Path $BuildToolsPackageDir)))
+
+# Download the package version props file, if  was passed in the environment.
+$packageVersionPropsUrl = $env:PB_PACKAGEVERSIONPROPSURL
+$packageVersionPropsPath = $env:PackageVersionPropsDownloadPath
+
+if ($packageVersionPropsUrl)
+{
+    if (-not $packageVersionPropsPath)
+    {
+        throw "Url '$packageVersionPropsUrl' (PB_PACKAGEVERSIONPROPSURL) specified, but no download path (PackageVersionPropsDownloadPath)."
+    }
+
+    $dir = Split-Path -Parent $packageVersionPropsPath
+    if (-not (Test-Path $dir))
+    {
+        mkdir $dir
+    }
+
+    Write-Host "Downloading package version props from '$packageVersionPropsUrl' to '$packageVersionPropsPath'..."
+
+    # Copied from init-tools.cmd in CoreFX
+    $retryCount = 0
+    $success = $false
+    $proxyCredentialsRequired = $false
+    do
+    {
+        try
+        {
+            $wc = New-Object Net.WebClient
+            if ($proxyCredentialsRequired)
+            {
+                [Net.WebRequest]::DefaultWebProxy.Credentials = [Net.CredentialCache]::DefaultNetworkCredentials
+            }
+            $wc.DownloadFile($packageVersionPropsUrl, $packageVersionPropsPath)
+            $success = $true
+        }
+        catch
+        {
+            if ($retryCount -ge 6)
+            {
+                throw
+            }
+            else
+            {
+                $we = $_.Exception.InnerException -as [Net.WebException]
+                $proxyCredentialsRequired = ($we -ne $null -and ([Net.HttpWebResponse]$we.Response).StatusCode -eq [Net.HttpStatusCode]::ProxyAuthenticationRequired)
+                Start-Sleep -Seconds (5 * $retryCount)
+                $retryCount++
+            } 
+        }
+    } while ($success -eq $false);
+
+    Write-Host "Downloaded package version props."
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -93,4 +93,28 @@ __MNCA_FOLDER=$(dirname $__DOTNET_CMD)/shared/Microsoft.NETCore.App
 __HIGHEST_RUNTIME_VERSION=`ls $__MNCA_FOLDER | sed 'r/\([0-9]\+\).*/\1/g' | sort -n | tail -1`
 sed -i -e "s/1.1.0/$__HIGHEST_RUNTIME_VERSION/g" $__TOOLRUNTIME_DIR/*.runtimeconfig.json
 
+# Download the package version props file, if passed in the environment.
+__PACKAGE_VERSION_PROPS_URL="${PB_PACKAGEVERSIONPROPSURL:-}"
+__PACKAGE_VERSION_PROPS_PATH="${PackageVersionPropsDownloadPath:-}"
+
+if [ "$__PACKAGE_VERSION_PROPS_URL" ]; then
+    if [ -z "$__PACKAGE_VERSION_PROPS_PATH" ]; then
+        echo "Url '$__PACKAGE_VERSION_PROPS_URL' (PB_PACKAGEVERSIONPROPSURL) specified, but no download path (PackageVersionPropsDownloadPath)."
+        exit 1
+    fi
+
+    mkdir -p "$(dirname "$__PACKAGE_VERSION_PROPS_PATH")"
+
+    echo "Downloading package version props from '$__PACKAGE_VERSION_PROPS_URL' to '$__PACKAGE_VERSION_PROPS_PATH'..."
+
+    # Copied from CoreFX init-tools.sh
+    if command -v curl > /dev/null; then
+        curl --retry 10 -sSL --create-dirs -o "$__PACKAGE_VERSION_PROPS_PATH" "$__PACKAGE_VERSION_PROPS_URL"
+    else
+        wget -q -O "$__PACKAGE_VERSION_PROPS_PATH" "$__PACKAGE_VERSION_PROPS_URL"
+    fi
+
+    echo "Downloaded package version props."
+fi
+
 exit 0

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -94,17 +94,10 @@ __HIGHEST_RUNTIME_VERSION=`ls $__MNCA_FOLDER | sed 'r/\([0-9]\+\).*/\1/g' | sort
 sed -i -e "s/1.1.0/$__HIGHEST_RUNTIME_VERSION/g" $__TOOLRUNTIME_DIR/*.runtimeconfig.json
 
 # Download the package version props file, if passed in the environment.
-__PACKAGE_VERSION_PROPS_URL="${PB_PACKAGEVERSIONPROPSURL:-}"
-__PACKAGE_VERSION_PROPS_PATH="${PackageVersionPropsDownloadPath:-}"
+__PACKAGE_VERSION_PROPS_URL="${PACKAGEVERSIONPROPSURL:-}"
+__PACKAGE_VERSION_PROPS_PATH="$__TOOLRUNTIME_DIR/DownloadedPackageVersions.props"
 
 if [ "$__PACKAGE_VERSION_PROPS_URL" ]; then
-    if [ -z "$__PACKAGE_VERSION_PROPS_PATH" ]; then
-        echo "Url '$__PACKAGE_VERSION_PROPS_URL' (PB_PACKAGEVERSIONPROPSURL) specified, but no download path (PackageVersionPropsDownloadPath)."
-        exit 1
-    fi
-
-    mkdir -p "$(dirname "$__PACKAGE_VERSION_PROPS_PATH")"
-
     echo "Downloading package version props from '$__PACKAGE_VERSION_PROPS_URL' to '$__PACKAGE_VERSION_PROPS_PATH'..."
 
     # Copied from CoreFX init-tools.sh
@@ -114,7 +107,8 @@ if [ "$__PACKAGE_VERSION_PROPS_URL" ]; then
         wget -q -O "$__PACKAGE_VERSION_PROPS_PATH" "$__PACKAGE_VERSION_PROPS_URL"
     fi
 
-    echo "Downloaded package version props."
+    echo "Downloaded package version props:"
+    cat "$__PACKAGE_VERSION_PROPS_PATH"
 fi
 
 exit 0


### PR DESCRIPTION
This implementation is in `init-tools.ps1` and `init-tools.sh`, which runs after the BuildTools package is restored. `RepoAPI.Mapping.props` then picks up on the downloaded file inside the MSBuild call.

This downloads the file pointed to by the environment variable `PACKAGEVERSIONPROPSURL` and uses the props file during the build.

CoreFX only needs to add a VSTS variable `PACKAGEVERSIONPROPSURL` with the value of `PB_PackageVersionPropsUrl` to put the URL value in the environment var. (This only works if it's not a secret. For now, this flow does not support a package version props URL that requires auth.)

I rely on the environment to pass the arg deep into the init-tools flow to avoid adding more args that need to pass all the way through. Using the env is bad for discoverability, but makes my changes contained and less likely to break other scenarios.

The init-tools flow seems like a reasonable place for this for the Core repos: it is already behind a semaphore, so there's no need to worry about downloading the file more than once. It's also a common entry point that happens before the MSBuild call, which is necessary so that the `Import` can find the `DotNetPackageVersionPropsPath` file.