### PR TITLE
Revert "Use the built tasks to update dotnet/versions"

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -12,17 +12,6 @@
     <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>
   </PropertyGroup>
 
-  <!--
-    Load the UpdatePublishedVersions VersionTools task that was just built, if there is one. This
-    allows BuildTools builds to use the current task even when running on a very old BuildTools
-    toolset. Specifically, the TLS 1.2 fix is required.
-
-    TODO: Remove this workaround once BuildTools uses a new BuildTools version: https://github.com/dotnet/buildtools/issues/1934
-  -->
-  <UsingTask TaskName="UpdatePublishedVersions"
-             AssemblyFile="$(BuildToolsBuildTaskOutputFile)"
-             Condition="Exists('$(BuildToolsBuildTaskOutputFile)')" />
-
   <Import Project="$(ToolsDir)VersionTools.targets" Condition="Exists('$(ToolsDir)VersionTools.targets')" />
 
   <ItemGroup>

--- a/dir.props
+++ b/dir.props
@@ -210,16 +210,6 @@
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
   </PropertyGroup>
 
-  <!--
-    Set up the path where an earlier build placed its BuildTools task DLLs.
-
-    TODO: Remove this workaround once BuildTools uses a new BuildTools version: https://github.com/dotnet/buildtools/issues/1934
-  -->
-  <PropertyGroup>
-    <BuildToolsOutputProjectSuffix Condition="'$(BuildToolsTargets45)' == 'true'">.net45</BuildToolsOutputProjectSuffix>
-    <BuildToolsBuildTaskOutputFile>$(PackagesBasePath)\Microsoft.DotNet.Build.Tasks$(BuildToolsOutputProjectSuffix)\Microsoft.DotNet.Build.Tasks.dll</BuildToolsBuildTaskOutputFile>
-  </PropertyGroup>
-
   <!-- Set up common target properties that we use to conditionally include sources -->
   <PropertyGroup>
     <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>

--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -9,7 +9,6 @@
     <ProjectGuid>{B3331D88-7569-42D5-919B-F267DA011911}</ProjectGuid>
     <DefineConstants>net45</DefineConstants>
     <TargetFrameworkProfile />
-    <VersionToolsProjectReferenceSuffix>.net45</VersionToolsProjectReferenceSuffix>
   </PropertyGroup>
   <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.csproj" />
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -134,9 +134,10 @@
       <Project>{2179f9b5-1dba-4563-9402-a94de75ea9fa}</Project>
       <Name>Microsoft.Cci.Extensions</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix)\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix).csproj">
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj">
       <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
       <Name>Microsoft.DotNet.VersionTools</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -51,6 +51,7 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
+    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
 
     <file src="..\obj\version.txt" target="" />
   </files>


### PR DESCRIPTION
This reverts commit f8444e2bfdd036a2de0fcc7041b12ccc22c09168. (https://github.com/dotnet/buildtools/pull/1935)

The fix didn't work: my local validation was using Visual Studio 2017 where the fix apparently isn't needed, but official builds use 2015. `VersionTools.dll` was still being loaded from `Tools\net45\` rather than `bin\`. I haven't seen a clear way to influence the DLL loading dir, so this fix seems like a dead end.

Instead, we can change the official build to use `Tools\dotnetcli\dotnet.exe Tools\MSBuild.exe /t:UpdatePublishedVersions` to update dotnet/versions rather than `build.cmd`. .NET Core doesn't require the TLS1.2 fix. (build.cmd uses the full framework.) This is a cleaner fix anyway. I tried this out and it worked: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=1427629

(Running MSBuild with CLI works in BuildTools because the BuildTools toolset is old: CoreFX, for example, can't currently use the CLI to run msbuild on Windows: https://github.com/dotnet/buildtools/issues/1811.)

FYI @weshaggard 