### PR TITLE
use "$@" instead of $* to properly preserve arguments with spaces

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/msbuild.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 working_tree_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$working_tree_root/dotnetcli/dotnet msbuild $*
+$working_tree_root/dotnetcli/dotnet msbuild "$@"
 exit $?


### PR DESCRIPTION
This is final part of fix for https://github.com/dotnet/corefx/issues/23360

With this following command works as expected.

msbuild.sh  /t:RebuildAndTest /p:XunitOptions="-showprogress -parallel none"

 