### PR TITLE
Adding 5 minute timeout to HttpClient for UploadToAzure scenarios

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
@@ -46,6 +46,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             string ContainerName,
             string filePath,
             string destinationBlob,
+            int uploadTimeout,
             string leaseId = "")
         {
             string resourceUrl = AzureHelper.GetContainerRestUrl(AccountName, ContainerName);
@@ -86,7 +87,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                         client.DefaultRequestHeaders.Clear();
 
                         // In random occassions the request fails if the network is slow and it takes more than 100 seconds to upload 4MB. 
-                        client.Timeout = TimeSpan.FromMinutes(5);
+                        client.Timeout = TimeSpan.FromMinutes(uploadTimeout);
                         Func<HttpRequestMessage> createRequest = () =>
                         {
                             DateTime dt = DateTime.UtcNow;

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
@@ -84,6 +84,9 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     using (HttpClient client = new HttpClient())
                     {
                         client.DefaultRequestHeaders.Clear();
+
+                        // In random occassions the request fails if the network is slow and it takes more than 100 seconds to upload 4MB. 
+                        client.Timeout = TimeSpan.FromMinutes(5);
                         Func<HttpRequestMessage> createRequest = () =>
                         {
                             DateTime dt = DateTime.UtcNow;

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -47,6 +47,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         /// </summary>
         public int MaxClients { get; set; } = 8;
 
+        public int UploadTimeoutInMinutes { get; set; } = 5;
+
         public void Cancel()
         {
             TokenSource.Cancel();
@@ -151,7 +153,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                         AccountKey,
                         ContainerName,
                         item.ItemSpec,
-                        relativeBlobPath);
+                        relativeBlobPath,
+                        UploadTimeoutInMinutes);
             }
             finally
             {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return !Log.HasLoggedErrors;
         }
 
-        public async Task UploadAssets(ITaskItem item, SemaphoreSlim clientThrottle, bool allowOverwrite = false)
+        public async Task UploadAssets(ITaskItem item, SemaphoreSlim clientThrottle, int uploadTimeout, bool allowOverwrite = false)
         {
             string relativeBlobPath = item.GetMetadata("RelativeBlobPath");
 
@@ -136,7 +136,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         feed.AccountKey,
                         feed.ContainerName,
                         item.ItemSpec,
-                        relativeBlobPath);
+                        relativeBlobPath,
+                        uploadTimeout);
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -32,6 +32,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public bool SkipCreateContainer { get; set; } = false;
 
+        public int UploadTimeoutInMinutes { get; set; } = 5;
+
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -91,7 +93,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 using (var clientThrottle = new SemaphoreSlim(this.MaxClients, this.MaxClients))
                 {
                     Log.LogMessage($"Uploading {taskItems.Count()} items...");
-                    await Task.WhenAll(taskItems.Select(item => blobFeedAction.UploadAssets(item, clientThrottle, Overwrite)));
+                    await Task.WhenAll(taskItems.Select(item => blobFeedAction.UploadAssets(item, clientThrottle, UploadTimeoutInMinutes, Overwrite)));
                 }
             }
         }


### PR DESCRIPTION
Some core-setup and corefx build are recently failing when trying to upload big symbol packages. At this point HttpClient uses the default timeout of 100 seconds which in some cases is not enough