### PR TITLE
Refuse to create an unnamed virtual directory

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -119,6 +119,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             relativeBlobPath = $"{feed.RelativePath}{relativeBlobPath}".Replace("\\", "/");
 
+            if (relativeBlobPath.Contains("//"))
+            {
+                Log.LogError(
+                    $"Item '{item.ItemSpec}' RelativeBlobPath contains virtual directory " +
+                    $"without name (double forward slash): '{relativeBlobPath}'");
+                return;
+            }
+
             Log.LogMessage($"Uploading {relativeBlobPath}");
 
             await clientThrottle.WaitAsync();


### PR DESCRIPTION
Surfacing this as an error will make it easier to spot and correct, rather than browsing blob storage.

Use LogError rather than throwing an exception so that every bad item gets an error message.

@natemcmaster 