### PR TITLE
Create Public containers through PushToFeed

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -274,7 +274,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             LocalSettings settings = GetSettings();
             AzureFileSystem fileSystem = GetAzureFileSystem();
-            bool result = await InitCommand.RunAsync(settings, fileSystem, true, false, new SleetLogger(Log), CancellationToken);
+            bool result = await InitCommand.RunAsync(settings, fileSystem, true, true, new SleetLogger(Log), CancellationToken);
             return result;
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private SleetSource source;
         private int retries;
         private int delay;
+        private bool hasToken = false;
 
         public BlobFeed feed;
 
@@ -45,6 +46,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 feedUrl = m.Groups["feedurl"].Value;
                 retries = retryAttempts;
                 delay = retryDelay;
+                hasToken = !string.IsNullOrEmpty(m.Groups["token"].Value);
 
                 source = new SleetSource
                 {
@@ -205,7 +207,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 AccountName = feed.AccountName,
                 ContainerName = feed.ContainerName,
                 FailIfExists = false,
-                IsPublic = true,
+                IsPublic = !hasToken,
                 BuildEngine = buildEngine
             };
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -205,6 +205,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 AccountName = feed.AccountName,
                 ContainerName = feed.ContainerName,
                 FailIfExists = false,
+                IsPublic = true,
                 BuildEngine = buildEngine
             };
 
@@ -271,7 +272,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             LocalSettings settings = GetSettings();
             AzureFileSystem fileSystem = GetAzureFileSystem();
-            bool result = await InitCommand.RunAsync(settings, fileSystem, true, true, new SleetLogger(Log), CancellationToken);
+            bool result = await InitCommand.RunAsync(settings, fileSystem, true, false, new SleetLogger(Log), CancellationToken);
             return result;
         }
     }


### PR DESCRIPTION
If a token is not provided in the ExpectedFeedUrl when we create a container we make them public.

/cc: @weshaggard @karajas 