### PR TITLE
Don't preemptively omit inbox frameworks when creating trimmed dependencies

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/CreateTrimDependencyGroups.cs
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             var supportedInboxFrameworks = index.GetAlllInboxFrameworks().Where(fx => IsSupported(fx, resolver));
 
             var newDependencyGroups = new Queue<TaskItemPackageDependencyGroup>();
-            // For each inbox framework determine its best compatible dependency group
+            // For each inbox framework determine its best compatible dependency group and create an explictit group, trimming out any inbox dependencies
             foreach(var supportedInboxFramework in supportedInboxFrameworks)
             {
                 var nearestDependencyGroup = dependencyGroups.GetNearest(supportedInboxFramework);
@@ -94,13 +94,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                 {
                     // remove all dependencies which are inbox on supportedInboxFramework
                     var filteredDependencies = nearestDependencyGroup.Packages.Where(d => !index.IsInbox(d.Id, supportedInboxFramework, d.AssemblyVersion)).ToArray();
-
-                    // only create the new group if we removed some inbox dependencies
-                    if (filteredDependencies.Length != nearestDependencyGroup.Packages.Count)
-                    {
-                        // copy remaining dependencies
-                        newDependencyGroups.Enqueue(new TaskItemPackageDependencyGroup(supportedInboxFramework, filteredDependencies));
-                    }
+                    
+                    newDependencyGroups.Enqueue(new TaskItemPackageDependencyGroup(supportedInboxFramework, filteredDependencies));
                 }
             }
 


### PR DESCRIPTION
When creating trimmed dependency groups we cannot know if a group is redundant
during the first pass (since another group might be created).  Always create the group
and only trim in the second pass where we have the full set of dependency groups and
can know for certain if an addition is redundant.

Here's the diff after making this change: https://github.com/ericstj/scratch/commit/1db38c5c0777fb9fc9676a9aa3528be13e949c8f

It impacted a single project, the one with this issue: https://github.com/dotnet/corefx/issues/29149