### PR TITLE
Provide a way to ignore BuildConfigurations through _ prefix in the build configuration

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Configuration/ConfigurationFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Configuration/ConfigurationFactory.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.Build.Tasks
     public class ConfigurationFactory
     {
         internal const char PropertySeparator = '-';
+        internal const string NopConfigurationPrefix = "_";
 
         private Dictionary<string, PropertyInfo> Properties { get; }
 
@@ -170,6 +171,11 @@ namespace Microsoft.DotNet.Build.Tasks
         /// <returns></returns>
         internal Configuration ParseConfiguration(string configurationString, bool permitUnknownValues = false)
         {
+            if (configurationString.StartsWith(NopConfigurationPrefix))
+            {
+                configurationString = configurationString.Substring(1);
+            }
+
             var values = configurationString.Split(PropertySeparator);
 
             var valueSet = new PropertyValue[PropertiesByOrder.Length];


### PR DESCRIPTION
This will allow to add a build configuration with an _ at the beginning of it and it will be a negation of that build configuration. 

The build system will find those build configurations, will turn them to a valid configuration by removing the prefix and if that configuration is present in the best build configurations then we will return an empty set of best build configurations and will turn in a noop for that project.

Changes will need to be made in corefx to add this negative build configurations to the projects that are inbox on netfx.

Contributes to: https://github.com/dotnet/corefx/issues/24903

cc: @danmosemsft 