### PR TITLE
Add idempotency options to publish tasks

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 {
                     client.Timeout = TimeSpan.FromMinutes(10);
                     Log.LogMessage(MessageImportance.Low, "Downloading BLOB - {0}", blob);
-                    string urlGetBlob = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, blob);
+                    string blobUrl = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, blob);
                     filename = Path.Combine(DownloadDirectory, Path.GetFileName(blob));
 
                     if (!DownloadFlatFiles)
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                         filename = Path.Combine(downloadBlobDirectory, blobFilename);
                     }
 
-                    var createRequest = AzureHelper.RequestMessage("GET", urlGetBlob, AccountName, AccountKey);
+                    var createRequest = AzureHelper.RequestMessage("GET", blobUrl, AccountName, AccountKey);
 
                     using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
                     {

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
@@ -228,8 +228,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     MessageImportance.Low,
                     $"Downloading blob {destinationBlob} to check if identical.");
 
-                string urlGetBlob = AzureHelper.GetBlobRestUrl(accountName, containerName, destinationBlob);
-                var createRequest = AzureHelper.RequestMessage("GET", urlGetBlob, accountName, accountKey);
+                string blobUrl = AzureHelper.GetBlobRestUrl(accountName, containerName, destinationBlob);
+                var createRequest = AzureHelper.RequestMessage("GET", blobUrl, accountName, accountKey);
 
                 using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(
                     log,

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
@@ -8,10 +8,12 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.DotNet.Build.CloudTestTasks
@@ -208,6 +210,57 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 }
             }
         }
+
+        public async Task<bool> FileEqualsExistingBlobAsync(
+            string accountName,
+            string accountKey,
+            string containerName,
+            string filePath,
+            string destinationBlob,
+            int uploadTimeout)
+        {
+            using (var client = new HttpClient
+            {
+                Timeout = TimeSpan.FromMinutes(uploadTimeout)
+            })
+            {
+                log.LogMessage(
+                    MessageImportance.Low,
+                    $"Downloading blob {destinationBlob} to check if identical.");
+
+                string urlGetBlob = AzureHelper.GetBlobRestUrl(accountName, containerName, destinationBlob);
+                var createRequest = AzureHelper.RequestMessage("GET", urlGetBlob, accountName, accountKey);
+
+                using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(
+                    log,
+                    client,
+                    createRequest))
+                {
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        throw new HttpRequestException(
+                            $"Failed to retrieve existing blob {destinationBlob}, " +
+                            $"status code {response.StatusCode}.");
+                    }
+
+                    byte[] existingBytes = await response.Content.ReadAsByteArrayAsync();
+                    byte[] localBytes = File.ReadAllBytes(filePath);
+
+                    bool equal = localBytes.SequenceEqual(existingBytes);
+
+                    if (equal)
+                    {
+                        log.LogMessage(
+                            MessageImportance.Normal,
+                            "Item exists in blob storage, and is verified to be identical. " +
+                            $"File: '{filePath}' Blob: '{destinationBlob}'");
+                    }
+
+                    return equal;
+                }
+            }
+        }
+
         private string DetermineContentTypeBasedOnFileExtension(string filename)
         {
             if (Path.GetExtension(filename) == ".svg")

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             if (!Overwrite && blobsPresent.Contains(relativeBlobPath))
             {
                 if (PassIfExistingItemIdentical &&
-                    await ItemEqualsExistingBlob(item, relativeBlobPath, uploadClient, clientThrottle))
+                    await ItemEqualsExistingBlobAsync(item, relativeBlobPath, uploadClient, clientThrottle))
                 {
                     return;
                 }
@@ -184,7 +184,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
         }
 
-        private async Task<bool> ItemEqualsExistingBlob(
+        private async Task<bool> ItemEqualsExistingBlobAsync(
             ITaskItem item,
             string relativeBlobPath,
             UploadClient client,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
@@ -69,19 +69,36 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public async Task<string> DownloadBlobAsString(string blobPath)
         {
+            using (HttpResponseMessage response = await DownloadBlob(blobPath))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    return await response.Content.ReadAsStringAsync();
+                }
+                return null;
+            }
+        }
+
+        public async Task<byte[]> DownloadBlobAsBytes(string blobPath)
+        {
+            using (HttpResponseMessage response = await DownloadBlob(blobPath))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    return await response.Content.ReadAsByteArrayAsync();
+                }
+                return null;
+            }
+        }
+
+        private async Task<HttpResponseMessage> DownloadBlob(string blobPath)
+        {
             string url = $"{FeedContainerUrl}/{blobPath}";
             using (HttpClient client = new HttpClient())
             {
                 client.DefaultRequestHeaders.Clear();
                 var request = AzureHelper.RequestMessage("GET", url, AccountName, AccountKey)();
-                using (HttpResponseMessage response = await client.SendAsync(request))
-                {
-                    if (response.IsSuccessStatusCode)
-                    {
-                        return await response.Content.ReadAsStringAsync();
-                    }
-                    return null;
-                }
+                return await client.SendAsync(request);
             }
         }
     }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeed.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
         public string FeedContainerUrl => AzureHelper.GetContainerRestUrl(AccountName, ContainerName);
 
-        public async Task<bool> CheckIfBlobExists(string blobPath)
+        public async Task<bool> CheckIfBlobExistsAsync(string blobPath)
         {
             string url = $"{FeedContainerUrl}/{blobPath}?comp=metadata";
             using (HttpClient client = new HttpClient())
@@ -67,9 +67,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        public async Task<string> DownloadBlobAsString(string blobPath)
+        public async Task<string> DownloadBlobAsStringAsync(string blobPath)
         {
-            using (HttpResponseMessage response = await DownloadBlob(blobPath))
+            using (HttpResponseMessage response = await DownloadBlobAsync(blobPath))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -79,9 +79,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        public async Task<byte[]> DownloadBlobAsBytes(string blobPath)
+        public async Task<byte[]> DownloadBlobAsBytesAsync(string blobPath)
         {
-            using (HttpResponseMessage response = await DownloadBlob(blobPath))
+            using (HttpResponseMessage response = await DownloadBlobAsync(blobPath))
             {
                 if (response.IsSuccessStatusCode)
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        private async Task<HttpResponseMessage> DownloadBlob(string blobPath)
+        private async Task<HttpResponseMessage> DownloadBlobAsync(string blobPath)
         {
             string url = $"{FeedContainerUrl}/{blobPath}";
             using (HttpClient client = new HttpClient())

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return !Log.HasLoggedErrors;
         }
 
-        public async Task UploadAssetsAsync(
+        public async Task UploadAssetAsync(
             ITaskItem item,
             SemaphoreSlim clientThrottle,
             int uploadTimeout,
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             "Package exists on the feed, and is verified to be identical. " +
                             $"Skipping upload: '{item}'");
                     }
-                    else if (identical == false)
+                    else
                     {
                         Log.LogError(
                             "Package exists on the feed, but contents are different. " +

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        public async Task<bool> PushToFeed(
+        public async Task<bool> PushToFeedAsync(
             IEnumerable<string> items,
             bool allowOverwrite = false,
             bool passIfExistingItemIdentical = false)
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return !Log.HasLoggedErrors;
         }
 
-        public async Task UploadAssets(
+        public async Task UploadAssetsAsync(
             ITaskItem item,
             SemaphoreSlim clientThrottle,
             int uploadTimeout,
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 UploadClient uploadClient = new UploadClient(Log);
 
-                if (!allowOverwrite && await feed.CheckIfBlobExists(relativeBlobPath))
+                if (!allowOverwrite && await feed.CheckIfBlobExistsAsync(relativeBlobPath))
                 {
                     if (passIfExistingItemIdentical)
                     {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -6,6 +6,8 @@ using Microsoft.Build.Framework;
 using Microsoft.DotNet.Build.CloudTestTasks;
 using Microsoft.WindowsAzure.Storage;
 using Newtonsoft.Json.Linq;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using Sleet;
 using System;
 using System.Collections.Generic;
@@ -14,9 +16,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using NuGet.Packaging.Core;
 using MSBuild = Microsoft.Build.Utilities;
-using CloudTestTasks = Microsoft.DotNet.Build.CloudTestTasks;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
@@ -65,7 +65,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        public async Task<bool> PushToFeed(IEnumerable<string> items, bool allowOverwrite = false)
+        public async Task<bool> PushToFeed(
+            IEnumerable<string> items,
+            bool allowOverwrite = false,
+            bool passIfExistingItemIdentical = false)
         {
             if (IsSanityChecked(items))
             {
@@ -75,13 +78,16 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                     CancellationToken.ThrowIfCancellationRequested();
                 }
 
-                await PushItemsToFeedAsync(items, allowOverwrite);
+                await PushItemsToFeedAsync(items, allowOverwrite, passIfExistingItemIdentical);
             }
 
             return !Log.HasLoggedErrors;
         }
 
-        public async Task<bool> PushItemsToFeedAsync(IEnumerable<string> items, bool allowOverwrite)
+        public async Task<bool> PushItemsToFeedAsync(
+            IEnumerable<string> items,
+            bool allowOverwrite,
+            bool passIfExistingItemIdentical)
         {
             Log.LogMessage(MessageImportance.Low, $"START pushing items to feed");
 
@@ -93,7 +99,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             try
             {
-                bool result = await PushAsync(items, allowOverwrite);
+                bool result = await PushAsync(items, allowOverwrite, passIfExistingItemIdentical);
                 return result;
             }
             catch (Exception e)
@@ -104,7 +110,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return !Log.HasLoggedErrors;
         }
 
-        public async Task UploadAssets(ITaskItem item, SemaphoreSlim clientThrottle, int uploadTimeout, bool allowOverwrite = false)
+        public async Task UploadAssets(
+            ITaskItem item,
+            SemaphoreSlim clientThrottle,
+            int uploadTimeout,
+            bool allowOverwrite = false,
+            bool passIfExistingItemIdentical = false)
         {
             string relativeBlobPath = item.GetMetadata("RelativeBlobPath");
 
@@ -133,17 +144,33 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             try
             {
-                bool blobExists = false;
+                UploadClient uploadClient = new UploadClient(Log);
 
-                if (!allowOverwrite)
+                if (!allowOverwrite && await feed.CheckIfBlobExists(relativeBlobPath))
                 {
-                    blobExists = await feed.CheckIfBlobExists(relativeBlobPath);
+                    if (passIfExistingItemIdentical)
+                    {
+                        if (!await uploadClient.FileEqualsExistingBlobAsync(
+                            feed.AccountName,
+                            feed.AccountKey,
+                            feed.ContainerName,
+                            item.ItemSpec,
+                            relativeBlobPath,
+                            uploadTimeout))
+                        {
+                            Log.LogError(
+                                $"Item '{item}' already exists with different contents " +
+                                $"at '{relativeBlobPath}'");
+                        }
+                    }
+                    else
+                    {
+                        Log.LogError($"Item '{item}' already exists at '{relativeBlobPath}'");
+                    }
                 }
-
-                if (allowOverwrite || !blobExists)
+                else
                 {
                     Log.LogMessage($"Uploading {item} to {relativeBlobPath}.");
-                    UploadClient uploadClient = new UploadClient(Log);
                     await uploadClient.UploadBlockBlobAsync(
                         CancellationToken,
                         feed.AccountName,
@@ -153,10 +180,6 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         relativeBlobPath,
                         contentType,
                         uploadTimeout);
-                }
-                else
-                {
-                    Log.LogError($"Item '{item}' already exists in {relativeBlobPath}.");
                 }
             }
             catch (Exception exc)
@@ -252,6 +275,35 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return true;
         }
 
+        private async Task<bool?> IsPackageIdenticalOnFeedAsync(
+            string item,
+            PackageIndex packageIndex,
+            ISleetFileSystem source,
+            FlatContainer flatContainer,
+            SleetLogger log)
+        {
+            using (var package = new PackageArchiveReader(item))
+            {
+                var id = await package.GetIdentityAsync(CancellationToken);
+                if (await packageIndex.Exists(id))
+                {
+                    using (Stream remoteStream = await source
+                        .Get(flatContainer.GetNupkgPath(id))
+                        .GetStream(log, CancellationToken))
+                    using (var remote = new MemoryStream())
+                    {
+                        await remoteStream.CopyToAsync(remote);
+
+                        byte[] existingBytes = remote.ToArray();
+                        byte[] localBytes = File.ReadAllBytes(item);
+
+                        return existingBytes.SequenceEqual(localBytes);
+                    }
+                }
+                return null;
+            }
+        }
+
         private LocalSettings GetSettings()
         {
             SleetSettings sleetSettings = new SleetSettings()
@@ -277,12 +329,80 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             return fileSystem;
         }
 
-        private async Task<bool> PushAsync(IEnumerable<string> items, bool allowOverwrite)
+        private async Task<bool> PushAsync(
+            IEnumerable<string> items,
+            bool allowOverwrite,
+            bool passIfExistingItemIdentical)
         {
             LocalSettings settings = GetSettings();
             AzureFileSystem fileSystem = GetAzureFileSystem();
-            bool result = await PushCommand.RunAsync(settings, fileSystem, items.ToList(), allowOverwrite, skipExisting: false, log: new SleetLogger(Log));
-            return result;
+            SleetLogger log = new SleetLogger(Log);
+
+            if (!allowOverwrite && passIfExistingItemIdentical)
+            {
+                var context = new SleetContext
+                {
+                    LocalSettings = settings,
+                    Log = log,
+                    Source = fileSystem,
+                    Token = CancellationToken
+                };
+                context.SourceSettings = await FeedSettingsUtility.GetSettingsOrDefault(
+                    context.Source,
+                    context.Log,
+                    context.Token);
+
+                var flatContainer = new FlatContainer(context);
+
+                var packageIndex = new PackageIndex(context);
+
+                var packagesToPush = new List<string>();
+
+                // Check packages sequentially: Task.WhenAll caused IO exceptions in Sleet.
+                foreach (var item in items)
+                {
+                    bool? identical = await IsPackageIdenticalOnFeedAsync(
+                        item,
+                        packageIndex,
+                        context.Source,
+                        flatContainer,
+                        log);
+
+                    if (identical == true)
+                    {
+                        Log.LogMessage(
+                            MessageImportance.Normal,
+                            "Package exists on the feed, and is verified to be identical. " +
+                            $"Skipping upload: '{item}'");
+                    }
+                    else if (identical == false)
+                    {
+                        Log.LogError(
+                            "Package exists on the feed, but contents are different. " +
+                            $"Upload failed: '{item}'");
+                    }
+                    else
+                    {
+                        packagesToPush.Add(item);
+                    }
+                }
+
+                items = packagesToPush;
+
+                if (!items.Any())
+                {
+                    Log.LogMessage("After skipping idempotent uploads, no items need pushing.");
+                    return true;
+                }
+            }
+
+            return await PushCommand.RunAsync(
+                settings,
+                fileSystem,
+                items.ToList(),
+                allowOverwrite,
+                skipExisting: false,
+                log: log);
         }
 
         private async Task<bool> InitAsync()

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/Microsoft.DotNet.Build.Tasks.Feed.csproj
@@ -51,6 +51,7 @@
     <Compile Include="GetBlobFeedPackageList.cs" />
     <Compile Include="CopyBlobDirectory.cs" />
     <Compile Include="ParseBlobUrl.cs" />
+    <Compile Include="PushOptions.cs" />
     <Compile Include="PushToBlobFeed.cs" />
     <Compile Include="SleetLogger.cs" />
     <Compile Include="SleetSettings.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushOptions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushOptions.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public class PushOptions
+    {
+        public bool AllowOverwrite { get; set; }
+
+        public bool PassIfExistingItemIdentical { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 using (var clientThrottle = new SemaphoreSlim(MaxClients, MaxClients))
                 {
-                    await blobFeedAction.UploadAssetsAsync(
+                    await blobFeedAction.UploadAssetAsync(
                         item,
                         clientThrottle,
                         UploadTimeoutInMinutes,
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     Log.LogMessage($"Uploading {taskItems.Count()} items...");
                     await Task.WhenAll(taskItems.Select(
-                        item => blobFeedAction.UploadAssetsAsync(
+                        item => blobFeedAction.UploadAssetAsync(
                             item,
                             clientThrottle,
                             UploadTimeoutInMinutes,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                         var packagePaths = packageItems.Select(i => i.ItemSpec);
 
-                        await blobFeedAction.PushToFeed(packagePaths, Overwrite, PassIfExistingItemIdentical);
+                        await blobFeedAction.PushToFeedAsync(packagePaths, Overwrite, PassIfExistingItemIdentical);
                         await PublishToFlatContainerAsync(symbolItems, blobFeedAction);
 
                         packageArtifacts = ConcatPackageArtifacts(packageArtifacts, packageItems);
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             IEnumerable<BlobArtifactModel> blobArtifacts,
             IEnumerable<PackageArtifactModel> packageArtifacts)
         {
-            bool disabledByBlob = await blobFeedAction.feed.CheckIfBlobExists(
+            bool disabledByBlob = await blobFeedAction.feed.CheckIfBlobExistsAsync(
                 $"{blobFeedAction.feed.RelativePath}{DisableManifestPushConfigurationBlob}");
 
             if (disabledByBlob)
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
             string blobPath = $"{AssetsVirtualDir}{ManifestAssetOutputDir}{ManifestName}.xml";
 
-            string existingStr = await blobFeedAction.feed.DownloadBlobAsString(
+            string existingStr = await blobFeedAction.feed.DownloadBlobAsStringAsync(
                 $"{blobFeedAction.feed.RelativePath}{blobPath}");
 
             BuildModel buildModel;
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                 using (var clientThrottle = new SemaphoreSlim(MaxClients, MaxClients))
                 {
-                    await blobFeedAction.UploadAssets(
+                    await blobFeedAction.UploadAssetsAsync(
                         item,
                         clientThrottle,
                         UploadTimeoutInMinutes,
@@ -220,7 +220,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 {
                     Log.LogMessage($"Uploading {taskItems.Count()} items...");
                     await Task.WhenAll(taskItems.Select(
-                        item => blobFeedAction.UploadAssets(
+                        item => blobFeedAction.UploadAssetsAsync(
                             item,
                             clientThrottle,
                             UploadTimeoutInMinutes,

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                         var packagePaths = packageItems.Select(i => i.ItemSpec);
 
-                        await blobFeedAction.PushToFeedAsync(packagePaths, Overwrite, PassIfExistingItemIdentical);
+                        await blobFeedAction.PushToFeedAsync(packagePaths, CreatePushOptions());
                         await PublishToFlatContainerAsync(symbolItems, blobFeedAction);
 
                         packageArtifacts = ConcatPackageArtifacts(packageArtifacts, packageItems);
@@ -200,7 +200,10 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         item,
                         clientThrottle,
                         UploadTimeoutInMinutes,
-                        allowOverwrite: true);
+                        new PushOptions
+                        {
+                            AllowOverwrite = true
+                        });
                 }
             }
             finally
@@ -224,8 +227,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                             item,
                             clientThrottle,
                             UploadTimeoutInMinutes,
-                            Overwrite,
-                            PassIfExistingItemIdentical)));
+                            CreatePushOptions())));
                 }
             }
         }
@@ -303,6 +305,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 })
                 .Where(pair => pair != null)
                 .ToDictionary(pair => pair.Key, pair => pair.Value);
+        }
+
+        private PushOptions CreatePushOptions()
+        {
+            return new PushOptions
+            {
+                AllowOverwrite = Overwrite,
+                PassIfExistingItemIdentical = PassIfExistingItemIdentical
+            };
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
@@ -31,7 +31,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <NuGetPushCommand Include="@(PackagesToPush -> '$(NuGetExePath) $(NuGetPushArgsBase) %(Identity)')" />
+      <NuGetPushCommand Include="@(PackagesToPush -> '$(NuGetExePath) $(NuGetPushArgsBase) %(Identity)')">
+        <PackageToPush>%(Identity)</PackageToPush>
+      </NuGetPushCommand>
 
       <!-- There are special failure scenarios that we want to ignore.  Those scenarios are
            when NuGet reports a failure during a push attempt for something server or timeout related, 
@@ -51,6 +53,7 @@
 
     <ExecWithRetriesForNuGetPush
       Command="%(NuGetPushCommand.Identity)"
+      PackageFile="%(NuGetPushCommand.PackageToPush)"
       MaxAttempts="$(MaxAttempts)"
       RetryDelayBase="$(RetryDelayBase)"
       RetryDelayConstant="$(RetryDelayConstant)"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PublishProduct.targets
@@ -53,11 +53,12 @@
 
     <ExecWithRetriesForNuGetPush
       Command="%(NuGetPushCommand.Identity)"
-      PackageFile="%(NuGetPushCommand.PackageToPush)"
       MaxAttempts="$(MaxAttempts)"
       RetryDelayBase="$(RetryDelayBase)"
       RetryDelayConstant="$(RetryDelayConstant)"
-      IgnoredErrorMessagesWithConditional="@(IgnorableErrorMessages)" />
+      IgnoredErrorMessagesWithConditional="@(IgnorableErrorMessages)"
+      PackageFile="%(NuGetPushCommand.PackageToPush)"
+      PassIfIdenticalV2Feed="$(PassIfIdenticalV2Feed)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Added `PassIfExistingItemIdentical` to `UploadToAzure` and `PushToBlobFeed`. The `PushToBlobFeed` implementation works on asset and package pushes.

Push to MyGet is a little more complicated. I used the existing system to ignore error messages and added a new `ConditionalIdenticalOnFeed` metadata that takes a NuGet v2 feed endpoint. If it encounters the 409, it checks the contents of the package on the v2 feed. (v2 for now because it's dead simple. It avoids having to hop through the redirects of v3 or attempting to use the NuGet library packages.)

I tested each path with a new artifact publish, two publishes with the same artifacts, and modifying the artifact on the endpoint before a publish. Seems to work as intended. Haven't done any regression testing except accidentally when I didn't plumb the new properties through all the way.

https://github.com/dotnet/core-eng/issues/2449