### PR TITLE
Tasks to create package version props using Sleet

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Packaging.Core;
 using MSBuild = Microsoft.Build.Utilities;
 using CloudTestTasks = Microsoft.DotNet.Build.CloudTestTasks;
 
@@ -184,6 +185,25 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 Log.LogErrorFromException(e);
             }
+        }
+
+        public async Task<ISet<PackageIdentity>> GetPackageIdentitiesAsync()
+        {
+            var context = new SleetContext
+            {
+                LocalSettings = GetSettings(),
+                Log = new SleetLogger(Log),
+                Source = GetAzureFileSystem(),
+                Token = CancellationToken
+            };
+            context.SourceSettings = await FeedSettingsUtility.GetSettingsOrDefault(
+                context.Source,
+                context.Log,
+                context.Token);
+
+            var packageIndex = new PackageIndex(context);
+
+            return await packageIndex.GetPackagesAsync();
         }
 
         private bool IsSanityChecked(IEnumerable<string> items)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/GetBlobFeedPackageList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/GetBlobFeedPackageList.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using NuGet.Packaging.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MSBuild = Microsoft.Build.Utilities;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class GetBlobFeedPackageList : MSBuild.Task
+    {
+        private const string NuGetPackageInfoId = "PackageId";
+        private const string NuGetPackageInfoVersion = "PackageVersion";
+
+        [Required]
+        public string ExpectedFeedUrl { get; set; }
+
+        [Required]
+        public string AccountKey { get; set; }
+
+        [Output]
+        public ITaskItem[] PackageInfos { get; set; }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        private async Task<bool> ExecuteAsync()
+        {
+            try
+            {
+                Log.LogMessage(MessageImportance.High, "Listing blob feed packages...");
+
+                BlobFeedAction action = new BlobFeedAction(ExpectedFeedUrl, AccountKey, Log);
+
+                ISet<PackageIdentity> packages = await action.GetPackageIdentitiesAsync();
+
+                PackageInfos = packages.Select(ConvertToPackageInfoItem).ToArray();
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private ITaskItem ConvertToPackageInfoItem(PackageIdentity identity)
+        {
+            var metadata = new Dictionary<string, string>
+            {
+                [NuGetPackageInfoId] = identity.Id,
+                [NuGetPackageInfoVersion] = identity.Version.ToString()
+            };
+
+            return new MSBuild.TaskItem(identity.ToString(), metadata);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -42,6 +42,7 @@
     <Compile Include="BlobFeed.cs" />
     <Compile Include="BlobFeedAction.cs" />
     <Compile Include="ConfigureInputFeed.cs" />
+    <Compile Include="GetBlobFeedPackageList.cs" />
     <Compile Include="PushToBlobFeed.cs" />
     <Compile Include="SleetLogger.cs" />
     <Compile Include="SleetSettings.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -29,8 +29,9 @@
     <_TaskDir>$(MSBuildThisFileDirectory)net46/</_TaskDir>
     <_TaskDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)netstandard1.5/</_TaskDir>
   </PropertyGroup>
-  <UsingTask TaskName="PushToBlobFeed" AssemblyFile="$(_TaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="ConfigureInputFeeds" AssemblyFile="$(_TaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
+  <UsingTask TaskName="GetBlobFeedPackageList" AssemblyFile="$(_TaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
+  <UsingTask TaskName="PushToBlobFeed" AssemblyFile="$(_TaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
 
   <PropertyGroup>
     <PushToBlobFeed_Overwrite Condition="'$(PushToBlobFeed_Overwrite)' == ''">false</PushToBlobFeed_Overwrite>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -57,6 +57,7 @@
     <Compile Include="ExecWithRetries.cs" />
     <Compile Include="ExecWithRetriesForNuGetPush.cs" />
     <Compile Include="OpenSourceSign.cs" />
+    <Compile Include="Orchestration\WriteBuildOutputProps.cs" />
     <Compile Include="PackageRestoreLogger.cs" />
     <Compile Include="ParseTestCoverageInfo.cs" />
     <Compile Include="PreprocessFile.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Orchestration/WriteBuildOutputProps.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Orchestration/WriteBuildOutputProps.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using NuGet.Packaging.Core;
+using NuGet.Versioning;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Build.Tasks.Orchestration
+{
+    public class WriteBuildOutputProps : BuildTask
+    {
+        private const string NuGetPackageInfoId = "PackageId";
+        private const string NuGetPackageInfoVersion = "PackageVersion";
+
+        [Required]
+        public ITaskItem[] NuGetPackageInfos { get; set; }
+
+        [Required]
+        public string OutputPath { get; set; }
+
+        /// <summary>
+        /// Prevents overriding stable packages. Adds a condition to each package version property:
+        /// only set the property when the property already exists and specifies a prerelease.
+        /// </summary>
+        public bool OnlyUpdatePrereleaseVersions { get; set; }
+
+        public override bool Execute()
+        {
+            PackageIdentity[] latestPackages = NuGetPackageInfos
+                .Select(item =>
+                {
+                    var id = item.GetMetadata(NuGetPackageInfoId);
+                    var version = item.GetMetadata(NuGetPackageInfoVersion);
+
+                    if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(version))
+                    {
+                        return null;
+                    }
+
+                    return new PackageIdentity(id, NuGetVersion.Parse(version));
+                })
+                .Where(identity => identity != null)
+                .GroupBy(identity => identity.Id)
+                .Select(g => g.OrderBy(id => id.Version).Last())
+                .OrderBy(id => id.Id)
+                .ToArray();
+
+            Directory.CreateDirectory(Path.GetDirectoryName(OutputPath));
+
+            var invalidElementNameCharRegex = new Regex(@"(^|[^A-Za-z0-9])(?<FirstPartChar>.)");
+
+            using (var outStream = File.Open(OutputPath, FileMode.Create))
+            using (var sw = new StreamWriter(outStream, new UTF8Encoding(false)))
+            {
+                sw.WriteLine(@"<?xml version=""1.0"" encoding=""utf-8""?>");
+                sw.WriteLine(@"<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">");
+                sw.WriteLine(@"  <PropertyGroup>");
+                foreach (PackageIdentity packageIdentity in latestPackages)
+                {
+                    string formattedId = invalidElementNameCharRegex.Replace(
+                        packageIdentity.Id,
+                        match => match.Groups?["FirstPartChar"].Value.ToUpperInvariant()
+                            ?? string.Empty);
+
+                    string propertyName = $"{formattedId}PackageVersion";
+
+                    string condition = string.Empty;
+                    if (OnlyUpdatePrereleaseVersions)
+                    {
+                        condition = $@" Condition=""$({propertyName}.Contains('-'))""";
+                    }
+
+                    sw.WriteLine($"    <{propertyName}{condition}>{packageIdentity.Version}</{propertyName}>");
+                }
+                sw.WriteLine(@"  </PropertyGroup>");
+                sw.WriteLine(@"</Project>");
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Tasks for an orchestration utility build def that takes in a blob feed and adds a package version props file to it. Usage:

```xml
<Target Name="UpdatePackageVersionProps">
  <PropertyGroup>
    <TempPackageVersionPropsFile>$(BaseIntermediateOutputPath)PackageVersions.props</TempPackageVersionPropsFile>
  </PropertyGroup>

  <GetBlobFeedPackageList
    ExpectedFeedUrl="$(ExpectedFeedUrl)"
    AccountKey="$(AccountKey)">
    <Output TaskParameter="PackageInfos" ItemName="PackageInfos" />
  </GetBlobFeedPackageList>

  <WriteBuildOutputProps
    NuGetPackageInfos="@(PackageInfos)"
    OutputPath="$(TempPackageVersionPropsFile)"
    OnlyUpdatePrereleaseVersions="true" />

  <ItemGroup>
    <TempPackageVersionPropsFileForUpload Include="$(TempPackageVersionPropsFile)">
      <RelativeBlobPath>orchestration-metadata/PackageVersions.props</RelativeBlobPath>
    </TempPackageVersionPropsFileForUpload>
  </ItemGroup>

  <PushToBlobFeed
    ExpectedFeedUrl="$(ExpectedFeedUrl)"
    AccountKey="$(AccountKey)"
    ItemsToPush="@(TempPackageVersionPropsFileForUpload)"
    Overwrite="true"
    PublishFlatContainer="true" />
</Target>
```