### PR TITLE
Produce 2.1.0-preview3-* packages

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -13,7 +13,7 @@
 
     <!-- Use the same package version for all output packages. -->
     <DoNotGeneratePackageVersion>true</DoNotGeneratePackageVersion>
-    <PackageVersion>2.1.0-preview2-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
+    <PackageVersion>2.1.0-preview3-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This matches what the Core repos are doing in `master` to make room for `release/2.1` starting preview2 builds.