### PR TITLE
Fix dumplinghelper to not log 'error format'

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -27,7 +27,7 @@ def install_dumpling():
 
     subprocess.call([sys.executable, dumplingPath, "install"])
   except urllib2.HTTPError, e:
-    print("Dumpling cannot be installed due to: " + str(e))
+    print("Dumpling cannot be installed due to: " + str(e).replace(':', '')) # Remove : to avoid looking like error format
   except  urllib2.URLError, e:
     print(e.reason)
   except:


### PR DESCRIPTION
My previous fix solved the problem of HTTPError.reason not always being present by using `str()` instead. This caused another problem: to MSBuild, `Dumpling cannot be installed due to : HTTP error 403: Site Disabled` looks like standard error format, so absent other instructions, it fails the build.

Fix _that_ by removing any colon.