### PR TITLE
Printing Managed Call stack, native call stack and managed exceptions using lldb

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -3,6 +3,20 @@
 export RUNTIME_PATH=$1
 export EXECUTION_DIR=$(dirname "$0")
 
+function print_info_from_core_file_using_lldb {
+  local core_file_name=$1
+  local executable_name=$2
+  local plugin_path_name="$RUNTIME_PATH/shared/Microsoft.NETCore.App/9.9.9/libsosplugin.so"
+
+  # check for existence of lldb-3.9 on the path
+  hash lldb-3.9 2>/dev/null || { echo >&2 "lldb-3.9 was not found. Unable to print core file."; return; }
+  echo ----- start ===============  lldb Output =====================================================
+  # clrstack can throw exception if there is no managed call stack. so we are doing it at kast
+  echo Printing native call stack followed by managed exceptions and managed call stack.
+  lldb-3.9 -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path_name" -o "bt all" -o "pe -nested" -o "clrstack -all" -o "quit"  --core $core_file_name $executable_name
+  echo ----- end ===============  lldb Output =======================================================
+}
+
 function print_info_from_core_file {
   local core_file_name=$1
   local executable_name=$RUNTIME_PATH/$2
@@ -15,14 +29,18 @@ function print_info_from_core_file {
     return
   fi
 
+  print_info_from_core_file_using_lldb $core_file_name $executable_name
+
   # Check for the existence of GDB on the path
   hash gdb 2>/dev/null || { echo >&2 "GDB was not found. Unable to print core file."; return; }
 
+  echo ----- start ===============  GDB Output =====================================================
   echo "Printing info from core file $core_file_name"
 
   # Open the dump in GDB and print the stack from each thread. We can add more
   # commands here if desired.
   gdb --batch -ex "thread apply all bt full" -ex "quit" $executable_name $core_file_name
+  echo ----- end ===============  Gdb Output =======================================================
 }
 
 function copy_core_file_to_temp_location {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -21,8 +21,8 @@ function print_info_from_core_file_using_lldb {
   local executable_name=$2
   local plugin_path_name="$RUNTIME_PATH/shared/Microsoft.NETCore.App/9.9.9/libsosplugin.so"
 
-  # check for existence of lldb-3.9 on the path
-  hash lldb-3.9 2>/dev/null || { echo >&2 "lldb-3.9 was not found. Unable to print core file."; return; }
+  # check for existence of lldb on the path
+  hash lldb 2>/dev/null || { echo >&2 "lldb was not found. Unable to print core file."; return; }
 
   # pe and clrstack are defined in libsosplugin.so
   if [ ! -f $plugin_path_name ]; then
@@ -32,7 +32,7 @@ function print_info_from_core_file_using_lldb {
 
   echo ----- start ===============  lldb Output =====================================================
   echo Printing managed exceptions and managed call stack.
-  lldb-3.9 -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path_name" -o "pe -nested" -o "clrstack -all -a -f" -o "quit"  --core $core_file_name $executable_name
+  lldb -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path_name" -o "pe -nested" -o "clrstack -all -a -f" -o "quit"  --core $core_file_name $executable_name
   echo ----- end ===============  lldb Output =======================================================
 }
 
@@ -126,7 +126,7 @@ popd
 echo ----- end $(date +"%T") ----- exit code $test_exitcode ----------------------------------------------------------
 
 if [[ ($test_exitcode -ge 129 && $test_exitcode -le 160) || $test_exitcode -eq 0 ]]; then
-  echo ----- exit code $test_exitcode means ${exitcode_list[$test_exitcode]}--------------------------------------------------
+  echo exit code $test_exitcode means ${exitcode_list[$test_exitcode]}
 fi
 # ========================= END Test Execution ===============================
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -125,7 +125,7 @@ test_exitcode=$?
 popd
 echo ----- end $(date +"%T") ----- exit code $test_exitcode ----------------------------------------------------------
 
-if [[ ($test_exitcode -ge 129 && $test_exitcode -le 160) || $test_exitcode -eq 0 ]]; then
+if [ "${exitcode_list[$test_exitcode]}" != "" ]; then
   echo exit code $test_exitcode means ${exitcode_list[$test_exitcode]}
 fi
 # ========================= END Test Execution ===============================

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -3,6 +3,7 @@
 export RUNTIME_PATH=$1
 export EXECUTION_DIR=$(dirname "$0")
 
+exitcode_list[0]="Exited Successfully"
 exitcode_list[130]="SIGINT  Ctrl-C occurred. Likely tests timed out."
 exitcode_list[131]="SIGQUIT Ctrl-\ occurred. Core dumped."
 exitcode_list[132]="SIGILL  Illegal Instruction. Core dumped. Likely codegen issue."
@@ -123,7 +124,10 @@ pushd $EXECUTION_DIR
 test_exitcode=$?
 popd
 echo ----- end $(date +"%T") ----- exit code $test_exitcode ----------------------------------------------------------
-echo ----- exit code $test_exitcode means ${exitcode_list[$test_exitcode]}--------------------------------------------------
+
+if [[ ($test_exitcode -ge 129 && $test_exitcode -le 160) || $test_exitcode -eq 0 ]]; then
+  echo ----- exit code $test_exitcode means ${exitcode_list[$test_exitcode]}--------------------------------------------------
+fi
 # ========================= END Test Execution ===============================
 
 # ======================= BEGIN Core File Inspection =========================

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -19,7 +19,7 @@ function print_info_from_core_file_using_lldb {
 
   echo ----- start ===============  lldb Output =====================================================
   echo Printing managed exceptions and managed call stack.
-  lldb-3.9 -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path_name" -o "pe -nested" -o "clrstack -a -f" -o "quit"  --core $core_file_name $executable_name
+  lldb-3.9 -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path_name" -o "pe -nested" -o "clrstack -all -a -f" -o "quit"  --core $core_file_name $executable_name
   echo ----- end ===============  lldb Output =======================================================
 }
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -10,11 +10,32 @@ function print_info_from_core_file_using_lldb {
 
   # check for existence of lldb-3.9 on the path
   hash lldb-3.9 2>/dev/null || { echo >&2 "lldb-3.9 was not found. Unable to print core file."; return; }
+
+  # pe and clrstack are defined in libsosplugin.so
+  if [ ! -f $plugin_path_name ]; then
+    echo $plugin_path_name cannot be found.
+    return
+  fi
+
   echo ----- start ===============  lldb Output =====================================================
-  # clrstack can throw exception if there is no managed call stack. so we are doing it at kast
-  echo Printing native call stack followed by managed exceptions and managed call stack.
-  lldb-3.9 -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path_name" -o "bt all" -o "pe -nested" -o "clrstack -all" -o "quit"  --core $core_file_name $executable_name
+  echo Printing managed exceptions and managed call stack.
+  lldb-3.9 -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path_name" -o "pe -nested" -o "clrstack -a -f" -o "quit"  --core $core_file_name $executable_name
   echo ----- end ===============  lldb Output =======================================================
+}
+
+function print_info_from_core_file_using_gdb {
+  local core_file_name=$1
+  local executable_name=$2
+
+  # Check for the existence of GDB on the path
+  hash gdb 2>/dev/null || { echo >&2 "GDB was not found. Unable to print core file."; return; }
+
+  echo ----- start ===============  GDB Output =====================================================
+  # Open the dump in GDB and print the stack from each thread. We can add more
+  # commands here if desired.
+  echo printing native stack.
+  gdb --batch -ex "thread apply all bt full" -ex "quit" $executable_name $core_file_name
+  echo ----- end ===============  GDB Output =======================================================
 }
 
 function print_info_from_core_file {
@@ -28,19 +49,9 @@ function print_info_from_core_file {
     echo "Unable to find core file $core_file_name"
     return
   fi
-
-  print_info_from_core_file_using_lldb $core_file_name $executable_name
-
-  # Check for the existence of GDB on the path
-  hash gdb 2>/dev/null || { echo >&2 "GDB was not found. Unable to print core file."; return; }
-
-  echo ----- start ===============  GDB Output =====================================================
   echo "Printing info from core file $core_file_name"
-
-  # Open the dump in GDB and print the stack from each thread. We can add more
-  # commands here if desired.
-  gdb --batch -ex "thread apply all bt full" -ex "quit" $executable_name $core_file_name
-  echo ----- end ===============  Gdb Output =======================================================
+  print_info_from_core_file_using_lldb $core_file_name $executable_name
+  print_info_from_core_file_using_gdb $core_file_name $executable_name
 }
 
 function copy_core_file_to_temp_location {

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -3,6 +3,18 @@
 export RUNTIME_PATH=$1
 export EXECUTION_DIR=$(dirname "$0")
 
+exitcode_list[130]="SIGINT  Ctrl-C occurred. Likely tests timed out."
+exitcode_list[131]="SIGQUIT Ctrl-\ occurred. Core dumped."
+exitcode_list[132]="SIGILL  Illegal Instruction. Core dumped. Likely codegen issue."
+exitcode_list[133]="SIGTRAP Breakpoint hit. Core dumped."
+exitcode_list[134]="SIGABRT Abort. Managed or native assert, or runtime check such as heap corruption, caused call to abort(). Core dumped."
+exitcode_list[135]="IGBUS  Unaligned memory access. Core dumped."
+exitcode_list[136]="SIGFPE  Bad floating point arguments. Core dumped."
+exitcode_list[137]="SIGKILL Killed eg by kill"
+exitcode_list[139]="SIGSEGV Illegal memory access. Deref invalid pointer, overrunning buffer, stack overflow etc. Core dumped."
+exitcode_list[143]="SIGTERM Terminated. Usually before SIGKILL."
+exitcode_list[159]="SIGSYS  Bad System Call."
+
 function print_info_from_core_file_using_lldb {
   local core_file_name=$1
   local executable_name=$2
@@ -111,6 +123,7 @@ pushd $EXECUTION_DIR
 test_exitcode=$?
 popd
 echo ----- end $(date +"%T") ----- exit code $test_exitcode ----------------------------------------------------------
+echo ----- exit code $test_exitcode means ${exitcode_list[$test_exitcode]}--------------------------------------------------
 # ========================= END Test Execution ===============================
 
 # ======================= BEGIN Core File Inspection =========================
@@ -133,6 +146,7 @@ if [ "$(uname -s)" == "Linux" ]; then
       [[ $f =~ core.[0-9]+ ]] && print_info_from_core_file "$f" "dotnet" && copy_core_file_to_temp_location "$f" && rm "$f"
     done
   elif [ -f core ]; then
+    echo found a dump named core in $EXECUTION_DIR !
     print_info_from_core_file "core" "dotnet"
     copy_core_file_to_temp_location "core"
     rm "core"


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/28509

Sample output wrt to https://github.com/dotnet/corefx/pull/27899
```
 Discovering: System.Collections.Specialized.Tests
  Discovered:  System.Collections.Specialized.Tests
  Starting:    System.Collections.Specialized.Tests
  /git/corefx/bin/tests/System.Collections.Specialized.Tests/netcoreapp-Linux-Debug-x64/RunTests.sh: line 100: 40236 Segmentation fault      (core dumped) $RUNTIME_PATH/dotnet xunit.console.netcore.exe System.Collections.Specialized.Tests.dll -xml testResults.xml -notrait Benchmark=true -notrait category=nonnetcoreapptests -notrait category=nonlinuxtests -notrait category=OuterLoop -notrait category=failing
  /git/corefx/src/System.Collections.Specialized/tests
  ----- end 07:14:51 ----- exit code 139 ----------------------------------------------------------
  Looking around for any Linux dump...
  ----- start =============== lldb Output =====================================================
  (lldb) pe -nested
  There is no current managed exception on this thread
  (lldb) clrstack -all
  ----- end =============== lldb Output =======================================================
  /git/corefx/bin/tests/System.Collections.Specialized.Tests/netcoreapp-Linux-Debug-x64/RunTests.sh: line 6: 40252 Segmentation fault      (core dumped) lldb-3.9 -O "settings set target.exec-search-paths $RUNTIME_PATH" -o "plugin load $plugin_path" -o "bt all" -o "pe -nested" -o "clrstack -all" -o "quit" --core $core_file_name $executable_name
  GDB was not found. Unable to print core file.
  Copying core file core to /tmp/coredumps/core.2718 in case you need it.
```