### PR TITLE
Compatibility issue fix

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -8,7 +8,7 @@
       as we know it is safe to resolve its assets as net461.
     -->
     <NoWarn>$(NoWarn);NU1701</NoWarn>
-        <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -7,8 +7,8 @@
       disable NU1701 that we are getting for Microsoft.Net.Compilers.Targets.NetCore
       as we know it is safe to resolve its assets as net461.
     -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+        <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -7,6 +7,7 @@
       disable NU1701 that we are getting for Microsoft.Net.Compilers.Targets.NetCore
       as we know it is safe to resolve its assets as net461.
     -->
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tool-runtime/project.csproj
@@ -7,7 +7,7 @@
       disable NU1701 that we are getting for Microsoft.Net.Compilers.Targets.NetCore
       as we know it is safe to resolve its assets as net461.
     -->
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
A change to this file in https://github.com/dotnet/buildtools/commit/21e36983f28a5e587e300c506641f1b698b6decb is causing that when running init-tools errors like the below are thrown:

error : Package Microsoft.Net.Compilers.Targets.NetCore 0.1.5-dev is not compatible with netcoreapp2.0 (.NETCoreApp,Version=v2.0). Package Microsoft.Net.Compilers.Targets.NetCore 0.1.5-dev supports: dotnet (.NETPlatform,Version=v5.0) [G:\Code\coreclr\packages\microsoft.dotnet.buildtools\2.0.0-prerelease-02012-01\lib\tool-runtime\project.csproj]
