### PR TITLE
Use ChecksumAlgorithm property

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -16,7 +16,7 @@
   <Import Project="$(MSBuildThisFileDirectory)RepoAPI.Mapping.props" />
 
   <PropertyGroup>
-    <CompilerResponseFile Condition="'$(CheckSumSHA256)'!='false'">$(MSBuildThisFileDirectory)checksum.rsp</CompilerResponseFile>
+    <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/checksum.rsp
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/checksum.rsp
@@ -1,2 +1,0 @@
-# CSC needs checksumalgorithm to be passed in.
-/checksumalgorithm:SHA256


### PR DESCRIPTION
csc task uses `ChecksumAlgorithm` property to set the checksum algorithm. No need for .rsp file.