### PR TITLE
Move commit link out of summary: make it clickable

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/PullRequestCreator.cs
@@ -171,13 +171,19 @@ namespace Microsoft.DotNet.VersionTools.Automation
                     .ToArray());
 
             string commentBody =
-                "<details>" +
-                "<summary>" +
-                $"\r\n\r\nDiscarded [`{oldCommit.Sha.Substring(0, 7)}`]({oldCommit.HtmlUrl}) " +
-                $"({ciSummary}) {oldCommit.Message}\r\n" +
-                "</summary>" +
-                $"\r\n\r\n{statusLines}\r\n" +
-                "</details>";
+                $"Discarded [`{oldCommit.Sha.Substring(0, 7)}`]({oldCommit.HtmlUrl}): " +
+                $"`{oldCommit.Message}`";
+
+            if (statuses.Any())
+            {
+                commentBody += "\r\n\r\n" +
+                    "<details>" +
+                    "<summary>" +
+                    $"CI Status: {ciSummary} (click to expand)\r\n" +
+                    "</summary>" +
+                    $"\r\n\r\n{statusLines}\r\n" +
+                    "</details>";
+            }
 
             await client.PostCommentAsync(
                 baseProject,


### PR DESCRIPTION
Also only add CI info when info exists to avoid creating a confusing empty collapsible section.

Fixes https://github.com/dotnet/buildtools/issues/1827

The commit discard comments will now look like this:

> Discarded [`b31c17b`](https://github.com/dagood-bot/corefx/commit/b31c17b0bf93d8fd5eaace693eb775989b8662d5): `Update BuildTools, CoreClr, CoreFx, CoreSetup, ProjectNTfs, ProjectNTfsTestILC to prerelease-02402-01, preview1-26102-02, preview1-26102-01, preview1-26101-02, beta-26028-00, beta-26028-00, respectively`
> 
> <details><summary>CI Status: 1:x: (click to expand)
> </summary>
> 
>  * :x: **testing-fail** [Desc](https://example.org)
> 
> </details>