### PR TITLE
Package VersionTools desktop implementation

### DIFF
--- a/src/nuget/Microsoft.DotNet.VersionTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.VersionTools.nuspec
@@ -15,11 +15,13 @@
     <copyright>Copyright © Microsoft Corporation</copyright>
     <tags></tags>
     <dependencies>
-      <group targetFramework="netstandard1.5">
-        <dependency id="NETStandard.Library" version="1.6.0" />
+      <group>
         <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="NuGet.Packaging" version="4.3.0" />
         <dependency id="NuGet.Versioning" version="4.3.0" />
+      </group>
+      <group targetFramework="netstandard1.5">
+        <dependency id="NETStandard.Library" version="1.6.0" />
         <dependency id="System.Diagnostics.Process" version="4.1.0" />
         <dependency id="System.Diagnostics.TraceSource" version="4.0.0" />
       </group>
@@ -27,7 +29,7 @@
   </metadata>
   <files>
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib\netstandard1.5" />
-
+    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net45" />
     <file src="..\obj\version.txt" target="" />
   </files>
 </package>


### PR DESCRIPTION
This is so that the feed task can consume versiontools as a PackageReference instead of a ProjectReference.  It needs to be able to compile against the desktop implementation.

