### PR TITLE
Log blobs/directory names that would trigger PathTooLongException in …

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         private static readonly CancellationTokenSource TokenSource = new CancellationTokenSource();
         private static readonly CancellationToken CancellationToken = TokenSource.Token;
         private static readonly string PathLengthTaskItemMetadataKey = "DestinationPathLength";
-        private static readonly string DestinationPathTaskItemMetadataKey = "DestinationPathLength";
+        private static readonly string DestinationPathTaskItemMetadataKey = "DestinationPath";
 
         private IList<ITaskItem> _pathTooLongEntries = new List<ITaskItem>();
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
             catch (Exception e)
             {
-                Log.LogErrorFromException(e, true);
+                Log.LogError(e.ToString());
             }
             return !Log.HasLoggedErrors;
         }
@@ -173,7 +173,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                             }
                             else
                             {
-                                Log.LogWarning($"Unable to download blob '{blob}' as it has a directory-like name. This may cause problems if it was needed.");
+                                Log.LogWarning($"Unable to download blob '{blob}' as it has a directory-like name.  This may cause problems if it was needed.");
                             }
                         }
                         else
@@ -189,7 +189,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
             catch (Exception ex)
             {
-                Log.LogErrorFromException(ex, true);
+                Log.LogError(ex.ToString());
             }
             finally
             {


### PR DESCRIPTION
…Microsoft.DotNet.Build.CloudTestTasks.DownloadFromAzure

Enables Option 2 in #1757 

Verified by running the modified task in Win10/Win7/Ubuntu environments.

If the input directory name already hits MAX_PATH, then the task errors out (it already did this)

If the path is exceeded when expanding the Blob's path and actually trying to save the file, then a warning is logged (which is consistent with what specifying invalid directory-type blob names does already). Additionally, The task can now return a list of all the entries that were not saved because of PathTooLong exceptions.