### PR TITLE
Filter out empty dependencies from promotion consideration

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -714,8 +714,12 @@
       <Output TaskParameter="TrimmedDependencies" ItemName="FilePackageDependency" />
     </CreateTrimDependencyGroups>
 
+    <ItemGroup>
+      <NonEmptyFilePackageDependency Include="@(FilePackageDependency)" Condition="'%(FilePackageDependency.Identity)' != '_._'" />
+    </ItemGroup>
+
     <!-- Promote dependencies from ref to lib and vice-versa -->
-    <PromoteDependencies Dependencies="@(FilePackageDependency)"
+    <PromoteDependencies Dependencies="@(NonEmptyFilePackageDependency)"
                          PackageIndexes="@(PackageIndex)"
                          Condition="'@(FilePackageDependency)' != ''">
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />


### PR DESCRIPTION
We have a number of cases were we were incorrectly promoting
dependencies from netstandard refs to net4x dependency groups which
aren't needed and cause extra dependencies and in some cases cause
issue (see https://github.com/dotnet/corefx/issues/26129).

A diff of corefx nuspec's before and after this change shows about
14 different affected packages which now have correctly cleaned
up dependency groups for net4x.

cc @ericstj 