### PR TITLE
Add space around '=' when defining optional arguments

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Cci.Writers.CSharp
             WriteIdentifier(parameter.Name);
             if (parameter.IsOptional && parameter.HasDefaultValue)
             {
-                WriteSymbol("=");
+                WriteSymbol(" = ");
                 WriteMetadataConstant(parameter.DefaultValue, parameter.Type);
             }
         }


### PR DESCRIPTION
From https://github.com/dotnet/corefx/pull/26518#discussion_r163066777

cc @jkotas, @weshaggard 