### PR TITLE
Fix behavior when there is no CurrentRef property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateToRemoteDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateToRemoteDependencies.cs
@@ -103,9 +103,14 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                 path,
                 contents =>
                 {
-                    Group g = CreateXmlUpdateRegex(elementName, valueGroup)
-                        .Match(contents)
-                        .Groups[valueGroup];
+                    Match match = CreateXmlUpdateRegex(elementName, valueGroup).Match(contents);
+
+                    if (!match.Success)
+                    {
+                        throw new Exception($"Could not find element '{elementName}' in '{path}'.");
+                    }
+
+                    Group g = match.Groups[valueGroup];
 
                     return contents
                         .Remove(g.Index, g.Length)


### PR DESCRIPTION
Assuming the match was successful prepended the CurrentRef value to the file because Index and Length are 0 for a failed match. When this value shows up in pull requests due to bad VersionTools config, it can be hard to debug.

Fixes https://github.com/dotnet/buildtools/issues/1374