### PR TITLE
Port recent changes to release/2.1

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestToFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestToFile.cs
@@ -42,11 +42,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
                 ManifestCommit = null;
             }
 
-            var orchestratedBuild = new OrchestratedBuildModel(new BuildIdentity(
-                ManifestName,
-                ManifestBuildId,
-                ManifestBranch,
-                ManifestCommit))
+            var identity = new BuildIdentity
+            {
+                Name = ManifestName,
+                BuildId = ManifestBuildId,
+                Branch = ManifestBranch,
+                Commit = ManifestCommit
+            };
+
+            var orchestratedBuild = new OrchestratedBuildModel(identity)
             {
                 Endpoints = new List<EndpointModel>
                 {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -85,6 +85,7 @@
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestCommit="$(ManifestCommit)"
+                    ManifestBuildData="$(ManifestBuildData)"
                     SkipCreateManifest="$(SkipCreateManifest)" />
   </Target>
 
@@ -115,6 +116,7 @@
                     ManifestBuildId="$(ManifestBuildId)"
                     ManifestBranch="$(ManifestBranch)"
                     ManifestCommit="$(ManifestCommit)"
+                    ManifestBuildData="$(ManifestBuildData)"
                     SkipCreateManifest="$(SkipCreateManifest)" />
 
   </Target>
@@ -230,6 +232,10 @@
       %(Identity): 'Package' or 'Blob', matching manifest element name.
       %(Xml): The raw XML string representing the artifact in the manifest.
       %(...): Metadata is created for each attribute on the element.
+    @(OrchestratedBuilds): An item for each Build in the orchestrated build manifest.
+      %(Identity): The name of the build.
+      %(Xml): The raw XML string representing the artifact in the manifest.
+      %(...): Metadata is created for each attribute on the element.
   -->
   <Target Name="FetchOrchestratedBuildManifestInfo"
           DependsOnTargets="CreateVersionsRepoDefaults">
@@ -251,6 +257,7 @@
       <Output TaskParameter="OrchestratedIdentity" PropertyName="OrchestratedIdentity" />
       <Output TaskParameter="OrchestratedBlobFeed" ItemName="OrchestratedBlobFeed" />
       <Output TaskParameter="OrchestratedBlobFeedArtifacts" ItemName="OrchestratedBlobFeedArtifacts" />
+      <Output TaskParameter="OrchestratedBuilds" ItemName="OrchestratedBuilds" />
     </FetchOrchestratedBuildManifestInfo>
 
     <PropertyGroup>

--- a/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/BuildManifestClientTests.cs
+++ b/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/BuildManifestClientTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
             var mockGitHub = new Mock<IGitHubClient>(MockBehavior.Strict);
 
             var client = new BuildManifestClient(mockGitHub.Object);
-            var build = new OrchestratedBuildModel(new BuildIdentity("orch", "123"));
+            var build = new OrchestratedBuildModel(new BuildIdentity { Name = "orch", BuildId = "123"});
             var proj = new GitHubProject("versions", "dotnet");
             string @ref = "heads/master";
             string basePath = "build-info/dotnet/product/cli/master";
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
             string message = "Test change manifest commit";
             string addSemaphorePath = "add-identity.semaphore";
 
-            var fakeExistingBuild = new OrchestratedBuildModel(new BuildIdentity("orch", "123"));
+            var fakeExistingBuild = new OrchestratedBuildModel(new BuildIdentity { Name = "orch", BuildId = "123"});
             string fakeExistingBuildString = fakeExistingBuild.ToXml().ToString();
             string fakeCommitHash = "fakeCommitHash";
             string fakeTreeHash = "fakeTreeHash";
@@ -173,8 +173,8 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
             string message = "Test change manifest commit";
             string addSemaphorePath = "add-identity.semaphore";
 
-            var fakeExistingBuild = new OrchestratedBuildModel(new BuildIdentity("orch", "123"));
-            var fakeNewExistingBuild = new OrchestratedBuildModel(new BuildIdentity("orch", "456"));
+            var fakeExistingBuild = new OrchestratedBuildModel(new BuildIdentity { Name = "orch", BuildId = "123" });
+            var fakeNewExistingBuild = new OrchestratedBuildModel(new BuildIdentity { Name = "orch", BuildId = "456" });
             string fakeCommitHash = "fakeCommitHash";
 
             mockGitHub
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
             var mockGitHub = new Mock<IGitHubClient>(MockBehavior.Strict);
 
             var client = new BuildManifestClient(mockGitHub.Object);
-            var build = new OrchestratedBuildModel(new BuildIdentity("orch", "123"));
+            var build = new OrchestratedBuildModel(new BuildIdentity { Name = "orch", BuildId = "123" });
             var proj = new GitHubProject("versions", "dotnet");
             string @ref = "heads/master";
             string basePath = "build-info/dotnet/product/cli/master";

--- a/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
+++ b/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/ManifestModelTests.cs
@@ -44,6 +44,19 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
         }
 
         [Fact]
+        public void TestExampleCustomBuildIdentityRoundtrip()
+        {
+            XElement xml = XElement.Parse(
+                @"<Build Name=""Example"" BuildId=""123"" ProductVersion=""1.0.0-preview"" Branch=""master"" Commit=""abcdef"" BlankExtra="""" Extra=""extra-foo"" />");
+            var model = BuildModel.Parse(xml);
+            XElement modelXml = model.ToXml();
+
+            Assert.True(
+                XNode.DeepEquals(xml, modelXml),
+                "Model failed to output the parsed XML.");
+        }
+
+        [Fact]
         public void TestPackageOnlyBuildManifest()
         {
             var model = CreatePackageOnlyBuildManifestModel();
@@ -56,7 +69,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
         [Fact]
         public void TestMergeBuildManifests()
         {
-            var orchestratedModel = new OrchestratedBuildModel(new BuildIdentity("Orchestrated", "123"))
+            var orchestratedModel = new OrchestratedBuildModel(new BuildIdentity { Name = "Orchestrated", BuildId = "123" })
             {
                 Endpoints = new List<EndpointModel>
                 {
@@ -87,7 +100,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
 
         private BuildModel CreatePackageOnlyBuildManifestModel()
         {
-            return new BuildModel(new BuildIdentity("SimpleBuildManifest", "123"))
+            return new BuildModel(new BuildIdentity { Name = "SimpleBuildManifest", BuildId = "123" })
             {
                 Artifacts = new ArtifactSet
                 {

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BlobArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BlobArtifactModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.VersionTools.Util;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
@@ -14,11 +15,11 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             nameof(Id)
         };
 
-        public Dictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
+        public IDictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
 
         public string Id
         {
-            get { return Attributes[nameof(Id)]; }
+            get { return Attributes.GetOrDefault(nameof(Id)); }
             set { Attributes[nameof(Id)] = value; }
         }
 
@@ -26,12 +27,15 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
 
         public XElement ToXml() => new XElement(
             "Blob",
-            Attributes.CreateXmlAttributes(AttributeOrder));
+            Attributes
+                .ThrowIfMissingAttributes(AttributeOrder)
+                .CreateXmlAttributes(AttributeOrder));
 
         public static BlobArtifactModel Parse(XElement xml) => new BlobArtifactModel
         {
-            Id = xml.GetRequiredAttribute(nameof(Id)),
-            Attributes = xml.CreateAttributeDictionary()
+            Attributes = xml
+                .CreateAttributeDictionary()
+                .ThrowIfMissingAttributes(AttributeOrder)
         };
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/BuildModel.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
 
         public XElement ToXml() => new XElement(
             "Build",
-            Identity.ToXml(),
+            Identity.ToXmlAttributes(),
             Artifacts.ToXml());
 
         public static BuildModel Parse(XElement xml) => new BuildModel(BuildIdentity.Parse(xml))

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/EndpointModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/EndpointModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.VersionTools.Util;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
@@ -24,19 +25,19 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
 
         public string Id
         {
-            get { return Attributes[nameof(Id)]; }
+            get { return Attributes.GetOrDefault(nameof(Id)); }
             set { Attributes[nameof(Id)] = value; }
         }
 
         public string Type
         {
-            get { return Attributes[nameof(Type)]; }
+            get { return Attributes.GetOrDefault(nameof(Type)); }
             set { Attributes[nameof(Type)] = value; }
         }
 
         public string Url
         {
-            get { return Attributes[nameof(Url)]; }
+            get { return Attributes.GetOrDefault(nameof(Url)); }
             set { Attributes[nameof(Url)] = value; }
         }
 

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/OrchestratedBuildModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/OrchestratedBuildModel.cs
@@ -42,9 +42,9 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
 
         public XElement ToXml() => new XElement(
             "OrchestratedBuild",
-            Identity.ToXml(),
+            Identity.ToXmlAttributes(),
             Endpoints.Select(x => x.ToXml()),
-            Builds.Select(x => new XElement("Build", x.ToXml())));
+            Builds.Select(x => x.ToXmlBuildElement()));
 
         public static OrchestratedBuildModel Parse(XElement xml) => new OrchestratedBuildModel(BuildIdentity.Parse(xml))
         {

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.VersionTools.Util;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
@@ -15,17 +16,17 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             nameof(Version)
         };
 
-        public Dictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
+        public IDictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
 
         public string Id
         {
-            get { return Attributes[nameof(Id)]; }
+            get { return Attributes.GetOrDefault(nameof(Id)); }
             set { Attributes[nameof(Id)] = value; }
         }
 
         public string Version
         {
-            get { return Attributes[nameof(Version)]; }
+            get { return Attributes.GetOrDefault(nameof(Version)); }
             set { Attributes[nameof(Version)] = value; }
         }
 
@@ -33,13 +34,15 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
 
         public XElement ToXml() => new XElement(
             "Package",
-            Attributes.CreateXmlAttributes(AttributeOrder));
+            Attributes
+                .ThrowIfMissingAttributes(AttributeOrder)
+                .CreateXmlAttributes(AttributeOrder));
 
         public static PackageArtifactModel Parse(XElement xml) => new PackageArtifactModel
         {
-            Id = xml.GetRequiredAttribute(nameof(Id)),
-            Version = xml.GetRequiredAttribute(nameof(Version)),
-            Attributes = xml.CreateAttributeDictionary()
+            Attributes = xml
+                .CreateAttributeDictionary()
+                .ThrowIfMissingAttributes(AttributeOrder)
         };
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/XElementParsingExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/XElementParsingExtensions.cs
@@ -28,14 +28,29 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
         }
 
         public static XAttribute[] CreateXmlAttributes(
-            this Dictionary<string, string> attributes,
+            this IDictionary<string, string> attributes,
             string[] keySortOrder)
         {
             return attributes
+                .Where(pair => pair.Value != null)
                 .OrderBy(pair => keySortOrder.TakeWhile(o => pair.Key != o).Count())
                 .ThenBy(pair => pair.Key, StringComparer.OrdinalIgnoreCase)
                 .Select(pair => new XAttribute(pair.Key, pair.Value))
                 .ToArray();
+        }
+
+        public static IDictionary<string, string> ThrowIfMissingAttributes(
+            this IDictionary<string, string> attributes,
+            IEnumerable<string> requiredAttributes)
+        {
+            var missing = requiredAttributes?.Where(r => !attributes.ContainsKey(r)).ToArray();
+            if (missing?.Any() == true)
+            {
+                throw new ArgumentException(
+                    $"Required attribute(s) missing: {string.Join(", ", missing)}");
+            }
+
+            return attributes;
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Util/EnumerableExtensions.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/EnumerableExtensions.cs
@@ -13,5 +13,14 @@ namespace Microsoft.DotNet.VersionTools.Util
         {
             return source ?? Enumerable.Empty<T>();
         }
+
+        public static TValue GetOrDefault<TKey, TValue>(
+            this IDictionary<TKey, TValue> attributes,
+            TKey key)
+        {
+            TValue value;
+            attributes.TryGetValue(key, out value);
+            return value;
+        }
     }
 }

--- a/src/nuget/Microsoft.DotNet.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.VersionTools.nuspec
@@ -18,8 +18,8 @@
       <group targetFramework="netstandard1.5">
         <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="Newtonsoft.Json" version="9.0.1" />
-        <dependency id="NuGet.Packaging" version="4.3.0-preview2-4095" />
-        <dependency id="NuGet.Versioning" version="4.3.0-preview2-4095" />
+        <dependency id="NuGet.Packaging" version="4.3.0" />
+        <dependency id="NuGet.Versioning" version="4.3.0" />
         <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
       </group>


### PR DESCRIPTION
This brings 2.1 up to speed after initial creation.

Port https://github.com/dotnet/buildtools/pull/1882 (Needed for product build.)
Port https://github.com/dotnet/buildtools/pull/1884 (A VersionTools package fix we might as well include.)

Excludes https://github.com/dotnet/buildtools/pull/1879 because it's not known if it will be in 2.1. (https://github.com/dotnet/core-setup/pull/3646#issuecomment-361707945)