### PR TITLE
Allow versioning.props to be imported directly.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <BuildToolsVersioningPropsImported>true</BuildToolsVersioningPropsImported>
+
     <Company Condition="'$(Company)' == ''">Microsoft Corporation</Company>
     <Copyright Condition="'$(Copyright)' == ''">%A9 Microsoft Corporation.  All rights reserved.</Copyright>
     <Description Condition="'$(Description)' == ''">$(AssemblyName)</Description>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildToolsVersioningPropsImported>true</BuildToolsVersioningPropsImported>
+    <BuildToolsVersioningPropsHasBeenImported>true</BuildToolsVersioningPropsHasBeenImported>
 
     <Company Condition="'$(Company)' == ''">Microsoft Corporation</Company>
     <Copyright Condition="'$(Copyright)' == ''">%A9 Microsoft Corporation.  All rights reserved.</Copyright>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -24,7 +24,7 @@
     <AssemblyFileVersion Condition="'$(AssemblyFileVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</AssemblyFileVersion>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)versioning.props" Condition="'$(BuildToolsVersioningPropsImported)' != 'true'" />
+  <Import Project="$(MSBuildThisFileDirectory)versioning.props" Condition="'$(BuildToolsVersioningPropsHasBeenImported)' != 'true'" />
 
   <PropertyGroup>
     <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">true</GenerateAssemblyInfo>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -24,7 +24,7 @@
     <AssemblyFileVersion Condition="'$(AssemblyFileVersion)'==''">$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)</AssemblyFileVersion>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)versioning.props" />
+  <Import Project="$(MSBuildThisFileDirectory)versioning.props" Condition="'$(BuildToolsVersioningPropsImported)' != 'true'" />
 
   <PropertyGroup>
     <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)'==''">true</GenerateAssemblyInfo>


### PR DESCRIPTION
When repo's try to use pieces of buildtools, they get warnings because the versioning.props file is already imported.  This change checks the versioning.props file is already imported, and not importing it again.