### PR TITLE
Add osGroup scenario to placeholder build configurations to FindBestConfiguration task

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Configuration/Configuration.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Configuration/Configuration.cs
@@ -28,6 +28,8 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public static IEqualityComparer<Configuration> CompatibleComparer { get; } = new CompatibleConfigurationComparer();
 
+        public bool IsPlaceHolderConfiguration { get; set; }
+
         /// <summary>
         /// Constructs a configuration string from this configuration
         /// </summary>

--- a/src/Microsoft.DotNet.Build.Tasks/Configuration/ConfigurationFactory.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Configuration/ConfigurationFactory.cs
@@ -171,9 +171,12 @@ namespace Microsoft.DotNet.Build.Tasks
         /// <returns></returns>
         internal Configuration ParseConfiguration(string configurationString, bool permitUnknownValues = false)
         {
+            bool isPlaceHolderConfiguration = false;
+
             if (configurationString.StartsWith(NopConfigurationPrefix))
             {
                 configurationString = configurationString.Substring(1);
+                isPlaceHolderConfiguration = true;
             }
 
             var values = configurationString.Split(PropertySeparator);
@@ -243,7 +246,10 @@ namespace Microsoft.DotNet.Build.Tasks
                 valueSet[propertyIndex] = propertyValue;
             }
 
-            return new Configuration(valueSet);
+            return new Configuration(valueSet)
+            {
+                IsPlaceHolderConfiguration = isPlaceHolderConfiguration
+            };
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/FindBestConfigurations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/FindBestConfigurations.cs
@@ -32,8 +32,6 @@ namespace Microsoft.DotNet.Build.Tasks
                 SupportedConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => ConfigurationFactory.ParseConfiguration(c)),
                 Configuration.CompatibleComparer);
 
-            var placeHolderBuildConfigurations = new HashSet<string>(SupportedConfigurations.Where(c => c.StartsWith(ConfigurationFactory.NopConfigurationPrefix)));
-
             var bestConfigurations = new List<ITaskItem>();
 
             foreach (var configurationItem in Configurations)
@@ -42,7 +40,18 @@ namespace Microsoft.DotNet.Build.Tasks
 
                 var compatibleConfigurations = ConfigurationFactory.GetCompatibleConfigurations(buildConfiguration, DoNotAllowCompatibleValues);
 
-                var bestConfiguration = compatibleConfigurations.FirstOrDefault(c => supportedProjectConfigurations.Contains(c));
+                bool isPlaceHolderConfiguration = false;
+                var bestConfiguration = compatibleConfigurations.FirstOrDefault(c =>
+                {
+                    var supportedConfiguration = supportedProjectConfigurations.FirstOrDefault(sc => Configuration.CompatibleComparer.Equals(sc, c));
+                    if (supportedConfiguration != null)
+                    {
+                        isPlaceHolderConfiguration = supportedConfiguration.IsPlaceHolderConfiguration;
+                        return true;
+                    }
+
+                    return false;
+                });
 
                 if (bestConfiguration == null)
                 {
@@ -51,12 +60,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 }
                 else
                 {
-                    string targetGroup = bestConfiguration.Values[0].Value; // TargetGroup is in property value index 0
-                    string osGroup = bestConfiguration.Values[1].Value; // OSGroup is in property value index 1
-                    string buildConfigurationNoConfigurationGroup = osGroup != "AnyOS" ? $"{targetGroup}-{osGroup}" : targetGroup; // BuildConfigurations in configurations.props don't include ConfigurationGroup, so we need to try to find placeholder configurations without it.
-
-                    // placeholder configurations will be in the form of TargetGroup-OSGroup or TargetGroup so we need to fallback to _TargetGroup to ignore it because that means it needs to be ignored in all OSGroups.
-                    if (placeHolderBuildConfigurations.Contains($"{ConfigurationFactory.NopConfigurationPrefix}{buildConfigurationNoConfigurationGroup}") || placeHolderBuildConfigurations.Contains($"{ConfigurationFactory.NopConfigurationPrefix}{targetGroup}"))
+                    if (isPlaceHolderConfiguration)
                     {
                         BestConfigurations = Array.Empty<ITaskItem>();
                         return !Log.HasLoggedErrors;


### PR DESCRIPTION
Currently the only scenario that was supported was to add a default placeholder configuration (no osgroup) `_netfx` and in debug mode. If we build for Release, the configuration infrastructure would add a -Release or Windows_NT-Release suffix when parsing the build configuration and it will not be ignored. 

With this change it will allow to add placeholder configurations including the osgroup (`_netfx-Windows_NT`) and to fallback to the default targetgroup (`_netfx`). So this way if I add a `_netfx` configuration all the `_netfx` configurations will be ignored when building for that project. If I add `_netcoreapp-Windows_NT`, it will be ignored only in Windows for netcoreapp. 

Contributes to: https://github.com/dotnet/corefx/issues/24903

cc: @weshaggard @danmosemsft 