### PR TITLE
[release/2.1] Use TLS 1.2 security protocol in GitHubClient (#1925)

### DIFF
--- a/src/Microsoft.DotNet.VersionTools.net45/Automation/GitHubApi/GitHubClient.Desktop.cs
+++ b/src/Microsoft.DotNet.VersionTools.net45/Automation/GitHubApi/GitHubClient.Desktop.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Net;
+
+namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
+{
+    public partial class GitHubClient : IGitHubClient, IDisposable
+    {
+        static GitHubClient()
+        {
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools.net45/Microsoft.DotNet.VersionTools.net45.csproj
+++ b/src/Microsoft.DotNet.VersionTools.net45/Microsoft.DotNet.VersionTools.net45.csproj
@@ -14,6 +14,9 @@
     <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)/Automation/GitHubApi/GitHubClient.Desktop.cs" />
+  </ItemGroup>  
+  <ItemGroup>
     <TargetingPackReference Include="System" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.IO.Compression" />

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
 {
-    public class GitHubClient : IGitHubClient, IDisposable
+    public partial class GitHubClient : IGitHubClient, IDisposable
     {
         /// <summary>
         /// A default user agent to use if none is provided to the constructor. GitHub always


### PR DESCRIPTION
(cherry picked from commit 92bd8486db627660500b878c1836a8eff5228467)

---

Ports https://github.com/dotnet/buildtools/pull/1925 to release/2.1 to fix VersionTools GitHub requests on net45.