### PR TITLE
Add ability to make feed container private even if no token is present

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -190,7 +190,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             }
         }
 
-        public async Task CreateContainerAsync(IBuildEngine buildEngine, bool publishFlatContainer)
+        public async Task CreateContainerAsync(IBuildEngine buildEngine, bool publishFlatContainer, bool isContainerPublic)
         {
             Log.LogMessage($"Creating container {feed.ContainerName}...");
 
@@ -200,7 +200,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 AccountName = feed.AccountName,
                 ContainerName = feed.ContainerName,
                 FailIfExists = false,
-                IsPublic = !hasToken,
+                IsPublic = isContainerPublic && !hasToken,
                 BuildEngine = buildEngine
             };
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -60,6 +60,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public string ManifestBuildData { get; set; }
 
         /// <summary>
+        /// If the ExpectedFeedUrl includes an authentication token, this property is ignored.
+        /// </summary>
+        public bool MakeContainerPublic { get; set; } = true;
+
+        /// <summary>
         /// When publishing build outputs to an orchestrated blob feed, do not change this property.
         /// 
         /// The virtual dir to place the manifest XML file in, under the assets/ virtual dir. The
@@ -92,7 +97,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
 
                     if (!SkipCreateContainer)
                     {
-                        await blobFeedAction.CreateContainerAsync(BuildEngine, PublishFlatContainer);
+                        await blobFeedAction.CreateContainerAsync(BuildEngine, PublishFlatContainer, MakeContainerPublic);
                     }
 
                     if (PublishFlatContainer)


### PR DESCRIPTION
This change allows the task to be called with an optional MakeContainerPublic param that can be overridden to create a private container.