### PR TITLE
Add branch name to version information

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -262,8 +262,13 @@
   <Target Name="CreateOrUpdateCurrentVersionFile"
       BeforeTargets="ResolveProjectReferences"
       Condition="'$(SkipVersionGeneration)' != 'true' AND '$(VersionPropsImported)' != 'true'">
-    <!-- ############################### -->
 
+    <!-- ############################### -->
+    <Exec Command="git rev-parse --abbrev-ref HEAD 2>&amp;1" StandardOutputImportance="Low" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true" Condition="'$(GitBranchName)' == ''">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitBranchName" />
+    </Exec>
+
+    <!-- ############################### -->
     <PropertyGroup Condition="'$(LatestCommit)' != ''">
       <LatestCommitExitCode>0</LatestCommitExitCode>
     </PropertyGroup>
@@ -365,6 +370,8 @@
     <PropertyGroup Condition="'$(BuiltByString)' == ''">
       <!-- Set the @BuiltBy key-value pair -->
       <BuiltByString Condition="'$(VersionUserName)' != '' AND '$(VersionHostName)' != ''">$(BuiltByString) %40BuiltBy: $(VersionUserName)-$(VersionHostName)</BuiltByString>
+      <!-- Set the @Branch key-value pair -->
+      <BuiltByString Condition="'$(GitBranchName)' != ''">$(BuiltByString) %40Branch: $(GitBranchName)</BuiltByString>
       <!-- Set the @SrcCode key-value pair -->
       <BuiltByString Condition="'$(GitHubRepositoryUrl)' != '' AND '$(LatestCommit)' != 'N/A'">$(BuiltByString) %40SrcCode: $(GitHubRepositoryUrl)/tree/$(LatestCommit)</BuiltByString>
       <!-- If that does not work, try setting the @Commit key-value pair -->


### PR DESCRIPTION
We already add interesting information like @buildBy, and the @srcCode tags to our version information.

However it is still non-trivial to know what branch the build was from.    Adding this.   Now when you do a 
```
filever -v   coreclr.dll
```
You will get something like this
```
       ProductVersion  4.6.26201.0 @BuiltBy: vancem-VANCEM1 @Branch: master @SrcCode: https://github.com/dotnet/coreclr/tree/c137bc294620bbf36a7f0130c7d4a17f9e471ed6
```
The new part is the '@Branch: master' in the ProductVersion.   

This allows you to quickly determine if the build you are using came from the release branch (and exactly which one, or from a daily build from the master branch.     You can actually figure this out from the commit, but it is not a completely trivial process.  This makes it easy.

The change is designed to be 'safe' in that if somethings goes wrong, it simply is not added.  

@dagood 
