### PR TITLE
Allow excluding namespaces via DocId in Microsoft.Cci.Extensions

### DIFF
--- a/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdExcludeListFilter.cs
@@ -28,7 +28,13 @@ namespace Microsoft.Cci.Filters
         public bool Include(INamespaceDefinition ns)
         {
             // Only include non-empty namespaces
-            return ns.GetTypes().Any(Include);
+            if (!ns.GetTypes().Any(Include))
+                return false;
+
+            string namespaceId = ns.DocId();
+
+            // include so long as it isn't in the exclude list.
+            return !_docIds.Contains(namespaceId);
         }
 
         public bool Include(ITypeDefinition type)

--- a/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
+++ b/src/Microsoft.Cci.Extensions/Filters/DocIdIncludeListFilter.cs
@@ -30,7 +30,11 @@ namespace Microsoft.Cci.Filters
         public bool Include(INamespaceDefinition ns)
         {
             // Only include non-empty namespaces
-            return ns.GetTypes().Any(Include);
+            if (!ns.GetTypes().Any(Include))
+                return false;
+
+            string namespaceId = ns.DocId();
+            return _docIds.Contains(namespaceId);
         }
 
         public bool Include(ITypeDefinition type)

--- a/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
+++ b/src/Microsoft.Cci.Extensions/Traversers/SimpleTypeMemberTraverser.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Cci.Traversers
 
         public virtual void Visit(IEnumerable<INamespaceDefinition> namespaces)
         {
+            namespaces = namespaces.Where(_filter.Include);
             namespaces = namespaces.Where(ns => ns.GetTypes(this.IncludeForwardedTypes).Any(_filter.Include));
             namespaces = namespaces.OrderBy(GetNamespaceKey, StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
Before it only excluded empty namespaces, now we support the exclude list too.

This simplifies lists such as https://github.com/dotnet/standard/blob/64bdab44e93e4f156b677f36ccebd528b0cae7c3/platforms/xamarin.android/apiExcludeList.txt since whole namespaces can be excluded.