### PR TITLE
Changes required in order to build corefx on linux using CLI's MSBuild

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -7,6 +7,9 @@
   <Target Name="Test" />
 
   <PropertyGroup>
+    <!-- Due to a bug in the Roslyn Microsoft.NETCore.Compilers.props file, VisualBasicCoreTargetsPath is not set, and instead they set BasicCoreTargetsPath so the wrong targets get imported -->
+    <VisualBasicCoreTargetsPath Condition="'$(VisualBasicCoreTargetsPath)' == '' And '$(BasicCoreTargetsPath)' != ''">$(BasicCoreTargetsPath)</VisualBasicCoreTargetsPath>    
+
     <BuildToolsTaskDir Condition="'$(BuildToolsTaskDir)' == ''">$(ToolsDir)</BuildToolsTaskDir>
 
     <!-- For UAP, we need to bin place the resources as resw files to create the runner's pri file. -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -106,8 +106,13 @@
   <Import Project="IL.targets"
            Condition="'$(MSBuildProjectExtension)' == '.ilproj' AND '$(SkipImportILTargets)'!='true'" />
 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
+   <PropertyGroup Condition="'$(RunningOnCore)' == 'true'">
+     <CSharpCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
+     <VisualBasicCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
+   </PropertyGroup>
+ 
+ <!--   <Import Project="$(MSBuildThisFileDirectory)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
+           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' And '$(_IsDesktop)' != 'true'" /> -->
 
   <!--
       workaround file casing issue where it has different casing in different places which fails on linux builds
@@ -118,11 +123,22 @@
     <CSharpTargetsFile Condition="!Exists('$(CSharpTargetsFile)')">$(MSBuildToolsPath)\Microsoft.CSharp.Targets</CSharpTargetsFile>
   </PropertyGroup>
 
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft.CSharp.targets"
+           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' and '$(RunningOnCore)' == 'true'" />
+
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
+           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' and '$(RunningOnCore)' != 'true'" />
+ 
+
   <Import Project="$(CSharpTargetsFile)"
           Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
 
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft.VisualBasic.targets"
+           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj' and '$(RunningOnCore)' == 'true'" />
+ 
+
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.VisualBasic.targets"
-          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj'" />
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj' and '$(RunningOnCore)' != 'true'" />
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets"
           Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj'" />

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -106,14 +106,6 @@
   <Import Project="IL.targets"
            Condition="'$(MSBuildProjectExtension)' == '.ilproj' AND '$(SkipImportILTargets)'!='true'" />
 
-   <PropertyGroup Condition="'$(RunningOnCore)' == 'true'">
-     <CSharpCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
-     <VisualBasicCoreTargetsPath>$(MSBuildExtensionsPath32)\Roslyn\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
-   </PropertyGroup>
- 
- <!--   <Import Project="$(MSBuildThisFileDirectory)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets"
-           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' And '$(_IsDesktop)' != 'true'" /> -->
-
   <!--
       workaround file casing issue where it has different casing in different places which fails on linux builds
       https://github.com/dotnet/buildtools/issues/1464

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
@@ -14,7 +14,8 @@
     On Unix we always use a version of Roslyn we restore from NuGet and we have to work around some known issues.
   -->
   <PropertyGroup Condition="'$(RoslynPropsFile)' == '' and '$(RunningOnCore)' == 'true'">
-    <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName).$(RoslynVersion)/</RoslynPackageDir>
+    <RoslynPackageName>Microsoft.NETCore.Compilers</RoslynPackageName>
+    <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName.ToLower())/$(RoslynVersion)/</RoslynPackageDir>
     <RoslynPropsFile>$(RoslynPackageDir)build/$(RoslynPackageName).props</RoslynPropsFile>
 
     <!--

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
@@ -18,7 +18,7 @@ restore_crossgen()
 
     __pjDir=$__toolsDir/crossgen
     mkdir -p $__pjDir
-    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><NoWarn>$(NoWarn);NU1605;NU1103</NoWarn><TargetFramework>netcoreapp2.0</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.App\" Version=\"$__sharedFxVersion\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
+    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TreatWarningsAsErrors>false</TreatWarningsAsErrors><NoWarn>$(NoWarn);NU1605;NU1103</NoWarn><TargetFramework>netcoreapp2.0</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.App\" Version=\"$__sharedFxVersion\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
     $__dotnet restore $__pjDir/crossgen.csproj --packages $__packagesDir --source $__MyGetFeed
     __crossgen=$__packagesDir/runtime.$__packageRid.microsoft.netcore.app/$__sharedFxVersion/tools/crossgen
     if [ ! -e $__crossgen ]; then

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
@@ -18,7 +18,7 @@ restore_crossgen()
 
     __pjDir=$__toolsDir/crossgen
     mkdir -p $__pjDir
-    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><TargetFramework>netcoreapp2.0</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.App\" Version=\"$__sharedFxVersion\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
+    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><NoWarn>$(NoWarn);NU1605;NU1103</NoWarn><TargetFramework>netcoreapp2.0</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.App\" Version=\"$__sharedFxVersion\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
     $__dotnet restore $__pjDir/crossgen.csproj --packages $__packagesDir --source $__MyGetFeed
     __crossgen=$__packagesDir/runtime.$__packageRid.microsoft.netcore.app/$__sharedFxVersion/tools/crossgen
     if [ ! -e $__crossgen ]; then

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -15,6 +15,7 @@ __PACKAGES_DIR=${4:-$__TOOLRUNTIME_DIR}
 __TOOLS_DIR=$(cd "$(dirname "$0")"; pwd -P)
 __MICROBUILD_VERSION=0.2.0
 __PORTABLETARGETS_VERSION=0.1.1-dev
+__ROSLYNCOMPILER_VERSION=2.6.0-beta3-62316-02
 
 __PORTABLETARGETS_PROJECT_CONTENT="
 <Project Sdk=\"Microsoft.NET.Sdk\">
@@ -25,6 +26,7 @@ __PORTABLETARGETS_PROJECT_CONTENT="
   <ItemGroup>
     <PackageReference Include=\"MicroBuild.Core\" Version=\"$__MICROBUILD_VERSION\" />
     <PackageReference Include=\"Microsoft.Portable.Targets\" Version=\"$__PORTABLETARGETS_VERSION\" />
+    <PackageReference Include=\"Microsoft.NETCore.Compilers\" Version=\"$__ROSLYNCOMPILER_VERSION\" />
   </ItemGroup>
 </Project>"
 __PUBLISH_TFM=netcoreapp2.0

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/dotnetcli/dotnet $working_tree_root/MSBuild.dll $*
+$working_tree_root/dotnetcli/dotnet msbuild $*
 exit $?


### PR DESCRIPTION
cc: @weshaggard @ericstj 

These are the changes required in order to build corefx successfully on Linux using the MSBuild inside the CLI. I was able to run both `build.sh` and `build-tests.sh` successfully with these changes. These do not include the cleanup of the MSBuild that we restore on the Tools folder since I haven't verified if that is still needed on other repos. It is worth noting that in order to successfully build corefx with this, we require the SDK to be > 2.1. [Here are the changes](https://github.com/joperezr/corefx/commit/1e99cdb873495965d5d913433de6980c46100826) inside corefx that I needed to do in order to get a successful build.

Once this is merged and repos start ingesting this new version, we can take care of cleaning up all of the things that won't be required in buildtools any longer.

**Repos verified that work after consuming these changes**
 - [X] corefx (Green after [these changes](https://github.com/joperezr/corefx/commit/1e99cdb873495965d5d913433de6980c46100826))
 - [X] coreclr (Green after [these changes](https://github.com/joperezr/coreclr/commit/67ec57c6a852987d62e57896466a57e0d5468f66))
 - [x] standard (Green after [these changes](https://github.com/joperezr/standard/commit/3f0bd350d305bb305e9d14287f00fc76a932ac33))
 - [x] core-setup
 - [x] wcf