### PR TITLE
Add ILAsm to buildtools

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
@@ -4,6 +4,14 @@
   <!-- Required by Microsoft.Common.targets -->
   <Target Name="CreateManifestResourceNames" Condition="'@(EmbeddedResource)' != ''" />
 
+  <!-- Default to ILAsm shipped with buildtools -->
+  <PropertyGroup Condition="'$(IlasmToolPath)' == ''">
+    <IlasmPath>$(MSBuildThisFileDirectory)\ilasm\</IlasmPath>
+    <IlasmToolPath Condition="'$(RunningOnUnix)'!='true' And Exists('$(IlasmPath)ilasm.exe')">$(IlasmPath)ilasm.exe</IlasmToolPath>
+    <IlasmToolPath Condition="'$(RunningOnUnix)'=='true' And Exists('$(IlasmPath)ilasm')">$(IlasmPath)ilasm</IlasmToolPath>
+  </PropertyGroup>
+
+  <!-- If buildtools wasn't restored with ILAsm, on Windows we can fallback to ILAsm from the framework -->
   <Target Name="GetIlasmPath"
           Condition="'$(RunningOnUnix)'!='true' And '$(IlasmToolPath)' == ''">
     <GetFrameworkPath>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- suppress the attempt to copy build output. -->
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+  </PropertyGroup>
+
+  <Target Name="CoreCompile">
+    <Copy SourceFiles="@(NativeCopyLocalItems)" DestinationFolder="$(MSBuildThisFileDirectory)" />
+  </Target>
+
+  <!-- Required by Common.Targets -->
+  <Target Name="CreateManifestResourceNames" />
+
+  <PropertyGroup>
+    <NuGetTargetMoniker>.NETCoreApp,Version=v2.0</NuGetTargetMoniker>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RidSpecificAssets>true</RidSpecificAssets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.0-preview1-25916-01" />
+    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="2.1.0-preview1-25916-01" />
+  </ItemGroup>
+</Project> 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- suppress the attempt to copy build output. -->
@@ -19,7 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="2.1.0-preview1-25916-01" />
-    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="2.1.0-preview1-25916-01" />
+    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(ILAsmPackageVersion)" />
+
+    <!-- ILAsm has a very unfortunate runtime dependency on CoreCLR, so we need to grab that too -->
+    <!-- https://github.com/dotnet/coreclr/issues/15059 -->
+    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="$(ILAsmPackageVersion)" />
   </ItemGroup>
 </Project> 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <!-- suppress the attempt to copy build output. -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -13,6 +13,11 @@ set MICROBUILD_VERSION=0.2.0
 set PORTABLETARGETS_VERSION=0.1.1-dev
 set ROSLYNCOMPILERS_VERSION=2.6.0-beta1-62126-01
 
+:: Default to x64 native tools if nothing was specified.
+if [%NATIVE_TOOLS_RID%]==[] (
+  set NATIVE_TOOLS_RID=win-x64
+)
+
 set MSBUILD_PROJECT_CONTENT= ^
  ^^^<Project Sdk=^"Microsoft.NET.Sdk^"^^^> ^
   ^^^<PropertyGroup^^^> ^
@@ -96,10 +101,6 @@ Robocopy "%PACKAGES_DIR%\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%
 
 :: Restore ILAsm if the caller asked for it by setting the environment variable
 if [%ILASMCOMPILER_VERSION%]==[] goto :afterILAsmRestore
-if [%NATIVE_TOOLS_RID%]==[] (
-  echo ERROR: Asked to restore ILAsm but didn't specify the RID
-  exit /b 1
-)
 
 @echo on
 call "%DOTNET_CMD%" build "%TOOLRUNTIME_DIR%\ilasm\ilasm.depproj" -r %NATIVE_TOOLS_RID% --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --packages "%PACKAGES_DIR%\." /p:ILAsmPackageVersion=%ILASMCOMPILER_VERSION%

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -95,6 +95,19 @@ Robocopy "%PACKAGES_DIR%\MicroBuild.Core\%MICROBUILD_VERSION%\build\." "%TOOLRUN
 Robocopy "%PACKAGES_DIR%\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%TOOLRUNTIME_DIR%\net46\roslyn\." /E
 
 @echo on
+call "%DOTNET_CMD%" build "%TOOLRUNTIME_DIR%\ilasm\ilasm.depproj" -r win-x64 --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --packages "%PACKAGES_DIR%\."
+set RESTORE_ILASM_ERROR_LEVEL=%ERRORLEVEL%
+@echo off
+if not [%RESTORE_ILASM_ERROR_LEVEL%]==[0] (
+  echo ERROR: An error ocurred when running: '"%DOTNET_CMD%" build "%TOOLRUNTIME_DIR%\ilasm\ilasm.depproj"'. Please check above for more details.
+  exit /b %RESTORE_ILASM_ERROR_LEVEL%
+)
+if not exist "%TOOLRUNTIME_DIR%\ilasm\ilasm.exe" (
+  echo ERROR: Failed to restore ilasm.exe
+  exit /b 1
+)
+
+@echo on
 powershell -NoProfile -ExecutionPolicy unrestricted %BUILDTOOLS_PACKAGE_DIR%\init-tools.ps1 -ToolRuntimePath %TOOLRUNTIME_DIR% -DotnetCmd %DOTNET_CMD% -BuildToolsPackageDir %BUILDTOOLS_PACKAGE_DIR%
 set POWERSHELL_INIT_TOOLS_ERROR_LEVEL=%ERRORLEVEL%
 @echo off

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -7,6 +7,8 @@
     <ProjectsToExclude Include="xunit.runner.uap\RunnerRemoteExecutionServiceUAP\RunnerRemoteExecutionServiceUAP.csproj" />
     <!-- tool-runtime\project.csproj is not a real project to build, it's part of the buildtools package for initialization. -->
     <ProjectsToExclude Include="Microsoft.DotNet.Build.Tasks\PackageFiles\tool-runtime\project.csproj" />
+    <!-- ilasm\ilasm.depproj is not a real project to build, it's part of the buildtools package for initialization. -->
+    <ProjectsToExclude Include="Microsoft.DotNet.Build.Tasks\PackageFiles\ilasm\ilasm.depproj" />
     <!-- Exclude the UWP console from the build on non windows because it requires nuget.exe to restore a packages.config -->
     <ProjectsToExclude Include="xunit.console.uwp\xunit.console.uwp.csproj" Condition="'$(OSEnvironment)' != 'Windows_NT'" />
   </ItemGroup>

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <Project Include="*\**\*.csproj" Exclude="@(ProjectsToExclude)" />
-    <Project Include="*\**\*.depproj" />
+    <Project Include="*\**\*.depproj" Exclude="@(ProjectsToExclude)" />
   </ItemGroup>
 
   <Import Project="..\dir.targets" />


### PR DESCRIPTION
Windows-only for now since that's what I need. I think we would want the bootstrapper (the thing that invokes init-tools) to pass us the RID it used to restore .NET CLI so that we can restore the appropriate version of the native tools. RID in the Windows batch file was easy to hardcode since we seem to hardcode x64 on Windows everywhere.

Contributes to #1363.