### PR TITLE
Improve unit test output to show how to repro directly

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -45,7 +45,6 @@ then
 echo error: RUNTIME_PATH is not defined.  Usage: $0 RUNTIME_PATH
 exit -1
 fi
-echo Using $RUNTIME_PATH as the test runtime folder.
 
 # ========================= BEGIN Core File Setup ============================
 if [ "$(uname -s)" == "Darwin" ]; then
@@ -72,17 +71,16 @@ fi
 # ========================= END Core File Setup ==============================
 
 # ========================= BEGIN Test Execution =============================
-echo Running tests... Start time: $(date +"%T")
-echo ====== To repro directly: =================================================
+echo ----- start $(date +"%T") ===============  To repro directly: ===================================================== 
 echo pushd $EXECUTION_DIR
 [[TestRunCommandsEcho]]
 echo popd
-echo ===========================================================================
+echo ===========================================================================================================
 pushd $EXECUTION_DIR
 [[TestRunCommands]]
 test_exitcode=$?
 popd
-echo Finished running tests.  End time=$(date +"%T").  Return value was $test_exitcode
+echo ----- end $(date +"%T") ----- exit code $test_exitcode ----------------------------------------------------------
 # ========================= END Test Execution ===============================
 
 # ======================= BEGIN Core File Inspection =========================

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -45,7 +45,7 @@ then
 echo error: RUNTIME_PATH is not defined.  Usage: $0 RUNTIME_PATH
 exit -1
 fi
-echo Using $RUNTIME_DIR as the test runtime folder.
+echo Using $RUNTIME_PATH as the test runtime folder.
 
 # ========================= BEGIN Core File Setup ============================
 if [ "$(uname -s)" == "Darwin" ]; then
@@ -73,14 +73,18 @@ fi
 
 # ========================= BEGIN Test Execution =============================
 echo Running tests... Start time: $(date +"%T")
-echo Commands:
+echo ====== To repro directly: =================================================
+echo pushd $EXECUTION_DIR
 [[TestRunCommandsEcho]]
+echo popd
+echo ===========================================================================
 pushd $EXECUTION_DIR
 [[TestRunCommands]]
 test_exitcode=$?
 popd
 echo Finished running tests.  End time=$(date +"%T").  Return value was $test_exitcode
 # ========================= END Test Execution ===============================
+
 # ======================= BEGIN Core File Inspection =========================
 if [ "$(uname -s)" == "Linux" ]; then
   # Depending on distro/configuration, the core files may either be named "core"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
@@ -11,18 +11,17 @@ set EXECUTION_DIR=%~dp0
 echo Executing in %EXECUTION_DIR% 
 
 :: ========================= BEGIN Test Execution ============================= 
-echo Running tests... Start time: %TIME%
-echo ====== To repro directly: =================================================
+echo ----- start %TIME% ===============  To repro directly: ===================================================== 
 echo pushd %EXECUTION_DIR%
  [[TestRunCommandsEcho]]
 echo popd
-echo ===========================================================================
+echo ===========================================================================================================
 pushd %EXECUTION_DIR%
 echo on
 [[TestRunCommands]]
 @echo off
 popd
-echo Finished running tests.  End time=%TIME%, Exit code = %ERRORLEVEL%
+echo ----- end %TIME% ----- exit code %ERRORLEVEL% ----------------------------------------------------------
 EXIT /B %ERRORLEVEL%
 :: ========================= END Test Execution =================================
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Windows.txt
@@ -12,6 +12,11 @@ echo Executing in %EXECUTION_DIR%
 
 :: ========================= BEGIN Test Execution ============================= 
 echo Running tests... Start time: %TIME%
+echo ====== To repro directly: =================================================
+echo pushd %EXECUTION_DIR%
+ [[TestRunCommandsEcho]]
+echo popd
+echo ===========================================================================
 pushd %EXECUTION_DIR%
 echo on
 [[TestRunCommands]]


### PR DESCRIPTION
Often I want to run tests as directly as possible (for example to run them easily under a debugger, or to run them in a loop) but it's obfuscated how to do that.

Update the logging to make it easy to see how to do that.
Fix a mistake in the Unix logging.