### PR TITLE
Update CCI extensions to understand new C# lang features

### DIFF
--- a/src/ApiCompat/Rules/Compat/TypeCannotChangeClassification.cs
+++ b/src/ApiCompat/Rules/Compat/TypeCannotChangeClassification.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Cci.Differs.Rules
                 return DifferenceType.Changed;
             }
 
-            if (impl.Attributes.HasIsReadOnlyAttribute() && !contract.Attributes.HasIsReadOnlyAttribute())
+            if (contract.Attributes.HasIsReadOnlyAttribute() && !impl.Attributes.HasIsReadOnlyAttribute())
             {
                 differences.AddIncompatibleDifference(this,
-                    "Type '{0}' is marked as readonly in the implementation so it must also be marked readonly in the contract.",
+                    "Type '{0}' is marked as readonly in the contract so it must also be marked readonly in the implementation.",
                     impl.FullName());
 
                 return DifferenceType.Changed;

--- a/src/ApiCompat/Rules/Compat/TypeCannotChangeClassification.cs
+++ b/src/ApiCompat/Rules/Compat/TypeCannotChangeClassification.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Cci.Extensions;
+using Microsoft.Cci.Extensions.CSharp;
 
 namespace Microsoft.Cci.Differs.Rules
 {
@@ -20,8 +21,19 @@ namespace Microsoft.Cci.Differs.Rules
             if (implObjType != contractObjType)
             {
                 differences.AddIncompatibleDifference(this,
-                    "Type '{0}' is a {1} in the implementation but is a {2} in the contract.",
+                    "Type '{0}' is a '{1}' in the implementation but is a '{2}' in the contract.",
                     impl.FullName(), implObjType, contractObjType);
+
+                return DifferenceType.Changed;
+            }
+
+            if (impl.Attributes.HasIsReadOnlyAttribute() && !contract.Attributes.HasIsReadOnlyAttribute())
+            {
+                differences.AddIncompatibleDifference(this,
+                    "Type '{0}' is marked as readonly in the implementation so it must also be marked readonly in the contract.",
+                    impl.FullName());
+
+                return DifferenceType.Changed;
             }
 
             return DifferenceType.Unknown;
@@ -33,7 +45,12 @@ namespace Microsoft.Cci.Differs.Rules
                 return "class";
 
             if (type.IsValueType)
+            {
+                if (type.Attributes.HasIsByRefLikeAttribute())
+                    return "ref struct";
+
                 return "struct";
+            }
 
             if (type.IsInterface)
                 return "interface";

--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Cci.Extensions.CSharp
             if (!method.IsStatic)
                 return false;
 
-            return method.Attributes.Any(a => a.Type.AreEquivalent("System.Runtime.CompilerServices.ExtensionAttribute"));
+            return method.Attributes.HasAttributeOfType("System.Runtime.CompilerServices.ExtensionAttribute");
         }
 
         public static bool IsEffectivelySealed(this ITypeDefinition type)
@@ -551,6 +551,21 @@ namespace Microsoft.Cci.Extensions.CSharp
                     return true;
             }
             return false;
+        }
+
+        public static bool HasAttributeOfType(this IEnumerable<ICustomAttribute> attributes, string attributeName)
+        {
+            return attributes.Any(a => a.Type.AreEquivalent(attributeName));
+        }
+
+        public static bool HasIsByRefLikeAttribute(this IEnumerable<ICustomAttribute> attributes)
+        {
+            return attributes.HasAttributeOfType("System.Runtime.CompilerServices.IsByRefLikeAttribute");
+        }
+
+        public static bool HasIsReadOnlyAttribute(this IEnumerable<ICustomAttribute> attributes)
+        {
+            return attributes.HasAttributeOfType("System.Runtime.CompilerServices.IsReadOnlyAttribute");
         }
 
         private static IEnumerable<ITypeReference> GetBaseTypes(this ITypeReference typeRef)

--- a/src/Microsoft.Cci.Extensions/Filters/MappingDifferenceFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/MappingDifferenceFilter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Cci.Filters
                 return true;
 
             if (type.ShouldDiffMembers)
-                return type.Members.Any(Include);
+                return type.Members.Any(Include) || type.NestedTypes.Any(Include);
 
             return false;
         }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -387,7 +387,24 @@ namespace Microsoft.Cci.Writers.CSharp
                 case "System.Reflection.AssemblyDelaySignAttribute": return true;
                 case "System.Runtime.CompilerServices.ExtensionAttribute": return true;
                 case "System.Runtime.CompilerServices.DynamicAttribute": return true;
-            }
+                case "System.Runtime.CompilerServices.IsByRefLikeAttribute": return true;
+                case "System.Runtime.CompilerServices.IsReadOnlyAttribute": return true;
+                case "System.ObsoleteAttribute":
+                    {
+                        var arg = c.Arguments.OfType<IMetadataConstant>().FirstOrDefault();
+
+                        if (arg != null && arg.Value is string)
+                        {
+                            string argValue = (string)arg.Value;
+
+                            if (argValue == "Types with embedded references are not supported in this version of your compiler.")
+                            {
+                                return true;
+                            }
+                        }
+                        break;
+                    }
+    }
             return false;
         }
 

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Cci.Writers.CSharp
             {
                 WriteKeyword("typeof", noSpace: true);
                 WriteSymbol("(");
-                WriteTypeName(type.TypeToGet, noSpace: true);
+                WriteTypeName(type.TypeToGet, noSpace: true, omitGenericTypeList: true);
                 WriteSymbol(")");
                 return;
             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -393,10 +393,9 @@ namespace Microsoft.Cci.Writers.CSharp
                     {
                         var arg = c.Arguments.OfType<IMetadataConstant>().FirstOrDefault();
 
-                        if (arg != null && arg.Value is string)
+                        if (arg?.Value is string)
                         {
                             string argValue = (string)arg.Value;
-
                             if (argValue == "Types with embedded references are not supported in this version of your compiler.")
                             {
                                 return true;
@@ -404,7 +403,7 @@ namespace Microsoft.Cci.Writers.CSharp
                         }
                         break;
                     }
-    }
+            }
             return false;
         }
 

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -66,7 +66,12 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteAttributes(method.ReturnValueAttributes, true);
 
                 if (method.ReturnValueIsByRef)
+                {
                     WriteKeyword("ref");
+
+                    if (method.ReturnValueAttributes.HasIsReadOnlyAttribute())
+                        WriteKeyword("readonly");
+                }
 
                 // We are ignoring custom modifiers right now, we might need to add them later.
                 WriteTypeName(method.Type, method.ContainingType, isDynamic: IsDynamic(method.ReturnValueAttributes));
@@ -135,7 +140,16 @@ namespace Microsoft.Cci.Writers.CSharp
                 //if (parameter.IsOut)
                 //    WriteFakeAttribute("System.Runtime.InteropServices.Out", writeInline: true);
                 if (parameter.IsByReference)
-                    WriteKeyword("ref");
+                {
+                    if (parameter.Attributes.HasIsReadOnlyAttribute())
+                    {
+                        WriteKeyword("in");
+                    }
+                    else
+                    {
+                        WriteKeyword("ref");
+                    }
+                }
             }
 
             WriteTypeName(parameter.Type, containingType, isDynamic: IsDynamic(parameter.Attributes));

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -64,7 +64,12 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteKeyword("new");
 
             if (property.ReturnValueIsByRef)
+            { 
                 WriteKeyword("ref");
+
+                if (property.Attributes.HasIsReadOnlyAttribute())
+                    WriteKeyword("readonly");
+            }
 
             WriteTypeName(property.Type, isDynamic: IsDynamic(property.Attributes));
 

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Types.cs
@@ -152,6 +152,12 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteKeyword("enum");
             else if (type.IsValueType)
             {
+                if (type.Attributes.HasIsReadOnlyAttribute())
+                    WriteKeyword("readonly");
+
+                if (type.Attributes.HasIsByRefLikeAttribute())
+                    WriteKeyword("ref");
+
                 WritePartialKeyword();
                 WriteKeyword("struct");
             }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Cci.Writers.CSharp
             _writer.Write(literal);
         }
 
-        private void WriteTypeName(ITypeReference type, bool noSpace = false, bool isDynamic = false, bool useTypeKeywords = true)
+        private void WriteTypeName(ITypeReference type, bool noSpace = false, bool isDynamic = false, bool useTypeKeywords = true, bool omitGenericTypeList = false)
         {
             if (isDynamic)
             {
@@ -233,6 +233,9 @@ namespace Microsoft.Cci.Writers.CSharp
 
             if (!_forCompilation)
                 namingOptions |= NameFormattingOptions.OmitContainingNamespace;
+
+            if (omitGenericTypeList)
+                namingOptions |= NameFormattingOptions.EmptyTypeParameterList;
 
             string name = TypeHelper.GetTypeName(type, namingOptions);
 


### PR DESCRIPTION
With this change our tools like genapi and apicompat will understand

in params
ref readonly returns
readonly structs
ref structs

Also added apicompat rules to ensure the new annotations are compatible

Addresses https://github.com/dotnet/corefx/issues/25039.

cc @jkotas @jaredpar @VSadov 

These updates were used to find the incompatible annotations and regenerate ref files in PR https://github.com/dotnet/corefx/pull/26175. 