### PR TITLE
[release/2.1] Produce 2.1.0-preview1-* packages

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -13,7 +13,7 @@
 
     <!-- Use the same package version for all output packages. -->
     <DoNotGeneratePackageVersion>true</DoNotGeneratePackageVersion>
-    <PackageVersion>2.1.0-prerelease-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
+    <PackageVersion>2.1.0-preview1-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Match the Core repo versioning scheme.

See https://github.com/dotnet/buildtools/pull/1888