### PR TITLE
Turn Off DiskUsage Reporting in CleanUpVSTSAgent

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/scripts/vstsagent/cleanupagent.proj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <RetentionDays Condition="'$(RetentionDays)' == ''">1</RetentionDays>
     <DoClean Condition="'$(DoClean)' == ''">false</DoClean>
-    <DoReport Condition="'$(DoReport)' == ''">true</DoReport>
+    <DoReport Condition="'$(DoReport)' == ''">false</DoReport>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
DiskUsage Reporting alone is taking ~20 mins on OSX machines for each of the folders getting cleaned. Turning off to improve the perf. 