### PR TITLE
Ignore placeholder configurations in UpdateVSConfigurations task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/UpdateVSConfigurations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/UpdateVSConfigurations.cs
@@ -77,10 +77,11 @@ namespace Microsoft.DotNet.Build.Tasks
 
             ProjectCollection.GlobalProjectCollection.UnloadProject(configurationProject);
 
+            // if starts with _ it is a placeholder configuration and we should ignore it.
             var configurations = buildConfigurations.Trim()
                                       .Split(';')
                                       .Select(c => c.Trim())
-                                      .Where(c => !String.IsNullOrEmpty(c));
+                                      .Where(c => !String.IsNullOrEmpty(c) && !c.StartsWith("_"));
 
             if (addSuffixes)
             {


### PR DESCRIPTION
Right now if we add a placeholder configuration to .props file (_netfx) when running UpdateVSConfigurations target, this gets added as a configuration to the sln and .csproj file. 

contributes to: https://github.com/dotnet/corefx/issues/24903
cc: @danmosemsft @weshaggard 