### PR TITLE
Use ProductVersion when creating prodcon readmes

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BuildManifest/WriteOrchestratedBuildManifestSummaryToFile.cs
@@ -35,19 +35,15 @@ namespace Microsoft.DotNet.Build.Tasks.Feed.BuildManifest
 
             string sdkProductVersion = model.Builds
                 .FirstOrDefault(b => b.Name == "cli")
-                ?.BuildId;
+                ?.ProductVersion;
 
-            string runtimeProductVersion = blobFeed.Artifacts.Blobs
-                .FirstOrDefault(b =>
-                    b.Id.StartsWith("Runtime/") &&
-                    b.Id.EndsWith("/Microsoft.NET.CoreRuntime.2.1.appx"))
-                ?.Id.Split('/')[1];
+            string runtimeProductVersion = model.Builds
+                .FirstOrDefault(b => b.Name == "core-setup")
+                ?.ProductVersion;
 
-            string aspnetProductVersion = blobFeed.Artifacts.Blobs
-                .FirstOrDefault(b =>
-                    b.Id.StartsWith("Runtime/") &&
-                    b.Id.EndsWith("/aspnetcore_base_runtime.version"))
-                ?.Id.Split('/')[1];
+            string aspnetProductVersion = model.Builds
+                .FirstOrDefault(b => b.Name == "aspnet")
+                ?.ProductVersion;
 
             var builder = new StringBuilder();
 


### PR DESCRIPTION
This resolves https://github.com/dotnet/buildtools/pull/1881#discussion_r164246219 and fixes the aspnet readme after the `Runtime/` -> `aspnetcore/Runtime/` move. (It hasn't been produced for recent builds because the assumptions here didn't line up.)

Doing this as part of https://github.com/dotnet/core-eng/issues/2612 since we're generating checksums for aspnet that I plan to include on the readme.

FYI @natemcmaster 