### PR TITLE
[release/2.0.0] Port VersionTools auto-update pull request fixes

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubApiModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubApiModel.cs
@@ -50,6 +50,12 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
         public string Content { get; set; }
     }
 
+    public class GitHubCombinedStatus
+    {
+        public string State { get; set; }
+        public GitHubStatus[] Statuses { get; set; }
+    }
+
     public class GitHubStatus
     {
         public string State { get; set; }

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -234,14 +234,14 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             }
         }
 
-        public async Task<GitHubStatus[]> GetStatusesAsync(GitHubProject project, string @ref)
+        public async Task<GitHubCombinedStatus> GetStatusAsync(GitHubProject project, string @ref)
         {
-            string url = $"https://api.github.com/repos/{project.Segments}/commits/{@ref}/statuses";
+            string url = $"https://api.github.com/repos/{project.Segments}/commits/{@ref}/status";
 
             using (HttpResponseMessage response = await _httpClient.GetAsync(url))
             {
                 Trace.TraceInformation($"Getting info about ref {@ref} in {project.Segments}");
-                return await DeserializeSuccessfulAsync<GitHubStatus[]>(response);
+                return await DeserializeSuccessfulAsync<GitHubCombinedStatus>(response);
             }
         }
 

--- a/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
@@ -152,13 +152,16 @@ namespace Microsoft.DotNet.VersionTools.Automation
             // GitHub returns the HTML "commit" url, but we want "commits" so that CI results show.
             string oldCommitsUrl = oldCommit.HtmlUrl.Replace("commit", "commits");
 
-            GitHubStatus[] statuses = await client.GetStatusesAsync(baseProject, oldCommit.Sha);
+            GitHubCombinedStatus combinedStatus = await client.GetStatusAsync(
+                baseProject,
+                oldCommit.Sha);
 
-            string statusLines = statuses
-                    .OrderBy(s => s.State)
-                    .ThenBy(s => s.Context)
-                    .Select(GetStatusLine)
-                    .Aggregate(string.Empty, (acc, line) => acc + line + "\r\n");
+            string statusLines = combinedStatus
+                .Statuses
+                .OrderBy(s => s.State)
+                .ThenBy(s => s.Context)
+                .Select(GetStatusLine)
+                .Aggregate(string.Empty, (acc, line) => acc + line + "\r\n");
 
             string oldCommitEntry =
                 $" * [`{oldCommit.Sha.Substring(0, 7)}`]({oldCommitsUrl}) {oldCommit.Message}\r\n" +

--- a/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
@@ -245,9 +245,14 @@ namespace Microsoft.DotNet.VersionTools.Automation
                 emoticon = ":x:";
             }
 
-            return
-                $"   * {emoticon} **{status.Context}** {status.Description} " +
-                $"[Details]({status.TargetUrl})";
+            string line = $"   * {emoticon} **{status.Context}** {status.Description}";
+
+            if (!string.IsNullOrEmpty(status.TargetUrl))
+            {
+                line += $" [Details]({status.TargetUrl})";
+            }
+
+            return line;
         }
     }
 }


### PR DESCRIPTION
I noticed release/2.0.0 is missing https://github.com/dotnet/buildtools/pull/1775 and https://github.com/dotnet/buildtools/pull/1794 in this submodule auto-update PR: https://github.com/dotnet/source-build/pull/294.