### PR TITLE
Use the built tasks to update dotnet/versions

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -12,6 +12,17 @@
     <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>
   </PropertyGroup>
 
+  <!--
+    Load the UpdatePublishedVersions VersionTools task that was just built, if there is one. This
+    allows BuildTools builds to use the current task even when running on a very old BuildTools
+    toolset. Specifically, the TLS 1.2 fix is required.
+
+    TODO: Remove this workaround once BuildTools uses a new BuildTools version: https://github.com/dotnet/buildtools/issues/1934
+  -->
+  <UsingTask TaskName="UpdatePublishedVersions"
+             AssemblyFile="$(BuildToolsBuildTaskOutputFile)"
+             Condition="Exists('$(BuildToolsBuildTaskOutputFile)')" />
+
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
 
   <ItemGroup>

--- a/dir.props
+++ b/dir.props
@@ -210,6 +210,16 @@
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
   </PropertyGroup>
 
+  <!--
+    Set up the path where an earlier build placed its BuildTools task DLLs.
+
+    TODO: Remove this workaround once BuildTools uses a new BuildTools version: https://github.com/dotnet/buildtools/issues/1934
+  -->
+  <PropertyGroup>
+    <BuildToolsOutputProjectSuffix Condition="'$(BuildToolsTargets45)' == 'true'">.net45</BuildToolsOutputProjectSuffix>
+    <BuildToolsBuildTaskOutputFile>$(PackagesBasePath)\Microsoft.DotNet.Build.Tasks$(BuildToolsOutputProjectSuffix)\Microsoft.DotNet.Build.Tasks.dll</BuildToolsBuildTaskOutputFile>
+  </PropertyGroup>
+
   <!-- Set up common target properties that we use to conditionally include sources -->
   <PropertyGroup>
     <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -9,6 +9,7 @@
     <ProjectGuid>{B3331D88-7569-42D5-919B-F267DA011911}</ProjectGuid>
     <DefineConstants>net45</DefineConstants>
     <TargetFrameworkProfile />
+    <VersionToolsProjectReferenceSuffix>.net45</VersionToolsProjectReferenceSuffix>
   </PropertyGroup>
   <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.csproj" />
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -134,10 +134,9 @@
       <Project>{2179f9b5-1dba-4563-9402-a94de75ea9fa}</Project>
       <Name>Microsoft.Cci.Extensions</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj">
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix)\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix).csproj">
       <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
       <Name>Microsoft.DotNet.VersionTools</Name>
-      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -51,7 +51,6 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
-    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
 
     <file src="..\obj\version.txt" target="" />
   </files>


### PR DESCRIPTION
This allows us to use the TLS 1.2 UpdatePublishedVersions fix without upgrading the BuildTools toolset version.

Doing this properly (updating the BuildTools toolset version) is tracked by https://github.com/dotnet/buildtools/issues/1934. I hit enough obstacles that I don't think it's in scope for First Responder.

https://github.com/dotnet/core-eng/issues/2734: Unblocks auto-update of `master` BuildTools builds to subscribing repos. This change will need to be ported to `release/2.1`, at least.

