### PR TITLE
Fix dumplinghelper.py to not assume HTTPError.reason exists

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -27,7 +27,7 @@ def install_dumpling():
 
     subprocess.call([sys.executable, dumplingPath, "install"])
   except urllib2.HTTPError, e:
-    print("Dumpling cannot be installed due to " + e.reason + " and HTTP Status Code " + str(e.code))
+    print("Dumpling cannot be installed due to: " + str(e))
   except  urllib2.URLError, e:
     print(e.reason)
   except:


### PR DESCRIPTION
It seems it doesn't always, despite [the docs](https://docs.python.org/2/library/urllib2.html).

```
2018-02-11T01:44:02.4080300Z   Traceback (most recent call last):
2018-02-11T01:44:02.4095790Z     File "/root/corefx-1372779/Tools/DumplingHelper.py", line 131, in <module>
2018-02-11T01:44:02.4121220Z       main(sys.argv)
2018-02-11T01:44:02.4135960Z     File "/root/corefx-1372779/Tools/DumplingHelper.py", line 113, in main
2018-02-11T01:44:02.4156070Z       install_dumpling()
2018-02-11T01:44:02.4172300Z     File "/root/corefx-1372779/Tools/DumplingHelper.py", line 30, in install_dumpling
2018-02-11T01:44:02.4188550Z       print("Dumpling cannot be installed due to " + e.reason + " and HTTP Status Code " + str(e.code))
2018-02-11T01:44:02.4204590Z   AttributeError: 'HTTPError' object has no attribute 'reason'
2018-02-11T01:44:02.4222880Z /root/corefx-1372779/Tools/Dumpling.targets(30,5): error MSB3073: The command "python /root/corefx-1372779/Tools/DumplingHelper.py install_dumpling" exited with code 1. [/root/corefx-1372779/src/tests.builds]
```