### PR TITLE
Update submodules from ProdCon orchestrated build manifests

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/VersionTools.targets
@@ -56,7 +56,7 @@
     'TargetSubmodule' property to the name/path of the submodule.
   -->
   <Target Name="CreateDefaultSubmoduleUpdateSteps"
-          Condition="'$(GitModulesPath)' != ''">
+          Condition="'$(CreateDefaultSubmoduleUpdateSteps)' == 'true'">
     <ReadGitConfigFile File="$(GitModulesPath)">
       <Output TaskParameter="SubmoduleConfiguration" ItemName="SubmoduleConfiguration" />
     </ReadGitConfigFile>
@@ -112,7 +112,9 @@
     <UpdateDependencies DependencyInfo="@(DependencyInfo)"
                         ProjectJsonFiles="@(ProjectJsonFiles)"
                         UpdateStep="@(UpdateStep)"
-                        BuildInfoCacheDir="$(BuildInfoCacheDir)" />
+                        BuildInfoCacheDir="$(BuildInfoCacheDir)"
+                        GitHubAuthToken="$(GitHubAuthToken)"
+                        GitHubUser="$(GitHubUser)" />
   </Target>
 
   <Target Name="VerifyDependencies"

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateToRemoteDependencies.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/UpdateToRemoteDependencies.cs
@@ -16,14 +16,6 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
     {
         public string CurrentRefXmlPath { get; set; }
 
-        /// <summary>
-        /// If provided, GitHub authentication info is used to fetch the remote dotnet/versions
-        /// commit. The anonymous user rate limit is small, and this can be used to use an account's
-        /// quota instead. The "...AndSubmitPullRequest" subclass also uses this to create the PR.
-        /// </summary>
-        public string GitHubAuthToken { get; set; }
-        public string GitHubUser { get; set; }
-
         [Output]
         public bool MadeChanges { get; set; }
 

--- a/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/BuildManifest/BuildManifestClient.cs
@@ -33,7 +33,14 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
             string @ref,
             string basePath)
         {
-            return OrchestratedBuildModel.Parse(await FetchModelXmlAsync(project, @ref, basePath));
+            XElement contents = await FetchModelXmlAsync(project, @ref, basePath);
+
+            if (contents == null)
+            {
+                return null;
+            }
+
+            return OrchestratedBuildModel.Parse(contents);
         }
 
         public async Task<SemaphoreModel> FetchSemaphoreAsync(
@@ -200,6 +207,11 @@ namespace Microsoft.DotNet.VersionTools.BuildManifest
                 $"{basePath}/{BuildManifestXmlName}",
                 project,
                 @ref);
+
+            if (contents == null)
+            {
+                return null;
+            }
 
             return XElement.Parse(contents);
         }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Automation;
+using Microsoft.DotNet.VersionTools.BuildManifest;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildManifest
+{
+    public class OrchestratedBuildDependencyInfo : IDependencyInfo
+    {
+        public static async Task<OrchestratedBuildDependencyInfo> CreateAsync(
+            string simpleName,
+            GitHubProject project,
+            string @ref,
+            string basePath,
+            BuildManifestClient client)
+        {
+            OrchestratedBuildModel model = await client.FetchManifestAsync(
+                project,
+                @ref,
+                basePath);
+
+            if (model == null)
+            {
+                throw new ArgumentException(
+                    $"Found no manifest for '{simpleName}' at " +
+                    $"'{project.Segments}' '{basePath}' ref '{@ref}'");
+            }
+
+            return new OrchestratedBuildDependencyInfo(simpleName, basePath, model);
+        }
+
+        public string SimpleName { get; }
+
+        public string SimpleVersion => OrchestratedBuildModel.Identity.BuildId;
+
+        public string BasePath { get; }
+
+        public OrchestratedBuildModel OrchestratedBuildModel { get; }
+
+        public OrchestratedBuildDependencyInfo(
+            string simpleName,
+            string basePath,
+            OrchestratedBuildModel model)
+        {
+            SimpleName = simpleName;
+            BasePath = basePath;
+            OrchestratedBuildModel = model;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/OrchestratedBuildSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/OrchestratedBuildSubmoduleUpdater.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
+{
+    public class OrchestratedBuildSubmoduleUpdater : SubmoduleUpdater
+    {
+        public string BuildName { get; set; }
+
+        public string GitUrl { get; set; }
+
+        protected override string GetDesiredCommitHash(
+            IEnumerable<IDependencyInfo> dependencyInfos,
+            out IEnumerable<IDependencyInfo> usedDependencyInfos)
+        {
+            DependencyInfoMatch[] matches = dependencyInfos
+                .OfType<OrchestratedBuildDependencyInfo>()
+                .SelectMany(info => info.OrchestratedBuildModel.Builds
+                    .Where(b => b.Name.Equals(BuildName, StringComparison.OrdinalIgnoreCase))
+                    .Select(b => new DependencyInfoMatch { Info = info, Match = b }))
+                .ToArray();
+
+            if (matches.Length != 1)
+            {
+                throw new ArgumentException(
+                    $"For '{Path}', expected 1 build matching '{BuildName}', " +
+                    $"but found {matches.Length}: '{string.Join(", ", matches.AsEnumerable())}'");
+            }
+
+            DependencyInfoMatch match = matches[0];
+
+            if (string.IsNullOrEmpty(match.Match.Commit))
+            {
+                throw new ArgumentException(
+                    $"For '{Path}', found match '{match}', but no commit on '{match.Match}'.");
+            }
+
+            usedDependencyInfos = new[] { match.Info };
+            return match.Match.Commit;
+        }
+
+        protected override void FetchRemoteBranch()
+        {
+            Trace.TraceInformation($"In '{Path}', fetching from '{GitUrl}'");
+            GitCommand.Fetch(Path, GitUrl);
+        }
+
+        private class DependencyInfoMatch
+        {
+            public OrchestratedBuildDependencyInfo Info { get; set; }
+            public BuildIdentity Match { get; set; }
+
+            public override string ToString() => $"'{Match}' from '{Info.SimpleName}'";
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -55,6 +55,8 @@
     <Compile Include="Automation\GitHubProject.cs" />
     <Compile Include="Automation\PullRequestCreator.cs" />
     <Compile Include="Automation\GitHubApi\GitHubApiModel.cs" />
+    <Compile Include="Dependencies\BuildManifest\OrchestratedBuildDependencyInfo.cs" />
+    <Compile Include="Dependencies\Submodule\OrchestratedBuildSubmoduleUpdater.cs" />
     <Compile Include="Dependencies\Submodule\SubmoduleDependencyInfo.cs" />
     <Compile Include="Dependencies\BuildOutput\ToolVersionsUpdater.cs" />
     <Compile Include="Dependencies\BuildOutput\FilePackageUpdater.cs" />

--- a/src/Microsoft.DotNet.VersionTools/Util/GitCommand.cs
+++ b/src/Microsoft.DotNet.VersionTools/Util/GitCommand.cs
@@ -75,19 +75,26 @@ namespace Microsoft.DotNet.VersionTools.Util
 
         internal static void Fetch(
             string path,
-            string repository = "",
-            string refspec = "")
+            string repository)
+        {
+            Create("-C", path, "fetch", repository)
+                .Execute()
+                .EnsureSuccessful();
+        }
+
+        internal static void Fetch(
+            string path,
+            string repository,
+            string refspec)
         {
             Create("-C", path, "fetch", repository, refspec)
                 .Execute()
                 .EnsureSuccessful();
         }
 
-        internal static void FetchAll(
-            string path,
-            string repository = "")
+        internal static void FetchAll(string path)
         {
-            Create("-C", path, "fetch", "--all", repository)
+            Create("-C", path, "fetch", "--all")
                 .Execute()
                 .EnsureSuccessful();
         }


### PR DESCRIPTION
This will be used by source-build to move the submodules to the hashes that were successful in the latest orchestrated build.

Setting this up in source-build: https://github.com/dagood/source-build/commit/47918930761a74b6b92f9f432cec8b7839a52596. To avoid duplicating info outside the project files, I used the MSBuild task and Target output flow @eerhardt suggested a while back.

https://github.com/dotnet/source-build/issues/342