### PR TITLE
Produce 2.2.0-prerelease-* packages

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -13,7 +13,7 @@
 
     <!-- Use the same package version for all output packages. -->
     <DoNotGeneratePackageVersion>true</DoNotGeneratePackageVersion>
-    <PackageVersion>2.1.0-prerelease-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
+    <PackageVersion>2.2.0-prerelease-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I jumped to `2.2.0-prerelease` because BuildTools isn't currently on `preview1`-`preview2` naming, and it's next in the scheme after `2.1.x`, but we could go for that to match the Core repos.