### PR TITLE
Filter should be appended when getting the next page of results

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureBlobs.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureBlobs.cs
@@ -102,6 +102,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 while (!string.IsNullOrEmpty(nextMarker))
                 {
                     urlListBlobs = string.Format($"https://{AccountName}.blob.core.windows.net/{ContainerName}?restype=container&comp=list&marker={nextMarker}");
+                    if (!string.IsNullOrWhiteSpace(FilterBlobNames))
+                    {
+                        urlListBlobs += $"&prefix={FilterBlobNames}";
+                    }
                     var nextRequest = AzureHelper.RequestMessage("GET", urlListBlobs, AccountName, AccountKey);
                     using (HttpResponseMessage nextResponse = AzureHelper.RequestWithRetry(Log, client, nextRequest).GetAwaiter().GetResult())
                     {


### PR DESCRIPTION
The next marker is often non-empty even when the first page of blob results returned is empty.  Without adding the filter again, we will then list everything in the container