### PR TITLE
Allow disabling fxcop analyzers

### DIFF
--- a/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
+++ b/src/Microsoft.DotNet.CodeAnalysis/PackageFiles/codeAnalysis.targets
@@ -19,7 +19,7 @@
     <ValidPInvokeMappings Condition="'$(UWPCompatible)'=='true' and '$(EnablePinvokeUWPAnalyzer)' == 'true'">$(MSBuildThisFileDirectory)PinvokeAnalyzer_Win32UWPApis.txt</ValidPInvokeMappings>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(EnableFxCopAnalyzers)' == ''">
     <!-- %24 = $ -->
     <EnableFxCopAnalyzers Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectDirectory), 'src%24'))">true</EnableFxCopAnalyzers>
     <EnableFxCopAnalyzers Condition="'$(EnableFxCopAnalyzers)' != 'true'">false</EnableFxCopAnalyzers>


### PR DESCRIPTION
Restores #1350 that got trampled over in e23965130c93c3cc66846efc60f6034e5710ef51.