### PR TITLE
 Create build manifest in PushToBlobFeed for orchestrated build final publish

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.net45/Microsoft.DotNet.Build.Tasks.Feed.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.net45/Microsoft.DotNet.Build.Tasks.Feed.net45.csproj
@@ -7,6 +7,7 @@
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
     <ImportedProjectRelativePath>..\Microsoft.DotNet.Build.Tasks.Feed\</ImportedProjectRelativePath>
     <ProjectGuid>{17C66BCE-EB35-44CA-893C-8AAFB67708E9}</ProjectGuid>
+    <TargetFrameworkProjectSuffix>.net45</TargetFrameworkProjectSuffix>
   </PropertyGroup>
   <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.Feed.csproj" />
   <PropertyGroup>
@@ -18,6 +19,7 @@
     <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Net.Http" />
+    <TargetingPackReference Include="System.Collections" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.IO" />
     <TargetingPackReference Include="System.IO.Compression" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
@@ -66,5 +66,23 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
             }
         }
+
+        public async Task<string> DownloadBlobAsString(string blobPath)
+        {
+            string url = $"{FeedContainerUrl}/{blobPath}";
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Clear();
+                var request = AzureHelper.RequestMessage("GET", url, AccountName, AccountKey)();
+                using (HttpResponseMessage response = await client.SendAsync(request))
+                {
+                    if (response.IsSuccessStatusCode)
+                    {
+                        return await response.Content.ReadAsStringAsync();
+                    }
+                    return null;
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -55,6 +55,12 @@
     <None Include="PackageFiles\Microsoft.DotNet.Build.Tasks.Feed.targets" />
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools$(TargetFrameworkProjectSuffix)\Microsoft.DotNet.VersionTools$(TargetFrameworkProjectSuffix).csproj">
+      <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
+      <Name>Microsoft.DotNet.VersionTools$(TargetFrameworkProjectSuffix)</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="AfterBuild">
     <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -3,18 +3,25 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Build.Framework;
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using MSBuild = Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
     public class PushToBlobFeed : MSBuild.Task
     {
+        private static readonly char[] ManifestDataPairSeparators = { ';' };
+        private const string DisableManifestPushConfigurationBlob = "disable-manifest-push";
+        private const string AssetsVirtualDir = "assets/";
+
         [Required]
         public string ExpectedFeedUrl { get; set; }
 
@@ -33,6 +40,22 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public bool SkipCreateContainer { get; set; } = false;
 
         public int UploadTimeoutInMinutes { get; set; } = 5;
+
+        public bool SkipCreateManifest { get; set; }
+
+        public string ManifestName { get; set; } = "anonymous";
+        public string ManifestBuildId { get; set; } = "no build id provided";
+        public string ManifestBranch { get; set; }
+        public string ManifestCommit { get; set; }
+
+        /// <summary>
+        /// When publishing build outputs to an orchestrated blob feed, do not change this property.
+        /// 
+        /// The virtual dir to place the manifest XML file in, under the assets/ virtual dir. The
+        /// default value is the well-known location that orchestration searches to find all
+        /// manifest XML files and combine them into the orchestrated build output manifest.
+        /// </summary>
+        public string ManifestAssetOutputDir { get; set; } = "orchestration-metadata/manifests/";
 
         public override bool Execute()
         {
@@ -53,6 +76,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     BlobFeedAction blobFeedAction = new BlobFeedAction(ExpectedFeedUrl, AccountKey, Log);
 
+                    IEnumerable<BlobArtifactModel> blobArtifacts = Enumerable.Empty<BlobArtifactModel>();
+                    IEnumerable<PackageArtifactModel> packageArtifacts = Enumerable.Empty<PackageArtifactModel>();
+
                     if (!SkipCreateContainer)
                     {
                         await blobFeedAction.CreateContainerAsync(BuildEngine, PublishFlatContainer);
@@ -61,6 +87,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     if (PublishFlatContainer)
                     {
                         await PublishToFlatContainerAsync(ItemsToPush, blobFeedAction);
+                        blobArtifacts = ConcatBlobArtifacts(blobArtifacts, ItemsToPush);
                     }
                     else
                     {
@@ -69,12 +96,24 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             string fileName = Path.GetFileName(i.ItemSpec);
                             i.SetMetadata("RelativeBlobPath", $"symbols/{fileName}");
                             return i;
-                        });
+                        }).ToArray();
 
-                        var packageItems = ItemsToPush.Where(i => !symbolItems.Contains(i)).Select(i => i.ItemSpec);
+                        ITaskItem[] packageItems = ItemsToPush
+                            .Where(i => !symbolItems.Contains(i))
+                            .ToArray();
 
-                        await blobFeedAction.PushToFeed(packageItems, Overwrite);
+                        var packagePaths = packageItems.Select(i => i.ItemSpec);
+
+                        await blobFeedAction.PushToFeed(packagePaths, Overwrite);
                         await PublishToFlatContainerAsync(symbolItems, blobFeedAction);
+
+                        packageArtifacts = ConcatPackageArtifacts(packageArtifacts, packageItems);
+                        blobArtifacts = ConcatBlobArtifacts(blobArtifacts, symbolItems);
+                    }
+
+                    if (!SkipCreateManifest)
+                    {
+                        await PushBuildManifestAsync(blobFeedAction, blobArtifacts, packageArtifacts);
                     }
                 }
             }
@@ -84,6 +123,76 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
 
             return !Log.HasLoggedErrors;
+        }
+
+        private async Task PushBuildManifestAsync(
+            BlobFeedAction blobFeedAction,
+            IEnumerable<BlobArtifactModel> blobArtifacts,
+            IEnumerable<PackageArtifactModel> packageArtifacts)
+        {
+            bool disabledByBlob = await blobFeedAction.feed.CheckIfBlobExists(
+                $"{blobFeedAction.feed.RelativePath}{DisableManifestPushConfigurationBlob}");
+
+            if (disabledByBlob)
+            {
+                Log.LogMessage(
+                    MessageImportance.Normal,
+                    $"Skipping manifest push: feed has '{DisableManifestPushConfigurationBlob}'.");
+                return;
+            }
+
+            string blobPath = $"{AssetsVirtualDir}{ManifestAssetOutputDir}{ManifestName}.xml";
+
+            string existingStr = await blobFeedAction.feed.DownloadBlobAsString(
+                $"{blobFeedAction.feed.RelativePath}{blobPath}");
+
+            BuildModel buildModel;
+
+            if (existingStr != null)
+            {
+                buildModel = BuildModel.Parse(XElement.Parse(existingStr));
+            }
+            else
+            {
+                buildModel = new BuildModel(
+                    new BuildIdentity(
+                        ManifestName,
+                        ManifestBuildId,
+                        ManifestBranch,
+                        ManifestCommit));
+            }
+
+            buildModel.Artifacts.Blobs.AddRange(blobArtifacts);
+            buildModel.Artifacts.Packages.AddRange(packageArtifacts);
+
+            string tempFile = null;
+            try
+            {
+                tempFile = Path.GetTempFileName();
+
+                File.WriteAllText(tempFile, buildModel.ToXml().ToString());
+
+                var item = new MSBuild.TaskItem(tempFile, new Dictionary<string, string>
+                {
+                    ["RelativeBlobPath"] = blobPath
+                });
+
+                using (var clientThrottle = new SemaphoreSlim(MaxClients, MaxClients))
+                {
+                    await blobFeedAction.UploadAssets(
+                        item,
+                        clientThrottle,
+                        UploadTimeoutInMinutes,
+                        allowOverwrite: true);
+                }
+            }
+            finally
+            {
+                if (tempFile != null)
+                {
+                    File.Delete(tempFile);
+                }
+            }
         }
 
         private async Task PublishToFlatContainerAsync(IEnumerable<ITaskItem> taskItems, BlobFeedAction blobFeedAction)
@@ -96,6 +205,75 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     await Task.WhenAll(taskItems.Select(item => blobFeedAction.UploadAssets(item, clientThrottle, UploadTimeoutInMinutes, Overwrite)));
                 }
             }
+        }
+
+        private static IEnumerable<PackageArtifactModel> ConcatPackageArtifacts(
+            IEnumerable<PackageArtifactModel> artifacts,
+            IEnumerable<ITaskItem> items)
+        {
+            return artifacts.Concat(items
+                .Select(CreatePackageArtifactModel));
+        }
+
+        private static IEnumerable<BlobArtifactModel> ConcatBlobArtifacts(
+            IEnumerable<BlobArtifactModel> artifacts,
+            IEnumerable<ITaskItem> items)
+        {
+            return artifacts.Concat(items
+                .Select(CreateBlobArtifactModel)
+                .Where(blob => blob != null));
+        }
+
+        private static PackageArtifactModel CreatePackageArtifactModel(ITaskItem item)
+        {
+            NupkgInfo info = new NupkgInfo(item.ItemSpec);
+
+            return new PackageArtifactModel
+            {
+                Attributes = ParseCustomAttributes(item),
+                Id = info.Id,
+                Version = info.Version
+            };
+        }
+
+        private static BlobArtifactModel CreateBlobArtifactModel(ITaskItem item)
+        {
+            string path = item.GetMetadata("RelativeBlobPath");
+
+            // Only include assets in the manifest if they're in "assets/".
+            if (path?.StartsWith(AssetsVirtualDir, StringComparison.Ordinal) == true)
+            {
+                return new BlobArtifactModel
+                {
+                    Attributes = ParseCustomAttributes(item),
+                    Id = path.Substring(AssetsVirtualDir.Length)
+                };
+            }
+            return null;
+        }
+
+        private static Dictionary<string, string> ParseCustomAttributes(ITaskItem item)
+        {
+            Dictionary<string, string> customAttributes = item
+                .GetMetadata("ManifestArtifactData")
+                ?.Split(ManifestDataPairSeparators, StringSplitOptions.RemoveEmptyEntries)
+                .Select(pair =>
+                {
+                    int keyValueSeparatorIndex = pair.IndexOf('=');
+                    if (keyValueSeparatorIndex > 0)
+                    {
+                        return new
+                        {
+                            Key = pair.Substring(0, keyValueSeparatorIndex).Trim(),
+                            Value = pair.Substring(keyValueSeparatorIndex + 1).Trim()
+                        };
+                    }
+                    return null;
+                })
+                .Where(pair => pair != null)
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+
+            return customAttributes ?? new Dictionary<string, string>();
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/LaunchDebugger.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/LaunchDebugger.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Utilities;
+using System.Diagnostics;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class LaunchDebugger : Task
+    {
+        public override bool Execute()
+        {
+            Debugger.Launch();
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -48,6 +48,7 @@
     <Compile Include="GetTargetMachineInfo.cs" />
     <Compile Include="GetNetCoreAppVersionsFromFile.cs" />
     <Compile Include="InstallPackageFromFile.cs" />
+    <Compile Include="LaunchDebugger.cs" />
     <Compile Include="LocatePreviousContract.cs" />
     <Compile Include="NormalizePaths.cs" />
     <Compile Include="NormalizeAssemblyName.cs" />

--- a/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
+++ b/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
@@ -1,0 +1,164 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System.Xml.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
+{
+    public class ManifestModelTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ManifestModelTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void TestExampleBuildManifestRoundtrip()
+        {
+            XElement xml = XElement.Parse(ExampleBuildString);
+            var model = BuildModel.Parse(xml);
+            XElement modelXml = model.ToXml();
+
+            Assert.True(
+                XNode.DeepEquals(xml, modelXml),
+                "Model failed to output the parsed XML.");
+        }
+
+        [Fact]
+        public void TestExampleOrchestratedBuildManifestRoundtrip()
+        {
+            XElement xml = XElement.Parse(ExampleOrchestratedBuildString);
+            var model = OrchestratedBuildModel.Parse(xml);
+            XElement modelXml = model.ToXml();
+
+            Assert.True(
+                XNode.DeepEquals(xml, modelXml),
+                "Model failed to output the parsed XML.");
+        }
+
+        [Fact]
+        public void TestPackageOnlyBuildManifest()
+        {
+            var model = CreatePackageOnlyBuildManifestModel();
+            XElement modelXml = model.ToXml();
+            XElement xml = XElement.Parse(@"<Build Name=""SimpleBuildManifest"" BuildId=""123""><Package Id=""Foo"" Version=""1.2.3-example"" /></Build>");
+
+            Assert.True(XNode.DeepEquals(xml, modelXml));
+        }
+
+        [Fact]
+        public void TestMergeBuildManifests()
+        {
+            var orchestratedModel = new OrchestratedBuildModel(new BuildIdentity("Orchestrated", "123"))
+            {
+                Endpoints = new List<EndpointModel>
+                {
+                    EndpointModel.CreateOrchestratedBlobFeed("http://example.org")
+                }
+            };
+
+            orchestratedModel.AddParticipantBuild(CreatePackageOnlyBuildManifestModel());
+            orchestratedModel.AddParticipantBuild(BuildModel.Parse(XElement.Parse(ExampleBuildString)));
+
+            XElement modelXml = orchestratedModel.ToXml();
+            XElement xml = XElement.Parse(@"
+<OrchestratedBuild Name=""Orchestrated"" BuildId=""123"">
+  <Endpoint Id=""Orchestrated"" Type=""BlobFeed"" Url=""http://example.org"">
+    <Package Id=""Foo"" Version=""1.2.3-example"" />
+    <Package Id=""runtime.rhel.6-x64.Microsoft.Private.CoreFx.NETCoreApp"" Version=""4.5.0-preview1-25929-04"" Category=""noship"" />
+    <Package Id=""System.Memory"" Version=""4.5.0-preview1-25927-01"" />
+    <Blob Id=""symbols/inner/blank-dir-nonshipping"" NonShipping=""false"" />
+    <Blob Id=""symbols/runtime.rhel.6-x64.Microsoft.Private.CoreFx.NETCoreApp.4.5.0-preview1-25929-04.symbols.nupkg"" />
+    <Blob Id=""symbols/System.ValueTuple.4.5.0-preview1-25929-04.symbols.nupkg"" NonShipping=""true"" />
+  </Endpoint>
+  <Build Name=""SimpleBuildManifest"" BuildId=""123"" />
+  <Build Name=""corefx"" BuildId=""20171129-04"" Branch=""master"" Commit=""defb6d52047cc3d6b5f5d0853b0afdb1512dfbf4"" />
+</OrchestratedBuild>");
+
+            Assert.True(XNode.DeepEquals(xml, modelXml));
+        }
+
+        private BuildModel CreatePackageOnlyBuildManifestModel()
+        {
+            return new BuildModel(new BuildIdentity("SimpleBuildManifest", "123"))
+            {
+                Artifacts = new ArtifactSet
+                {
+                    Packages = new List<PackageArtifactModel>
+                    {
+                        new PackageArtifactModel
+                        {
+                            Id = "Foo",
+                            Version = "1.2.3-example"
+                        }
+                    }
+                }
+            };
+        }
+
+        private const string ExampleBuildString = @"
+<Build
+  Name=""corefx""
+  BuildId=""20171129-04""
+  Branch=""master""
+  Commit=""defb6d52047cc3d6b5f5d0853b0afdb1512dfbf4"">
+
+  <Package Id=""runtime.rhel.6-x64.Microsoft.Private.CoreFx.NETCoreApp"" Version=""4.5.0-preview1-25929-04"" Category=""noship"" />
+  <Package Id=""System.Memory"" Version=""4.5.0-preview1-25927-01"" />
+
+  <Blob Id=""symbols/inner/blank-dir-nonshipping"" NonShipping=""false"" />
+  <Blob Id=""symbols/runtime.rhel.6-x64.Microsoft.Private.CoreFx.NETCoreApp.4.5.0-preview1-25929-04.symbols.nupkg"" />
+  <Blob Id=""symbols/System.ValueTuple.4.5.0-preview1-25929-04.symbols.nupkg"" NonShipping=""true"" />
+
+</Build>";
+
+        private const string ExampleOrchestratedBuildString = @"
+<OrchestratedBuild
+  Name=""core-setup""
+  BuildId=""20171129-02""
+  Branch=""master"">
+
+  <Endpoint
+    Id=""Orchestrated""
+    Type=""BlobFeed""
+    Url=""https://dotnetfeed.blob.core.windows.net/orchestrated-aspnet/20171129-02/index.json"">
+
+    <Package Id=""Microsoft.NETCore.App"" Version=""2.1.0-preview1-26001-02"" />
+    <Package Id=""Microsoft.NETCore.UniversalWindowsPlatform"" Version=""6.1.0-preview1-25927-01"" NonShipping=""true"" />
+    <Package Id=""runtime.rhel.6-x64.Microsoft.Private.CoreFx.NETCoreApp"" Version=""4.5.0-preview1-25929-04"" NonShipping=""true"" />
+    <Package Id=""System.Memory"" Version=""4.5.0-preview1-25927-01"" />
+
+    <Blob Id=""orchestration-metadata/manifests/core-setup.xml"" />
+    <Blob Id=""orchestration-metadata/manifests/corefx.xml"" />
+    <Blob Id=""orchestration-metadata/PackageVersions.props"" />
+    <Blob Id=""Runtime/2.1.0-preview1-25929-04/dotnet-runtime-2.1.0-preview1-25929-04-win-x64.msi"" ShipInstaller=""dotnetcli"" />
+    <Blob Id=""Runtime/2.1.0-preview1-25929-04/dotnet-runtime-2.1.0-preview1-25929-04-win-x64.msi.sha512"" ShipInstaller=""dotnetclichecksums"" />
+    <Blob Id=""symbols/Microsoft.DotNet.PlatformAbstractions.2.1.0-preview1-25929-04.symbols.nupkg"" />
+    <Blob Id=""symbols/runtime.rhel.6-x64.Microsoft.Private.CoreFx.NETCoreApp.4.5.0-preview1-25929-04.symbols.nupkg"" />
+    <Blob Id=""symbols/System.ValueTuple.4.5.0-preview1-25929-04.symbols.nupkg"" />
+
+  </Endpoint>
+
+  <Build
+    Name=""corefx""
+    BuildId=""20171129-04""
+    Branch=""master""
+    Commit=""defb6d52047cc3d6b5f5d0853b0afdb1512dfbf4"" />
+
+  <Build
+    Name=""core-setup""
+    BuildId=""20171129-04""
+    Branch=""master""
+    Commit=""152dbe8a4b4e30eee26208ff6a850e9aa73c07f8"" />
+
+</OrchestratedBuild>
+";
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools.Tests/Microsoft.DotNet.VersionTools.Tests.csproj
+++ b/src/Microsoft.DotNet.VersionTools.Tests/Microsoft.DotNet.VersionTools.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.VersionTools.Tests/Microsoft.DotNet.VersionTools.Tests.sln
+++ b/src/Microsoft.DotNet.VersionTools.Tests/Microsoft.DotNet.VersionTools.Tests.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27217.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.VersionTools", "..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj", "{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.VersionTools.Tests", "Microsoft.DotNet.VersionTools.Tests.csproj", "{EF0E41A4-8717-45AD-AA4F-D4004EA61FFA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D524FA5-A8C5-4EBD-BA8B-2A4FED03EE58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF0E41A4-8717-45AD-AA4F-D4004EA61FFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF0E41A4-8717-45AD-AA4F-D4004EA61FFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF0E41A4-8717-45AD-AA4F-D4004EA61FFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF0E41A4-8717-45AD-AA4F-D4004EA61FFA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DB180638-F546-414C-8B38-E3AAAAD829A7}
+	EndGlobalSection
+EndGlobal

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/ArtifactSet.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/ArtifactSet.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    public class ArtifactSet
+    {
+        public List<PackageArtifactModel> Packages { get; set; } = new List<PackageArtifactModel>();
+
+        public List<BlobArtifactModel> Blobs { get; set; } = new List<BlobArtifactModel>();
+
+        public void Add(ArtifactSet source)
+        {
+            Packages.AddRange(source.Packages);
+            Blobs.AddRange(source.Blobs);
+        }
+
+        public IEnumerable<XElement> ToXml() => Enumerable.Concat(
+            Packages
+                .OrderBy(p => p.Id, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(p => p.Version, StringComparer.OrdinalIgnoreCase)
+                .Select(p => p.ToXml()),
+            Blobs
+                .OrderBy(b => b.Id, StringComparer.OrdinalIgnoreCase)
+                .Select(b => b.ToXml()));
+
+        public static ArtifactSet Parse(XElement xml) => new ArtifactSet
+        {
+            Packages = xml.Elements("Package").Select(PackageArtifactModel.Parse).ToList(),
+            Blobs = xml.Elements("Blob").Select(BlobArtifactModel.Parse).ToList(),
+        };
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BlobArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BlobArtifactModel.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    public class BlobArtifactModel
+    {
+        private static readonly string[] AttributeOrder =
+        {
+            nameof(Id)
+        };
+
+        public Dictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
+
+        public string Id
+        {
+            get { return Attributes[nameof(Id)]; }
+            set { Attributes[nameof(Id)] = value; }
+        }
+
+        public override string ToString() => $"Blob {Id}";
+
+        public XElement ToXml() => new XElement(
+            "Blob",
+            Attributes.CreateXmlAttributes(AttributeOrder));
+
+        public static BlobArtifactModel Parse(XElement xml) => new BlobArtifactModel
+        {
+            Id = xml.GetRequiredAttribute(nameof(Id)),
+            Attributes = xml.CreateAttributeDictionary()
+        };
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildIdentity.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildIdentity.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    public class BuildIdentity
+    {
+        public BuildIdentity(
+            string name,
+            string buildId,
+            string branch = null,
+            string commit = null)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentException("Expected a non-empty string.", nameof(name));
+            }
+            Name = name;
+            if (string.IsNullOrEmpty(buildId))
+            {
+                throw new ArgumentException("Expected a non-empty string.", nameof(buildId));
+            }
+            BuildId = buildId;
+            Branch = branch;
+            Commit = commit;
+        }
+
+        public string Name { get; }
+        public string BuildId { get; }
+        public string Branch { get; }
+        public string Commit { get; }
+
+        public override string ToString()
+        {
+            string s = $"{Name} '{BuildId}'";
+            if (!string.IsNullOrEmpty(Branch))
+            {
+                s += $" on '{Branch}'";
+            }
+            if (!string.IsNullOrEmpty(Commit))
+            {
+                s += $" ({Commit})";
+            }
+            return s;
+        }
+
+        public IEnumerable<XAttribute> ToXml()
+        {
+            yield return new XAttribute(nameof(Name), Name);
+            yield return new XAttribute(nameof(BuildId), BuildId);
+            if (!string.IsNullOrEmpty(Branch))
+            {
+                yield return new XAttribute(nameof(Branch), Branch);
+            }
+            if (!string.IsNullOrEmpty(Commit))
+            {
+                yield return new XAttribute(nameof(Commit), Commit);
+            }
+        }
+
+        public static BuildIdentity Parse(XElement xml)
+        {
+            return new BuildIdentity(
+                xml.GetRequiredAttribute(nameof(Name)),
+                xml.GetRequiredAttribute(nameof(BuildId)),
+                xml.Attribute(nameof(Branch))?.Value,
+                xml.Attribute(nameof(Commit))?.Value);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildModel.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    public class BuildModel
+    {
+        public BuildModel(BuildIdentity identity)
+        {
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+            Identity = identity;
+        }
+
+        public BuildIdentity Identity { get; set; }
+
+        public ArtifactSet Artifacts { get; set; } = new ArtifactSet();
+
+        public override string ToString() => $"Build {Identity}";
+
+        public XElement ToXml() => new XElement(
+            "Build",
+            Identity.ToXml(),
+            Artifacts.ToXml());
+
+        public static BuildModel Parse(XElement xml) => new BuildModel(BuildIdentity.Parse(xml))
+        {
+            Artifacts = ArtifactSet.Parse(xml)
+        };
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/EndpointModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/EndpointModel.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    public class EndpointModel
+    {
+        private static readonly string[] AttributeOrder =
+        {
+            nameof(Id),
+            nameof(Type),
+            nameof(Url)
+        };
+
+        public const string BlobFeedType = "BlobFeed";
+
+        public const string OrchestratedBlobFeedId = "Orchestrated";
+
+        public Dictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
+
+        public string Id
+        {
+            get { return Attributes[nameof(Id)]; }
+            set { Attributes[nameof(Id)] = value; }
+        }
+
+        public string Type
+        {
+            get { return Attributes[nameof(Type)]; }
+            set { Attributes[nameof(Type)] = value; }
+        }
+
+        public string Url
+        {
+            get { return Attributes[nameof(Url)]; }
+            set { Attributes[nameof(Url)] = value; }
+        }
+
+        public ArtifactSet Artifacts { get; set; } = new ArtifactSet();
+
+        public override string ToString() => $"Endpoint {Id}, {Type} '{Url}'";
+
+        public bool IsOrchestratedBlobFeed => Id == OrchestratedBlobFeedId && Type == BlobFeedType;
+
+        public XElement ToXml() => new XElement(
+            "Endpoint",
+            Attributes.CreateXmlAttributes(AttributeOrder),
+            Artifacts?.ToXml());
+
+        public static EndpointModel Parse(XElement xml) => new EndpointModel
+        {
+            Attributes = xml.CreateAttributeDictionary(),
+            Artifacts = ArtifactSet.Parse(xml)
+        };
+
+        public static EndpointModel CreateOrchestratedBlobFeed(string url) => new EndpointModel
+        {
+            Id = OrchestratedBlobFeedId,
+            Type = BlobFeedType,
+            Url = url
+        };
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/OrchestratedBuildModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/OrchestratedBuildModel.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    public class OrchestratedBuildModel
+    {
+        public OrchestratedBuildModel(BuildIdentity identity)
+        {
+            if (identity == null)
+            {
+                throw new ArgumentNullException(nameof(identity));
+            }
+            Identity = identity;
+        }
+
+        public BuildIdentity Identity { get; set; }
+
+        public List<EndpointModel> Endpoints { get; set; } = new List<EndpointModel>();
+
+        public List<BuildIdentity> Builds { get; set; } = new List<BuildIdentity>();
+
+        public void AddParticipantBuild(BuildModel build)
+        {
+            EndpointModel[] feeds = Endpoints.Where(e => e.IsOrchestratedBlobFeed).ToArray();
+            if (feeds.Length != 1)
+            {
+                throw new InvalidOperationException(
+                    $"1 orchestrated blob feed must exist, but found {feeds.Length}.");
+            }
+            EndpointModel feed = feeds[0];
+
+            feed.Artifacts.Add(build.Artifacts);
+            Builds.Add(build.Identity);
+        }
+
+        public XElement ToXml() => new XElement(
+            "OrchestratedBuild",
+            Identity.ToXml(),
+            Endpoints.Select(x => x.ToXml()),
+            Builds.Select(x => new XElement("Build", x.ToXml())));
+
+        public static OrchestratedBuildModel Parse(XElement xml) => new OrchestratedBuildModel(BuildIdentity.Parse(xml))
+        {
+            Endpoints = xml.Elements("Endpoint").Select(EndpointModel.Parse).ToList(),
+            Builds = xml.Elements("Build").Select(BuildIdentity.Parse).ToList()
+        };
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    public class PackageArtifactModel
+    {
+        private static readonly string[] AttributeOrder =
+        {
+            nameof(Id),
+            nameof(Version)
+        };
+
+        public Dictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
+
+        public string Id
+        {
+            get { return Attributes[nameof(Id)]; }
+            set { Attributes[nameof(Id)] = value; }
+        }
+
+        public string Version
+        {
+            get { return Attributes[nameof(Version)]; }
+            set { Attributes[nameof(Version)] = value; }
+        }
+
+        public override string ToString() => $"Package {Id} {Version}";
+
+        public XElement ToXml() => new XElement(
+            "Package",
+            Attributes.CreateXmlAttributes(AttributeOrder));
+
+        public static PackageArtifactModel Parse(XElement xml) => new PackageArtifactModel
+        {
+            Id = xml.GetRequiredAttribute(nameof(Id)),
+            Version = xml.GetRequiredAttribute(nameof(Version)),
+            Attributes = xml.CreateAttributeDictionary()
+        };
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/XElementParsingExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/XElementParsingExtensions.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
+{
+    internal static class XElementParsingExtensions
+    {
+        public static string GetRequiredAttribute(this XElement element, XName name)
+        {
+            string value = element.Attribute(name)?.Value;
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException(
+                    $"Required attribute '{name}' is null or empty on '{element}'");
+            }
+            return value;
+        }
+
+        public static Dictionary<string, string> CreateAttributeDictionary(this XElement element)
+        {
+            return element.Attributes().ToDictionary(a => a.Name.LocalName, a => a.Value);
+        }
+
+        public static XAttribute[] CreateXmlAttributes(
+            this Dictionary<string, string> attributes,
+            string[] keySortOrder)
+        {
+            return attributes
+                .OrderBy(pair => keySortOrder.TakeWhile(o => pair.Key != o).Count())
+                .ThenBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(pair => new XAttribute(pair.Key, pair.Value))
+                .ToArray();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -25,6 +25,14 @@
     <Compile Include="Automation\LocalVersionsRepoUpdater.cs" />
     <Compile Include="Automation\GitHubVersionsRepoUpdater.cs" />
     <Compile Include="Automation\PullRequestOptions.cs" />
+    <Compile Include="BuildManifest\Model\ArtifactSet.cs" />
+    <Compile Include="BuildManifest\Model\BlobArtifactModel.cs" />
+    <Compile Include="BuildManifest\Model\BuildIdentity.cs" />
+    <Compile Include="BuildManifest\Model\BuildModel.cs" />
+    <Compile Include="BuildManifest\Model\EndpointModel.cs" />
+    <Compile Include="BuildManifest\Model\PackageArtifactModel.cs" />
+    <Compile Include="BuildManifest\Model\OrchestratedBuildModel.cs" />
+    <Compile Include="BuildManifest\Model\XElementParsingExtensions.cs" />
     <Compile Include="Dependencies\BuildOutput\BuildDependencyInfo.cs" />
     <Compile Include="Dependencies\IDependencyInfo.cs" />
     <Compile Include="Dependencies\DependencyUpdateTask.cs" />

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -11,6 +11,8 @@
     <ProjectsToExclude Include="Microsoft.DotNet.Build.Tasks\PackageFiles\ilasm\ilasm.depproj" />
     <!-- Exclude the UWP console from the build on non windows because it requires nuget.exe to restore a packages.config -->
     <ProjectsToExclude Include="xunit.console.uwp\xunit.console.uwp.csproj" Condition="'$(OSEnvironment)' != 'Windows_NT'" />
+    <!-- Exclude the VersionTools test project because it only runs in Visual Studio: the BuildTools CLI is too old. -->
+    <ProjectsToExclude Include="Microsoft.DotNet.VersionTools.Tests\Microsoft.DotNet.VersionTools.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds functionality to `PushToBlobFeed` to create build output manifests. See [core-eng/publish.md](https://github.com/dotnet/core-eng/blob/master/Documentation/Orchestrated-Build/Api/publish.md#cookbook-using-pushtoblobfeed-to-generate-a-manifest) for details on usage.

https://github.com/dotnet/core-eng/issues/2287 "Add output manifest generation to PushToBlobFeed task"

---

This is intended for single/low-use feeds: the manifest(s) would build up over time on a central blob feed. Central feeds can ensure manifests are *never* pushed to them by putting a blob called `disable-manifest-push` at the root of the feed. (The blob's contents aren't examined and don't matter.)

> I initially wanted to use Sleet feed settings for this. However, `PushToBlobFeed` by default runs `Init` on every call, which clears the settings. I think it's infeasible and error-prone to distribute an update that disables the `Init` calls, so I decided to go with disabling via a blob.

I'll add this blob to the `dotnet-core` central feed before merging this change.
(Done: https://dotnetfeed.blob.core.windows.net/dotnet-core/disable-manifest-push)

FYI @jcagme @weshaggard 

---

I also added a small VersionTools test project. It doesn't match the existing BuildTools infra because it uses the new Core SDK project format (it won't run in CI). I wasn't able to quickly figure out how to get the existing BuildTools test project patterns to work any better than sometimes working with F5 in Visual Studio.

I also created a `LaunchDebugger` task that IMO is overdue. It makes it really easy to debug BuildTools tasks without temporarily hard-coding a `Debugger.Launch()`.
