### PR TITLE
detect long running tests and print out warning on console

### DIFF
--- a/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
@@ -73,12 +73,6 @@ namespace Xunit.ConsoleClient
                     Errors = Errors
                 });
 
-            if (watcher != null)
-            {
-            //    watcher.Interrupt();
-                //watcher.Abort();
-            //    watcher = null;
-            }
             runningTests = null;
             clock.Stop();
             return result;

--- a/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
@@ -17,10 +17,10 @@ namespace Xunit.ConsoleClient
         readonly string defaultDirectory;
         readonly bool showProgress;
         readonly Stopwatch clock;
-        private ConcurrentDictionary<String, long> runningTests;
+        private ConcurrentDictionary<string, long> runningTests;
         private Thread watcher;
-        readonly int longTestMaxMiliseconds = 1_000 * 60 * 5;
-        readonly int longTestCheckMiliseconds = 1_000 * 60;
+        readonly int longTestMaxMilliseconds = 1_000 * 60 * 5;
+        readonly int longTestCheckMilliseconds = 1_000 * 60;
 
 
         public StandardOutputVisitor(object consoleLock,
@@ -37,7 +37,7 @@ namespace Xunit.ConsoleClient
             this.showProgress = showProgress;
 
             this.clock =  new Stopwatch();
-            this.runningTests = new ConcurrentDictionary<String , long>();
+            this.runningTests = new ConcurrentDictionary<string, long>();
         }
 
         protected override bool Visit(ITestAssemblyStarting assemblyStarting)
@@ -48,7 +48,7 @@ namespace Xunit.ConsoleClient
                 Console.WriteLine("Starting:    {0}", Path.GetFileNameWithoutExtension(assemblyFileName));
 
             clock.Start();
-            watcher = new Thread(new ThreadStart(testWatcher));
+            watcher = new Thread(new ThreadStart(TestWatcher));
             watcher.IsBackground = true;
             watcher.Start();
 
@@ -124,7 +124,6 @@ namespace Xunit.ConsoleClient
                 }
             }
 
-
             if (!runningTests.TryAdd(testStarting.Test.DisplayName, clock.ElapsedMilliseconds))
             {
                 lock (consoleLock)
@@ -152,7 +151,7 @@ namespace Xunit.ConsoleClient
                     Console.WriteLine("ERROR: Failed to find {0} in running test set.", testFinished.Test.DisplayName);
                 }
             }
-            if (elapsed > longTestMaxMiliseconds)
+            if (elapsed > longTestMaxMilliseconds)
             {
                 lock (consoleLock)
                 {
@@ -241,13 +240,13 @@ namespace Xunit.ConsoleClient
             }
         }
 
-        private void testWatcher()
+        private void TestWatcher()
         {
             try
             {
                 while (runningTests != null)
                 {
-                    Thread.Sleep(longTestCheckMiliseconds);
+                    Thread.Sleep(longTestCheckMilliseconds);
 
                     if (runningTests == null)
                     {
@@ -255,9 +254,9 @@ namespace Xunit.ConsoleClient
                     }
 
                     long  now = clock.ElapsedMilliseconds;
-                    foreach (KeyValuePair<String, long> pair in runningTests)
+                    foreach (KeyValuePair<string, long> pair in runningTests)
                     {
-                        if (( now - pair.Value) > longTestMaxMiliseconds)
+                        if (( now - pair.Value) > longTestMaxMilliseconds)
                         {
                             lock (consoleLock)
                             {

--- a/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
@@ -267,7 +267,7 @@ namespace Xunit.ConsoleClient
                         {
                             lock (consoleLock)
                             {
-                                Console.WriteLine("WARNING: {0} is running for {1}ms.", pair.Key, now - pair.Value);
+                                Console.WriteLine("WARNING: {0} is running for {1}s.", pair.Key, (now - pair.Value) / 1000);
                             }
                         }
                     }

--- a/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Xml.Linq;
 using Xunit.Abstractions;
 
@@ -13,6 +16,12 @@ namespace Xunit.ConsoleClient
         readonly ConcurrentDictionary<string, ExecutionSummary> completionMessages;
         readonly string defaultDirectory;
         readonly bool showProgress;
+        readonly Stopwatch clock;
+        private ConcurrentDictionary<String, long> runningTests;
+        private Thread watcher;
+        readonly int longTestMaxMiliseconds = 1_000 * 60 * 5;
+        readonly int longTestCheckMiliseconds = 1_000 * 60;
+
 
         public StandardOutputVisitor(object consoleLock,
                                      string defaultDirectory,
@@ -26,6 +35,9 @@ namespace Xunit.ConsoleClient
             this.defaultDirectory = defaultDirectory;
             this.completionMessages = completionMessages;
             this.showProgress = showProgress;
+
+            this.clock =  new Stopwatch();
+            this.runningTests = new ConcurrentDictionary<String , long>();
         }
 
         protected override bool Visit(ITestAssemblyStarting assemblyStarting)
@@ -34,6 +46,11 @@ namespace Xunit.ConsoleClient
 
             lock (consoleLock)
                 Console.WriteLine("Starting:    {0}", Path.GetFileNameWithoutExtension(assemblyFileName));
+
+            clock.Start();
+            watcher = new Thread(new ThreadStart(testWatcher));
+            watcher.IsBackground = true;
+            watcher.Start();
 
             return base.Visit(assemblyStarting);
         }
@@ -56,6 +73,14 @@ namespace Xunit.ConsoleClient
                     Errors = Errors
                 });
 
+            if (watcher != null)
+            {
+            //    watcher.Interrupt();
+                //watcher.Abort();
+            //    watcher = null;
+            }
+            runningTests = null;
+            clock.Stop();
             return result;
         }
 
@@ -64,7 +89,7 @@ namespace Xunit.ConsoleClient
             lock (consoleLock)
             {
                 // TODO: Thread-safe way to figure out the default foreground color
-                
+
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.Error.WriteLine("   {0} [FAIL]", XmlEscape(testFailed.Test.DisplayName));
                 Console.ForegroundColor = ConsoleColor.Gray;
@@ -104,6 +129,16 @@ namespace Xunit.ConsoleClient
                     Console.WriteLine("   {0} [STARTING]", XmlEscape(testStarting.Test.DisplayName));
                 }
             }
+
+
+            if (!runningTests.TryAdd(testStarting.Test.DisplayName, clock.ElapsedMilliseconds))
+            {
+                lock (consoleLock)
+                {
+                    Console.WriteLine("ERROR: Failed to add {0} to running tests set.", testStarting.Test.DisplayName);
+                }
+            }
+
             return base.Visit(testStarting);
         }
 
@@ -116,6 +151,22 @@ namespace Xunit.ConsoleClient
                     Console.WriteLine("   {0} [FINISHED] Time: {1}s", XmlEscape(testFinished.Test.DisplayName), testFinished.ExecutionTime);
                 }
             }
+            if (!runningTests.TryRemove(testFinished.Test.DisplayName, out long elapsed))
+            {
+                lock (consoleLock)
+                {
+                    Console.WriteLine("ERROR: Failed to find {0} in running test set.", testFinished.Test.DisplayName);
+                }
+            }
+            if (elapsed > longTestMaxMiliseconds)
+            {
+                lock (consoleLock)
+                {
+                    Console.WriteLine("WARNING: Long running test {0} finished in {1}ms.", testFinished.Test.DisplayName, elapsed);
+                }
+
+            }
+
             return base.Visit(testFinished);
         }
 
@@ -194,6 +245,35 @@ namespace Xunit.ConsoleClient
             {
                 Console.Error.WriteLine("         {0}", StackFrameTransformer.TransformFrame(stackFrame, defaultDirectory));
             }
+        }
+
+        private void testWatcher()
+        {
+            try
+            {
+                while (runningTests != null)
+                {
+                    Thread.Sleep(longTestCheckMiliseconds);
+
+                    if (runningTests == null)
+                    {
+                        break;
+                    }
+
+                    long  now = clock.ElapsedMilliseconds;
+                    foreach (KeyValuePair<String, long> pair in runningTests)
+                    {
+                        if (( now - pair.Value) > longTestMaxMiliseconds)
+                        {
+                            lock (consoleLock)
+                            {
+                                Console.WriteLine("WARNING: {0} is running for {1}ms.", pair.Key, now - pair.Value);
+                            }
+                        }
+                    }
+                }
+            }
+            catch { };
         }
     }
 }

--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -52,6 +52,9 @@
     <Compile Include="Visitors\StandardOutputVisitor.cs" />
   </ItemGroup>
   <ItemGroup>
+      <Reference Include="System.Threading.Thread" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="xUnit1.xslt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
This is meant to improve our ability to triage hanging tests in CI runs. 

It is also somewhat temporary fix. The whole Visitor class is obsolete in current version on Xunit (2.3.x) and it will need to be re-written when we upgrade. 
In mean time, this should provide some more insight. It won't fore-fail tests (yet) but it should provide more visibility. 

I tested this using private tests with sleep as well as I followed instructions for dog-fooding and I modified one of HTTP tests to have incorrect async await. When I run the test, after 5 minutes I see following console output:

> Discovering: System.Net.Http.Functional.Tests
> Discovered:  System.Net.Http.Functional.Tests
> Starting:    System.Net.Http.Functional.Tests
>    System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress.ManyClients_ManyGets [SKIP]
>       Condition(s) not met: \"IsStressModeEnabled\"
>    System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress.CreateAndDestroyManyClients [SKIP]
>       Condition(s) not met: **\"IsStressModeEnabled\"
> ...
>   System.Net.Http.Functional.Tests.PlatformHandler_HttpClientHandlerTest.Ctor_ExpectedDefaultPropertyValues_UapPlatform [SKIP]
>       Condition(s) not met: \"IsUap\"
>    System.Net.Http.Functional.Tests.PlatformHandler_HttpClientHandlerTest.SendAsync_RequestVersion20_ResponseVersion20 [SKIP]
>       Condition(s) not met: \"IsWindows10Version1607OrGreater\"
> **WARNING: System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandlerTest.ProxyAuth_Digest_Succeeds is running for 348s.**
> WARNING: System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandlerTest.ProxyAuth_Digest_Succeeds is running for 408s.
> WARNING: System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandlerTest.ProxyAuth_Digest_Succeeds is running for 468s.
> WARNING: System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandlerTest.ProxyAuth_Digest_Succeeds is running for 528s.
> 

Note this did not make the time configurable. XUnit 2.3 has some parameters and we may want to watch them.  Since CI kills tests  in ~ 10 minutes, I use 5 delay and than 1 minute probes. 
 