### PR TITLE
Add task to get the resources and merge them into the common pri for …

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
@@ -1,0 +1,328 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections;
+using System.IO;
+using System.Reflection;
+using System.Resources;
+using System.Xml.Linq;
+using System.Reflection.PortableExecutable;
+using System.Reflection.Metadata;
+
+namespace Microsoft.DotNet.Build.Tasks
+{ 
+    public class ExtractResWResourcesFromAssemblies : Task
+    {
+        [Required]
+        public ITaskItem[] InputAssemblies { get; set; }
+
+        [Required]
+        public string OutputPath { get; set; }
+
+        [Required]
+        public string InternalReswDirectory { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                Directory.CreateDirectory(OutputPath);
+                CreateReswFiles();
+            }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, showStackTrace: true);
+            }
+
+            return !Log.HasLoggedErrors;
+        }
+
+        public void CreateReswFiles()
+        {
+            foreach (ITaskItem assemblySpec in InputAssemblies)
+            {
+                string assemblyPath = assemblySpec.ItemSpec;
+                string assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
+
+                if (assemblyName.Equals("System.Private.CoreLib"))
+                {
+                    continue; // we don't want to extract the resources from Private CoreLib since this resources are managed by the legacy ResourceManager which gets them from the embedded and not from PRI. 
+                }
+
+                if (!ShouldExtractResources($"FxResources.{assemblyName}.SR.resw", assemblyPath))
+                {
+                    continue; // we skip framework assemblies that resources already exist and don't need to be extracted to avoid reading dll metadata.
+                }
+
+                try
+                {
+                    using (FileStream assemblyStream = File.OpenRead(assemblyPath))
+                    using (PEReader peReader = new PEReader(assemblyStream))
+                    {
+                        if (!peReader.HasMetadata)
+                        {
+                            continue; // native assembly
+                        }
+
+                        MetadataReader metadataReader = peReader.GetMetadataReader();
+                        foreach (ManifestResourceHandle resourceHandle in metadataReader.ManifestResources)
+                        {
+                            ManifestResource resource = metadataReader.GetManifestResource(resourceHandle);
+
+                            if (!resource.Implementation.IsNil)
+                            {
+                                continue; // not embedded resource
+                            }
+
+                            string resourceName = metadataReader.GetString(resource.Name);
+
+                            if (!resourceName.EndsWith(".resources"))
+                            {
+                                continue; // we only need to get the resources strings to produce the resw files.
+                            }
+
+                            string reswName = $"{Path.GetFileNameWithoutExtension(resourceName)}.resw";
+
+                            if (!reswName.StartsWith("FxResources") && !ShouldExtractResources(reswName, assemblyPath)) // already checked for FxResources previously
+                            {
+                                continue; // resw output file already exists and is up to date, so we should skip this resource file.
+                            }
+
+                            string reswPath = Path.Combine(OutputPath, reswName);
+                            using (Stream resourceStream = GetResourceStream(peReader, resource))
+                            using (ResourceReader resourceReader = new ResourceReader(resourceStream))
+                            using (ReswResourceWriter resourceWriter = new ReswResourceWriter(reswPath))
+                            {
+                                IDictionaryEnumerator enumerator = resourceReader.GetEnumerator();
+                                while (enumerator.MoveNext())
+                                {
+                                    resourceWriter.AddResource(enumerator.Key.ToString(), enumerator.Value.ToString());
+                                }
+                            }
+                        }
+                    }
+                }
+                catch (BadImageFormatException)
+                {
+                    continue; // not a Portable Executable. 
+                }
+            }
+        }
+
+        // If the repo that we are building has some projects that contain an embedded resx file we will create the resw file for that project when building the src project in resources.targets
+        // those resw files live in "InternalReswDirectory" so that is why in this case we don't need to check for a timestamp if the resw file already exists there we just skip those resources.
+        // the reason why we skip it is because the incremental build will handle the timestamps, as we have a target to copy the resx files to resw files from EmbeddedResources inside the .csproj
+        private bool ShouldExtractResources(string expectedReswFileName, string assemblyPath)
+        {
+            string internalReswPath = Path.Combine(InternalReswDirectory, expectedReswFileName);
+            if (File.Exists(internalReswPath))
+            {
+                return false; // internal resw files are handled in build time by resources.targets, so we shouldn't care about timestamps since it uses incremental build
+            }
+
+            string externalReswPath = Path.Combine(OutputPath, expectedReswFileName);
+            if (File.Exists(externalReswPath))
+            {
+                var reswFileInfo = new FileInfo(externalReswPath);
+                var assemblyFileInfo = new FileInfo(assemblyPath);
+                return reswFileInfo.LastWriteTimeUtc < assemblyFileInfo.LastWriteTimeUtc;
+            }
+
+            return true;
+        }
+
+        private unsafe Stream GetResourceStream(PEReader peReader, ManifestResource resource)
+        {
+            checked // arithmetic overflow here could cause AV
+            {
+                PEMemoryBlock memoryBlock = peReader.GetEntireImage();
+                byte * peImageStart = memoryBlock.Pointer;
+                byte * peImageEnd = peImageStart + memoryBlock.Length;
+
+                // Locate resource's offset within the Portable Executable image.
+                int resourcesDirectoryOffset;
+                if (!peReader.PEHeaders.TryGetDirectoryOffset(peReader.PEHeaders.CorHeader.ResourcesDirectory, out resourcesDirectoryOffset))
+                {
+                    throw new InvalidDataException("Failed to extract the resources from assembly when getting the offset to resources in the PE file.");
+                }
+
+                byte * resourceStart = peImageStart + resourcesDirectoryOffset + resource.Offset;
+
+                // We need to get the resource length out from the first int in the resourceStart pointer
+                if (resourceStart >= peImageEnd - sizeof(int))
+                {
+                    throw new InvalidDataException("Failed to extract the resources from assembly because resource offset was out of bounds.");
+                }
+
+                int resourceLength = new BlobReader(resourceStart, sizeof(int)).ReadInt32();
+                resourceStart += sizeof(int);
+                if (resourceLength < 0 || resourceStart >= peImageEnd - resourceLength)
+                {
+                    throw new InvalidDataException($"Failed to extract the resources from assembly because resource offset or length was out of bounds.");
+                }
+
+                return new UnmanagedMemoryStream(resourceStart, resourceLength);
+            }
+        }
+    }
+
+    internal class ReswResourceWriter : IDisposable
+    {
+        private readonly XElement _root;
+
+        private readonly XDocument _document;
+
+        private readonly string _filePath;
+
+        internal ReswResourceWriter(string filePath)
+        {
+            _filePath = filePath;
+            _document = XDocument.Parse(headers);
+            _root = _document.Element("root");
+        }
+
+        internal void AddResource(string key, string value)
+        {
+            XNamespace ns = "http://www.w3.org/XML/1998/namespace";
+            var newElement = new XElement("data", 
+                new XAttribute("name", key),
+                new XAttribute(ns + "space", "preserve"),
+                new XElement("value", value));
+
+            _root.Add(newElement);
+        }
+
+        public void Dispose()
+        {
+            using (Stream fileStream = File.Create(_filePath))
+            {
+                _document.Save(fileStream);
+            }
+        }
+
+        private string headers = 
+            @"<?xml version=""1.0"" encoding=""utf-8""?>
+            <root>
+            <!--
+            Microsoft ResX Schema 
+
+            Version 2.0
+
+            The primary goals of this format is to allow a simple XML format 
+            that is mostly human readable. The generation and parsing of the 
+            various data types are done through the TypeConverter classes 
+            associated with the data types.
+
+            Example:
+
+            ... ado.net/XML headers & schema ...
+            <resheader name=""resmimetype"">text/microsoft-resx</resheader>
+            <resheader name=""version"">2.0</resheader>
+            <resheader name=""reader"">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+            <resheader name=""writer"">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+            <data name=""Name1""><value>this is my long string</value><comment>this is a comment</comment></data>
+            <data name=""Color1"" type=""System.Drawing.Color, System.Drawing"">Blue</data>
+            <data name=""Bitmap1"" mimetype=""application/x-microsoft.net.object.binary.base64"">
+                <value>[base64 mime encoded serialized .NET Framework object]</value>
+            </data>
+            <data name=""Icon1"" type=""System.Drawing.Icon, System.Drawing"" mimetype=""application/x-microsoft.net.object.bytearray.base64"">
+                <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+                <comment>This is a comment</comment>
+            </data>
+                        
+            There are any number of ""resheader"" rows that contain simple 
+            name/value pairs.
+
+            Each data row contains a name, and value. The row also contains a 
+            type or mimetype. Type corresponds to a .NET class that support 
+            text/value conversion through the TypeConverter architecture. 
+            Classes that don't support this are serialized and stored with the 
+            mimetype set.
+
+            The mimetype is used for serialized objects, and tells the 
+            ResXResourceReader how to depersist the object. This is currently not 
+            extensible. For a given mimetype the value must be set accordingly:
+
+            Note - application/x-microsoft.net.object.binary.base64 is the format 
+            that the ResXResourceWriter will generate, however the reader can 
+            read any of the formats listed below.
+
+            mimetype: application/x-microsoft.net.object.binary.base64
+            value   : The object must be serialized with 
+                    : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+                    : and then encoded with base64 encoding.
+
+            mimetype: application/x-microsoft.net.object.soap.base64
+            value   : The object must be serialized with 
+                    : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+                    : and then encoded with base64 encoding.
+            mimetype: application/x-microsoft.net.object.bytearray.base64
+            value   : The object must be serialized into a byte array 
+                    : using a System.ComponentModel.TypeConverter
+                    : and then encoded with base64 encoding.
+            -->
+            <xsd:schema id=""root"" xmlns="""" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"">
+            <xsd:import namespace=""http://www.w3.org/XML/1998/namespace"" />
+            <xsd:element name=""root"" msdata:IsDataSet=""true"">
+                <xsd:complexType>
+                <xsd:choice maxOccurs=""unbounded"">
+                    <xsd:element name=""metadata"">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                        <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" />
+                        </xsd:sequence>
+                        <xsd:attribute name=""name"" use=""required"" type=""xsd:string"" />
+                        <xsd:attribute name=""type"" type=""xsd:string"" />
+                        <xsd:attribute name=""mimetype"" type=""xsd:string"" />
+                        <xsd:attribute ref=""xml:space"" />
+                    </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name=""assembly"">
+                    <xsd:complexType>
+                        <xsd:attribute name=""alias"" type=""xsd:string"" />
+                        <xsd:attribute name=""name"" type=""xsd:string"" />
+                    </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name=""data"">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                        <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+                        <xsd:element name=""comment"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""2"" />
+                        </xsd:sequence>
+                        <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" msdata:Ordinal=""1"" />
+                        <xsd:attribute name=""type"" type=""xsd:string"" msdata:Ordinal=""3"" />
+                        <xsd:attribute name=""mimetype"" type=""xsd:string"" msdata:Ordinal=""4"" />
+                        <xsd:attribute ref=""xml:space"" />
+                    </xsd:complexType>
+                    </xsd:element>
+                    <xsd:element name=""resheader"">
+                    <xsd:complexType>
+                        <xsd:sequence>
+                        <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
+                        </xsd:sequence>
+                        <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" />
+                    </xsd:complexType>
+                    </xsd:element>
+                </xsd:choice>
+                </xsd:complexType>
+            </xsd:element>
+            </xsd:schema>
+            <resheader name=""resmimetype"">
+            <value>text/microsoft-resx</value>
+            </resheader>
+            <resheader name=""version"">
+            <value>2.0</value>
+            </resheader>
+            <resheader name=""reader"">
+            <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+            </resheader>
+            <resheader name=""writer"">
+            <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+            </resheader>
+            </root>";
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/ExtractResWResourcesFromAssemblies.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Build.Tasks
                     continue; // we don't want to extract the resources from Private CoreLib since this resources are managed by the legacy ResourceManager which gets them from the embedded and not from PRI. 
                 }
 
-                if (!ShouldExtractResources($"FxResources.{assemblyName}.SR.resw", assemblyPath))
+                if (!ShouldExtractResources($"FxResources.{Helper.NormalizeAssemblyName(assemblyName)}.SR.resw", assemblyPath))
                 {
                     continue; // we skip framework assemblies that resources already exist and don't need to be extracted to avoid reading dll metadata.
                 }

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -31,13 +31,17 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string AssemblyName { get; set; }
 
+        [Output]
+        public string NormalizedAssemblyName { get; set; }
+
         public bool DebugOnly { get; set; }
 
         public override bool Execute()
         {
             try
             {
-                _resourcesName = "FxResources." + AssemblyName;
+                NormalizedAssemblyName = Helper.NormalizeAssemblyName(AssemblyName);
+                _resourcesName = "FxResources." + NormalizedAssemblyName;
 
                 using (_targetStream = File.CreateText(OutputSourceFilePath))
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -31,17 +31,13 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public string AssemblyName { get; set; }
 
-        [Output]
-        public string NormalizedAssemblyName { get; set; }
-
         public bool DebugOnly { get; set; }
 
         public override bool Execute()
         {
             try
             {
-                NormalizedAssemblyName = Helper.NormalizeAssemblyName(AssemblyName);
-                _resourcesName = "FxResources." + NormalizedAssemblyName;
+                _resourcesName = "FxResources." + AssemblyName;
 
                 using (_targetStream = File.CreateText(OutputSourceFilePath))
                 {

--- a/src/Microsoft.DotNet.Build.Tasks/Helper.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/Helper.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    internal static class Helper
+    {
+        // normalize the passed name so it can be used as namespace name inside the code
+        internal static string NormalizeAssemblyName(string name)
+        {
+            if (String.IsNullOrEmpty(name))
+                return name;
+
+            bool insertUnderscore = Char.IsNumber(name[0]);
+            int i = 0;
+
+            while (i < name.Length)
+            {
+                char c = name[i];
+                if (!Char.IsLetter(c) && c != '.' && c != '_' && !Char.IsNumber(c))
+                    break;
+                i++;
+            }
+
+            if (i >= name.Length)
+                return insertUnderscore ? "_" + name : name;
+
+            StringBuilder sb = new StringBuilder();
+            if (insertUnderscore)
+            {
+                sb.Append('_');
+            }
+
+            for (int j = 0; j < i; j++)
+            {
+                sb.Append(name[j]);
+            }
+
+            sb.Append('_');
+            i++;
+
+            while (i < name.Length)
+            {
+                char c = name[i];
+                if (Char.IsLetter(c) || c == '.' || c == '_' || Char.IsNumber(c))
+                    sb.Append(c);
+                else
+                    sb.Append('_');
+                i++;
+            }
+
+            return sb.ToString();
+        }
+
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -49,6 +49,7 @@
     <Compile Include="InstallPackageFromFile.cs" />
     <Compile Include="LocatePreviousContract.cs" />
     <Compile Include="NormalizePaths.cs" />
+    <Compile Include="NormalizeAssemblyName.cs" />
     <Compile Include="GetDoItemsIntersect.cs" />
     <Compile Include="NugetMsBuildLogger.cs" />
     <Compile Include="NuGetPackageObject.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -37,6 +37,7 @@
     <Compile Include="GenerateCurrentVersion.cs" />
     <Compile Include="GenerateResourcesCode.cs" />
     <Compile Include="GenerateEncodingTable.cs" />
+    <Compile Include="Helper.cs" />
     <Compile Include="EncryptedConfigNuGetRestore.cs" />
     <Compile Include="GenerateUnencryptedNuGetConfig.cs" />
     <Compile Include="GenFacadesTask.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{17C66BCE-EB35-44CA-893C-8AAFB67708E9}</ProjectGuid>
@@ -24,6 +25,7 @@
     <Compile Include="Delegates.cs" />
     <Compile Include="ExceptionFromResource.cs" />
     <Compile Include="ExecWithMutex.cs" />
+    <Compile Include="ExtractResWResourcesFromAssemblies.cs" />
     <Compile Include="GatherFoldersToRestore.cs" />
     <Compile Include="GenerateAssemblyList.cs" />
     <Compile Include="AddDependenciesToProjectJson.cs" />

--- a/src/Microsoft.DotNet.Build.Tasks/NormalizeAssemblyName.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/NormalizeAssemblyName.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+
+namespace Microsoft.DotNet.Build.Tasks
+{
+    public class NormalizeAssemblyName : BuildTask
+    {
+        [Required]
+        public string AssemblyName { get; set; }
+
+        [Output]
+        public string NormalizedAssemblyName { get; set; }
+
+        public override bool Execute()
+        {
+            try
+            {
+                NormalizedAssemblyName = Helper.NormalizeAssemblyName(AssemblyName);
+            }
+            catch (Exception e)
+            {
+                Log.LogError($"Failed to normalize the assembly name {AssemblyName} with error:\n{e.Message}");
+                return false; // fail the task
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -75,7 +75,21 @@
     <GenerateResourcesCode
         ResxFilePath="$(StringResourcesPath)" 
         OutputSourceFilePath="$(IntermediateResOutputFileFullPath)" 
-        AssemblyName="$(AssemblyName)" />
+        AssemblyName="$(AssemblyName)" >
+
+        <Output TaskParameter="NormalizedAssemblyName" PropertyName="_NormalizedAssemblyName" />
+    </GenerateResourcesCode>
+
+    <ItemGroup>
+      <!-- 
+         EmbeddedResource is defined outside the target and cannot be defined inside this target 
+         we need to update logical name and ReswName after we normalize the assembly name.
+      -->
+      <EmbeddedResource Condition="'%(EmbeddedResource.LogicalName)'=='FxResources.$(AssemblyName).SR.resources'">
+        <LogicalName>FxResources.$(_NormalizedAssemblyName).SR.resources</LogicalName>
+        <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(_NormalizedAssemblyName).SR</ReswName>
+      </EmbeddedResource>
+    </ItemGroup>    
 
     <ItemGroup>
       <!-- The following Compile element has to be included dynamically inside the Target otherwise intellisense will not work -->
@@ -94,7 +108,7 @@
       <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(AssemblyName).SR</ReswName>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <Choose>
     <When Condition="Exists('$(StringResourcesPath)') And '$(SkipCommonResourcesIncludes)'=='' AND '$(OmitResources)'!='true'">
       <Choose>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="GenerateResourcesCode" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+  <UsingTask TaskName="NormalizeAssemblyName" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
 
   <PropertyGroup>
     <GenerateResourceMSBuildRuntime>CurrentRuntime</GenerateResourceMSBuildRuntime>
@@ -62,10 +63,29 @@
   
   <PropertyGroup Condition="'$(StringResourcesPath)'!=''">
       <CompileDependsOn>
+          NormalizeAssemblyName;
           GenerateResourcesSource;
           $(CompileDependsOn);
       </CompileDependsOn>
   </PropertyGroup>
+
+  <Target Name="NormalizeAssemblyName" Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'">
+    <NormalizeAssemblyName
+        AssemblyName="$(AssemblyName)" >
+        <Output TaskParameter="NormalizedAssemblyName" PropertyName="_NormalizedAssemblyName" />
+    </NormalizeAssemblyName>
+
+    <ItemGroup>
+      <!--
+         EmbeddedResource is defined outside the target and cannot be defined inside this target
+         we need to update logical name and ReswName after we normalize the assembly name.
+      -->
+      <EmbeddedResource Condition="'%(EmbeddedResource.LogicalName)'=='FxResources.$(AssemblyName).SR.resources'">
+        <LogicalName>FxResources.$(_NormalizedAssemblyName).SR.resources</LogicalName>
+        <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(_NormalizedAssemblyName).SR</ReswName>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
 
   <Target Name="GenerateResourcesSource"
           Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'"
@@ -73,23 +93,10 @@
           Outputs="$(IntermediateResOutputFileFullPath)">
 
     <GenerateResourcesCode
-        ResxFilePath="$(StringResourcesPath)" 
-        OutputSourceFilePath="$(IntermediateResOutputFileFullPath)" 
-        AssemblyName="$(AssemblyName)" >
-
-        <Output TaskParameter="NormalizedAssemblyName" PropertyName="_NormalizedAssemblyName" />
+        ResxFilePath="$(StringResourcesPath)"
+        OutputSourceFilePath="$(IntermediateResOutputFileFullPath)"
+        AssemblyName="$(_NormalizedAssemblyName)" >
     </GenerateResourcesCode>
-
-    <ItemGroup>
-      <!-- 
-         EmbeddedResource is defined outside the target and cannot be defined inside this target 
-         we need to update logical name and ReswName after we normalize the assembly name.
-      -->
-      <EmbeddedResource Condition="'%(EmbeddedResource.LogicalName)'=='FxResources.$(AssemblyName).SR.resources'">
-        <LogicalName>FxResources.$(_NormalizedAssemblyName).SR.resources</LogicalName>
-        <ReswName Condition="'$(BuildingUAPVertical)' == 'true'">FxResources.$(_NormalizedAssemblyName).SR</ReswName>
-      </EmbeddedResource>
-    </ItemGroup>    
 
     <ItemGroup>
       <!-- The following Compile element has to be included dynamically inside the Target otherwise intellisense will not work -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -6,6 +6,7 @@
   <Import Project="$(ToolsDir)PerfTesting.targets" Condition="Exists('$(ToolsDir)PerfTesting.targets') and '$(Performance)' == 'true'"/>
   <UsingTask TaskName="GenerateTestExecutionScripts" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask Condition="'$(BuildingUAPVertical)' == 'true'" TaskName="ExtractResWResourcesFromAssemblies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
     <!-- Which categories of tests to run by default -->
   <PropertyGroup>
@@ -169,7 +170,28 @@
     <_MakePriConfigFile>$(_MakePriHelpersDir)/ModifiedConfigFile.xml</_MakePriConfigFile>
     <_ReswListFile>$(_MakePriHelpersDir)/reswlist.RESFILES</_ReswListFile>
     <_PriListFile>$(_MakePriHelpersDir)/prilist.RESFILES</_PriListFile>
+    <_ExternalReswOutputPath>$(ResourcesFolderPath)/external/</_ExternalReswOutputPath>
   </PropertyGroup>
+  
+  <ItemGroup Condition="'$(BuildingUAPVertical)' == 'true'">
+    <_AllRuntimeDllFiles Include="$(RuntimePath)\*.dll" />
+    <_ExternalReswFiles Include="$(_ExternalReswOutputPath)*.resw" />
+    
+    <!-- The first time the CreateReswFilesForExternalDependencies target is executed the itemgroup _ExternalReswFiles will be empty
+    and that will avoid the target from executing, so we add a dummy file if they are empty so that the target is executed the first time. -->
+    <_ExternalReswFiles Condition="@(_ExternalReswFiles) == ''" Include="$(_ExternalReswOutputPath)dummy.resw" />
+  </ItemGroup>
+
+  <Target Name="CreateReswFilesForExternalDependencies" 
+          Condition="'$(BuildingUAPVertical)' == 'true' AND '$(ShouldSkipExternalResources)' != 'true'"
+          Inputs="@(_AllRuntimeDllFiles)"
+          Outputs="@(_ExternalReswFiles)">
+
+    <ExtractResWResourcesFromAssemblies InputAssemblies="@(_AllRuntimeDllFiles)"
+                                        OutputPath="$(_ExternalReswOutputPath)"
+                                        InternalReswDirectory="$(ResourcesFolderPath)" />
+
+  </Target>
 
   <!-- This target the necessary config file in order to create the UAP runner's resources.pri file using MakePri.exe -->
   <Target Name="CreateMakePriConfigFileFromTemplate"
@@ -190,10 +212,13 @@
   </Target>
 
   <!-- This target gets all the resw files to be used to create the UAP runner's resources.pri file -->
-  <Target Name="CalculateResWFiles" Condition="'$(BuildingUAPVertical)' == 'true'">
+  <Target Name="CalculateResWFiles" 
+          Condition="'$(BuildingUAPVertical)' == 'true'"
+          DependsOnTargets="CreateReswFilesForExternalDependencies">
+
     <ItemGroup>
       <_TestResWFiles Include="$(TestResourcesFolderPath)\*.resw" />
-      <_CommonResWFiles Include="$(ResourcesFolderPath)\*.resw" />
+      <_CommonResWFiles Include="$(ResourcesFolderPath)\**\*.resw" />
     </ItemGroup>
   </Target>
 
@@ -251,8 +276,13 @@
     <!-- We call MakePri.exe to create common resources.pri file only if this test project has its own resources. -->
     <Exec Command="$(_MakePriCommand)" StandardOutputImportance="Low" StdErrEncoding="Unicode" Condition="'$(TestProjectNeedsModifiedPriFile)' == 'true'" />
 
-    <Copy Condition="'$(TestProjectNeedsModifiedPriFile)' != 'true'"
+    <Copy Condition="'$(TestProjectNeedsModifiedPriFile)' != 'true' AND Exists('$(_CommonPriFile)')"
           SourceFiles="$(_CommonPriFile)"
+          DestinationFiles="$(TestPath)\resources.pri"
+          SkipUnchangedFiles="true" />
+
+    <Copy Condition="'$(TestProjectNeedsModifiedPriFile)' != 'true' AND !Exists('$(_CommonPriFile)')"
+          SourceFiles="$(TestHostRootPath)\Runner\resources.pri"
           DestinationFiles="$(TestPath)\resources.pri"
           SkipUnchangedFiles="true" />
 

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -18,6 +18,7 @@
     "NuGet.Versioning": "4.3.0-preview2-4095",
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Dynamic.Runtime": "4.0.11",
+    "System.IO.UnmanagedMemoryStream": "4.3.0",
     "System.Linq.Parallel": "4.0.1",
     "System.Net.Http": "4.1.0",
     "System.Reflection.Metadata": "1.4.2",


### PR DESCRIPTION
…external dependencies (#1630)

* Add task to get the resources and merge them into the common pri for external dependencies

* PR Feedback

* PR Feedback, remove System.Windows.Forms dependency, and change target Outputs

* Make RewResourceWriter IDisposable

* Fix assembly filtering when it doesn't need resources to be extracted

* Change to NS implementation using MetadataReader instead of Assembly.LoadFrom

* Add option to disable external resources extraction and use runner's default pri file if common pri doesn't exist