### PR TITLE
Fix to unbreak Linux build.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
@@ -38,17 +38,17 @@
           DestinationFolder="$(GenFacadesInputPath)"
     />
 
-    <!-- Move the PDB into a subdirectory for GenFacades if we are producing PDBs -->
-    <Move SourceFiles="$(PartialFacadeSymbols)"
-          DestinationFolder="$(GenFacadesInputPath)"
-          Condition="'$(DebugSymbols)' != 'false' AND '$(OSGroup)' == 'Windows_NT'" />
-
     <PropertyGroup>
       <ProducePdb>true</ProducePdb>
       <ProducePdb Condition="'$(DebugSymbols)' == 'false' OR '$(OSGroup)' != 'Windows_NT'">false</ProducePdb>
       <GenFacadesIgnoreMissingTypes Condition="'$(GenFacadesIgnoreMissingTypes)' == ''">false</GenFacadesIgnoreMissingTypes>
       <GenFacadesIgnoreBuildAndRevisionMismatch Condition="'$(GenFacadesIgnoreBuildAndRevisionMismatch)' == ''">false</GenFacadesIgnoreBuildAndRevisionMismatch>
     </PropertyGroup>
+
+    <!-- Move the PDB into a subdirectory for GenFacades if we are producing PDBs -->
+    <Move SourceFiles="$(PartialFacadeSymbols)"
+          DestinationFolder="$(GenFacadesInputPath)"
+          Condition="$(ProducePdb)" />
 
     <PropertyGroup Condition="'$(IsReferenceAssembly)' != 'true'">
       <GenFacadesPartialFacadeAssemblyPath>$(GenFacadesInputAssembly)</GenFacadesPartialFacadeAssemblyPath>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
@@ -41,12 +41,11 @@
     <!-- Move the PDB into a subdirectory for GenFacades if we are producing PDBs -->
     <Move SourceFiles="$(PartialFacadeSymbols)"
           DestinationFolder="$(GenFacadesInputPath)"
-          Condition="'$(DebugSymbols)' != 'false'"
-    />
+          Condition="'$(DebugSymbols)' != 'false' AND '$(OSGroup)' == 'Windows_NT'" />
 
     <PropertyGroup>
       <ProducePdb>true</ProducePdb>
-      <ProducePdb Condition="'$(DebugSymbols)' == 'false'">false</ProducePdb>
+      <ProducePdb Condition="'$(DebugSymbols)' == 'false' OR '$(OSGroup)' != 'Windows_NT'">false</ProducePdb>
       <GenFacadesIgnoreMissingTypes Condition="'$(GenFacadesIgnoreMissingTypes)' == ''">false</GenFacadesIgnoreMissingTypes>
       <GenFacadesIgnoreBuildAndRevisionMismatch Condition="'$(GenFacadesIgnoreBuildAndRevisionMismatch)' == ''">false</GenFacadesIgnoreBuildAndRevisionMismatch>
     </PropertyGroup>


### PR DESCRIPTION
This is a second attempt.   The first attempt was a misunderstanding of how Linux builds worked.

Before trying to support protable PDBs, GenFacades had a condition that it was never called if
Portable PDBs are used.   However we WANTED to used portable PDBs so we added support for
that and dropped the condition to skip GenFacades if portable PDBs were used.

However this had the effect of running GenFacades on Linux, where previously it never ran there
(because Linux always used portable PDBs).

This fix basically puts the behavior back EXACTLY as it was before on non-windows platforms.
This will fix errors (they happen to be index out of range errors) on Linux builds (because we
are running GenFacades where we should not be).

@dagood  @stephentoub 