### PR TITLE
[release/2.0.0] Update GenFacades targets to support all options

### DIFF
--- a/src/GenFacades/GenFacades.Core/GenFacades.cs
+++ b/src/GenFacades/GenFacades.Core/GenFacades.cs
@@ -116,7 +116,9 @@ namespace GenFacades
                                     partialFacadeAssembly.AssemblyIdentity));
                         }
 
-                        Assembly filledPartialFacade = facadeGenerator.GenerateFacade(contractAssembly, seedCoreAssemblyRef, ignoreMissingTypes, overrideContractAssembly: partialFacadeAssembly);
+                        Assembly filledPartialFacade = facadeGenerator.GenerateFacade(contractAssembly, seedCoreAssemblyRef, ignoreMissingTypes, 
+                            overrideContractAssembly: partialFacadeAssembly, 
+                            forceAssemblyReferenceVersionsToZero: forceZeroVersionSeeds);
 
                         if (filledPartialFacade == null)
                         {
@@ -402,7 +404,11 @@ namespace GenFacades
                 _assemblyFileVersion = assemblyFileVersion;
             }
 
-            public Assembly GenerateFacade(IAssembly contractAssembly, IAssemblyReference seedCoreAssemblyReference, bool ignoreMissingTypes, IAssembly overrideContractAssembly = null, bool buildPartialReferenceFacade = false)
+            public Assembly GenerateFacade(IAssembly contractAssembly, 
+                IAssemblyReference seedCoreAssemblyReference, 
+                bool ignoreMissingTypes, IAssembly overrideContractAssembly = null,
+                bool buildPartialReferenceFacade = false, 
+                bool forceAssemblyReferenceVersionsToZero = false)
             {
                 Assembly assembly;
                 if (overrideContractAssembly != null)
@@ -420,6 +426,14 @@ namespace GenFacades
                     {
                         ReferenceAssemblyToFacadeRewriter rewriter = new ReferenceAssemblyToFacadeRewriter(_seedHost, _contractHost, seedCoreAssemblyReference, _assemblyFileVersion != null);
                         rewriter.Rewrite(assembly);
+                    }
+                }
+
+                if (forceAssemblyReferenceVersionsToZero)
+                {
+                    foreach (AssemblyReference ar in assembly.AssemblyReferences)
+                    {
+                        ar.Version = new Version(0, 0, 0, 0);
                     }
                 }
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/partialfacades.task.targets
@@ -68,8 +68,14 @@
       FacadePath="$(GenFacadesOutputPath.TrimEnd('/'))"
       SeedTypePreferencesUnsplit="@(SeedTypePreference)"
       ProducePdb="$(ProducePdb)"
+      ClearBuildAndRevision="$(GenFacadesClearBuildAndRevision)"
       IgnoreMissingTypes="$(GenFacadesIgnoreMissingTypes)"
       IgnoreBuildAndRevisionMismatch="$(GenFacadesIgnoreBuildAndRevisionMismatch)"
+      BuildDesignTimeFacades="$(GenFacadesBuildDesignTimeFacades)"
+      InclusionContracts="$(GenFacadesInclusionContracts)"
+      SeedLoadErrorTreatment="$(GenFacadesSeedLoadErrorTreatment)"
+      ContractLoadErrorTreatment="$(GenFacadesContractLoadErrorTreatment)"
+      ForceZeroVersionSeeds="$(GenFacadesForceZeroVersionSeeds)"
       BuildPartialReferenceFacade="$(GenFacadesBuildPartialReferenceFacade)"
     />
 


### PR DESCRIPTION
Porting https://github.com/dotnet/buildtools/pull/1970 to release/2.0.0

Our genfacades task targets file was missing some options we support
this exposes those as properties.

This change also includes a fix in GenFacades tool to force all
assembly references to 0.0.0.0 when the option is set. Currently it
forces all the seed assemblies to 0.0.0.0 but not any pre-existing
references from our partial facade inputs. This change will force those
to 0.0.0.0 as well.

cc @ericstj 