### PR TITLE
Enforce order of references passed to ApiCompat

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
@@ -31,7 +31,9 @@
     <ItemGroup>
       <_DependencyDirectoriesTemp Include="@(ReferencePath->'%(RootDir)%(Directory)')" />
       <!-- Remove duplicate directories by batching over them -->
-      <_DependencyDirectories Include="%(_DependencyDirectoriesTemp.Identity)" />
+      <!-- Add project references first to give precedence to project-specific files -->
+      <_DependencyDirectories Condition="'%(_DependencyDirectoriesTemp.ReferenceSourceTarget)'=='ProjectReference'" Include="%(_DependencyDirectoriesTemp.Identity)" />
+      <_DependencyDirectories Condition="'%(_DependencyDirectoriesTemp.ReferenceSourceTarget)'!='ProjectReference'" Include="%(_DependencyDirectoriesTemp.Identity)" />
       <_ContractDependencyDirectories Include="@(ResolvedMatchingContract->'%(RootDir)%(Directory)')" />
       <_ContractDependencyDirectories Include="$(ContractOutputPath)" />
     </ItemGroup>


### PR DESCRIPTION
ApiCompat depends on the order of the references, this change ensures that project references come first.