### PR TITLE
Using traceback library to give call stack

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/DumplingHelper.py
@@ -7,6 +7,7 @@ import time
 import sys
 import subprocess
 import string
+import traceback
 
 def get_timestamp():
   print(time.time())
@@ -31,7 +32,7 @@ def install_dumpling():
   except  urllib2.URLError, e:
     print(e.reason)
   except:
-    print("An unexpected error was encountered while installing dumpling.py: " + sys.exc_info()[0])
+    print("An unexpected error was encountered while installing dumpling.py: " + traceback.format_exc())
 
 def ensure_installed():
   if (not os.path.isfile(dumplingPath)):


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/pull/28225#issuecomment-374409319
Earlier Version
```
Traceback (most recent call last):
  File "src\Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\DumplingHelper.py", line 131, in <module>
    main(sys.argv)
  File "src\Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\DumplingHelper.py", line 113, in main
    install_dumpling()
  File "src\Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\DumplingHelper.py", line 34, in install_dumpling
    print("An unexpected error was encountered while installing dumpling.py: " + sys.exc_info()[0])
TypeError: cannot concatenate 'str' and 'type' objects
```
New Version
```
An unexpected error was encountered while installing dumpling.py: Traceback (most recent call last):
  File "src\Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\DumplingHelper.py", line 21, in install_dumpling
    response = urllib2.urlopen(url)
  File "C:\Python27\lib\urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "C:\Python27\lib\urllib2.py", line 429, in open
    response = self._open(req, data)
  File "C:\Python27\lib\urllib2.py", line 447, in _open
    '_open', req)
  File "C:\Python27\lib\urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "C:\Python27\lib\urllib2.py", line 1241, in https_open
    context=self._context)
  File "C:\Python27\lib\urllib2.py", line 1195, in do_open
    h.request(req.get_method(), req.get_selector(), req.data, headers)
  File "C:\Python27\lib\httplib.py", line 1042, in request
    self._send_request(method, url, body, headers)
  File "C:\Python27\lib\httplib.py", line 1082, in _send_request
    self.endheaders(body)
  File "C:\Python27\lib\httplib.py", line 1038, in endheaders
    self._send_output(message_body)
  File "C:\Python27\lib\httplib.py", line 882, in _send_output
    self.send(msg)
  File "C:\Python27\lib\httplib.py", line 844, in send
    self.connect()
  File "C:\Python27\lib\httplib.py", line 1263, in connect
    server_hostname=server_hostname)
  File "C:\Python27\lib\ssl.py", line 363, in wrap_socket
    _context=self)
  File "C:\Python27\lib\ssl.py", line 611, in __init__
    self.do_handshake()
  File "C:\Python27\lib\ssl.py", line 848, in do_handshake
    match_hostname(self.getpeercert(), self.server_hostname)
  File "C:\Python27\lib\ssl.py", line 286, in match_hostname
    % (hostname, dnsnames[0]))
CertificateError: hostname 'dumpling.azurewebsites.net' doesn't match 'dumpling.int-dot.net'
```