### PR TITLE
Open files for upload with Read access

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             List<string> blockIds = new List<string>();
             int numberOfBlocks = (size / blockSize) + 1;
             int countForId = 0;
-            using (FileStream fileStreamTofilePath = new FileStream(filePath, FileMode.Open))
+            using (FileStream fileStreamTofilePath = new FileStream(filePath, FileMode.Open, FileAccess.Read))
             {
                 int offset = 0;
 


### PR DESCRIPTION
@trylek  FYI.  We obviously want to rewrite these tasks using the Azure Client SDKs but folks do hit this bug and it's trivial to fix.