### PR TITLE
Fix dumping stack from test coredumps on Linux

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -83,7 +83,7 @@ echo ----- end $(date +"%T") ----- exit code $test_exitcode --------------------
 # ========================= END Test Execution ===============================
 
 # ======================= BEGIN Core File Inspection =========================
-pushd $EXECUTION_DIR
+pushd $EXECUTION_DIR > nul
 if [ "$(uname -s)" == "Linux" ]; then
   echo Looking around for any Linux dump...
   # Depending on distro/configuration, the core files may either be named "core"
@@ -109,6 +109,6 @@ if [ "$(uname -s)" == "Linux" ]; then
     echo ... found no dump in $PWD
   fi
 fi
-popd
+popd > nul
 # ======================== END Core File Inspection ==========================
 exit $test_exitcode

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -5,7 +5,7 @@ export EXECUTION_DIR=$(dirname "$0")
 
 function print_info_from_core_file {
   local core_file_name=$1
-  local executable_name=$2
+  local executable_name=$RUNTIME_PATH/$2
 
   if ! [ -e $executable_name ]; then
     echo "Unable to find executable $executable_name"
@@ -33,11 +33,10 @@ function copy_core_file_to_temp_location {
   # Create the directory (this shouldn't fail even if it already exists).
   mkdir -p $storage_location
 
-  # Only copy the file over if the directory is empty. Otherwise, do nothing.
-  if [ ! "$(ls -A $storage_location)" ]; then 
-    echo "Copying core file $core_file_name to $storage_location"
-    cp $core_file_name $storage_location
-  fi
+  local new_location=$storage_location/core.$RANDOM
+
+  echo "Copying core file $core_file_name to $new_location in case you need it."
+  cp $core_file_name $new_location
 }
 
 if [ "$RUNTIME_PATH" == "" ]
@@ -84,7 +83,9 @@ echo ----- end $(date +"%T") ----- exit code $test_exitcode --------------------
 # ========================= END Test Execution ===============================
 
 # ======================= BEGIN Core File Inspection =========================
+pushd $EXECUTION_DIR
 if [ "$(uname -s)" == "Linux" ]; then
+  echo Looking around for any Linux dump...
   # Depending on distro/configuration, the core files may either be named "core"
   # or "core.<PID>" by default. We read /proc/sys/kernel/core_uses_pid to 
   # determine which it is.
@@ -96,14 +97,18 @@ if [ "$(uname -s)" == "Linux" ]; then
   if [ $core_name_uses_pid == "1" ]; then
     # We don't know what the PID of the process was, so let's look at all core
     # files whose name matches core.NUMBER
+    echo Looking for files matching core.* ...
     for f in core.*; do
-      [[ $f =~ core.[0-9]+ ]] && print_info_from_core_file "$f" "corerun" && copy_core_file_to_temp_location "$f" && rm "$f"
+      [[ $f =~ core.[0-9]+ ]] && print_info_from_core_file "$f" "dotnet" && copy_core_file_to_temp_location "$f" && rm "$f"
     done
   elif [ -f core ]; then
-    print_info_from_core_file "core" "corerun"
+    print_info_from_core_file "core" "dotnet"
     copy_core_file_to_temp_location "core"
     rm "core"
+  else
+    echo ... found no dump in $PWD
   fi
 fi
+popd
 # ======================== END Core File Inspection ==========================
 exit $test_exitcode


### PR DESCRIPTION
- The dumps were in $EXECUTION_DIR. Pushd to that to find them.
- Corerun is someplace else. Use $RUNTIME_PATH/dotnet instead. It's what we actually ran, anyway.
- Add random suffix to keep more than one old dump

Tested locally by using `kill -SIGABRT` on running tests.

Fixes https://github.com/dotnet/corefx/issues/27818