### PR TITLE
Pin to LangVersion 6 to match our official build machines

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -127,13 +127,13 @@
     <UseOpenKey>true</UseOpenKey>
   </PropertyGroup>
 
-  <!-- 
+  <!--
   Projects that have no OS-specific implementations just use Debug and Release for $(Configuration).
   Projects that do have OS-specific implementations use OS_Debug and OS_Release, for all OS's we support even
   if the code is the same between some OS's (so if you have some project that just calls POSIX APIs, we still have
   OSX_[Debug|Release] and Linux_[Debug|Release] configurations.  We do this so that we place all the output under
   a single binary folder and can have a similar experience between the command line and Visual Studio.
-  
+
   Since now have multiple *Debug and *Release configurations, ConfigurationGroup is set to Debug for any of the
   debug configurations, and to Release for any of the release configurations.
   -->
@@ -168,7 +168,7 @@
     <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
     <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
   </PropertyGroup>
-  
+
   <!-- Default Test platform to deploy the netstandard compiled tests to -->
   <PropertyGroup>
     <TestTFM Condition="'$(TestTFM)'==''">netcoreapp1.0</TestTFM>
@@ -184,6 +184,7 @@
 
   <!-- Set up handling of build warnings -->
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
+++ b/src/xunit.console.netcore/Visitors/StandardOutputVisitor.cs
@@ -19,8 +19,8 @@ namespace Xunit.ConsoleClient
         readonly Stopwatch clock;
         private ConcurrentDictionary<string, long> runningTests;
         private Thread watcher;
-        readonly int longTestMaxMilliseconds = 1_000 * 60 * 5;
-        readonly int longTestCheckMilliseconds = 1_000 * 60;
+        readonly int longTestMaxMilliseconds = 1000 * 60 * 5;
+        readonly int longTestCheckMilliseconds = 1000 * 60;
 
 
         public StandardOutputVisitor(object consoleLock,
@@ -144,7 +144,8 @@ namespace Xunit.ConsoleClient
                     Console.WriteLine("   {0} [FINISHED] Time: {1}s", XmlEscape(testFinished.Test.DisplayName), testFinished.ExecutionTime);
                 }
             }
-            if (!runningTests.TryRemove(testFinished.Test.DisplayName, out long elapsed))
+            long elapsed;
+            if (!runningTests.TryRemove(testFinished.Test.DisplayName, out elapsed))
             {
                 lock (consoleLock)
                 {


### PR DESCRIPTION
Currently our official builds still have msbuild 15 and an
older compiler so to prevent breaks we are pinning the version.

This also fixes the current breaks.

Fixes break in https://github.com/dotnet/buildtools/pull/1992/files#r180842286

cc @wfurt 