### PR TITLE
Push manifest summary/readme along with manifest

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
+{
+    public class WriteOrchestratedBuildManifestSummaryToFile : Task
+    {
+        private static readonly Dictionary<string, string> SdkFileEndingLinks = new Dictionary<string, string>
+        {
+            ["alpine.3.6-x64.tar.gz"] = "alpine-3.6-targz",
+            ["linux-x64.tar.gz"] = "linux-targz",
+            ["osx-x64.pkg"] = "osx-installer",
+            ["osx-x64.tar.gz"] = "osx-targz",
+            ["rhel-x64.rpm"] = "rhel-7-installer",
+            ["rhel.6-x64.tar.gz"] = "rhel-6-targz",
+            ["win-x64.exe"] = "win-x64-installer",
+            ["win-x64.zip"] = "win-x64-zip",
+            ["win-x86.exe"] = "win-x86-installer",
+            ["win-x86.zip"] = "win-x86-zip",
+            ["x64.deb"] = "linux-DEB-installer"
+        };
+
+        private const string SdkTableText = @"
+| Platform | Build |
+| -------- | :-------------------------------------: |
+| **Windows x64** | [Installer][win-x64-installer] - [Checksum][win-x64-installer-checksum]<br>[zip][win-x64-zip] - [Checksum][win-x64-zip-checksum] |
+| **Windows x86** | [Installer][win-x86-installer] - [Checksum][win-x86-installer-checksum]<br>[zip][win-x86-zip] - [Checksum][win-x86-zip-checksum] |
+| **macOS** | [Installer][osx-installer] - [Checksum][osx-installer-checksum]<br>[tar.gz][osx-targz] - [Checksum][osx-targz-checksum] |
+| **Linux x64** | [DEB Installer][linux-DEB-installer] - [Checksum][linux-DEB-installer-checksum]<br>[tar.gz][linux-targz] - [Checksum][linux-targz-checksum] |
+| **RHEL 7.2** | [Installer][rhel-7-installer] - [Checksum][rhel-7-installer-checksum]<br>[tar.gz][linux-targz] - [Checksum][linux-targz-checksum] |
+| **RHEL 6** | [tar.gz][rhel-6-targz] - [Checksum][rhel-6-targz-checksum] |
+| **Alpine 3.6** | [tar.gz][alpine-3.6-targz] - [Checksum][alpine-3.6-targz-checksum] |";
+
+        [Required]
+        public string File { get; set; }
+
+        [Required]
+        public string ManifestFile { get; set; }
+
+        public override bool Execute()
+        {
+            string contents = System.IO.File.ReadAllText(ManifestFile);
+            OrchestratedBuildModel model = OrchestratedBuildModel.Parse(XElement.Parse(contents));
+
+            var builder = new StringBuilder();
+
+            builder.Append("## Product build: ");
+            builder.AppendLine(model.Identity.ToString());
+
+            builder.AppendLine();
+            builder.AppendLine("### SDK Installers and Binaries");
+            builder.AppendLine(SdkTableText);
+
+            builder.AppendLine();
+            EndpointModel blobFeed = model.Endpoints.First(e => e.IsOrchestratedBlobFeed);
+            foreach (var link in blobFeed.Artifacts.Blobs
+                .Select(b => new
+                {
+                    b.Id,
+                    Description = GetSdkInstallerDescription(b)
+                })
+                .Where(d => d.Description != null))
+            {
+                builder.Append("[");
+                builder.Append(link.Description);
+                builder.Append("]: ");
+                builder.Append(blobFeed.Url.Replace("/index.json", "/assets/"));
+                builder.AppendLine(link.Id);
+            }
+
+            builder.AppendLine();
+            builder.AppendLine("### Built Repositories");
+
+            foreach (BuildIdentity build in model.Builds
+                .Where(b => b.Name != "anonymous")
+                .OrderBy(b => b.Name))
+            {
+                builder.Append(" * ");
+                builder.AppendLine(build.ToString());
+            }
+
+            System.IO.File.WriteAllText(File, builder.ToString());
+
+            return !Log.HasLoggedErrors;
+        }
+
+        private static string GetSdkInstallerDescription(BlobArtifactModel blob)
+        {
+            string shipInstaller;
+
+            if (blob.Attributes.TryGetValue("ShipInstaller", out shipInstaller))
+            {
+                string[] blobPathParts = blob.Id.Split('/');
+
+                if (blobPathParts.Length == 3 && blobPathParts[0] == "Sdk")
+                {
+                    string version = blobPathParts[1];
+                    string[] fileParts = blobPathParts[2].Split(
+                        new[] {$"-{version}-"},
+                        StringSplitOptions.None);
+
+                    if (fileParts.Length == 2 && fileParts[0] == "dotnet-sdk")
+                    {
+                        string linkText;
+
+                        if (shipInstaller == "dotnetcli" &&
+                            SdkFileEndingLinks.TryGetValue(fileParts[1], out linkText))
+                        {
+                            return linkText;
+                        }
+
+                        if (shipInstaller == "dotnetclichecksums" &&
+                            SdkFileEndingLinks.TryGetValue(fileParts[1].Replace(".sha", ""), out linkText))
+                        {
+                            return $"{linkText}-checksum";
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
@@ -5,8 +5,6 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
@@ -15,67 +13,50 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
 {
     public class WriteOrchestratedBuildManifestSummaryToFile : Task
     {
-        private static readonly Dictionary<string, string> SdkFileEndingLinks = new Dictionary<string, string>
-        {
-            ["alpine.3.6-x64.tar.gz"] = "alpine-3.6-targz",
-            ["linux-x64.tar.gz"] = "linux-targz",
-            ["osx-x64.pkg"] = "osx-installer",
-            ["osx-x64.tar.gz"] = "osx-targz",
-            ["rhel-x64.rpm"] = "rhel-7-installer",
-            ["rhel.6-x64.tar.gz"] = "rhel-6-targz",
-            ["win-x64.exe"] = "win-x64-installer",
-            ["win-x64.zip"] = "win-x64-zip",
-            ["win-x86.exe"] = "win-x86-installer",
-            ["win-x86.zip"] = "win-x86-zip",
-            ["x64.deb"] = "linux-DEB-installer"
-        };
-
-        private const string SdkTableText = @"
-| Platform | Build |
-| -------- | :-------------------------------------: |
-| **Windows x64** | [Installer][win-x64-installer] - [Checksum][win-x64-installer-checksum]<br>[zip][win-x64-zip] - [Checksum][win-x64-zip-checksum] |
-| **Windows x86** | [Installer][win-x86-installer] - [Checksum][win-x86-installer-checksum]<br>[zip][win-x86-zip] - [Checksum][win-x86-zip-checksum] |
-| **macOS** | [Installer][osx-installer] - [Checksum][osx-installer-checksum]<br>[tar.gz][osx-targz] - [Checksum][osx-targz-checksum] |
-| **Linux x64** | [DEB Installer][linux-DEB-installer] - [Checksum][linux-DEB-installer-checksum]<br>[tar.gz][linux-targz] - [Checksum][linux-targz-checksum] |
-| **RHEL 7.2** | [Installer][rhel-7-installer] - [Checksum][rhel-7-installer-checksum]<br>[tar.gz][linux-targz] - [Checksum][linux-targz-checksum] |
-| **RHEL 6** | [tar.gz][rhel-6-targz] - [Checksum][rhel-6-targz-checksum] |
-| **Alpine 3.6** | [tar.gz][alpine-3.6-targz] - [Checksum][alpine-3.6-targz-checksum] |";
-
         [Required]
         public string File { get; set; }
 
         [Required]
         public string ManifestFile { get; set; }
 
+        public string SdkTableTemplateFile { get; set; }
+
+        public string RuntimeTableTemplateFile { get; set; }
+
         public override bool Execute()
         {
             string contents = System.IO.File.ReadAllText(ManifestFile);
             OrchestratedBuildModel model = OrchestratedBuildModel.Parse(XElement.Parse(contents));
+            EndpointModel blobFeed = model.Endpoints.First(e => e.IsOrchestratedBlobFeed);
+
+            string feedAssetsRoot = blobFeed.Url.Replace("/index.json", "/assets");
+
+            string sdkProductVersion = model.Builds.First(b => b.Name == "cli").BuildId;
+            string runtimeProductVersion = blobFeed.Artifacts.Blobs
+                .First(b => b.Id.StartsWith("Runtime/"))
+                .Id.Split('/')[1];
 
             var builder = new StringBuilder();
 
             builder.Append("## Product build: ");
             builder.AppendLine(model.Identity.ToString());
 
-            builder.AppendLine();
-            builder.AppendLine("### SDK Installers and Binaries");
-            builder.AppendLine(SdkTableText);
-
-            builder.AppendLine();
-            EndpointModel blobFeed = model.Endpoints.First(e => e.IsOrchestratedBlobFeed);
-            foreach (var link in blobFeed.Artifacts.Blobs
-                .Select(b => new
-                {
-                    b.Id,
-                    Description = GetSdkInstallerDescription(b)
-                })
-                .Where(d => d.Description != null))
+            if (!string.IsNullOrEmpty(SdkTableTemplateFile))
             {
-                builder.Append("[");
-                builder.Append(link.Description);
-                builder.Append("]: ");
-                builder.Append(blobFeed.Url.Replace("/index.json", "/assets/"));
-                builder.AppendLine(link.Id);
+                builder.AppendLine();
+                builder.AppendLine(FillTemplate(
+                    SdkTableTemplateFile,
+                    feedAssetsRoot,
+                    sdkProductVersion));
+            }
+
+            if (!string.IsNullOrEmpty(RuntimeTableTemplateFile))
+            {
+                builder.AppendLine();
+                builder.AppendLine(FillTemplate(
+                    RuntimeTableTemplateFile,
+                    feedAssetsRoot,
+                    runtimeProductVersion));
             }
 
             builder.AppendLine();
@@ -94,41 +75,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
             return !Log.HasLoggedErrors;
         }
 
-        private static string GetSdkInstallerDescription(BlobArtifactModel blob)
+        private static string FillTemplate(string templateFile, string feedAssetsRoot, string productVersion)
         {
-            string shipInstaller;
-
-            if (blob.Attributes.TryGetValue("ShipInstaller", out shipInstaller))
-            {
-                string[] blobPathParts = blob.Id.Split('/');
-
-                if (blobPathParts.Length == 3 && blobPathParts[0] == "Sdk")
-                {
-                    string version = blobPathParts[1];
-                    string[] fileParts = blobPathParts[2].Split(
-                        new[] {$"-{version}-"},
-                        StringSplitOptions.None);
-
-                    if (fileParts.Length == 2 && fileParts[0] == "dotnet-sdk")
-                    {
-                        string linkText;
-
-                        if (shipInstaller == "dotnetcli" &&
-                            SdkFileEndingLinks.TryGetValue(fileParts[1], out linkText))
-                        {
-                            return linkText;
-                        }
-
-                        if (shipInstaller == "dotnetclichecksums" &&
-                            SdkFileEndingLinks.TryGetValue(fileParts[1].Replace(".sha", ""), out linkText))
-                        {
-                            return $"{linkText}-checksum";
-                        }
-                    }
-                }
-            }
-
-            return null;
+            return System.IO.File.ReadAllText(templateFile)
+                .Replace("{{FeedAssetsRoot}}", feedAssetsRoot)
+                .Replace("{{ProductVersion}}", productVersion);
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
@@ -31,17 +31,19 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
 
             string feedAssetsRoot = blobFeed.Url.Replace("/index.json", "/assets");
 
-            string sdkProductVersion = model.Builds.First(b => b.Name == "cli").BuildId;
+            string sdkProductVersion = model.Builds
+                .FirstOrDefault(b => b.Name == "cli")
+                ?.BuildId;
             string runtimeProductVersion = blobFeed.Artifacts.Blobs
-                .First(b => b.Id.StartsWith("Runtime/"))
-                .Id.Split('/')[1];
+                .FirstOrDefault(b => b.Id.StartsWith("Runtime/"))
+                ?.Id.Split('/')[1];
 
             var builder = new StringBuilder();
 
             builder.Append("## Product build: ");
             builder.AppendLine(model.Identity.ToString());
 
-            if (!string.IsNullOrEmpty(SdkTableTemplateFile))
+            if (!string.IsNullOrEmpty(SdkTableTemplateFile) && sdkProductVersion != null)
             {
                 builder.AppendLine();
                 builder.AppendLine(FillTemplate(
@@ -50,7 +52,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
                     sdkProductVersion));
             }
 
-            if (!string.IsNullOrEmpty(RuntimeTableTemplateFile))
+            if (!string.IsNullOrEmpty(RuntimeTableTemplateFile) && runtimeProductVersion != null)
             {
                 builder.AppendLine();
                 builder.AppendLine(FillTemplate(

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -45,6 +45,7 @@
     <Compile Include="BuildManifest\FetchOrchestratedBuildManifestInfo.cs" />
     <Compile Include="BuildManifest\UpdateOrchestratedBuildManifest.cs" />
     <Compile Include="BuildManifest\PushOrchestratedBuildManifest.cs" />
+    <Compile Include="BuildManifest\WriteOrchestratedBuildManifestSummaryToFile.cs" />
     <Compile Include="BuildManifest\WriteOrchestratedBuildManifestToFile.cs" />
     <Compile Include="ConfigureInputFeed.cs" />
     <Compile Include="GetBlobFeedPackageList.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -158,7 +158,9 @@
                                           ManifestBuildId="$(ManifestBuildId)" />
 
     <WriteOrchestratedBuildManifestSummaryToFile File="$(ManifestSummaryFile)"
-                                                 ManifestFile="$(ManifestFile)" />
+                                                 ManifestFile="$(ManifestFile)"
+                                                 SdkTableTemplateFile="$(SdkTableTemplateFile)"
+                                                 RuntimeTableTemplateFile="$(RuntimeTableTemplateFile)" />
 
     <ItemGroup>
       <SupplementaryFiles Include="$(ManifestSummaryFile)" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -52,6 +52,7 @@
   <UsingTask TaskName="PushToBlobFeed" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="UpdateOrchestratedBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   <UsingTask TaskName="WriteOrchestratedBuildManifestToFile" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
+  <UsingTask TaskName="WriteOrchestratedBuildManifestSummaryToFile" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll"/>
   
   <PropertyGroup>
     <PushToBlobFeed_Overwrite Condition="'$(PushToBlobFeed_Overwrite)' == ''">false</PushToBlobFeed_Overwrite>
@@ -131,6 +132,7 @@
       <ManifestTempDir Condition="'$(ManifestTempDir)' == ''">$(BaseIntermediateOutputPath)manifest-temp/</ManifestTempDir>
       <ManifestDownloadDir Condition="'$(ManifestDownloadDir)' == ''">$(ManifestTempDir)downloads/</ManifestDownloadDir>
       <ManifestFile Condition="'$(ManifestFile)' == ''">$(ManifestTempDir)build.xml</ManifestFile>
+      <ManifestSummaryFile Condition="'$(ManifestSummaryFile)' == ''">$(ManifestTempDir)README.md</ManifestSummaryFile>
     </PropertyGroup>
 
     <ParseBlobUrl BlobUrl="$(ExpectedFeedUrl.Replace('/index.json', ''))">
@@ -154,6 +156,13 @@
                                           BuildManifestFiles="@(BuildManifests)"
                                           ManifestName="$(ManifestName)"
                                           ManifestBuildId="$(ManifestBuildId)" />
+
+    <WriteOrchestratedBuildManifestSummaryToFile File="$(ManifestSummaryFile)"
+                                                 ManifestFile="$(ManifestFile)" />
+
+    <ItemGroup>
+      <SupplementaryFiles Include="$(ManifestSummaryFile)" />
+    </ItemGroup>
   </Target>
 
   <!--
@@ -175,7 +184,8 @@
                                    VersionsRepo="$(VersionsRepo)"
                                    VersionsRepoOwner="$(VersionsRepoOwner)"
                                    VersionsRepoBranch="$(VersionsRepoBranch)"
-                                   CommitMessage="$(CommitMessage)" />
+                                   CommitMessage="$(CommitMessage)"
+                                   SupplementaryFiles="@(SupplementaryFiles)" />
 
   </Target>
 


### PR DESCRIPTION
When these changes are used by the utility repo, we'll get readmes in dotnet/versions like [README.md](https://github.com/dagood/versions/blob/905a3d202ecdcd9293a5f8756ffa522a14b79566/build-info/dotnet/product/test-push-manifest/master/README.md) uploaded alongside the orchestrated build manifest.

@shawnro, does that example readme file have all the info you're looking for? Should I add in the table of Core-Setup (Runtime) installer links, too?

The table is copied from https://github.com/dotnet/cli/blob/master/README.md, but the links are build-specific, acquired from the manifest.

I hard-coded the blob to link associations into the task to keep it simple for now. In the future, I think the best approach is to have the CLI repo pass along this info in the manifest so we don't have to associate at all.

https://github.com/dotnet/core-eng/issues/2473