### PR TITLE
Updating DefaultTarget property

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,4 +1,4 @@
 Microsoft.DotNet.BuildTools=1.0.27-prerelease-01205-03
 Microsoft.DotNet.BuildTools.Run=1.0.1-prerelease-01205-03
-Microsoft.DotNet.Build.Tasks.Feed=2.2.0-preview1-02801-01
+Microsoft.DotNet.Build.Tasks.Feed=1.0.0-prerelease-02131-03 
 NuGet.CommandLine=3.4.3

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PackageFiles/Microsoft.DotNet.Build.Tasks.Feed.targets
@@ -1,4 +1,4 @@
-<Project ToolsVersion="12.0" DefaultTargets="PublishOutputLeg" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="PublishPackagesToBlobFeed" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     Publish targets:
       PublishPackagesToBlobFeed


### PR DESCRIPTION
Before it was pointing to a target that no longer existed. Also reverted the version to the previous one so this is actually published. Will need to update the version to the package containing this change in a following PR