### PR TITLE
Update CSharpWriter to handle private fields in structs

### DIFF
--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -123,16 +123,16 @@ namespace Microsoft.Cci.Extensions.CSharp
                 var typeToCheck = typesToCheck.Dequeue();
                 visited.Add(typeToCheck);
 
-                if (!typeToCheck.IsValueType)
-                    return true;
-
                 var resolvedType = typeToCheck.ResolvedType;
 
                 // If it is dummy we cannot really check so assume it does because that is will be the most conservative 
                 if (resolvedType is Dummy)
                     return true;
 
-                foreach (var field in resolvedType.Fields)
+                if (resolvedType.IsReferenceType)
+                    return true;
+
+                foreach (var field in resolvedType.Fields.Where(f => !f.IsStatic))
                 {
                     if (!visited.Contains(field.Type))
                     {

--- a/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
+++ b/src/Microsoft.Cci.Extensions/Extensions/CSharp/CSharpCciExtensions.cs
@@ -132,6 +132,10 @@ namespace Microsoft.Cci.Extensions.CSharp
                 if (resolvedType.IsReferenceType)
                     return true;
 
+                // ByReference<T> is a special type understood by runtime to hold a ref T.
+                if (resolvedType.AreEquivalent("System.ByReference<T>"))
+                    return true;
+
                 foreach (var field in resolvedType.Fields.Where(f => !f.IsStatic))
                 {
                     if (!visited.Contains(field.Type))

--- a/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Cci.Traversers
 
         public virtual void Visit(ITypeDefinition type)
         {
-            Visit(type.Fields);
+            Visit(type, type.Fields);
             Visit(type.Methods.Where(m => m.IsConstructor));
             Visit(type.Properties);
             Visit(type.Events);
@@ -84,6 +84,11 @@ namespace Microsoft.Cci.Traversers
 
             foreach (var member in members)
                 Visit(member);
+        }
+
+        public virtual void Visit(ITypeDefinition parentType, IEnumerable<IFieldDefinition> fields)
+        {
+            this.Visit((IEnumerable<ITypeDefinitionMember>)fields);
         }
 
         public virtual string GetMemberKey(ITypeDefinitionMember member)

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
@@ -52,7 +52,13 @@ namespace Microsoft.Cci.Writers.CSharp
                     WriteKeyword("new");
 
                 WriteTypeName(field.Type);
-                WriteIdentifier(field.Name);
+
+                string name = field.Name.Value;
+                if (name.Contains("<") || name.Contains(">"))
+                {
+                    name = name.Replace("<", "_").Replace(">", "_");
+                }
+                WriteIdentifier(name, true);
 
                 if (field.Constant != null && field.IsCompileTimeConstant)
                 {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using Microsoft.Cci.Extensions.CSharp;
 
 namespace Microsoft.Cci.Writers.CSharp
@@ -14,7 +15,7 @@ namespace Microsoft.Cci.Writers.CSharp
                 return;
 
             WriteAttributes(field.Attributes);
-            if (!field.IsStatic && field.ContainingTypeDefinition.Layout == LayoutKind.Explicit)
+            if (!field.IsStatic && field.ContainingTypeDefinition.Layout == LayoutKind.Explicit && !(field is DummyPrivateField))
             {
                 WriteFakeAttribute("System.Runtime.InteropServices.FieldOffsetAttribute", field.Offset.ToString());
             }
@@ -100,6 +101,90 @@ namespace Microsoft.Cci.Writers.CSharp
             WriteTypeName(field.Type, noSpace: true);
             WriteSymbol(")");
             WriteMetadataConstant(field.Constant);
+        }
+    }
+
+    public class DummyPrivateField : IFieldDefinition
+    {
+        private ITypeDefinition _parentType;
+        private ITypeReference _type;
+        private IName _name;
+
+        public DummyPrivateField(ITypeDefinition parentType, ITypeReference type)
+        {
+            _parentType = parentType;
+            _type = type;
+            _name = new NameTable().GetNameFor("_dummy");
+        }
+
+        public uint BitLength => 0;
+
+        public IMetadataConstant CompileTimeValue => null;
+
+        public ISectionBlock FieldMapping => null;
+
+        public bool IsBitField => false;
+
+        public bool IsCompileTimeConstant => false;
+
+        public bool IsMapped => throw new System.NotImplementedException();
+
+        public bool IsMarshalledExplicitly => throw new System.NotImplementedException();
+
+        public bool IsNotSerialized => false;
+
+        public bool IsReadOnly => _parentType.Attributes.HasIsReadOnlyAttribute();
+
+        public bool IsRuntimeSpecial => false;
+
+        public bool IsSpecialName => false;
+
+        public IMarshallingInformation MarshallingInformation => throw new System.NotImplementedException();
+
+        public uint Offset => 0;
+
+        public int SequenceNumber => throw new System.NotImplementedException();
+
+        public ITypeDefinition ContainingTypeDefinition => _parentType;
+
+        public TypeMemberVisibility Visibility => TypeMemberVisibility.Private;
+
+        public ITypeDefinition Container => throw new System.NotImplementedException();
+
+        public IName Name => _name;
+
+        public IScope<ITypeDefinitionMember> ContainingScope => throw new System.NotImplementedException();
+
+        public IEnumerable<ICustomModifier> CustomModifiers => System.Linq.Enumerable.Empty<ICustomModifier>();
+
+        public uint InternedKey => throw new System.NotImplementedException();
+
+        public bool IsModified => throw new System.NotImplementedException();
+
+        public bool IsStatic => false;
+
+        public ITypeReference Type => _type;
+
+        public IFieldDefinition ResolvedField => throw new System.NotImplementedException();
+
+        public ITypeReference ContainingType => _parentType;
+
+        public ITypeDefinitionMember ResolvedTypeDefinitionMember => throw new System.NotImplementedException();
+
+        public IEnumerable<ICustomAttribute> Attributes => System.Linq.Enumerable.Empty<ICustomAttribute>();
+
+        public IEnumerable<ILocation> Locations => throw new System.NotImplementedException();
+
+        public IMetadataConstant Constant => null;
+
+        public void Dispatch(IMetadataVisitor visitor)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void DispatchAsReference(IMetadataVisitor visitor)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -175,6 +175,17 @@ namespace Microsoft.Cci.Writers
                         if (hasRefPrivateField)
                             fieldType = parentType.PlatformType.SystemObject;
 
+                        // For primiative types that have a field of their type set the dummy field to that type
+                        if (excludedFields.Count() == 1)
+                        {
+                            var onlyField = excludedFields.First();
+
+                            if (TypeHelper.TypesAreEquivalent(onlyField.Type, parentType))
+                            {
+                                fieldType = parentType;
+                            }
+                         }                     
+
                         newFields.Add(new DummyPrivateField(parentType, fieldType));
                     }
                 }

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -169,13 +169,13 @@ namespace Microsoft.Cci.Writers
                         bool hasRefPrivateField = excludedFields.Any(f => f.Type.IsOrContainsReferenceType());
                         ITypeReference fieldType = parentType.PlatformType.SystemInt32;
 
-                        // If at least one the private fields contains a reference type then we need to
+                        // If at least one of the private fields contains a reference type then we need to
                         // set this field type to object or reference field to inform the compiler to block
                         // taking pointers to this struct because the GC will not track updating those references
                         if (hasRefPrivateField)
                             fieldType = parentType.PlatformType.SystemObject;
 
-                        // For primiative types that have a field of their type set the dummy field to that type
+                        // For primitive types that have a field of their type set the dummy field to that type
                         if (excludedFields.Count() == 1)
                         {
                             var onlyField = excludedFields.First();

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSharpWriter.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Cci.Writers
         private readonly IStyleSyntaxWriter _styleWriter;
         private readonly CSDeclarationWriter _declarationWriter;
         private readonly bool _writeAssemblyAttributes;
+        private readonly bool _apiOnly;
+        private readonly ICciFilter _cciFilter;
+
         private bool _firstMemberGroup;
 
         public CSharpWriter(ISyntaxWriter writer, ICciFilter filter, bool apiOnly, bool writeAssemblyAttributes = false)
@@ -27,6 +30,8 @@ namespace Microsoft.Cci.Writers
         {
             _syntaxWriter = writer;
             _styleWriter = writer as IStyleSyntaxWriter;
+            _apiOnly = apiOnly;
+            _cciFilter = filter;
             _declarationWriter = new CSDeclarationWriter(_syntaxWriter, filter, !apiOnly);
             _writeAssemblyAttributes = writeAssemblyAttributes;
         }
@@ -59,8 +64,8 @@ namespace Microsoft.Cci.Writers
 
         public void WriteAssemblies(IEnumerable<IAssembly> assemblies)
         {
-            foreach (var assembly in assemblies)
-                Visit(assembly);
+                foreach (var assembly in assemblies)
+                    Visit(assembly);
         }
 
         public override void Visit(IAssembly assembly)
@@ -115,6 +120,7 @@ namespace Microsoft.Cci.Writers
                         _declarationWriter.WriteDeclaration(CSDeclarationWriter.GetDummyConstructor(type));
                         _syntaxWriter.WriteLine();
                     }
+
                     _firstMemberGroup = true;
                     base.Visit(type);
                 }
@@ -126,6 +132,63 @@ namespace Microsoft.Cci.Writers
         {
             WriteMemberGroupHeader(members.FirstOrDefault(Filter.Include));
             base.Visit(members);
+        }
+
+        public override void Visit(ITypeDefinition parentType, IEnumerable<IFieldDefinition> fields)
+        {
+            if (parentType.IsStruct && !_apiOnly)
+            {
+                // For compile-time compat, the following rules should work for producing a reference assembly. We drop all private fields, but add back certain synthesized private fields for a value type (struct) as follows:
+                // - If there are any private fields that are or contain any value type members, add a single private field of type int
+                // - If there are any private fields that are or contain any reference type members, add a single private field of type object.
+                // - If the type is generic, then for every type parameter of the type, if there are any private fields that are or contain any members whose type is that type parameter, we add a direct private field of that type.
+
+                // For more details see issue https://github.com/dotnet/corefx/issues/6185 
+                // this blog is helpful as well http://blog.paranoidcoding.com/2016/02/15/are-private-members-api-surface.html
+
+                List<IFieldDefinition> newFields = new List<IFieldDefinition>();
+                var includedVisibleFields = fields.Where(f => f.IsVisibleOutsideAssembly()).Where(_cciFilter.Include);
+                includedVisibleFields = includedVisibleFields.OrderBy(GetMemberKey, StringComparer.OrdinalIgnoreCase);
+
+                var excludedFields = fields.Except(includedVisibleFields).Where(f => !f.IsStatic);
+
+                if (excludedFields.Any())
+                {
+                    var genericTypedFields = excludedFields.Where(f => f.Type.UnWrap().IsGenericParameter());
+
+                    // Compiler needs to see any fields, even private, that have generic arugments to be able
+                    // to validate there aren't any struct layout cycles
+                    foreach (var genericField in genericTypedFields)
+                        newFields.Add(genericField);
+
+                    if (!genericTypedFields.Any())
+                    {
+                        // For definiteassignment checks the compiler needs to know there is a private field
+                        // that has not be initialized so if there are any we need to add a dummy private
+                        // field to help the compiler do its job and error about uninitialized structs
+                        bool hasRefPrivateField = excludedFields.Any(f => f.Type.IsOrContainsReferenceType());
+                        ITypeReference fieldType = parentType.PlatformType.SystemInt32;
+
+                        // If at least one the private fields contains a reference type then we need to
+                        // set this field type to object or reference field to inform the compiler to block
+                        // taking pointers to this struct because the GC will not track updating those references
+                        if (hasRefPrivateField)
+                            fieldType = parentType.PlatformType.SystemObject;
+
+                        newFields.Add(new DummyPrivateField(parentType, fieldType));
+                    }
+                }
+
+                foreach (var visibleField in includedVisibleFields)
+                    newFields.Add(visibleField);
+
+                foreach (var field in newFields)
+                    Visit(field);
+            }
+            else
+            {
+                base.Visit(parentType, fields);
+            }
         }
 
         public override void Visit(ITypeDefinitionMember member)


### PR DESCRIPTION
For compile-time compat, the following rules should work for producing a reference assembly. We drop all private fields, but add back certain synthesized private fields for a value type (struct) as follows:
- If there are any private fields that are or contain any value type members, add a single private field of type int
- If there are any private fields that are or contain any reference type members, add a single private field of type object.
- If the type is generic, then for every type parameter of the type, if there are any private fields that are or contain any members whose type is that type parameter, we add a direct private field of that type.

For more details see issue https://github.com/dotnet/corefx/issues/6185
this blog is helpful as well http://blog.paranoidcoding.com/2016/02/15/are-private-members-api-surface.html

PTAL @jkotas @VSadov @jaredpar @gafter 

To get an idea of what is produced see the updated System.Runtime with https://github.com/dotnet/corefx/commit/a2d4a328c5e6f297ddf93643b8d565cd2c56574c. 