### PR TITLE
Fix partial facade PDB generation for AnyOS libraries

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
@@ -40,7 +40,8 @@
 
     <PropertyGroup>
       <ProducePdb>true</ProducePdb>
-      <ProducePdb Condition="'$(DebugSymbols)' == 'false' OR '$(OSGroup)' != 'Windows_NT'">false</ProducePdb>
+      <!-- Partial facade PDB generation only functions on Windows -->
+      <ProducePdb Condition="'$(DebugSymbols)' == 'false' OR '$(RunningOnUnix)' == 'true'">false</ProducePdb>
       <GenFacadesIgnoreMissingTypes Condition="'$(GenFacadesIgnoreMissingTypes)' == ''">false</GenFacadesIgnoreMissingTypes>
       <GenFacadesIgnoreBuildAndRevisionMismatch Condition="'$(GenFacadesIgnoreBuildAndRevisionMismatch)' == ''">false</GenFacadesIgnoreBuildAndRevisionMismatch>
     </PropertyGroup>


### PR DESCRIPTION
The current check enables PDB generation only when the assembly is
being built as Windows-specific.  What it really means is that the
GenFacades PDB writer crashes on non-Windows systems, and thus that PDBs
cannot be generated when running on non-Windows.

This corrects the check to be about what OS the tool is executing on,
rather than what OS the binary is intended for.

AnyOS partial facades will now produce PDBs on Windows, allowing them
to run code coverage.