### PR TITLE
Features to allow build-info creation and upload for orchestrated builds

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/FetchOrchestratedBuildManifestInfo.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/FetchOrchestratedBuildManifestInfo.cs
@@ -36,6 +36,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
         public string OrchestratedIdentity { get; set; }
 
         [Output]
+        public ITaskItem OrchestratedBuild { get; set; }
+
+        [Output]
         public ITaskItem[] OrchestratedBlobFeed { get; set; }
 
         [Output]
@@ -63,6 +66,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
 
                 OrchestratedBuildId = manifest.Identity.BuildId;
                 OrchestratedIdentity = manifest.Identity.ToString();
+                OrchestratedBuild = CreateItem(manifest.Identity);
 
                 EndpointModel[] orchestratedFeeds = manifest.Endpoints
                     .Where(e => e.IsOrchestratedBlobFeed)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/PushOrchestratedBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/PushOrchestratedBuildManifest.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using Microsoft.DotNet.VersionTools.BuildManifest;
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -36,7 +37,9 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
 
         /// <summary>
         /// %(Identity): A file to upload to the versions repo.
-        /// %(RelativePath): Optional path to upload the file to, relative to VersionsRepoPath. 
+        /// %(RelativePath): Optional path to upload the file to, relative to VersionsRepoPath.
+        ///   If it begins with '/', it is treated as an absolute path within the versions repo.
+        ///   '\' is automatically converted to '/'.
         /// </summary>
         public ITaskItem[] SupplementaryFiles { get; set; }
 
@@ -55,33 +58,36 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
             {
                 var client = new BuildManifestClient(gitHubClient);
 
-                SupplementaryUploadRequest[] supplementaryUploads = SupplementaryFiles
-                    ?.Select(i =>
-                    {
-                        string path = i.GetMetadata("RelativePath");
-                        if (string.IsNullOrEmpty(path))
-                        {
-                            path = Path.GetFileName(i.ItemSpec);
-                        }
-                        return new SupplementaryUploadRequest
-                        {
-                            Contents = File.ReadAllText(i.ItemSpec),
-                            Path = path
-                        };
-                    })
-                    .ToArray();
-
                 var pushTask = client.PushNewBuildAsync(
                     new GitHubProject(VersionsRepo, VersionsRepoOwner),
                     $"heads/{VersionsRepoBranch}",
                     VersionsRepoPath,
                     model,
-                    supplementaryUploads,
+                    CreateUploadRequests(SupplementaryFiles),
                     CommitMessage);
 
                 pushTask.Wait();
             }
             return !Log.HasLoggedErrors;
+        }
+
+        public static SupplementaryUploadRequest[] CreateUploadRequests(IEnumerable<ITaskItem> items)
+        {
+            return items
+                ?.Select(i =>
+                {
+                    string path = i.GetMetadata("RelativePath")?.Replace('\\', '/');
+                    if (string.IsNullOrEmpty(path))
+                    {
+                        path = Path.GetFileName(i.ItemSpec);
+                    }
+                    return new SupplementaryUploadRequest
+                    {
+                        Contents = File.ReadAllText(i.ItemSpec),
+                        Path = path
+                    };
+                })
+                .ToArray();
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/UpdateOrchestratedBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/UpdateOrchestratedBuildManifest.cs
@@ -62,6 +62,14 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
 
         public string OrchestratedIdentity { get; set; }
 
+        /// <summary>
+        /// %(Identity): A file to upload to the versions repo.
+        /// %(RelativePath): Optional path to upload the file to, relative to VersionsRepoPath.
+        ///   If it begins with '/', it is treated as an absolute path within the versions repo.
+        ///   '\' is automatically converted to '/'.
+        /// </summary>
+        public ITaskItem[] SupplementaryFiles { get; set; }
+
         public override bool Execute()
         {
             if (string.IsNullOrEmpty(CommitMessage))
@@ -97,7 +105,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
                         }
                     },
                     SemaphoreNames,
-                    null,
+                    PushOrchestratedBuildManifest.CreateUploadRequests(SupplementaryFiles),
                     CommitMessage);
             }
             catch (ManifestChangeOutOfDateException e)

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestToFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestToFile.cs
@@ -63,6 +63,12 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
                 string contents = System.IO.File.ReadAllText(buildManifestFile.ItemSpec);
 
                 BuildModel build = BuildModel.Parse(XElement.Parse(contents));
+
+                foreach (PackageArtifactModel package in build.Artifacts.Packages)
+                {
+                    package.OriginBuildName = build.Identity.Name;
+                }
+
                 orchestratedBuild.AddParticipantBuild(build);
             }
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -222,6 +222,10 @@
     [Out]
     $(OrchestratedBuildId): The orchestrated build manifest's build id attribute value.
     $(OrchestratedIdentity): The human-readable full identity of the orchestrated build manifest.
+    @(OrchestratedBuild): A single item describing the root manifest element.
+      %(Identity): The name of the build.
+      %(Xml): The raw XML string representing the build in the manifest.
+      %(...): Metadata is created for each attribute on the element.
     @(OrchestratedBlobFeed): A single item for the orchestrated blob feed Endpoint.
       %(...): Metadata is created for each attribute on the element.
     @(ParsedOrchestratedBlobFeed): The result of parsing the OrchestratedBlobFeed url.
@@ -234,7 +238,7 @@
       %(...): Metadata is created for each attribute on the element.
     @(OrchestratedBuilds): An item for each Build in the orchestrated build manifest.
       %(Identity): The name of the build.
-      %(Xml): The raw XML string representing the artifact in the manifest.
+      %(Xml): The raw XML string representing the build in the manifest.
       %(...): Metadata is created for each attribute on the element.
   -->
   <Target Name="FetchOrchestratedBuildManifestInfo"
@@ -255,6 +259,7 @@
                                         VersionsRepoRef="$(VersionsRepoRef)">
       <Output TaskParameter="OrchestratedBuildId" PropertyName="OrchestratedBuildId" />
       <Output TaskParameter="OrchestratedIdentity" PropertyName="OrchestratedIdentity" />
+      <Output TaskParameter="OrchestratedBuild" ItemName="OrchestratedBuild" />
       <Output TaskParameter="OrchestratedBlobFeed" ItemName="OrchestratedBlobFeed" />
       <Output TaskParameter="OrchestratedBlobFeedArtifacts" ItemName="OrchestratedBlobFeedArtifacts" />
       <Output TaskParameter="OrchestratedBuilds" ItemName="OrchestratedBuilds" />
@@ -304,7 +309,15 @@
         <LowercaseVersion>$([System.String]::Copy('%(OrchestratedBlobFeedArtifacts.Version)').ToLowerInvariant())</LowercaseVersion>
       </FinalPackages>
 
-      <PackageBlobNames Include="$(BlobNamePrefix)%(FinalPackages.LowercaseId)/%(FinalPackages.LowercaseVersion)/%(FinalPackages.LowercaseId).%(FinalPackages.LowercaseVersion).nupkg" />
+      <FinalPackages>
+        <NupkgFile>%(LowercaseId).%(LowercaseVersion).nupkg</NupkgFile>
+      </FinalPackages>
+
+      <FinalPackages>
+        <DownloadFullPath>$(FinalDownloadDirectory)%(NupkgFile)</DownloadFullPath>
+      </FinalPackages>
+
+      <PackageBlobNames Include="$(BlobNamePrefix)%(FinalPackages.LowercaseId)/%(FinalPackages.LowercaseVersion)/%(FinalPackages.NupkgFile)" />
     </ItemGroup>
 
     <!-- Ensure no stale packages are on disk. -->
@@ -347,6 +360,9 @@
         a concise commit message. This is expected to come from FetchOrchestratedBuildManifestInfo.
         Default: the full VersionsRepoPath is used in the commit message.
       $(CommitMessage): Overrides the generated commit message.
+      @(SupplementaryFiles): Uploads supplementary files to the versions repo as part of the update.
+        For item requirements and behavior, see 'UpdateOrchestratedBuildManifest.cs' in
+        dotnet/buildtools.
   -->
   <Target Name="UpdateOrchestratedBuildManifest"
           DependsOnTargets="CreateVersionsRepoDefaults">
@@ -368,6 +384,7 @@
                                      VersionsRepoOwner="$(VersionsRepoOwner)"
                                      VersionsRepoBranch="$(VersionsRepoBranch)"
                                      CommitMessage="$(CommitMessage)"
-                                     OrchestratedIdentity="$(OrchestratedIdentity)" />
+                                     OrchestratedIdentity="$(OrchestratedIdentity)"
+                                     SupplementaryFiles="@(SupplementaryFiles)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/LocalUpdatePublishedVersions.cs
@@ -5,14 +5,13 @@
 using Microsoft.Build.Framework;
 using Microsoft.DotNet.VersionTools.Automation;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
     public class LocalUpdatePublishedVersions : BuildTask
     {
         [Required]
-        public ITaskItem[] ShippedNuGetPackage { get; set; }
+        public string[] ShippedNuGetPackage { get; set; }
 
         [Required]
         public string VersionsRepoLocalBaseDir { get; set; }
@@ -20,16 +19,47 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
         [Required]
         public string VersionsRepoPath { get; set; }
 
+        public string GitHubAuthToken { get; set; }
+        public string GitHubUser { get; set; }
+
+        /// <summary>
+        /// If specified, create the local build-infos based on the information available in the
+        /// versions repo. Specifically, Latest_Packages.txt will contain the latest version of each
+        /// package, even if this build didn't produce that certain package. Useful when servicing,
+        /// where a subset of packages are built.
+        /// </summary>
+        public string VersionsRepo { get; set; }
+        public string VersionsRepoOwner { get; set; }
+        public string VersionsRepoBranch { get; set; } = "master";
+
         public override bool Execute()
         {
             Trace.Listeners.MsBuildListenedInvoke(Log, () =>
             {
                 var updater = new LocalVersionsRepoUpdater();
 
-                updater.UpdateBuildInfoLatestPackages(
-                    ShippedNuGetPackage.Select(item => item.ItemSpec),
-                    VersionsRepoLocalBaseDir,
-                    VersionsRepoPath);
+                if (!string.IsNullOrEmpty(GitHubAuthToken))
+                {
+                    updater.GitHubAuth = new GitHubAuth(GitHubAuthToken, GitHubUser);
+                }
+
+                GitHubBranch branch = null;
+                if (!string.IsNullOrEmpty(VersionsRepo))
+                {
+                    branch = new GitHubBranch(
+                        VersionsRepoBranch,
+                        new GitHubProject(
+                            VersionsRepo,
+                            VersionsRepoOwner));
+                }
+
+                updater
+                    .UpdateBuildInfoFilesAsync(
+                        ShippedNuGetPackage,
+                        VersionsRepoLocalBaseDir,
+                        VersionsRepoPath,
+                        branch)
+                    .Wait();
             });
             return true;
         }

--- a/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/VersionsRepoUpdater.cs
@@ -2,9 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.VersionTools.Automation
 {
@@ -30,6 +34,62 @@ namespace Microsoft.DotNet.VersionTools.Automation
                 packages
                     .OrderBy(t => t.Key)
                     .Select(t => $"{t.Key} {t.Value}"));
+        }
+
+        protected static async Task AddExistingPackages(
+            GitHubClient client,
+            GitHubBranch branch,
+            string versionsRepoPath,
+            Dictionary<string, string> packages)
+        {
+            Dictionary<string, string> existingPackages = await GetPackagesAsync(
+                client,
+                branch,
+                $"{versionsRepoPath}/{BuildInfo.LatestPackagesTxtFilename}");
+
+            if (existingPackages == null)
+            {
+                Trace.TraceInformation(
+                    "No exising Latest_Packages file found; one will be " +
+                    $"created in '{versionsRepoPath}'");
+            }
+            else
+            {
+                // Add each existing package if there isn't a new package with the same id.
+                foreach (var package in existingPackages)
+                {
+                    if (!packages.ContainsKey(package.Key))
+                    {
+                        packages[package.Key] = package.Value;
+                    }
+                }
+            }
+        }
+
+        private static async Task<Dictionary<string, string>> GetPackagesAsync(
+            GitHubClient client,
+            GitHubBranch branch,
+            string path)
+        {
+            string latestPackages = await client.GetGitHubFileContentsAsync(path, branch);
+
+            if (latestPackages == null)
+            {
+                return null;
+            }
+
+            using (var reader = new StringReader(latestPackages))
+            {
+                return await BuildInfo.ReadPackageListAsync(reader);
+            }
+        }
+
+        protected static string GetPrereleaseVersion(NupkgInfo[] packages)
+        {
+            return packages
+                .Select(t => t.Prerelease)
+                .FirstOrDefault(prerelease => !string.IsNullOrEmpty(prerelease))
+                ?? "stable";
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestClient.cs
@@ -181,10 +181,11 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
             GitObject[] objects = uploads
                 .Select(upload => new GitObject
                 {
-                    Path = $"{basePath}/{upload.Path}",
+                    Path = upload.GetAbsolutePath(basePath),
                     Mode = GitObject.ModeFile,
                     Type = GitObject.TypeBlob,
-                    Content = upload.Contents
+                    // Always upload files using LF to avoid bad dev scenarios with Git autocrlf.
+                    Content = upload.Contents.Replace("\r\n", "\n")
                 })
                 .ToArray();
 

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/Model/PackageArtifactModel.cs
@@ -4,17 +4,23 @@
 
 using Microsoft.DotNet.VersionTools.Util;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Linq;
 
 namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
 {
     public class PackageArtifactModel
     {
-        private static readonly string[] AttributeOrder =
+        private static readonly string[] RequiredAttributes =
         {
             nameof(Id),
             nameof(Version)
         };
+
+        private static readonly string[] AttributeOrder = RequiredAttributes.Concat(new[]
+        {
+            nameof(OriginBuildName)
+        }).ToArray();
 
         public IDictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
 
@@ -30,19 +36,25 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest.Model
             set { Attributes[nameof(Version)] = value; }
         }
 
+        public string OriginBuildName
+        {
+            get { return Attributes.GetOrDefault(nameof(OriginBuildName)); }
+            set { Attributes[nameof(OriginBuildName)] = value; }
+        }
+
         public override string ToString() => $"Package {Id} {Version}";
 
         public XElement ToXml() => new XElement(
             "Package",
             Attributes
-                .ThrowIfMissingAttributes(AttributeOrder)
+                .ThrowIfMissingAttributes(RequiredAttributes)
                 .CreateXmlAttributes(AttributeOrder));
 
         public static PackageArtifactModel Parse(XElement xml) => new PackageArtifactModel
         {
             Attributes = xml
                 .CreateAttributeDictionary()
-                .ThrowIfMissingAttributes(AttributeOrder)
+                .ThrowIfMissingAttributes(RequiredAttributes)
         };
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/SupplementaryUploadRequest.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/SupplementaryUploadRequest.cs
@@ -6,8 +6,20 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
 {
     public class SupplementaryUploadRequest
     {
+        /// <summary>
+        /// Path, relative to the primary upload dir or absolute with a leading '/'.
+        /// </summary>
         public string Path { get; set; }
 
         public string Contents { get; set; }
+
+        public string GetAbsolutePath(string currentPath)
+        {
+            if (Path.StartsWith("/"))
+            {
+                return Path.Substring(1);
+            }
+            return $"{currentPath}/{Path}";
+        }
     }
 }


### PR DESCRIPTION
 * Export OrchestratedBuild so the manifest can specify a default branch.
 * Use '/' prefix for supplementary file upload to absolute repo paths.
 * Allow uploading supplementary files when updating manifest.
 * Add OriginBuildName to combined manifest packages to allow splitting them back into build-info files and associating them to their Builds.
 * Keep enough info in FinalPackages items to find downloaded nupkgs.
 * Make LocalUpdatePublishedVersions able to create Latest_Packages based on versions repo state.
 * Always upload files to GitHub using LF.

Instead of adding `OriginBuildName` to packages, I thought about moving the artifacts to the `Build` elements in the orchestrated build manifest. This is something I ultimately want to do to improve the manifest, but to be expedient, the extra attribute will work for now.

Example commit that this creates when submitting build-infos generated for a 2.1 prodcon build as supplementary uploads: https://github.com/dagood/versions/commit/8e0aec5149a26662ced4423614e1640c558c84a5 (based on [this testing manifest](https://github.com/dagood/versions/blob/8e0aec5149a26662ced4423614e1640c558c84a5/build-info/dotnet/product/test-cli-0202-02-origins/2.1-dedup/build.xml)).

https://github.com/dotnet/core-eng/issues/2435