### PR TITLE
Add support for named operands in ApiCompat

### DIFF
--- a/src/ApiCompat/ApiCompat.csproj
+++ b/src/ApiCompat/ApiCompat.csproj
@@ -20,6 +20,7 @@
     <Compile Include="NamespaceRemappingComparer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="PublicEditorBrowsableOnlyCciFilter.cs" />
+    <Compile Include="Rules\Compat\DifferenceRule.cs" />
     <Compile Include="Rules\Compat\AttributeDifference.cs" />
     <Compile Include="Rules\Compat\CannotAddAbstractMembers.cs" />
     <Compile Include="Rules\Compat\CannotMakeNonVirtual.cs" />
@@ -33,6 +34,7 @@
     <Compile Include="Rules\Compat\CannotRemoveGenerics.cs" />
     <Compile Include="Rules\Compat\TypeCannotChangeClassification.cs" />
     <Compile Include="Rules\Compat\TypesMustExist.cs" />
+    <Compile Include="Rules\Compat\IDifferenceOperands.cs" />
     <Compile Include="Rules\ParameterTypeCannotChange.cs" />
     <Compile Include="Rules\Compat\ParameterModifiersCannotChange.cs" />
     <Compile Include="Rules\InheritanceHierarchyChangeTracker.cs" />

--- a/src/ApiCompat/DifferenceWriter.cs
+++ b/src/ApiCompat/DifferenceWriter.cs
@@ -11,7 +11,7 @@ using Microsoft.Cci.Filters;
 using Microsoft.Cci.Mappings;
 using Microsoft.Cci.Traversers;
 using System;
-
+using System.Composition;
 
 namespace Microsoft.Cci.Writers
 {
@@ -21,6 +21,9 @@ namespace Microsoft.Cci.Writers
         private readonly TextWriter _writer;
         private int _totalDifferences = 0;
         public static int ExitCode { get; set; }
+
+        [Import]
+        public IDifferenceOperands Operands { get; set; }
 
         public DifferenceWriter(TextWriter writer, MappingSettings settings, IDifferenceFilter filter)
             : base(settings, filter)
@@ -37,7 +40,7 @@ namespace Microsoft.Cci.Writers
             {
                 if (_differences.Count > 0)
                 {
-                    string header = string.Format("Compat issues between implementation set {0} and contract set {1}:", oldAssembliesName, newAssembliesName);
+                    string header = $"Compat issues between {Operands.Right} set {oldAssembliesName} and {Operands.Left} set {newAssembliesName}:";
                     OutputDifferences(header, _differences);
                     _totalDifferences += _differences.Count;
                     _differences.Clear();

--- a/src/ApiCompat/Program.cs
+++ b/src/ApiCompat/Program.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Microsoft.Cci;
 using Microsoft.Cci.Comparers;
 using Microsoft.Cci.Differs;
+using Microsoft.Cci.Differs.Rules;
 using Microsoft.Cci.Extensions;
 using Microsoft.Cci.Filters;
 using Microsoft.Cci.Mappings;
@@ -25,13 +26,19 @@ namespace ApiCompat
     public class ExportCciSettings
     {
         public static IEqualityComparer<ITypeReference> StaticSettings { get; set; }
+        public static IDifferenceOperands  StaticOperands { get; set; }
+
         public ExportCciSettings()
         {
             Settings = StaticSettings;
+            Operands = StaticOperands;
         }
 
         [Export(typeof(IEqualityComparer<ITypeReference>))]
-        public IEqualityComparer<ITypeReference> Settings { get; set; }
+        public IEqualityComparer<ITypeReference> Settings { get; }
+
+        [Export(typeof(IDifferenceOperands))]
+        public IDifferenceOperands Operands { get; }
     }
 
     public class Program
@@ -122,12 +129,12 @@ namespace ApiCompat
 
         private static void implHost_UnableToResolve(object sender, UnresolvedReference<IUnit, AssemblyIdentity> e)
         {
-            Trace.TraceError("Unable to resolve assembly '{0}' referenced by the implementation assembly '{1}'.", e.Unresolved, e.Referrer);
+            Trace.TraceError($"Unable to resolve assembly '{e.Unresolved}' referenced by the {s_rightOperand} assembly '{e.Referrer}'.");
         }
 
         private static void contractHost_UnableToResolve(object sender, UnresolvedReference<IUnit, AssemblyIdentity> e)
         {
-            Trace.TraceError("Unable to resolve assembly '{0}' referenced by the contract assembly '{1}'.", e.Unresolved, e.Referrer);
+            Trace.TraceError($"Unable to resolve assembly '{e.Unresolved}' referenced by the {s_leftOperand} assembly '{e.Referrer}'.");
         }
 
         private static TextWriter GetOutput()
@@ -186,6 +193,11 @@ namespace ApiCompat
 
             ICciDifferenceWriter diffWriter = new DifferenceWriter(writer, settings, filter);
             ExportCciSettings.StaticSettings = settings.TypeComparer;
+            ExportCciSettings.StaticOperands = new DifferenceOperands()
+            {
+                Left = s_leftOperand,
+                Right = s_rightOperand,
+            };
 
             // Always compose the diff writer to allow it to import or provide exports
             container.SatisfyImports(diffWriter);
@@ -276,6 +288,10 @@ namespace ApiCompat
                 parser.DefineOptionalQualifier("mdil", ref s_mdil, "Enforce MDIL servicing rules in addition to IL rules.");
                 parser.DefineAliases("excludeNonBrowsable", "enb");
                 parser.DefineOptionalQualifier("excludeNonBrowsable", ref s_excludeNonBrowsable, "When MDIL servicing rules are not being enforced, exclude validation on types that are marked with EditorBrowsable(EditorBrowsableState.Never).");
+                parser.DefineAliases("leftOperand", "lhs");
+                parser.DefineOptionalQualifier("leftOperand", ref s_leftOperand, "Name for left operand in comparison, default is 'contract'.");
+                parser.DefineAliases("rightOperand", "rhs");
+                parser.DefineOptionalQualifier("rightOperand", ref s_rightOperand, "Name for right operand in comparison, default is 'implementation'.");
                 parser.DefineParameter<string>("contracts", ref s_contractSet, "Comma delimited list of assemblies or directories of assemblies for all the contract assemblies.");
             }, args);
         }
@@ -288,6 +304,8 @@ namespace ApiCompat
         private static string s_outFile;
         private static string s_baselineFileName;
         private static string s_remapFile;
+        private static string s_leftOperand = "contract";
+        private static string s_rightOperand = "implementation";
         private static bool s_groupByAssembly = true;
         private static bool s_mdil;
         private static bool s_resolveFx;

--- a/src/ApiCompat/Rules/Compat/AttributeDifference.cs
+++ b/src/ApiCompat/Rules/Compat/AttributeDifference.cs
@@ -141,8 +141,7 @@ namespace Microsoft.Cci.Differs.Rules
                             AttributeAdded(target, attribName);
 
                             differences.AddIncompatibleDifference("CannotAddAttribute",
-                                "Attribute '{0}' exists on '{1}' in the implementation but not the contract.",
-                                attribName, target.FullName());
+                                $"Attribute '{attribName}' exists on '{target.FullName()}' in the {Right} but not the {Left}.");
 
                             break;
                         }
@@ -160,8 +159,7 @@ namespace Microsoft.Cci.Differs.Rules
                                 break;
 
                             differences.AddIncompatibleDifference("CannotRemoveAttribute",
-                                "Attribute '{0}' exists on '{1}' in the contract but not the implementation.",
-                                attribName, target.FullName());
+                                $"Attribute '{attribName}' exists on '{target.FullName()}' in the {Left} but not the {Right}.");
 
                             break;
                         }

--- a/src/ApiCompat/Rules/Compat/CannotAddAbstractMembers.cs
+++ b/src/ApiCompat/Rules/Compat/CannotAddAbstractMembers.cs
@@ -27,8 +27,7 @@ namespace Microsoft.Cci.Differs.Rules
                     return DifferenceType.Unknown;
 
                 differences.AddIncompatibleDifference(this,
-                    "Member '{0}' is abstract in the implementation but is missing in the contract.",
-                    impl.FullName());
+                    $"Member '{impl.FullName()}' is abstract in the {Right} but is missing in the {Left}.");
                 return DifferenceType.Changed;
             }
             return DifferenceType.Unknown;

--- a/src/ApiCompat/Rules/Compat/CannotAddAttributes.cs
+++ b/src/ApiCompat/Rules/Compat/CannotAddAttributes.cs
@@ -106,8 +106,7 @@ namespace Microsoft.Cci.Differs.Rules
                             break;
 
                         differences.AddIncompatibleDifference(this,
-                            "Attribute '{0}' exists in the contract but not the implementation.",
-                            attribName, target.FullName());
+                            $"Attribute '{attribName}' exists in the {Left} but not the {Right}.");
 
                         added = true;
 

--- a/src/ApiCompat/Rules/Compat/CannotMakeAbstract.cs
+++ b/src/ApiCompat/Rules/Compat/CannotMakeAbstract.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (impl.IsAbstract() && !contract.IsAbstract())
             {
                 differences.AddIncompatibleDifference("CannotMakeMemberAbstract",
-                    "Member '{0}' is abstract in the implementation but is not abstract in the contract.",
-                    impl.FullName());
+                    $"Member '{impl.FullName()}' is abstract in the {Right} but is not abstract in the {Left}.");
 
                 return DifferenceType.Changed;
             }
@@ -35,8 +34,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (impl.IsAbstract && !contract.IsAbstract)
             {
                 differences.AddIncompatibleDifference("CannotMakeTypeAbstract",
-                    "Type '{0}' is abstract in the implementation but is not abstract in the contract.",
-                    impl.FullName());
+                    $"Type '{impl.FullName()}' is abstract in the {Right} but is not abstract in the {Left}.");
 
                 return DifferenceType.Changed;
             }

--- a/src/ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
+++ b/src/ApiCompat/Rules/Compat/CannotMakeMoreVisible.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (contract.Visibility != TypeMemberVisibility.Family && contract.Visibility != TypeMemberVisibility.FamilyOrAssembly)
                 {
                     differences.AddIncompatibleDifference(this,
-                        "Visibility of member '{0}' is '{1}' in the implementation but '{2}' in the contract.",
-                        impl.FullName(), impl.Visibility, contract.Visibility);
+                        $"Visibility of member '{impl.FullName()}' is '{impl.Visibility}' in the {Right} but '{contract.Visibility}' in the {Left}.");
                     return DifferenceType.Changed;
                 }
             }
@@ -50,8 +49,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (contract.GetVisibility() != TypeMemberVisibility.Family && contract.GetVisibility() != TypeMemberVisibility.FamilyOrAssembly)
                 {
                     differences.AddIncompatibleDifference(this,
-                        "Visibility of type '{0}' is '{1}' in the implementation but '{2}' in the contract.",
-                        impl.FullName(), impl.GetVisibility(), contract.GetVisibility());
+                        $"Visibility of type '{impl.FullName()}' is '{impl.GetVisibility()}' in the {Right} but '{contract.GetVisibility()}' in the {Left}.");
                     return DifferenceType.Changed;
                 }
             }

--- a/src/ApiCompat/Rules/Compat/CannotMakeNonVirtual.cs
+++ b/src/ApiCompat/Rules/Compat/CannotMakeNonVirtual.cs
@@ -34,8 +34,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (isContractOverridable && !isImplOverridable)
             {
                 differences.AddIncompatibleDifference("CannotMakeMemberNonVirtual",
-                    "Member '{0}' is non-virtual in the implementation but is virtual in the contract.",
-                    impl.FullName());
+                    $"Member '{impl.FullName()}' is non-virtual in the {Right} but is virtual in the {Left}.");
 
                 return DifferenceType.Changed;
             }

--- a/src/ApiCompat/Rules/Compat/CannotRemoveBaseTypeOrInterface.cs
+++ b/src/ApiCompat/Rules/Compat/CannotRemoveBaseTypeOrInterface.cs
@@ -43,8 +43,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (lastIndex < 0)
                 {
                     differences.AddIncompatibleDifference(this,
-                        "Type '{0}' does not inherit from base type '{1}' in the implementation but it does in the contract.",
-                        contract.FullName(), contractBaseType.FullName());
+                        $"Type '{contract.FullName()}' does not inherit from base type '{contractBaseType.FullName()}' in the {Right} but it does in the {Left}.");
                     return true;
                 }
             }
@@ -66,8 +65,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (!implInterfaces.Contains(contractInterface))
                 {
                     differences.AddIncompatibleDifference(this,
-                        "Type '{0}' does not implement interface '{1}' in the implementation but it does in the contract.",
-                            contract.FullName(), contractInterface.FullName());
+                        $"Type '{contract.FullName()}' does not implement interface '{contractInterface.FullName()}' in the {Right} but it does in the {Left}.");
                     return true;
                 }
             }

--- a/src/ApiCompat/Rules/Compat/CannotRemoveGenerics.cs
+++ b/src/ApiCompat/Rules/Compat/CannotRemoveGenerics.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Cci.Differs.Rules
                     contractParam.Variance != implParam.Variance)
                 {
                     differences.AddIncompatibleDifference("CannotChangeVariance",
-                        "Variance on generic parameter '{0}' for '{1}' is '{2}' in the implementation but '{3}' in the contract.",
-                        implParam.FullName(), target.FullName(), implParam.Variance, contractParam.Variance);
+                        $"Variance on generic parameter '{implParam.FullName()}' for '{target.FullName()}' is '{implParam.Variance}' in the {Right} but '{contractParam.Variance}' in the {Left}.");
                 }
 
                 string implConstraints = string.Join(",", GetConstraints(implParam).OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
@@ -66,8 +65,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (!string.Equals(implConstraints, contractConstraints))
                 {
                     differences.AddIncompatibleDifference("CannotChangeGenericConstraints",
-                        "Constraints for generic parameter '{0}' for '{1}' is '{2}' in the implementation but '{3}' in the contract.",
-                        implParam.FullName(), target.FullName(), implConstraints, contractConstraints);
+                        $"Constraints for generic parameter '{implParam.FullName()}' for '{target.FullName()}' is '{implConstraints}' in the {Right} but '{contractConstraints}' in the {Left}.");
                 }
             }
 

--- a/src/ApiCompat/Rules/Compat/CannotSealType.cs
+++ b/src/ApiCompat/Rules/Compat/CannotSealType.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (impl.IsEffectivelySealed() && !contract.IsEffectivelySealed())
             {
                 differences.AddIncompatibleDifference(this,
-                    "Type '{0}' is sealed in the implementation but not sealed in the contract.", impl.FullName());
+                    $"Type '{impl.FullName()}' is sealed in the {Right} but not sealed in the {Left}.");
 
                 return DifferenceType.Changed;
             }

--- a/src/ApiCompat/Rules/Compat/DelegatesMustMatch.cs
+++ b/src/ApiCompat/Rules/Compat/DelegatesMustMatch.cs
@@ -48,8 +48,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (!_typeComparer.Equals(implReturnType, contractReturnType))
             {
                 differences.AddTypeMismatchDifference("DelegateReturnTypesMustMatch", implReturnType, contractReturnType,
-                    "Return type on delegate '{0}' is '{1}' in the implementation but '{2}' in the contract.",
-                    implMethod.ContainingType.FullName(), implReturnType.FullName(), contractReturnType.FullName());
+                    $"Return type on delegate '{implMethod.ContainingType.FullName()}' is '{implReturnType.FullName()}' in the {Right} but '{contractReturnType.FullName()}' in the {Left}.");
                 return false;
             }
 
@@ -74,16 +73,14 @@ namespace Microsoft.Cci.Differs.Rules
                 if (!implParam.Name.Value.Equals(contractParam.Name.Value))
                 {
                     differences.AddIncompatibleDifference("DelegateParamNameMustMatch",
-                        "Parameter name on delegate '{0}' is '{1}' in the implementation but '{2}' in the contract.",
-                        implMethod.ContainingType.FullName(), implParam.Name.Value, contractParam.Name.Value);
+                        $"Parameter name on delegate '{implMethod.ContainingType.FullName()}' is '{implParam.Name.Value}' in the {Right} but '{contractParam.Name.Value}' in the {Left}.");
                     match = false;
                 }
 
                 if (!_typeComparer.Equals(implParam.Type, contractParam.Type))
                 {
                     differences.AddTypeMismatchDifference("DelegateParamTypeMustMatch", implParam.Type, contractParam.Type,
-                        "Type for parameter '{0}' on delegate '{1}' is '{2}' in the implementation but '{3}' in the contract.",
-                        implParam.Name.Value, implMethod.ContainingType.FullName(), implParam.Type.FullName(), contractParam.Type.FullName());
+                        $"Type for parameter '{implParam.Name.Value}' on delegate '{implMethod.ContainingType.FullName()}' is '{implParam.Type.FullName()}' in the {Right} but '{contractParam.Type.FullName()}' in the {Left}.");
                     match = false;
                 }
             }

--- a/src/ApiCompat/Rules/Compat/DifferenceRule.cs
+++ b/src/ApiCompat/Rules/Compat/DifferenceRule.cs
@@ -1,0 +1,13 @@
+﻿using System.Composition;
+
+namespace Microsoft.Cci.Differs.Rules
+{
+    internal abstract class DifferenceRule : Microsoft.Cci.Differs.DifferenceRule
+    {
+        [Import]
+        public IDifferenceOperands Operands { get; set; }
+
+        public string Left => Operands?.Left ?? "contract";
+        public string Right => Operands?.Right ?? "implementation";
+    }
+}

--- a/src/ApiCompat/Rules/Compat/EnumTypesMustMatch.cs
+++ b/src/ApiCompat/Rules/Compat/EnumTypesMustMatch.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (!_typeComparer.Equals(implType, contractType))
             {
                 differences.AddTypeMismatchDifference(this, implType, contractType,
-                    "Enum type for '{0}' is '{1}' in implementation but '{2}' in the contract.",
-                    impl.FullName(), implType.FullName(), contractType.FullName());
+                    $"Enum type for '{impl.FullName()}' is '{implType.FullName()}' in {Right} but '{contractType.FullName()}' in the {Left}.");
                 return DifferenceType.Changed;
             }
 

--- a/src/ApiCompat/Rules/Compat/EnumValuesMustMatch.cs
+++ b/src/ApiCompat/Rules/Compat/EnumValuesMustMatch.cs
@@ -35,9 +35,7 @@ namespace Microsoft.Cci.Differs.Rules
                 ITypeReference contractValType = contract.ContainingTypeDefinition.GetEnumType();
 
                 differences.AddIncompatibleDifference(this,
-                    "Enum value '{0}' is ({1}){2} in the implementation but ({3}){4} in the contract.",
-                    implField.FullName(), implValType.FullName(), implField.Constant.Value,
-                    contractValType.FullName(), contractField.Constant.Value);
+                    $"Enum value '{implField.FullName()}' is ({implValType.FullName()}){implField.Constant.Value} in the {Right} but ({contractValType.FullName()}){contractField.Constant.Value} in the {Left}.");
                 return DifferenceType.Changed;
             }
 

--- a/src/ApiCompat/Rules/Compat/IDifferenceOperands.cs
+++ b/src/ApiCompat/Rules/Compat/IDifferenceOperands.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Cci.Differs
+{
+    /// <summary>
+    /// Names for the left and right operands of a difference
+    /// </summary>
+    public interface IDifferenceOperands
+    {
+        /// <summary>
+        /// Name of left operand of a difference operation.  Typically called a contract or reference.
+        /// </summary>
+        string Left { get; }
+        /// <summary>
+        /// Name of right operand of a difference operation.  Typically called an implemenation.
+        /// </summary>
+        string Right { get; }
+    }
+
+    public class DifferenceOperands : IDifferenceOperands
+    {
+        public string Left { get; set; }
+
+        public string Right { get; set; }
+    }
+}

--- a/src/ApiCompat/Rules/Compat/InterfacesShouldHaveSameMembers.cs
+++ b/src/ApiCompat/Rules/Compat/InterfacesShouldHaveSameMembers.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Cci.Differs.Rules
             {
                 if (contract.ContainingTypeDefinition.IsInterface)
                 {
-                    differences.AddIncompatibleDifference(this, "Contract interface member '{0}' is not in the implementation.", contract.FullName());
+                    differences.AddIncompatibleDifference(this, $"Interface member '{contract.FullName()}' is present in the {Left} but not in the {Right}.");
                     return DifferenceType.Changed;
                 }
             }
@@ -30,7 +30,7 @@ namespace Microsoft.Cci.Differs.Rules
             {
                 if (impl.ContainingTypeDefinition.IsInterface)
                 {
-                    differences.AddIncompatibleDifference(this, "Implementation interface member '{0}' is not in the contract.", impl.FullName());
+                    differences.AddIncompatibleDifference(this, $"Interface member '{impl.FullName()}' is present in the {Right} but not in the {Left}.");
                     return DifferenceType.Changed;
                 }
             }

--- a/src/ApiCompat/Rules/Compat/MembersMustExist.cs
+++ b/src/ApiCompat/Rules/Compat/MembersMustExist.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Cci.Differs.Rules
             if (!(contractMember is IMethodDefinition || contractMember is IFieldDefinition))
                 return DifferenceType.Unknown;
 
-            string incompatibeDifferenceMessage = string.Format("Member '{0}' does not exist in the implementation but it does exist in the contract.", contractMember.FullName());
-            string returnTypeChangedMessageFormat = "Member '{0}' does not exist, but there does exist a member with return type '{1}' instead of '{2}'";
+            string incompatibeDifferenceMessage = $"Member '{contractMember.FullName()}' does not exist in the {Right} but it does exist in the {Left}.";
+
             ITypeDefinition contractType = mapping.ContainingType[0];
             if (contractType != null)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.Cci.Differs.Rules
                     if (lookForMethodInBaseResult == FindMethodResult.Found)
                         return DifferenceType.Unknown;
                     if (lookForMethodInBaseResult == FindMethodResult.ReturnTypeChanged)
-                        incompatibeDifferenceMessage = string.Format(returnTypeChangedMessageFormat, foundMethod.FullName(), foundMethod.GetReturnType().FullName(), contractMethod.GetReturnType().FullName());
+                        incompatibeDifferenceMessage += $" There does exist a member with return type '{foundMethod.GetReturnType().FullName()}' instead of '{contractMethod.GetReturnType().FullName()}'";
                 }
             }
 

--- a/src/ApiCompat/Rules/Compat/ParameterModifiersCannotChange.cs
+++ b/src/ApiCompat/Rules/Compat/ParameterModifiersCannotChange.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (GetModifier(implParam) != GetModifier(contractParam))
                 {
                     differences.AddIncompatibleDifference(this,
-                        "Modifiers on parameter '{0}' on method '{1}' are '{2}' in the implementation but '{3}' in the contract.",
-                        implParam.Name.Value, implMethod.FullName(), GetModifier(implParam), GetModifier(contractParam));
+                        $"Modifiers on parameter '{implParam.Name.Value}' on method '{implMethod.FullName()}' are '{GetModifier(implParam)}' in the {Right} but '{GetModifier(contractParam)}' in the {Left}.");
                     match = false;
                 }
 
@@ -68,8 +67,7 @@ namespace Microsoft.Cci.Differs.Rules
                     if (implParam.CustomModifiers.Count() != union.Count())
                     {
                         differences.AddIncompatibleDifference(this,
-                            "Custom modifiers on parameter '{0}' on method '{1}' are '{2}' in the implementation but '{3}' in the contract.",
-                            implParam.Name.Value, implMethod.FullName(), PrintCustomModifiers(implParam.CustomModifiers), PrintCustomModifiers(contractParam.CustomModifiers));
+                            $"Custom modifiers on parameter '{implParam.Name.Value}' on method '{implMethod.FullName()}' are '{PrintCustomModifiers(implParam.CustomModifiers)}' in the {Right} but '{PrintCustomModifiers(contractParam.CustomModifiers)}' in the {Left}.");
                         match = false;
                     }
                 }
@@ -81,8 +79,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (implReturnModifier != contractReturnModifier)
             {
                 differences.AddIncompatibleDifference(this,
-                    "Modifiers on return type of method '{0}' are '{1}' in the implementation but '{2}' in the contract.",
-                    implMethod.FullName(), implReturnModifier, contractReturnModifier);
+                    $"Modifiers on return type of method '{implMethod.FullName()}' are '{implReturnModifier}' in the {Right} but '{contractReturnModifier}' in the {Left}.");
                 match = false;
             }
 

--- a/src/ApiCompat/Rules/Compat/ParameterNamesCannotChange.cs
+++ b/src/ApiCompat/Rules/Compat/ParameterNamesCannotChange.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (!implParam.Name.Value.Equals(contractParam.Name.Value))
                 {
                     differences.AddIncompatibleDifference(this,
-                        "Parameter name on member '{0}' is '{1}' in the implementation but '{2}' in the contract.",
-                        implMethod.FullName(), implParam.Name.Value, contractParam.Name.Value);
+                        $"Parameter name on member '{implMethod.FullName()}' is '{implParam.Name.Value}' in the {Right} but '{contractParam.Name.Value}' in the {Left}.");
                     match = false;
                 }
             }

--- a/src/ApiCompat/Rules/Compat/TypeCannotChangeClassification.cs
+++ b/src/ApiCompat/Rules/Compat/TypeCannotChangeClassification.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (implObjType != contractObjType)
             {
                 differences.AddIncompatibleDifference(this,
-                    "Type '{0}' is a '{1}' in the implementation but is a '{2}' in the contract.",
-                    impl.FullName(), implObjType, contractObjType);
+                    $"Type '{impl.FullName()}' is a '{implObjType}' in the {Right} but is a '{contractObjType}' in the {Left}.");
 
                 return DifferenceType.Changed;
             }
@@ -30,8 +29,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (contract.Attributes.HasIsReadOnlyAttribute() && !impl.Attributes.HasIsReadOnlyAttribute())
             {
                 differences.AddIncompatibleDifference(this,
-                    "Type '{0}' is marked as readonly in the contract so it must also be marked readonly in the implementation.",
-                    impl.FullName());
+                    $"Type '{impl.FullName()}' is marked as readonly in the {Left} so it must also be marked readonly in the {Right}.");
 
                 return DifferenceType.Changed;
             }

--- a/src/ApiCompat/Rules/Compat/TypesMustAlwaysImplementIDisposable.cs
+++ b/src/ApiCompat/Rules/Compat/TypesMustAlwaysImplementIDisposable.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Cci.Differs.Rules
             if (ImplementsIDisposable(impl) && !ImplementsIDisposable(contract))
             {
                 differences.AddIncompatibleDifference(this,
-                    "Type '{0}' implements IDisposable in the implementation but not the contract.",
-                    impl.FullName());
+                    $"Type '{impl.FullName()}' implements IDisposable in the {Right} but not the {Left}.");
                 return DifferenceType.Changed;
             }
 

--- a/src/ApiCompat/Rules/Compat/TypesMustExist.cs
+++ b/src/ApiCompat/Rules/Compat/TypesMustExist.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Cci.Differs.Rules
                 if (!ReportAsMembersMustExist(contract, differences))
                 {
                     differences.AddIncompatibleDifference(this,
-                        "Type '{0}' does not exist in the implementation but it does exist in the contract.", contract.FullName());
+                        $"Type '{contract.FullName()}' does not exist in the {Right} but it does exist in the {Left}.");
                 }
 
                 return DifferenceType.Added;
@@ -40,7 +40,7 @@ namespace Microsoft.Cci.Differs.Rules
             //    {
             //        differences.AddIncompatibleDifference(
             //            "MembersMustExist",
-            //            "Member '{0}' does not exist in the implementation but it does exist in the contract.", member.FullName());
+            //            $"Member '{member.FullName()}' does not exist in the {Right} but it does exist in the {Left}.");
             //        specialCasedViolation = true;
             //    }
             //}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
@@ -93,7 +93,9 @@
     <PropertyGroup>
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) "$(ImplemetnationAssemblyAsContract)"</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -contractDepends:"@(_ContractDependencyDirectories, ','),"</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -lhs:implementation</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -implDirs:"@(_ImplementationDependencyDirectories, ','),"</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -rhs:reference</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs Condition="'$(BaselineAllMatchingRefApiCompatError)'!='true' and Exists('$(MatchingRefApiCompatBaseline)')">$(MatchingRefApiCompatArgs) -baseline:"$(MatchingRefApiCompatBaseline)"</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatBaselineAll Condition="'$(BaselineAllMatchingRefApiCompatError)'=='true'">&gt; $(MatchingRefApiCompatBaseline)</MatchingRefApiCompatBaselineAll>
 


### PR DESCRIPTION
In the case we run reverse API compat we swap the names of the operands so that it
makes sense.