### PR TITLE
Manual port of dotnet/buildtools#1925

### DIFF
--- a/src/Microsoft.DotNet.VersionTools.net45/Automation/GitHubApi/GitHubClient.Desktop.cs
+++ b/src/Microsoft.DotNet.VersionTools.net45/Automation/GitHubApi/GitHubClient.Desktop.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Net;
+
+namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
+{
+    public partial class GitHubClient : IDisposable
+    {
+        static GitHubClient()
+        {
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools.net45/Microsoft.DotNet.VersionTools.net45.csproj
+++ b/src/Microsoft.DotNet.VersionTools.net45/Microsoft.DotNet.VersionTools.net45.csproj
@@ -10,6 +10,9 @@
     <ProjectGuid>{B4C96AEE-C686-485A-B809-DAD65B141DE2}</ProjectGuid>
   </PropertyGroup>
   <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.VersionTools.csproj" />
+  <ItemGroup>  
+    <Compile Include="$(MSBuildThisFileDirectory)/Automation/GitHubApi/GitHubClient.Desktop.cs" />
+  </ItemGroup>
   <PropertyGroup>
     <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
   </PropertyGroup>

--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
 {
-    public class GitHubClient : IDisposable
+    public partial class GitHubClient : IDisposable
     {
         /// <summary>
         /// A default user agent to use if none is provided to the constructor. GitHub always


### PR DESCRIPTION
As seen in dotnet/buildtools#1925, just makes sure that when running on desktop we opt in to TLS 1.2 by default.