### PR TITLE
Changes required to let scriptrunner.py run commands outside of Helix Context

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/RunnerScripts/scriptrunner/scriptrunner.py
@@ -16,6 +16,8 @@ from helix.cmdline import command_main
 from helix.io import fix_path
 from helix_test_execution import HelixTestExecution
 
+import subprocess
+
 log = helix.logs.get_logger()
 
 
@@ -26,27 +28,31 @@ def main(args=None):
             xunitrunner
                 [--config config.json]
                 [--setting name=value]
-                --script
-                [--args arg1 arg2...]
+                --script=path
+                [--standalone]
+                [args]
         """
-        optdict = dict(optlist)
         log.info("BuildTools Helix Script Runner v0.1 starting")
-        if '--args' in optdict:
-            script_arguments = optdict['--args']
-            log.info("Script Arguments:"+script_arguments)
+
+        optdict = dict(optlist)
 
         script_to_execute = optdict['--script']
+        unpack_dir = fix_path(settings.workitem_payload_dir)
+        execution_args = [os.path.join(unpack_dir, script_to_execute)] + args
+
+        # If the user has specified to run the command in standalone mode then
+	    # we don't wrap the command execution in the Helix context.
+        if '--standalone' in optdict:
+            log.info("Going to execute the command+args: {}".format(execution_args))
+            subprocess.call(execution_args)
+            return None
 
         test_executor = HelixTestExecution(settings)
 
-        unpack_dir = fix_path(settings.workitem_payload_dir)
-
-        execution_args = [os.path.join(unpack_dir, script_to_execute)] + args
-
         return_code = helix.proc.run_and_log_output(
-            execution_args,
+       	    execution_args,
             cwd=unpack_dir,
-            env=None
+       	    env=None
         )
         event_client = helix.event.create_from_uri(settings.event_uri)
         results_location = os.path.join(unpack_dir, 'testResults.xml')
@@ -74,22 +80,22 @@ def main(args=None):
             result_url = test_executor.upload_file_to_storage(results_location, settings)
             log.info("Sending completion event")
             event_client.send(
-                {
-                    'Type': 'XUnitTestResult',
+       	        {
+               	    'Type': 'XUnitTestResult',
                     'WorkItemId': settings.workitem_id,
-                    'WorkItemFriendlyName': settings.workitem_friendly_name,
-                    'CorrelationId': settings.correlation_id,
+       	            'WorkItemFriendlyName': settings.workitem_friendly_name,
+               	    'CorrelationId': settings.correlation_id,
                     'ResultsXmlUri': result_url,
-                    'TestCount': test_count,
+       	            'TestCount': test_count,
                 }
-            )
+       	    )
         else:
             log.error("Error: No exception thrown, but XUnit results not created")
             test_executor.report_error(settings, failure_type="XUnitTestFailure")
 
         return return_code
 
-    return command_main(_main, ['script=', 'args='], args)
+    return command_main(_main, ['standalone', 'script=', 'args='], args)
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
Added a new optional parameter (--standalone) that let the user opt to execute the command outside the Helix context.

Part of the solution to: https://github.com/dotnet/core-eng/issues/2017