### PR TITLE
Limit inner iteration count to a max of 2

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -437,12 +437,14 @@ robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
       <!-- On Windows, call prevents the test command from making execution end prematurely -->
       <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(TestGCStressLevel)' != ''" Include="set COMPlus_GCStress=$(TestGCStressLevel)"/>
       <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MIN_ITERATION=1"/>
-      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MAX_ITERATION=1"/>
+      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MAX_ITERATION=2"/>
+      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED=2"/>
       <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT'" Include="call $(TestCommandLine)"/>
 
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(TestGCStressLevel)' != ''" Include="export COMPlus_GCStress=$(TestGCStressLevel)"/>
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MIN_ITERATION=1"/>
-      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION=1"/>
+      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION=2"/>
+      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED=2"/>
       <!-- Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424 -->
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="chmod +x $(TestProgram)"/>
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="$(TestCommandLine)"/>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -20,6 +20,12 @@
     <TestPath Condition="'$(TestPath)'==''">$(OutDir)</TestPath>
   </PropertyGroup>
 
+  <!-- In case that XunitPerfMaxIteration is not yet set, default it here -->
+  <PropertyGroup>
+    <XunitPerfMaxIteration Condition="'$(XunitPerfMaxIteration)'==''">1</XunitPerfMaxIteration>
+    <XunitPerfMaxIterationInner Condition="'$(XunitPerfMaxIterationInner)'==''">1</XunitPerfMaxIterationInner>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- Split semicolon separated lists -->
     <WithCategoriesItems Include="$(WithCategories)" />
@@ -437,14 +443,14 @@ robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
       <!-- On Windows, call prevents the test command from making execution end prematurely -->
       <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(TestGCStressLevel)' != ''" Include="set COMPlus_GCStress=$(TestGCStressLevel)"/>
       <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MIN_ITERATION=1"/>
-      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MAX_ITERATION=2"/>
-      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED=2"/>
+      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MAX_ITERATION=$(XunitPerfMaxIteration)"/>
+      <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT' and '$(OuterLoop)' == 'true'" Include="set XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED=$(XunitPerfMaxIterationInner)"/>
       <TestCommandLines  Condition="'$(TargetOS)'=='Windows_NT'" Include="call $(TestCommandLine)"/>
 
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(TestGCStressLevel)' != ''" Include="export COMPlus_GCStress=$(TestGCStressLevel)"/>
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MIN_ITERATION=1"/>
-      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION=2"/>
-      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED=2"/>
+      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION=$(XunitPerfMaxIteration)"/>
+      <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT' and '$(OuterLoop)' == 'true'" Include="export XUNIT_PERFORMANCE_MAX_ITERATION_INNER_SPECIFIED=$(XunitPerfMaxIterationInner)"/>
       <!-- Executables restored with .NET Core 2.0 do not have executable permission flags. https://github.com/NuGet/Home/issues/4424 -->
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="chmod +x $(TestProgram)"/>
       <TestCommandLines  Condition="'$(TargetOS)'!='Windows_NT'" Include="$(TestCommandLine)"/>


### PR DESCRIPTION
Helps resolve the timeout issue here: https://github.com/dotnet/corefx/issues/26265

The reason we are seeing this issue with System.Memory Performance tests, in particular, is that they heavily use the InnerIterationCount, and hence running those perf tests, especially in debug, will take longer than 20 minutes.

Increasing the Max Iteration from 1 to 2 as per @jorive's suggestion since the data from the first iteration is ignored.

cc @jorive, @danmosemsft, @KrzysztofCwalina, @joperezr, @Priya91, @weshaggard 