### PR TITLE
Publish symbols to flat containers

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -97,15 +97,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             string relativeBlobPath = item.GetMetadata("RelativeBlobPath");
 
-            if (string.IsNullOrEmpty(relativeBlobPath) || symbols)
+            if (string.IsNullOrEmpty(relativeBlobPath))
             {
-                string symbolsFolder = symbols ? "symbols/" : string.Empty;
                 string fileName = Path.GetFileName(item.ItemSpec);
                 string recursiveDir = item.GetMetadata("RecursiveDir");
-                relativeBlobPath = $"{feed.RelativePath}{symbolsFolder}{recursiveDir}{fileName}";
+                relativeBlobPath = $"{recursiveDir}{fileName}";
             }
 
-            relativeBlobPath = relativeBlobPath.Replace("\\", "/");
+            relativeBlobPath = $"{feed.RelativePath}{relativeBlobPath}".Replace("\\", "/");
 
             Log.LogMessage($"Uploading {relativeBlobPath}");
 
@@ -170,7 +169,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 try
                 {
-
                     bool result = await InitAsync();
 
                     if (result)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -82,8 +82,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             if (!items.Any())
             {
-                Log.LogError("No items to push found in the items list.");
-                return false;
+                Log.LogMessage("No items to push found in the items list.");
+                return true;
             }
 
             try

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             try
             {
-                bool result = await PushAsync(items.ToList(), allowOverwrite);
+                bool result = await PushAsync(items, allowOverwrite);
                 return result;
             }
             catch (Exception e)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             Log.LogMessage(MessageImportance.Low, $"START pushing items to feed");
 
-            if (items.Count() == 0)
+            if (!items.Any())
             {
                 Log.LogError("No items to push found in the items list.");
                 return false;

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -80,6 +80,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             Log.LogMessage(MessageImportance.Low, $"START pushing items to feed");
 
+            if (items.Count() == 0)
+            {
+                Log.LogError("No items to push found in the items list.");
+                return false;
+            }
+
             try
             {
                 bool result = await PushAsync(items.ToList(), allowOverwrite);
@@ -93,7 +99,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return !Log.HasLoggedErrors;
         }
 
-        public async Task UploadAssets(ITaskItem item, SemaphoreSlim clientThrottle, bool allowOverwrite = false, bool symbols = false)
+        public async Task UploadAssets(ITaskItem item, SemaphoreSlim clientThrottle, bool allowOverwrite = false)
         {
             string relativeBlobPath = item.GetMetadata("RelativeBlobPath");
 
@@ -239,15 +245,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         {
             LocalSettings settings = GetSettings();
             AzureFileSystem fileSystem = GetAzureFileSystem();
-            bool result = await PushCommand.RunAsync(settings, fileSystem, items.ToList(), allowOverwrite, false, new SleetLogger(Log));
+            bool result = await PushCommand.RunAsync(settings, fileSystem, items.ToList(), allowOverwrite, skipExisting: false, log: new SleetLogger(Log));
             return result;
         }
 
         private async Task<bool> InitAsync()
         {
+
             LocalSettings settings = GetSettings();
             AzureFileSystem fileSystem = GetAzureFileSystem();
-            bool result = await InitCommand.RunAsync(settings, fileSystem, false, false, new SleetLogger(Log), CancellationToken);
+            bool result = await InitCommand.RunAsync(settings, fileSystem, enableCatalog: false, enableSymbols: false, log: new SleetLogger(Log), token: CancellationToken);
             return result;
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -69,10 +69,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             return i;
                         });
 
-                        var packageItems = ItemsToPush.Where(i => !symbolItems.Contains(i)).Select(i => 
-                        {
-                            return i.ItemSpec;
-                        });
+                        var packageItems = ItemsToPush.Where(i => !symbolItems.Contains(i)).Select(i => i.ItemSpec);
 
                         await blobFeedAction.PushToFeed(packageItems, Overwrite);
                         await PublishToFlatContainerAsync(symbolItems, blobFeedAction);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         List<string> packageItems = GetPackageStringLists(packages);
 
                         await blobFeedAction.PushToFeed(packageItems, Overwrite);
-                        await PublishToFlatContainerAsync(symbolItems, blobFeedAction, true);
+                        await PublishToFlatContainerAsync(symbolItems, blobFeedAction);
                     }
                 }
             }
@@ -95,14 +95,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return stringList;
         }
 
-        private async Task PublishToFlatContainerAsync(ITaskItem[] taskItems, BlobFeedAction blobFeedAction, bool symbolItems = false)
+        private async Task PublishToFlatContainerAsync(ITaskItem[] taskItems, BlobFeedAction blobFeedAction)
         {
             if (taskItems.Length > 0)
             {
                 using (var clientThrottle = new SemaphoreSlim(this.MaxClients, this.MaxClients))
                 {
                     Log.LogMessage($"Uploading {taskItems.Length} items...");
-                    await Task.WhenAll(taskItems.Select(item => blobFeedAction.UploadAssets(item, clientThrottle, Overwrite, symbolItems)));
+                    await Task.WhenAll(taskItems.Select(item => blobFeedAction.UploadAssets(item, clientThrottle, Overwrite)));
                 }
             }
         }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -61,8 +61,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                     else
                     {
-                        List<string> packageItems = GetPackageStringLists(ItemsToPush);
                         ITaskItem[] symbolItems = ItemsToPush.Where(i => i.ItemSpec.Contains("symbols.nupkg")).ToArray();
+                        ITaskItem[] packages = ItemsToPush.Where(i => !symbolItems.Contains(i)).ToArray();
+                        List<string> packageItems = GetPackageStringLists(packages);
 
                         await blobFeedAction.PushToFeed(packageItems, Overwrite);
                         await PublishToFlatContainerAsync(symbolItems, blobFeedAction, true);
@@ -80,7 +81,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         private List<string> GetPackageStringLists(ITaskItem[] taskItems)
         {
             List<string> stringList = new List<string>();
-            foreach (var item in taskItems.Where(i => !i.ItemSpec.Contains("symbols.nupkg")))
+            foreach (var item in taskItems)
             {
                 stringList.Add(item.ItemSpec);
             }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -68,8 +68,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             i.SetMetadata("RelativeBlobPath", $"symbols/{fileName}");
                             return i;
                         });
-                        var packages = ItemsToPush.Where(i => !symbolItems.Contains(i));
-                        List<string> packageItems = GetPackageStringLists(packages);
+
+                        var packageItems = ItemsToPush.Where(i => !symbolItems.Contains(i)).Select(i => 
+                        {
+                            return i.ItemSpec;
+                        });
 
                         await blobFeedAction.PushToFeed(packageItems, Overwrite);
                         await PublishToFlatContainerAsync(symbolItems, blobFeedAction);
@@ -82,17 +85,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
 
             return !Log.HasLoggedErrors;
-        }
-
-        private List<string> GetPackageStringLists(IEnumerable<ITaskItem> taskItems)
-        {
-            List<string> stringList = new List<string>();
-            foreach (var item in taskItems)
-            {
-                stringList.Add(item.ItemSpec);
-            }
-
-            return stringList;
         }
 
         private async Task PublishToFlatContainerAsync(IEnumerable<ITaskItem> taskItems, BlobFeedAction blobFeedAction)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -5,6 +5,7 @@
 using Microsoft.Build.Framework;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -61,7 +62,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                     else
                     {
-                        ITaskItem[] symbolItems = ItemsToPush.Where(i => i.ItemSpec.Contains("symbols.nupkg")).ToArray();
+                        ITaskItem[] symbolItems = ItemsToPush.Where(i => i.ItemSpec.Contains("symbols.nupkg")).Select(i => 
+                        {
+                            string fileName = Path.GetFileName(i.ItemSpec);
+                            i.SetMetadata("RelativeBlobPath", $"symbols/{fileName}");
+                            return i;
+                        }).ToArray();
                         ITaskItem[] packages = ItemsToPush.Where(i => !symbolItems.Contains(i)).ToArray();
                         List<string> packageItems = GetPackageStringLists(packages);
 


### PR DESCRIPTION
We've decided that we'll publish symbols to flat containers by default instead of using Sleet. This change disables Sleet's symbols publishing and adds logic to identify and categorize packages and symbols