### PR TITLE
 Implement "join semaphore" groups

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/PushOrchestratedBuildManifest.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/PushOrchestratedBuildManifest.cs
@@ -58,10 +58,13 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
             {
                 var client = new BuildManifestClient(gitHubClient);
 
-                var pushTask = client.PushNewBuildAsync(
+                var location = new BuildManifestLocation(
                     new GitHubProject(VersionsRepo, VersionsRepoOwner),
                     $"heads/{VersionsRepoBranch}",
-                    VersionsRepoPath,
+                    VersionsRepoPath);
+
+                var pushTask = client.PushNewBuildAsync(
+                    location,
                     model,
                     CreateUploadRequests(SupplementaryFiles),
                     CommitMessage);

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -386,6 +386,7 @@
                                      VersionsRepoBranch="$(VersionsRepoBranch)"
                                      CommitMessage="$(CommitMessage)"
                                      OrchestratedIdentitySummary="$(OrchestratedIdentitySummary)"
-                                     SupplementaryFiles="@(SupplementaryFiles)" />
+                                     SupplementaryFiles="@(SupplementaryFiles)"
+                                     JoinSemaphoreGroups="@(JoinSemaphoreGroups)" />
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/BuildManifestClientTests.cs
+++ b/src/Microsoft.DotNet.VersionTools.Tests/BuildManifest/BuildManifestClientTests.cs
@@ -83,9 +83,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
                 .ReturnsAsync(() => null);
 
             await client.PushNewBuildAsync(
-                proj,
-                @ref,
-                basePath,
+                new BuildManifestLocation(proj, @ref, basePath),
                 build,
                 null,
                 message);
@@ -149,14 +147,12 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
                 .ReturnsAsync(() => null);
 
             await client.PushChangeAsync(
-                proj,
-                @ref,
-                basePath,
-                fakeExistingBuild.Identity.BuildId,
-                _ => { },
-                new[] { addSemaphorePath },
-                null,
-                message);
+                new BuildManifestChange(
+                    new BuildManifestLocation(proj, @ref, basePath),
+                    message,
+                    fakeExistingBuild.Identity.BuildId,
+                    new[] { addSemaphorePath },
+                    _ => { }));
 
             mockGitHub.VerifyAll();
         }
@@ -190,14 +186,13 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
 
             await Assert.ThrowsAsync<ManifestChangeOutOfDateException>(
                 async () => await client.PushChangeAsync(
-                    proj,
-                    @ref,
-                    basePath,
-                    fakeExistingBuild.Identity.BuildId,
-                    _ => { },
-                    new[] { addSemaphorePath },
-                    null,
-                    message));
+                    new BuildManifestChange(
+                        new BuildManifestLocation(proj, @ref, basePath),
+                        message,
+                        fakeExistingBuild.Identity.BuildId,
+                        new[] { addSemaphorePath },
+                        _ => { }
+                        )));
 
             mockGitHub.VerifyAll();
         }
@@ -245,9 +240,7 @@ namespace Microsoft.DotNet.VersionTools.Tests.BuildManifest
                 .ThrowsAsync(new NotFastForwardUpdateException("Testing non-fast-forward update."));
 
             await client.PushNewBuildAsync(
-                proj,
-                @ref,
-                basePath,
+                new BuildManifestLocation(proj, @ref, basePath),
                 build,
                 null,
                 message);

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestChange.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestChange.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest
+{
+    public class BuildManifestChange
+    {
+        public BuildManifestLocation Location { get; }
+
+        public string CommitMessage { get; }
+
+        public string OrchestratedBuildId { get; }
+
+        public IEnumerable<string> SemaphorePaths { get; }
+
+        public Action<OrchestratedBuildModel> ApplyModelChanges { get; }
+
+        public IEnumerable<JoinSemaphoreGroup> JoinSemaphoreGroups { get; set; }
+
+        public IEnumerable<SupplementaryUploadRequest> SupplementaryUploads { get; set; }
+
+        public BuildManifestChange(
+            BuildManifestLocation location,
+            string commitMessage,
+            string orchestratedBuildId,
+            IEnumerable<string> semaphorePaths,
+            Action<OrchestratedBuildModel> applyModelChanges)
+        {
+            if (location == null)
+            {
+                throw new ArgumentNullException(nameof(location));
+            }
+
+            if (string.IsNullOrEmpty(commitMessage))
+            {
+                throw new ArgumentException(nameof(commitMessage));
+            }
+
+            if (string.IsNullOrEmpty(orchestratedBuildId))
+            {
+                throw new ArgumentException(nameof(orchestratedBuildId));
+            }
+
+            if (applyModelChanges == null)
+            {
+                throw new ArgumentNullException(nameof(applyModelChanges));
+            }
+
+            if (semaphorePaths == null)
+            {
+                throw new ArgumentNullException(nameof(semaphorePaths));
+            }
+
+            Location = location;
+            CommitMessage = commitMessage;
+            OrchestratedBuildId = orchestratedBuildId;
+            SemaphorePaths = semaphorePaths;
+            ApplyModelChanges = applyModelChanges;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestClient.cs
@@ -47,20 +47,27 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
                 project,
                 @ref);
 
+            if (contents == null)
+            {
+                return null;
+            }
+
             return SemaphoreModel.Parse(semaphorePath, contents);
         }
 
         public async Task PushNewBuildAsync(
-            GitHubProject project,
-            string @ref,
-            string basePath,
+            BuildManifestLocation location,
             OrchestratedBuildModel build,
             IEnumerable<SupplementaryUploadRequest> supplementaryUploads,
             string message)
         {
             await Retry.RunAsync(async attempt =>
             {
-                string remoteCommit = (await _github.GetReferenceAsync(project, @ref)).Object.Sha;
+                GitReference remoteRef = await _github.GetReferenceAsync(
+                    location.GitHubProject,
+                    location.GitHubRef);
+
+                string remoteCommit = remoteRef.Object.Sha;
 
                 Trace.TraceInformation($"Creating update on remote commit: {remoteCommit}");
 
@@ -83,63 +90,86 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
                     })
                     .ToArray();
 
-                return await PushUploadsAsync(project, @ref, basePath, message, remoteCommit, uploads);
+                return await PushUploadsAsync(location, message, remoteCommit, uploads);
             });
         }
 
-        public async Task PushChangeAsync(
-            GitHubProject project,
-            string @ref,
-            string basePath,
-            string orchestratedBuildId,
-            Action<OrchestratedBuildModel> changeModel,
-            IEnumerable<string> semaphorePaths,
-            IEnumerable<SupplementaryUploadRequest> supplementaryUploads,
-            string message)
+        public async Task PushChangeAsync(BuildManifestChange change)
         {
             await Retry.RunAsync(async attempt =>
             {
+                BuildManifestLocation location = change.Location;
+
                 // Get the current commit. Use this throughout to ensure a clean transaction.
-                string remoteCommit = (await _github.GetReferenceAsync(project, @ref)).Object.Sha;
+                GitReference remoteRef = await _github.GetReferenceAsync(
+                    location.GitHubProject,
+                    location.GitHubRef);
+
+                string remoteCommit = remoteRef.Object.Sha;
 
                 Trace.TraceInformation($"Creating update on remote commit: {remoteCommit}");
 
-                // This is a subsequent publish step: check to make sure the build id matches.
-                XElement remoteModelXml = await FetchModelXmlAsync(project, remoteCommit, basePath);
+                XElement remoteModelXml = await FetchModelXmlAsync(
+                    location.GitHubProject,
+                    remoteCommit,
+                    location.GitHubBasePath);
 
                 OrchestratedBuildModel remoteModel = OrchestratedBuildModel.Parse(remoteModelXml);
 
-                if (orchestratedBuildId != remoteModel.Identity.BuildId)
+                // This is a subsequent publish step: make sure a new build hasn't happened already.
+                if (change.OrchestratedBuildId != remoteModel.Identity.BuildId)
                 {
                     throw new ManifestChangeOutOfDateException(
-                        orchestratedBuildId,
+                        change.OrchestratedBuildId,
                         remoteModel.Identity.BuildId);
                 }
 
                 OrchestratedBuildModel modifiedModel = OrchestratedBuildModel.Parse(remoteModelXml);
-                changeModel(modifiedModel);
+                change.ApplyModelChanges(modifiedModel);
 
-                if (modifiedModel.Identity.BuildId != orchestratedBuildId)
+                if (modifiedModel.Identity.BuildId != change.OrchestratedBuildId)
                 {
                     throw new ArgumentException(
                         "Change action shouldn't modify BuildId. Changed from " +
-                        $"'{orchestratedBuildId}' to '{modifiedModel.Identity.BuildId}'.",
-                        nameof(changeModel));
+                        $"'{change.OrchestratedBuildId}' to '{modifiedModel.Identity.BuildId}'.",
+                        nameof(change));
                 }
 
                 XElement modifiedModelXml = modifiedModel.ToXml();
 
-                IEnumerable<SupplementaryUploadRequest> uploads = semaphorePaths.NullAsEmpty()
+                string[] changedSemaphorePaths = change.SemaphorePaths.ToArray();
+
+                // Check if any join groups are completed by this change.
+                var joinCompleteCheckTasks = change.JoinSemaphoreGroups.NullAsEmpty()
+                    .Select(async g => new
+                    {
+                        Group = g,
+                        Joinable = await IsGroupJoinableAsync(
+                            location,
+                            remoteCommit,
+                            change.OrchestratedBuildId,
+                            changedSemaphorePaths,
+                            g)
+                    });
+
+                var completeJoinedSemaphores = (await Task.WhenAll(joinCompleteCheckTasks))
+                    .Where(g => g.Joinable)
+                    .Select(g => g.Group.JoinSemaphorePath)
+                    .ToArray();
+
+                IEnumerable<SupplementaryUploadRequest> semaphoreUploads = completeJoinedSemaphores
+                    .Concat(changedSemaphorePaths)
                     .Select(p => new SupplementaryUploadRequest
                     {
                         Path = p,
                         Contents = new SemaphoreModel
                         {
-                            BuildId = orchestratedBuildId
+                            BuildId = change.OrchestratedBuildId
                         }.ToFileContent()
-                    })
-                    .Concat(supplementaryUploads.NullAsEmpty())
-                    .ToArray();
+                    });
+
+                IEnumerable<SupplementaryUploadRequest> uploads =
+                    semaphoreUploads.Concat(change.SupplementaryUploads.NullAsEmpty());
 
                 if (!XNode.DeepEquals(modifiedModelXml, remoteModelXml))
                 {
@@ -153,7 +183,11 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
                     });
                 }
 
-                return await PushUploadsAsync(project, @ref, basePath, message, remoteCommit, uploads);
+                return await PushUploadsAsync(
+                    location,
+                    change.CommitMessage,
+                    remoteCommit,
+                    uploads);
             });
         }
 
@@ -171,9 +205,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
         }
 
         private async Task<bool> PushUploadsAsync(
-            GitHubProject project,
-            string @ref,
-            string basePath,
+            BuildManifestLocation location,
             string message,
             string remoteCommit,
             IEnumerable<SupplementaryUploadRequest> uploads)
@@ -181,7 +213,7 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
             GitObject[] objects = uploads
                 .Select(upload => new GitObject
                 {
-                    Path = upload.GetAbsolutePath(basePath),
+                    Path = upload.GetAbsolutePath(location.GitHubBasePath),
                     Mode = GitObject.ModeFile,
                     Type = GitObject.TypeBlob,
                     // Always upload files using LF to avoid bad dev scenarios with Git autocrlf.
@@ -189,10 +221,13 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
                 })
                 .ToArray();
 
-            GitTree tree = await _github.PostTreeAsync(project, remoteCommit, objects);
+            GitTree tree = await _github.PostTreeAsync(
+                location.GitHubProject,
+                remoteCommit,
+                objects);
 
             GitCommit commit = await _github.PostCommitAsync(
-                project,
+                location.GitHubProject,
                 message,
                 tree.Sha,
                 new[] { remoteCommit });
@@ -200,7 +235,11 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
             try
             {
                 // Only fast-forward. Don't overwrite other changes: throw exception instead.
-                await _github.PatchReferenceAsync(project, @ref, commit.Sha, force: false);
+                await _github.PatchReferenceAsync(
+                    location.GitHubProject,
+                    location.GitHubRef,
+                    commit.Sha,
+                    force: false);
             }
             catch (NotFastForwardUpdateException e)
             {
@@ -210,6 +249,41 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
             }
 
             return true;
+        }
+
+        private async Task<bool> IsGroupJoinableAsync(
+            BuildManifestLocation location,
+            string commit,
+            string buildId,
+            IEnumerable<string> changedSemaphorePaths,
+            JoinSemaphoreGroup joinGroup)
+        {
+            string[] remainingSemaphores = joinGroup
+                .ParallelSemaphorePaths
+                .Except(changedSemaphorePaths)
+                .ToArray();
+
+            if (remainingSemaphores.Length == joinGroup.ParallelSemaphorePaths.Count())
+            {
+                // No semaphores in this group are changing: it can't be joinable by this update.
+                return false;
+            }
+
+            // TODO: Avoid redundant fetches if multiple groups share a semaphore. https://github.com/dotnet/buildtools/issues/1910
+            bool[] remainingSemaphoreIsComplete = await Task.WhenAll(
+                remainingSemaphores.Select(
+                    async path =>
+                    {
+                        SemaphoreModel semaphore = await FetchSemaphoreAsync(
+                            location.GitHubProject,
+                            commit,
+                            location.GitHubBasePath,
+                            path);
+
+                        return semaphore?.BuildId == buildId;
+                    }));
+
+            return remainingSemaphoreIsComplete.All(x => x);
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestLocation.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestLocation.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Automation;
+using System;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest
+{
+    public class BuildManifestLocation
+    {
+        public GitHubProject GitHubProject { get; }
+
+        public string GitHubRef { get; }
+
+        public string GitHubBasePath { get; }
+
+        public BuildManifestLocation(
+            GitHubProject gitHubProject,
+            string gitHubRef,
+            string gitHubBasePath)
+        {
+            if (gitHubProject == null)
+            {
+                throw new ArgumentNullException(nameof(gitHubProject));
+            }
+
+            if (string.IsNullOrEmpty(gitHubRef))
+            {
+                throw new ArgumentException(nameof(gitHubRef));
+            }
+
+            if (string.IsNullOrEmpty(gitHubBasePath))
+            {
+                throw new ArgumentException(nameof(gitHubBasePath));
+            }
+
+            GitHubProject = gitHubProject;
+            GitHubRef = gitHubRef;
+            GitHubBasePath = gitHubBasePath;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/JoinSemaphoreGroup.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/JoinSemaphoreGroup.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.BuildManifest
+{
+    public class JoinSemaphoreGroup
+    {
+        public string JoinSemaphorePath { get; set; }
+
+        /// <summary>
+        /// Names of the semaphores that must all complete to update the join semaphore.
+        /// </summary>
+        public IEnumerable<string> ParallelSemaphorePaths { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -30,7 +30,9 @@
     <Compile Include="Automation\LocalVersionsRepoUpdater.cs" />
     <Compile Include="Automation\GitHubVersionsRepoUpdater.cs" />
     <Compile Include="Automation\PullRequestOptions.cs" />
+    <Compile Include="BuildManifest\BuildManifestChange.cs" />
     <Compile Include="BuildManifest\BuildManifestClient.cs" />
+    <Compile Include="BuildManifest\BuildManifestLocation.cs" />
     <Compile Include="BuildManifest\ManifestChangeOutOfDateException.cs" />
     <Compile Include="BuildManifest\Model\ArtifactSet.cs" />
     <Compile Include="BuildManifest\Model\BlobArtifactModel.cs" />
@@ -41,6 +43,7 @@
     <Compile Include="BuildManifest\Model\OrchestratedBuildModel.cs" />
     <Compile Include="BuildManifest\Model\SemaphoreModel.cs" />
     <Compile Include="BuildManifest\Model\XElementParsingExtensions.cs" />
+    <Compile Include="BuildManifest\JoinSemaphoreGroup.cs" />
     <Compile Include="BuildManifest\SupplementaryUploadRequest.cs" />
     <Compile Include="Dependencies\BuildOutput\BuildDependencyInfo.cs" />
     <Compile Include="Dependencies\IDependencyInfo.cs" />

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -11,6 +11,7 @@
     <CLSCompliant>false</CLSCompliant>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
+    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/2614

> `installers.semaphore` and `packages.semaphore` can each be used to trigger steps that rely on a specific type of publishing to complete. This works for some repos' dependency uptake because they only use packages, but others (e.g. dotnet-docker-nightly) need both packages and installers to be published for auto-PR CI to succeed.

> The join semaphores should be created in "finalize" style: when the `installers` and `packages` steps finish, they check to see if the other step already completed for the current build id. If so, it updates the combined semaphore.

This is related to https://github.com/dotnet/buildtools/pull/1907 which will allow us to make package version build-infos (for the Core repos to consume in particular). I haven't deployed that change to the utilities repo yet--I plan on lumping this change in so I only need to do one PR on the utilities repo.