### PR TITLE
Disabling lldb

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/RunnerTemplate.Unix.txt
@@ -130,7 +130,7 @@ fi
 
 # ======================= BEGIN Core File Inspection =========================
 pushd $EXECUTION_DIR >/dev/null
-if [ "$(uname -s)" == "Linux" ]; then
+if [[ "$(uname -s)" == "Linux" && $test_exitcode -ne 0 ]]; then
   echo Looking around for any Linux dump...
   # Depending on distro/configuration, the core files may either be named "core"
   # or "core.<PID>" by default. We read /proc/sys/kernel/core_uses_pid to 


### PR DESCRIPTION
Related to https://github.com/dotnet/buildtools/issues/1995
Running lldb output only when the task fails