### PR TITLE
Add target reverse APICompat check for libraries

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
@@ -10,14 +10,16 @@
     <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.$(TargetGroup).txt</ApiCompatBaseline>
     <ApiCompatBaseline Condition="!Exists('$(ApiCompatBaseline)')">$(MSBuildProjectDirectory)\ApiCompatBaseline.txt</ApiCompatBaseline>
 
+    <MatchingRefApiCompatBaseline Condition="!Exists('$(MatchingRefApiCompatBaseline)')">$(MSBuildProjectDirectory)\MatchingRefApiCompatBaseline.$(TargetGroup).txt</MatchingRefApiCompatBaseline>
+    <MatchingRefApiCompatBaseline Condition="'$(BaselineAllMatchingRefApiCompatError)' != 'true' and !Exists('$(MatchingRefApiCompatBaseline)')">$(MSBuildProjectDirectory)\MatchingRefApiCompatBaseline.txt</MatchingRefApiCompatBaseline>
+
     <RunApiCompatForSrc Condition="$(MSBuildProjectDirectory.EndsWith('src'))">true</RunApiCompatForSrc>
-    <!-- TODO: Disable the version over version ref compat checks for now because
-    we don't have a great way to get the previous version -->
-    <RunApiCompatForRef Condition="$(MSBuildProjectDirectory.EndsWith('ref'))">false</RunApiCompatForRef>
+
+    <RunMatchingRefApiCompat Condition="'$(RunMatchingRefApiCompat)' == ''">$(RunApiCompatForSrc)</RunMatchingRefApiCompat>
 
     <ResolveMatchingContract Condition="'$(RunApiCompatForSrc)'=='true'">true</ResolveMatchingContract>
     <TargetsTriggeredByCompilation Condition="'$(RunApiCompatForSrc)'=='true'">$(TargetsTriggeredByCompilation);ValidateApiCompatForSrc</TargetsTriggeredByCompilation>
-    <TargetsTriggeredByCompilation Condition="'$(RunApiCompatForRef)'=='true'">$(TargetsTriggeredByCompilation);ValidateApiCompatForRef</TargetsTriggeredByCompilation>
+    <TargetsTriggeredByCompilation Condition="'$(RunMatchingRefApiCompat)'=='true'">$(TargetsTriggeredByCompilation);RunMatchingRefApiCompat</TargetsTriggeredByCompilation>
   </PropertyGroup>
 
   <!-- ApiCompat for Implementation Assemblies  -->
@@ -70,55 +72,54 @@
     <Error Condition="'$(ApiCompatExitCode)'!='0'" Text="ApiCompat failed for '$(TargetPath)'" />
   </Target>
 
-  <!-- ApiCompat for Contract Assemblies -->
-  <Target Name="ValidateApiCompatForRef"
-          Condition="'$(RunApiCompatForRef)' == 'true' AND '$(RunApiCompat)' == 'true'" >
+  <!-- Reverse APICompat to verify that the reference assembly has all the APIs that are in the implementation -->
+  <Target Name="RunMatchingRefApiCompat"
+          Condition="'$(RunMatchingRefApiCompat)' == 'true' AND '$(RunApiCompat)' == 'true' AND '@(ReferenceFromRuntime)' == ''" >
 
-    <!--
-      This target is opportunistic in the sense it only runs if the previous contract version
-      has been built. If it doesn't find and older version then it will not run. This is because
-      we don't have a great way to always force that the older contract exists and has been built.
-    -->
-    <LocatePreviousContract CurrentContractProjectPath="$(ReferenceAssemblyOutputPath)$(AssemblyName)" AssemblyVersion="$(AssemblyVersion)">
-      <Output TaskParameter="PreviousContractVersion" PropertyName="PreviousContractVersion" />
-    </LocatePreviousContract>
-
-    <PropertyGroup Condition="'$(PreviousContractVersion)'!=''">
-      <PreviousContractAssembly>$(ReferenceAssemblyOutputPath)$(AssemblyName)\$(PreviousContractVersion)\$(AssemblyName).dll</PreviousContractAssembly>
+    <PropertyGroup>
+      <ImplemetnationAssemblyAsContract>@(IntermediateAssembly)</ImplemetnationAssemblyAsContract>
     </PropertyGroup>
 
     <ItemGroup>
-      <_CurrentContractDependencies Include="@(ReferencePath->'%(RootDir)%(Directory)')" />
-      <!--
-        Use the current contract dependencies for the previous contacts. While this isn't
-        100% correct it is the best way to ensure we have them all and it current version
-        should purely be a subset of the previous one.
-      -->
-      <_PreviousContractDependencyDirectories Include="@(_CurrentContractDependencies)" />
+      <_ContractDependencyDirectoriesTemp Include="@(ReferencePath->'%(RootDir)%(Directory)')" />
+      <!-- Remove duplicate directories by batching over them -->
+      <!-- Add project references first to give precedence to project-specific files -->
+      <_ContractDependencyDirectories Condition="'%(_ContractDependencyDirectoriesTemp.ReferenceSourceTarget)'=='ProjectReference'" Include="%(_ContractDependencyDirectoriesTemp.Identity)" />
+      <_ContractDependencyDirectories Condition="'%(_ContractDependencyDirectoriesTemp.ReferenceSourceTarget)'!='ProjectReference'" Include="%(_ContractDependencyDirectoriesTemp.Identity)" />
+      <_ImplementationDependencyDirectories Include="@(ResolvedMatchingContract->'%(RootDir)%(Directory)')" />
+      <_ImplementationDependencyDirectories Include="$(ContractOutputPath)" />
     </ItemGroup>
 
     <PropertyGroup>
-      <_ApiCompatCmd>$(ToolHostCmd) "$(ToolsDir)ApiCompat.exe" "$(PreviousContractAssembly)"</_ApiCompatCmd>
-      <_ApiCompatCmd>$(_ApiCompatCmd) -contractDepends:"@(_PreviousContractDependencyDirectories);"</_ApiCompatCmd>
-      <_ApiCompatCmd>$(_ApiCompatCmd) -implDirs:"$(IntermediateOutputPath);@(_CurrentContractDependencies);"</_ApiCompatCmd>
-      <_ApiCompatCmd Condition="Exists('$(ApiCompatBaseline)')">$(_ApiCompatCmd) -baseline:"$(ApiCompatBaseline)"</_ApiCompatCmd>
-      <ApiCompatExitCode>0</ApiCompatExitCode>
+      <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) "$(ImplemetnationAssemblyAsContract)"</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -contractDepends:"@(_ContractDependencyDirectories, ','),"</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -implDirs:"@(_ImplementationDependencyDirectories, ','),"</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatArgs Condition="'$(BaselineAllMatchingRefApiCompatError)'!='true' and Exists('$(MatchingRefApiCompatBaseline)')">$(MatchingRefApiCompatArgs) -baseline:"$(MatchingRefApiCompatBaseline)"</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatBaselineAll Condition="'$(BaselineAllMatchingRefApiCompatError)'=='true'">&gt; $(MatchingRefApiCompatBaseline)</MatchingRefApiCompatBaselineAll>
+
+      <MatchingRefApiCompatExitCode>0</MatchingRefApiCompatExitCode>
+
+      <MatchingRefApiCompatResponseFile>$(IntermediateOutputPath)MatchingRefApiCompat_verifyexactref.rsp</MatchingRefApiCompatResponseFile>
+      <MatchingRefApiCompatCmd>$(ToolHostCmd) "$(ToolsDir)ApiCompat.exe"</MatchingRefApiCompatCmd>
     </PropertyGroup>
 
-    <Exec Condition="Exists('$(PreviousContractAssembly)')"
-          Command="$(_ApiCompatCmd)"
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <WriteLinesToFile File="$(MatchingRefApiCompatResponseFile)" Lines="$(MatchingRefApiCompatArgs)" Overwrite="true" />
+
+    <Exec Condition="Exists('$(ReferenceAssembly)')"
+          Command="$(MatchingRefApiCompatCmd) @&quot;$(MatchingRefApiCompatResponseFile)&quot; $(MatchingRefApiCompatBaselineAll)"
           CustomErrorRegularExpression="^[a-zA-Z]+ :"
           StandardOutputImportance="Low"
           IgnoreExitCode="true"
     >
-      <Output TaskParameter="ExitCode" PropertyName="ApiCompatExitCode" />
+      <Output TaskParameter="ExitCode" PropertyName="MatchingRefApiCompatExitCode" />
     </Exec>
 
     <!--
-      To force incremental builds to show failures again we are invaliding
+      To force incremental builds to show failures again we are invalidating
        one compile input by touching the assembly info file
     -->
-    <Touch Condition="'$(ApiCompatExitCode)'!='0'" Files="$(AssemblyInfoFile)" />
-    <Error Condition="'$(ApiCompatExitCode)'!='0'" Text="ApiCompat failed for '$(TargetPath)'" />
+    <Touch Condition="'$(MatchingRefApiCompatExitCode)'!='0'" Files="$(AssemblyInfoFile)" />
+    <Error Condition="'$(MatchingRefApiCompatExitCode)'!='0'" Text="MatchingRefApiCompat failed - The reference assembly doesn't match all the APIs in the implementation for '$(TargetPath)'. To address either fix errors in the reference assembly (referenced as implementation in compat errors for this reverse compat check), add the issues to the baseline file '$(MatchingRefApiCompatBaseline)' or disable this check by setting RunMatchingRefApiCompat=false in this project." />
   </Target>
 </Project>


### PR DESCRIPTION
There are a lot of libraries that have a 1:1 ref and implementation
which want to keep the API surface in sync. In order to enforce that
we have a reverse APICompat check that will verify that the ref
has a matching compatibile set of APIs that the implementation has.

This target is called RunMatchingRefApiCompat. It is only enabled
if RunApiCompat=true and there are no ReferenceFromRuntime references.
It is skipped for projects with runtime references because those are
typically many implementation to one ref which doesn't work as well
for verifying the APIs match.

It can be individually controlled per-project:
1) RunMatchingRefApiCompat = false to disable the check completely
2) Add a baseline file MatchingRefApiCompatBaseline[.$(TargetGroup)]txt

Should address https://github.com/dotnet/corefx/issues/27639. 
cc @jkotas @ericstj @tmat 