### PR TITLE
When creating the supportedProjectConfigurations dictionary we need to make sure they are distinc elements

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/FindBestConfigurations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/FindBestConfigurations.cs
@@ -28,9 +28,10 @@ namespace Microsoft.DotNet.Build.Tasks
         {
             LoadConfiguration();
 
-            var supportedProjectConfigurations = new Dictionary<Configuration, Configuration>(
-                SupportedConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Distinct(StringComparer.OrdinalIgnoreCase).Select(c => ConfigurationFactory.ParseConfiguration(c)).ToDictionary(c => c, Configuration.CompatibleComparer),
-                Configuration.CompatibleComparer);
+            Dictionary<Configuration, Configuration> supportedProjectConfigurations = SupportedConfigurations.Where(c => !string.IsNullOrWhiteSpace(c))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(c => ConfigurationFactory.ParseConfiguration(c))
+                .ToDictionary(c => c, Configuration.CompatibleComparer);
 
             var bestConfigurations = new List<ITaskItem>();
 

--- a/src/Microsoft.DotNet.Build.Tasks/FindBestConfigurations.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/FindBestConfigurations.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Build.Tasks
             LoadConfiguration();
 
             var supportedProjectConfigurations = new Dictionary<Configuration, Configuration>(
-                SupportedConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => ConfigurationFactory.ParseConfiguration(c)).ToDictionary(c => c, Configuration.CompatibleComparer),
+                SupportedConfigurations.Where(c => !string.IsNullOrWhiteSpace(c)).Distinct(StringComparer.OrdinalIgnoreCase).Select(c => ConfigurationFactory.ParseConfiguration(c)).ToDictionary(c => c, Configuration.CompatibleComparer),
                 Configuration.CompatibleComparer);
 
             var bestConfigurations = new List<ITaskItem>();


### PR DESCRIPTION
If not we would fail with an ArgumentException that the key is already present if a project duplicates a build configuration for some reason. We're currently hitting that on: 

https://ci3.dot.net/job/dotnet_corefx/job/master/job/windows-TGroup_netcoreapp+CGroup_Release+AGroup_x86+TestOuter_false_prtest/6768/console

PR: https://github.com/dotnet/corefx/pull/26138

cc: @weshaggard 