### PR TITLE
In blob feeds, put detected symbol packages in assets/symbols/

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -91,12 +91,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     }
                     else
                     {
-                        var symbolItems = ItemsToPush.Where(i => i.ItemSpec.Contains("symbols.nupkg")).Select(i => 
-                        {
-                            string fileName = Path.GetFileName(i.ItemSpec);
-                            i.SetMetadata("RelativeBlobPath", $"symbols/{fileName}");
-                            return i;
-                        }).ToArray();
+                        ITaskItem[] symbolItems = ItemsToPush
+                            .Where(i => i.ItemSpec.Contains("symbols.nupkg"))
+                            .Select(i =>
+                            {
+                                string fileName = Path.GetFileName(i.ItemSpec);
+                                i.SetMetadata("RelativeBlobPath", $"{AssetsVirtualDir}symbols/{fileName}");
+                                return i;
+                            })
+                            .ToArray();
 
                         ITaskItem[] packageItems = ItemsToPush
                             .Where(i => !symbolItems.Contains(i))


### PR DESCRIPTION
This makes it so symbol packages will show up in manifests as `Blob` elements, and standardizes the `AssetRootUrl` that we pass orchestrated builds. https://github.com/dotnet/core-eng/issues/2274

We'll need to respond to this change in the orchestrated build pipelines by changing the url from `symbols/` to `assets/symbols/`. I'll keep watch over the buildtools auto-PRs and make the pipeline change when this BT change gets in.