### PR TITLE
Make finding the branch from GIT more robust.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -264,8 +264,8 @@
       Condition="'$(SkipVersionGeneration)' != 'true' AND '$(VersionPropsImported)' != 'true'">
 
     <!-- ############################### -->
-    <Exec Command="git rev-parse --abbrev-ref HEAD 2>&amp;1" StandardOutputImportance="Low" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true" Condition="'$(GitBranchName)' == ''">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitBranchName" />
+    <Exec Command="git describe --all HEAD 2>&amp;1" StandardOutputImportance="Low" IgnoreExitCode="true" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true" Condition="'$(RawGitBranchName)' == ''">
+      <Output TaskParameter="ConsoleOutput" PropertyName="RawGitBranchName" />
     </Exec>
 
     <!-- ############################### -->
@@ -283,6 +283,17 @@
     <PropertyGroup Condition="'$(LatestCommitExitCode)'!='0'">
       <LatestCommit>N/A</LatestCommit>
     </PropertyGroup>
+
+
+    <!-- If things match expected patterns, create $(GitBranchName) from $(RawGitBranchName) -->
+    <Message Text="GIT Branch Name as seen by git describe: '$(RawGitBranchName)'" /> 
+    <PropertyGroup Condition="$(RawGitBranchName.StartsWith('he:ads/'))">
+      <GitBranchName>$(RawGitBranchName.SubString(6))</GitBranchName>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(RawGitBranchName.StartsWith('remotes/origin/'))">
+      <GitBranchName>$(RawGitBranchName.SubString(15))</GitBranchName>
+    </PropertyGroup>
+    <Message Text="GIT Branch Name: '$(GitBranchName)'" /> 
 
     <!-- The GitHubOwnerName is the name of the entity that 'owns' a particular github repository (e.g the 'dotnet in https://github/dotnet/coreclr) -->
     <!-- we assume by default that these build tools are used by the 'dotnet' group.  This can be overridden. -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -284,16 +284,15 @@
       <LatestCommit>N/A</LatestCommit>
     </PropertyGroup>
 
-
     <!-- If things match expected patterns, create $(GitBranchName) from $(RawGitBranchName) -->
-    <Message Text="GIT Branch Name as seen by git describe: '$(RawGitBranchName)'" /> 
-    <PropertyGroup Condition="$(RawGitBranchName.StartsWith('he:ads/'))">
+    <Message Importance="high" Text="GIT Branch Name as seen by git describe: '$(RawGitBranchName)'" /> 
+    <PropertyGroup Condition="$(RawGitBranchName.StartsWith('heads/'))">
       <GitBranchName>$(RawGitBranchName.SubString(6))</GitBranchName>
     </PropertyGroup>
     <PropertyGroup Condition="$(RawGitBranchName.StartsWith('remotes/origin/'))">
       <GitBranchName>$(RawGitBranchName.SubString(15))</GitBranchName>
     </PropertyGroup>
-    <Message Text="GIT Branch Name: '$(GitBranchName)'" /> 
+    <Message Importance="high" Text="GIT Branch Name: '$(GitBranchName)'" /> 
 
     <!-- The GitHubOwnerName is the name of the entity that 'owns' a particular github repository (e.g the 'dotnet in https://github/dotnet/coreclr) -->
     <!-- we assume by default that these build tools are used by the 'dotnet' group.  This can be overridden. -->


### PR DESCRIPTION
Previously I tried to include the GIT branch name in the versioning information.   I used the 
rev-parse command , which worked locally but does not work if you don't have a local branch (which 
is what we do when we build in our automation).   The result is we get a unhelpful 'HEAD' as the 
name of the commit.

Changed this to use 'git describe -all' which should use all the remote branches as well.   I also changed
the logic so that if we don't get something reasonably sane out of 'git describe' I give up and don't put
any branch information in.  

I have tested this locally, but it still may need tweeks.   Still at worst it doesn't include branch information.  