### PR TITLE
Use AssemblyResolver during PushToBlobFeed

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.net45/Microsoft.DotNet.Build.Tasks.Feed.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.net45/Microsoft.DotNet.Build.Tasks.Feed.net45.csproj
@@ -14,6 +14,10 @@
     <NuGetTargetMoniker>.NETFramework,Version=v4.5</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)..\common\AssemblyResolver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PushToBlobFeed.Desktop.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <TargetingPackReference Include="Microsoft.Build.Tasks.v4.0" />
     <TargetingPackReference Include="Microsoft.Build.Framework" />
     <TargetingPackReference Include="Microsoft.Build.Utilities.v4.0" />

--- a/src/Microsoft.DotNet.Build.Tasks.Feed.net45/PushToBlobFeed.Desktop.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.net45/PushToBlobFeed.Desktop.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.Build.Common.Desktop;
+
+namespace Microsoft.DotNet.Build.Tasks.Feed
+{
+    public partial class PushToBlobFeed
+    {
+        static PushToBlobFeed()
+        {
+            AssemblyResolver.Enable();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -16,7 +16,7 @@ using MSBuild = Microsoft.Build.Utilities;
 
 namespace Microsoft.DotNet.Build.Tasks.Feed
 {
-    public class PushToBlobFeed : MSBuild.Task
+    public partial class PushToBlobFeed : MSBuild.Task
     {
         private static readonly char[] ManifestDataPairSeparators = { ';' };
         private const string DisableManifestPushConfigurationBlob = "disable-manifest-push";


### PR DESCRIPTION
Fixes failure to resolve NuGet.Common, Version=4.3.0.5 from Sleet dependency.

https://github.com/dotnet/core-eng/issues/2828