### PR TITLE
Synchronize manifest updates using feed lock

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -229,6 +229,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return await packageIndex.GetPackagesAsync();
         }
 
+        public ISleetFileSystemLock CreateLock()
+        {
+            return GetAzureFileSystem().CreateLock(new SleetLogger(Log));
+        }
+
         private bool IsSanityChecked(IEnumerable<string> items)
         {
             Log.LogMessage(MessageImportance.Low, $"START checking sanitized items for feed");


### PR DESCRIPTION
This prevents race conditions for builds that have multiple legs potentially pushing manifest changes.

Diff is much better ignoring whitespace changes: https://github.com/dotnet/buildtools/pull/1867/files?w=1

FYI @johnbeisner this fixes an edge case CLI could hit.

---

Tested:
 * Existing Sleet feed with the lock blob initially unleased or leased. Behavior is as expected: this task will wait for me to free my lease before taking its own lease and continuing.
 * Virtual dir with no blobs at all. I was concerned that Sleet would require a feed to exist to lock it, but it just creates the lock blob if needed. (And *only* the lock blob, no other Sleet feed blobs.)