### PR TITLE
Add Finalize/Copy to Latest task for final publish step

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureBlobLease.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureBlobLease.cs
@@ -154,7 +154,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 }
                 token.ThrowIfCancellationRequested();
 
-                Thread.Sleep(waitFor);
+                Task.Delay(waitFor, token).Wait();
             }
         }
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
@@ -14,6 +14,11 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 {
     public class CopyBlobsToLatest : AzureConnectionStringBuildTask
     {
+        private static readonly string[] DefaultLatestVersionFilenames =
+        {
+            "latest.version"
+        };
+
         [Required]
         public string ContainerName { get; set; }
 
@@ -29,7 +34,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         [Required]
         public string Commit { get; set; }
 
-        public bool Coherent { get; set; }
+        public string[] LatestVersionFilenames { get; set; }
 
         /// <summary>
         /// A list of full version strings that should be converted to "latest" for each blob id,
@@ -112,17 +117,16 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     $"{Commit}{Environment.NewLine}" +
                     $"{ProductVersion}{Environment.NewLine}";
 
-                PublishStringToBlob(
-                    ContainerName,
-                    $"{channelDir}latest.version",
-                    versionText,
-                    "text/plain");
+                if (LatestVersionFilenames?.Any() != true)
+                {
+                    LatestVersionFilenames = DefaultLatestVersionFilenames;
+                }
 
-                if (Coherent)
+                foreach (string latestFilename in LatestVersionFilenames)
                 {
                     PublishStringToBlob(
                         ContainerName,
-                        $"{channelDir}latest.coherent.version",
+                        $"{channelDir}{latestFilename}",
                         versionText,
                         "text/plain");
                 }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
-    public class FinalizeBuild : AzureConnectionStringBuildTask
+    public class CopyBlobsToLatest : AzureConnectionStringBuildTask
     {
         [Required]
         public string SemaphoreBlob { get; set; }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
             try
             {
-                string targetVersionFile = $"{channelDir}{Commit}";
+                string targetVersionFile = $"{channelDir}{ProductVersion}";
 
                 // Prevent race conditions by dropping a version hint of what version this is. If
                 // we see this file and it is the same as our version then we know that a race
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {
                     Log.LogMessage(
                         MessageImportance.High,
-                        $"Version '{Commit}' is already published, skipping finalization. " +
+                        $"Version '{ProductVersion}' is already published, skipping finalization. " +
                             $"Hint file: '{targetVersionFile}'");
 
                     return true;

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/CopyBlobsToLatest.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             {
                 if (EnableVersionHint)
                 {
-                    string targetVersionFile = $"{channelDir}/{ProductVersion}";
+                    string targetVersionFile = $"{channelDir}{ProductVersion}";
 
                     // Check if this build is already finalized.
                     if (IsLatestSpecifiedVersion(targetVersionFile))

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/FinalizeBuild.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/FinalizeBuild.cs
@@ -1,0 +1,200 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public class FinalizeBuild : AzureConnectionStringBuildTask
+    {
+        [Required]
+        public string SemaphoreBlob { get; set; }
+        [Required]
+        public string FinalizeContainer { get; set; }
+        public string MaxWait { get; set; }
+        public string Delay { get; set; }
+        [Required]
+        public string ContainerName { get; set; }
+        [Required]
+        public string Channel { get; set; }
+        [Required]
+        public string SharedFrameworkNugetVersion { get; set; }
+        [Required]
+        public string SharedHostNugetVersion { get; set; }
+        [Required]
+        public string UWPCoreRuntimeSdkFullVersion { get; set; }
+        [Required]
+        public string ProductVersion { get; set; }
+        [Required]
+        public string Version { get; set; }
+        [Required]
+        public string CommitHash { get; set; }
+        public bool ForcePublish { get; set; }
+
+        private Regex _versionRegex = new Regex(@"(?<version>\d+\.\d+\.\d+)(-(?<prerelease>[^-]+-)?(?<major>\d+)-(?<minor>\d+))?");
+
+        public override bool Execute()
+        {
+            ParseConnectionString();
+
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
+            if (!FinalizeContainer.EndsWith("/"))
+            {
+                FinalizeContainer = $"{FinalizeContainer}/";
+            }
+            string targetVersionFile = $"{FinalizeContainer}{Version}";
+
+            CreateBlobIfNotExists(SemaphoreBlob);
+
+            AzureBlobLease blobLease = new AzureBlobLease(AccountName, AccountKey, ConnectionString, ContainerName, SemaphoreBlob, Log);
+            Log.LogMessage($"Acquiring lease on semaphore blob '{SemaphoreBlob}'");
+            blobLease.Acquire();
+
+            // Prevent race conditions by dropping a version hint of what version this is. If we see this file
+            // and it is the same as our version then we know that a race happened where two+ builds finished 
+            // at the same time and someone already took care of publishing and we have no work to do.
+            if (IsLatestSpecifiedVersion(targetVersionFile) && !ForcePublish)
+            {
+                Log.LogMessage(MessageImportance.Low, $"version hint file for publishing finalization is {targetVersionFile}");
+                Log.LogMessage(MessageImportance.High, $"Version '{Version}' is already published, skipping finalization.");
+                Log.LogMessage($"Releasing lease on semaphore blob '{SemaphoreBlob}'");
+                blobLease.Release();
+                return true;
+            }
+            else
+            {
+
+                // Delete old version files
+                GetBlobList(FinalizeContainer)
+                    .Select(s => s.Replace("/dotnet/", ""))
+                    .Where(w => _versionRegex.Replace(Path.GetFileName(w), "") == "")
+                    .ToList()
+                    .ForEach(f => TryDeleteBlob(f));
+
+
+                // Drop the version file signaling such for any race-condition builds (see above comment).
+                CreateBlobIfNotExists(targetVersionFile);
+
+                try
+                {
+                    CopyBlobs($"Runtime/{ProductVersion}/", $"Runtime/{Channel}/");
+
+                    // Generate the latest version text file
+                    string sfxVersion = GetSharedFrameworkVersionFileContent();
+                    PublishStringToBlob(ContainerName, $"Runtime/{Channel}/latest.version", sfxVersion, "text/plain");
+                }
+                finally
+                {
+                    blobLease.Release();
+                }
+            }
+            return !Log.HasLoggedErrors;
+        }
+
+        private string GetSharedFrameworkVersionFileContent()
+        {
+            string returnString = $"{CommitHash}{Environment.NewLine}";
+            returnString += $"{SharedFrameworkNugetVersion}{Environment.NewLine}";
+            return returnString;
+        }
+
+        public bool CopyBlobs(string sourceFolder, string destinationFolder)
+        {
+            bool returnStatus = true;
+            List<Task<bool>> copyTasks = new List<Task<bool>>();
+            string[] blobs = GetBlobList(sourceFolder);
+            foreach (string blob in blobs)
+            {
+                string targetName = Path.GetFileName(blob)
+                                        .Replace(SharedFrameworkNugetVersion, "latest")
+                                        .Replace(SharedHostNugetVersion, "latest")
+                                        .Replace(UWPCoreRuntimeSdkFullVersion, "latest");
+                string sourceBlob = blob.Replace($"/{ContainerName}/", "");
+                string destinationBlob = $"{destinationFolder}{targetName}";
+                Log.LogMessage($"Copying blob '{sourceBlob}' to '{destinationBlob}'");
+                copyTasks.Add(CopyBlobAsync(sourceBlob, destinationBlob));
+            }
+            Task.WaitAll(copyTasks.ToArray());
+            copyTasks.ForEach(c => returnStatus &= c.Result);
+            return returnStatus;
+        }
+
+        public bool TryDeleteBlob(string path)
+        {
+            return DeleteBlob(ContainerName, path);
+        }
+
+        public void CreateBlobIfNotExists(string path)
+        {
+            var blobList = GetBlobList(path);
+            if (blobList.Count() == 0)
+            {
+                PublishStringToBlob(ContainerName, path, DateTime.Now.ToString());
+            }
+        }
+
+        public bool IsLatestSpecifiedVersion(string versionFile)
+        {
+            var blobList = GetBlobList(versionFile);
+            return blobList.Count() != 0;
+        }
+
+        public bool DeleteBlob(string container, string blob)
+        {
+            return DeleteAzureBlob.Execute(AccountName,
+                                           AccountKey,
+                                            ConnectionString,
+                                            container,
+                                            blob,
+                                            BuildEngine,
+                                            HostObject);
+        }
+
+        public Task<bool> CopyBlobAsync(string sourceBlobName, string destinationBlobName)
+        {
+            return CopyAzureBlobToBlob.ExecuteAsync(AccountName,
+                                               AccountKey,
+                                               ConnectionString,
+                                               ContainerName,
+                                               sourceBlobName,
+                                               destinationBlobName,
+                                               BuildEngine,
+                                               HostObject);
+        }
+
+        public string[] GetBlobList(string path)
+        {
+            return ListAzureBlobs.Execute(AccountName,
+                                            AccountKey,
+                                            ConnectionString,
+                                            ContainerName,
+                                            path,
+                                            BuildEngine,
+                                            HostObject);
+        }
+
+        public bool PublishStringToBlob(string container, string blob, string contents, string contentType = null)
+        {
+            return PublishStringToAzureBlob.Execute(AccountName,
+                                                    AccountKey,
+                                                    ConnectionString,
+                                                    container,
+                                                    blob,
+                                                    contents,
+                                                    contentType,
+                                                    BuildEngine,
+                                                    HostObject);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -29,7 +29,7 @@
     <Compile Include="AzureConnectionStringBuildTask.cs" />
     <Compile Include="AzureBlobLease.cs" />
     <Compile Include="AzureHelper.cs" />
-    <Compile Include="FinalizeBuild.cs" />
+    <Compile Include="CopyBlobsToLatest.cs" />
     <Compile Include="CopyAzureBlobToBlob.cs" />
     <Compile Include="CreateAzureContainer.cs" />
     <Compile Include="DeleteAzureBlob.cs" />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -29,6 +29,7 @@
     <Compile Include="AzureConnectionStringBuildTask.cs" />
     <Compile Include="AzureBlobLease.cs" />
     <Compile Include="AzureHelper.cs" />
+    <Compile Include="FinalizeBuild.cs" />
     <Compile Include="CopyAzureBlobToBlob.cs" />
     <Compile Include="CreateAzureContainer.cs" />
     <Compile Include="DeleteAzureBlob.cs" />


### PR DESCRIPTION
Adds `CopyBlobsToLatest` that will be used to finalize both Core-Setup and CLI blobs in product builds. (https://github.com/dotnet/core-eng/issues/2407.) I started with Core-Setup's `FinalizeBuild` with CLI's `CopyBlobsToLatest` as a reference and made changes to generalize. We should be able to use this central implementation in Core-Setup and CLI. We'll need a way to give CLI CloudTestTasks. (Right now, the focus is final publish.)

~`GetBlobProducts` determines what products a set of blobs represents. It's useful to parse this for final publish because we don't have the product version of Core-Setup at this point in the build.~ (Removed: ProductVersion will be passed in from the manifest for final publish.)

Tested on a cut-down manifest in my own `dagood` container on Core-Setup and CLI in `dotnetcli` and `dotnetclichecksums`, and it works as expected.

/cc @johnbeisner