### PR TITLE
Include manifest info properties in feed targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -63,7 +63,11 @@
                     AccountKey="$(AccountKey)"
                     ItemsToPush="@(_ItemsToPush)"
                     Overwrite="$(PushToBlobFeed_Overwrite)"
-                    MaxClients="$(PushToBlobFeed_MaxClients)" />
+                    MaxClients="$(PushToBlobFeed_MaxClients)"
+                    ManifestName="$(GitHubRepositoryName)"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)" />
   </Target>
 
   <Target Name="PublishFilesToBlobFeed">
@@ -88,7 +92,11 @@
                     ItemsToPush="@(_ItemsToPush)"
                     PublishFlatContainer="true"
                     Overwrite="$(PushToBlobFeed_Overwrite)"
-                    MaxClients="$(PushToBlobFeed_MaxClients)" />
+                    MaxClients="$(PushToBlobFeed_MaxClients)"
+                    ManifestName="$(GitHubRepositoryName)"
+                    ManifestBuildId="$(ManifestBuildId)"
+                    ManifestBranch="$(ManifestBranch)"
+                    ManifestCommit="$(ManifestCommit)" />
 
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -26,11 +26,13 @@
 
     Specifying build output manifest values:
 
-    GitHubRepositoryName - The repository name, listed inside the manifest and used to name the file. Default: "anonymous"
+    ManifestName - The repository name, listed inside the manifest and used to name the file.
+      If $(GitHubRepositoryName) is defined, its value is used. Default: "anonymous"
     ManifestBuildId - Build ID listed in the manifest. Default: "no build id provided"
     ManifestBranch - Branch listed in the manifest. Default: none
     ManifestCommit - Commit listed in the manifest. Default: none
-    SkipCreateManifest - If 'true', no manifest is written even if the blob feed allows them. Default: false
+    SkipCreateManifest - If 'true', no manifest is written even if the blob feed allows them.
+      Default: false
   -->
 
   <PropertyGroup>
@@ -50,6 +52,7 @@
     <PushToBlobFeed_MaxClients Condition="'$(PushToBlobFeed_MaxClients)' == ''">8</PushToBlobFeed_MaxClients>
     <FileRelativePathBase Condition="'$(FileRelativePathBase)' == ''">assets</FileRelativePathBase>
     <FileRelativePathBase Condition="!HasTrailingSlash('$(FileRelativePathBase)')">$(FileRelativePathBase)/</FileRelativePathBase>
+    <ManifestName Condition="'$(ManifestName)' == ''">$(GitHubRepositoryName)</ManifestName>
   </PropertyGroup>
 
 
@@ -72,7 +75,7 @@
                     ItemsToPush="@(_ItemsToPush)"
                     Overwrite="$(PushToBlobFeed_Overwrite)"
                     MaxClients="$(PushToBlobFeed_MaxClients)"
-                    ManifestName="$(GitHubRepositoryName)"
+                    ManifestName="$(ManifestName)"
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestCommit="$(ManifestCommit)"
@@ -102,7 +105,7 @@
                     PublishFlatContainer="true"
                     Overwrite="$(PushToBlobFeed_Overwrite)"
                     MaxClients="$(PushToBlobFeed_MaxClients)"
-                    ManifestName="$(GitHubRepositoryName)"
+                    ManifestName="$(ManifestName)"
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestCommit="$(ManifestCommit)"

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -23,6 +23,14 @@
     FilesToPublish - Item group that contains a list of files to be pushed, if glob isn't enough.
     %(RelativeBlobPath) - Metadata that can be put on file items to control the relative path where the file
     goes underneath the blob feed. If not specfied it is default based on the FileRelativePathBase
+
+    Specifying build output manifest values:
+
+    GitHubRepositoryName - The repository name, listed inside the manifest and used to name the file. Default: "anonymous"
+    ManifestBuildId - Build ID listed in the manifest. Default: "no build id provided"
+    ManifestBranch - Branch listed in the manifest. Default: none
+    ManifestCommit - Commit listed in the manifest. Default: none
+    SkipCreateManifest - If 'true', no manifest is written even if the blob feed allows them. Default: false
   -->
 
   <PropertyGroup>
@@ -67,7 +75,8 @@
                     ManifestName="$(GitHubRepositoryName)"
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
-                    ManifestCommit="$(ManifestCommit)" />
+                    ManifestCommit="$(ManifestCommit)"
+                    SkipCreateManifest="$(SkipCreateManifest)" />
   </Target>
 
   <Target Name="PublishFilesToBlobFeed">
@@ -96,7 +105,8 @@
                     ManifestName="$(GitHubRepositoryName)"
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
-                    ManifestCommit="$(ManifestCommit)" />
+                    ManifestCommit="$(ManifestCommit)"
+                    SkipCreateManifest="$(SkipCreateManifest)" />
 
   </Target>
 


### PR DESCRIPTION
Same addition as https://github.com/dotnet/coreclr/pull/15705 and https://github.com/dotnet/corefx/pull/26192. Adds manifest info properties to the `PushToBlobFeed` task call. Core-Setup needs this changed in BuildTools because it gets the targets from the Feeds package. (CoreCLR and CoreFX implement this targets file themselves.)