### PR TITLE
Revert "Filter out empty dependencies from promotion consideration"

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -721,12 +721,8 @@
       <Output TaskParameter="TrimmedDependencies" ItemName="FilePackageDependency" />
     </CreateTrimDependencyGroups>
 
-    <ItemGroup>
-      <NonEmptyFilePackageDependency Include="@(FilePackageDependency)" Condition="'%(FilePackageDependency.Identity)' != '_._'" />
-    </ItemGroup>
-
     <!-- Promote dependencies from ref to lib and vice-versa -->
-    <PromoteDependencies Dependencies="@(NonEmptyFilePackageDependency)"
+    <PromoteDependencies Dependencies="@(FilePackageDependency)"
                          PackageIndexes="@(PackageIndex)"
                          Condition="'@(FilePackageDependency)' != ''">
       <Output TaskParameter="PromotedDependencies" ItemName="FilePackageDependency" />


### PR DESCRIPTION
This reverts commit e8f73c0d8d8891fddacc344ddda1e702015d5dbd.

This commit causes other issues like https://github.com/dotnet/corefx/issues/26390
we need to revert and find another solution to the original issue
https://github.com/dotnet/corefx/issues/26129

cc @ericstj @joperezr 