### PR TITLE
Add asset upload support

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
@@ -39,13 +39,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             RelativePath = relativePath;
         }
 
-        public string FeedContainerUrl
-        {
-            get
-            {
-                return AzureHelper.GetContainerRestUrl(AccountName, ContainerName);
-            }
-        }
+        public string FeedContainerUrl => AzureHelper.GetContainerRestUrl(AccountName, ContainerName);
 
         public async Task<bool> CheckIfBlobExists(string blobPath)
         {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
@@ -38,59 +38,5 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             Log = loggingHelper;
             RelativePath = relativePath;
         }
-
-        public string FeedContainerUrl => AzureHelper.GetContainerRestUrl(AccountName, ContainerName);
-
-        public async Task<bool> CheckIfContainerExists()
-        {
-            string url = $"{FeedContainerUrl}?restype=container";
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Clear();
-                var request = AzureHelper.RequestMessage("GET", url, AccountName, AccountKey).Invoke();
-                using (HttpResponseMessage response = await client.SendAsync(request))
-                {
-                    if (response.IsSuccessStatusCode)
-                    {
-                        Log.LogMessage(
-                            MessageImportance.Low,
-                            $"Container {ContainerName} exists for {AccountName}: Status Code:{response.StatusCode} Status Desc: {await response.Content.ReadAsStringAsync()}");
-                    }
-                    else
-                    {
-                        Log.LogMessage(
-                            MessageImportance.Low,
-                            $"Container {ContainerName} does not exist for {AccountName}: Status Code:{response.StatusCode} Status Desc: {await response.Content.ReadAsStringAsync()}");
-                    }
-                    return response.IsSuccessStatusCode;
-                }
-            }
-        }
-
-        public async Task<bool> CheckIfBlobExists(string blobPath)
-        {
-            string url = $"{FeedContainerUrl}/{blobPath}?comp=metadata";
-            using (HttpClient client = new HttpClient())
-            {
-                client.DefaultRequestHeaders.Clear();
-                var request = AzureHelper.RequestMessage("GET", url, AccountName, AccountKey).Invoke();
-                using (HttpResponseMessage response = await client.SendAsync(request))
-                {
-                    if (response.IsSuccessStatusCode)
-                    {
-                        Log.LogMessage(
-                            MessageImportance.Low,
-                            $"Blob {blobPath} exists for {AccountName}: Status Code:{response.StatusCode} Status Desc: {await response.Content.ReadAsStringAsync()}");
-                    }
-                    else
-                    {
-                        Log.LogMessage(
-                            MessageImportance.Low,
-                            $"Blob {blobPath} does not exist for {AccountName}: Status Code:{response.StatusCode} Status Desc: {await response.Content.ReadAsStringAsync()}");
-                    }
-                    return response.IsSuccessStatusCode;
-                }
-            }
-        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -105,8 +105,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     {
                         Log.LogWarning($"Sleet was not able to get a lock on the feed. Sleeping {delay} seconds and retrying.");
 
-                        // Pushing packages might take more than just 60 seconds, so on each iteration we add the defined value to itself so wait for
-                        // a bit more the next iterations
+                        // Pushing packages might take more than just 60 seconds, so on each iteration we multiply the defined delay to a random factor
+                        // Using the defaults this could range from 30 seconds to 12.5 minutes.
                         await Task.Delay(TimeSpan.FromSeconds(rnd.Next(1, 5) * delay));
                     }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -118,7 +118,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             using (var clientThrottle = new SemaphoreSlim(this.MaxClients, this.MaxClients))
             {
-                await Task.WhenAll(items.Select(item => UploadAsync(item, $"{feed.RelativePath}assets/", clientThrottle, allowOverwrite, CancellationToken)));
+                try
+                {
+                    await Task.WhenAll(items.Select(item => UploadAsync(item, $"{feed.RelativePath}assets/", clientThrottle, allowOverwrite, CancellationToken)));
+                }
+                catch (Exception exc)
+                {
+                    Log.LogErrorFromException(exc);
+                    throw;
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -30,11 +30,10 @@
     <Compile Include="SleetSource.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="PackageFiles\Microsoft.DotNet.Build.Tasks.Feed.targets" />
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="PackageFiles\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -30,6 +30,9 @@
     <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\AzureHelper.cs">
       <Link>AzureHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\CreateAzureContainer.cs">
+      <Link>CreateAzureContainer.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\UploadClient.cs">
       <Link>UploadClient.cs</Link>
     </Compile>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -21,6 +21,21 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\AzureBlobLease.cs">
+      <Link>AzureBlobLease.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\AzureConnectionStringBuildTask.cs">
+      <Link>AzureConnectionStringBuildTask.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\AzureHelper.cs">
+      <Link>AzureHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\UploadClient.cs">
+      <Link>UploadClient.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.DotNet.Build.CloudTestTasks\UploadToAzure.cs">
+      <Link>UploadToAzure.cs</Link>
+    </Compile>
     <Compile Include="BlobFeed.cs" />
     <Compile Include="BlobFeedAction.cs" />
     <Compile Include="ConfigureInputFeed.cs" />
@@ -33,7 +48,6 @@
     <None Include="PackageFiles\Microsoft.DotNet.Build.Tasks.Feed.targets" />
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -45,8 +45,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     List<string> packageItems = ConvertToStringLists(ItemsToPush, true);
                     List<string> assetItems = ConvertToStringLists(ItemsToPush, false);
 
-                    await blobFeedAction.PushToFeed(packageItems, Overwrite);
-                    await blobFeedAction.UploadAssets(assetItems, Overwrite);
+                    if (packageItems.Count > 0)
+                    {
+                        await blobFeedAction.PushToFeed(packageItems, Overwrite);
+                    }
+
+                    if (assetItems.Count > 0)
+                    {
+                        await blobFeedAction.UploadAssets(assetItems, Overwrite);
+                    }
                 }
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -29,7 +29,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public int RetryAttempts { get; set; } = 5;
 
-        public int RetryDelayInSeconds { get; set; } = 5;
+        // Sleet's default delay
+        public int RetryDelayInSeconds { get; set; } = 60;
 
         public int MaxClients { get; set; } = 8;
 
@@ -78,7 +79,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             List<string> stringList = new List<string>();
             foreach (var item in taskItems)
             {
-                     stringList.Add(item.ItemSpec);
+                stringList.Add(item.ItemSpec);
             }
 
             return stringList;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/SleetLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/SleetLogger.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public void LogError(string data)
         {
-            _log.LogError(data);
+            _log.LogWarning(data);
         }
 
         public void LogInformation(string data)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/SleetLogger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/SleetLogger.cs
@@ -43,6 +43,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public void LogError(string data)
         {
+            // There are cases where Sleet fails and we retry on our side causing things to actually work but if Sleet logs an error the whole build leg
+            // is marked as failed even though it actually succeeded, hence we log a warning here but we will log an error if the retry did not help
             _log.LogWarning(data);
         }
 


### PR DESCRIPTION
Currently we just support uploading nukpg files to the feeds. With this change if we find non-nupkg files in ItemsToPush, we upload them using Azure APIs and place them in {container}/{relativePath}/assets/.

ItemsToPush can be composed of only nupkgs, only non-nupkgs or a mixture of both