### PR TITLE
Add XUnitFilter wrapper to exclude Methods, Classes and Namespaces

### DIFF
--- a/src/xunit.console.netcore/CommandLine.cs
+++ b/src/xunit.console.netcore/CommandLine.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Xunit.ConsoleClient.Project;
 
 namespace Xunit.ConsoleClient
 {
@@ -25,7 +26,7 @@ namespace Xunit.ConsoleClient
 
         public int? MaxParallelThreads { get; set; }
 
-        public XunitProject Project { get; protected set; }
+        public ExtendedXunitProject Project { get; protected set; }
 
         public bool? ParallelizeAssemblies { get; protected set; }
 
@@ -40,9 +41,9 @@ namespace Xunit.ConsoleClient
         public bool Wait { get; protected set; }
 
 
-        static XunitProject GetProjectFile(List<Tuple<string, string>> assemblies)
+        static ExtendedXunitProject GetProjectFile(List<Tuple<string, string>> assemblies)
         {
-            var result = new XunitProject();
+            var result = new ExtendedXunitProject();
 
             foreach (var assembly in assemblies)
                 result.Add(new XunitProjectAssembly
@@ -65,7 +66,7 @@ namespace Xunit.ConsoleClient
             return new CommandLine(args);
         }
 
-        protected XunitProject Parse(Predicate<string> fileExists)
+        protected ExtendedXunitProject Parse(Predicate<string> fileExists)
         {
             var assemblies = new List<Tuple<string, string>>();
 
@@ -222,6 +223,25 @@ namespace Xunit.ConsoleClient
                         throw new ArgumentException("missing argument for -method");
 
                     project.Filters.IncludedMethods.Add(option.Value);
+                }
+                else if (optionName == "-skipmethod")
+                {
+                    if (option.Value == null)
+                        throw new ArgumentException("missing argument for -skipmethod");
+                    project.Filters.ExcludedMethods.Add(option.Value);
+
+                }
+                else if (optionName == "-skipclass")
+                {
+                    if (option.Value == null)
+                        throw new ArgumentException("missing argument for -skipclass");
+                    project.Filters.ExcludedClasses.Add(option.Value);
+                }
+                else if (optionName == "-skipnamespace")
+                {
+                    if (option.Value == null)
+                        throw new ArgumentException("missing argument for -skipnamespace");
+                    project.Filters.ExcludedNamespaces.Add(option.Value);
                 }
                 else
                 {

--- a/src/xunit.console.netcore/CommandLine.cs
+++ b/src/xunit.console.netcore/CommandLine.cs
@@ -38,11 +38,8 @@ namespace Xunit.ConsoleClient
         /// </summary>
         /// <param name="responseFile">Path to the response file</param>
         /// <param name="arguments">The data structure in</param>
-        private IList<string> ParseResponseFile(string responseFile, char[] delimiters = null)
+        private IList<string> ParseResponseFile(string responseFile)
         {
-            // Accept formats of both -Qualifier Name and -Qualifier:Name
-            if (delimiters == null)
-                delimiters = new char[] { ' ', ':' };
 
             var argumentsList = new List<string>();
 
@@ -55,7 +52,7 @@ namespace Xunit.ConsoleClient
                 string cleanLine = line.Trim();
                 if (string.IsNullOrEmpty(cleanLine))
                     continue;
-                var rspArguments = cleanLine.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+                var rspArguments = cleanLine.Split();
                 foreach(string arg in rspArguments)
                     argumentsList.Add(arg);
             }

--- a/src/xunit.console.netcore/Filters/ExtendedXunitFilters.cs
+++ b/src/xunit.console.netcore/Filters/ExtendedXunitFilters.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Xunit.ConsoleClient.Filters
+{
+    /// <summary>
+    /// Wrapper class, which hides XunitFilters' Filter method and adds logic to exclude methods or namespaces
+    /// </summary>
+    public class ExtendedXunitFilters : XunitFilters
+    {
+        public HashSet<string> ExcludedMethods { get; private set; }
+        public HashSet<string> ExcludedClasses { get; private set; }
+        public HashSet<string> ExcludedNamespaces { get; private set; }
+
+        public ExtendedXunitFilters() : base()
+        {
+            ExcludedMethods = new HashSet<string>();
+            ExcludedClasses = new HashSet<string>();
+            ExcludedNamespaces = new HashSet<string>();
+        }
+
+        /// <summary>
+        /// Determine whether a passed test case should run
+        /// </summary>
+        /// <param name="testCase">Test case to filter</param>
+        /// <returns>Boolean - True runs the test case, False skips</returns>
+        public new bool Filter(ITestCase testCase)
+        {
+            // Exclusions supersede inclusions - i.e. if a method/class/namespace is both included and excluded it won't run
+            return FilterExcludedMethodsAndClasses(testCase) && base.Filter(testCase);
+        }
+
+        bool FilterExcludedMethodsAndClasses(ITestCase testCase)
+        {
+            // If no explicit exclusions have been defined, return true
+            if (ExcludedMethods.Count == 0 && ExcludedClasses.Count == 0 && ExcludedNamespaces.Count == 0)
+                return true;
+
+            if (ExcludedClasses.Count != 0 && ExcludedClasses.Contains(testCase.TestMethod.TestClass.Class.Name))
+                return false;
+
+            var methodName = $"{testCase.TestMethod.TestClass.Class.Name}.{testCase.TestMethod.Method.Name}";
+
+            if (ExcludedMethods.Count != 0 && ExcludedMethods.Contains(methodName))
+                return false;
+
+            if (ExcludedNamespaces.Count != 0 && ExcludedNamespaces.Any(a => testCase.TestMethod.TestClass.Class.Name.StartsWith($"{a}.", StringComparison.Ordinal)))
+                return false;
+
+            return true;
+        }
+
+    }
+}

--- a/src/xunit.console.netcore/Program.cs
+++ b/src/xunit.console.netcore/Program.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using Xunit.ConsoleClient.Filters;
+using Xunit.ConsoleClient.Project;
 
 namespace Xunit.ConsoleClient
 {
@@ -175,7 +177,7 @@ namespace Xunit.ConsoleClient
             );
         }
 
-        static int RunProject(string defaultDirectory, XunitProject project, bool teamcity, bool appVeyor, bool showProgress, bool? parallelizeAssemblies, bool? parallelizeTestCollections, int? maxThreadCount)
+        static int RunProject(string defaultDirectory, ExtendedXunitProject project, bool teamcity, bool appVeyor, bool showProgress, bool? parallelizeAssemblies, bool? parallelizeTestCollections, int? maxThreadCount)
         {
             XElement assembliesElement = null;
             var xmlTransformers = TransformFactory.GetXmlTransformers(project);
@@ -280,7 +282,7 @@ namespace Xunit.ConsoleClient
             return new StandardOutputVisitor(consoleLock, defaultDirectory, assemblyElement, () => cancel, completionMessages, showProgress);
         }
 
-        static XElement ExecuteAssembly(object consoleLock, string defaultDirectory, XunitProjectAssembly assembly, bool needsXml, bool teamCity, bool appVeyor, bool showProgress, bool? parallelizeTestCollections, int? maxThreadCount, XunitFilters filters)
+        static XElement ExecuteAssembly(object consoleLock, string defaultDirectory, XunitProjectAssembly assembly, bool needsXml, bool teamCity, bool appVeyor, bool showProgress, bool? parallelizeTestCollections, int? maxThreadCount, ExtendedXunitFilters filters)
         {
             if (cancel)
                 return null;

--- a/src/xunit.console.netcore/Project/ExtendedXunitProject.cs
+++ b/src/xunit.console.netcore/Project/ExtendedXunitProject.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit.ConsoleClient.Filters;
+
+namespace Xunit.ConsoleClient.Project
+{
+    public class ExtendedXunitProject : XunitProject
+    {
+        public new ExtendedXunitFilters Filters { get; private set; }
+        public ExtendedXunitProject() : base()
+        {
+            Filters = new ExtendedXunitFilters();
+        }
+    }
+}

--- a/src/xunit.console.netcore/Utility/TransformFactory.cs
+++ b/src/xunit.console.netcore/Utility/TransformFactory.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Xml;
 using System.Xml.Linq;
+using Xunit.ConsoleClient.Project;
 
 #if !NETCORE
 using System.Configuration;
@@ -50,7 +51,7 @@ namespace Xunit.ConsoleClient
             get { return instance.availableTransforms.Values.ToList(); }
         }
 
-        public static List<Action<XElement>> GetXmlTransformers(XunitProject project)
+        public static List<Action<XElement>> GetXmlTransformers(ExtendedXunitProject project)
         {
             return project.Output.Select(output => new Action<XElement>(xml => instance.availableTransforms[output.Key].OutputHandler(xml, output.Value))).ToList();
         }

--- a/src/xunit.console.netcore/xunit.console.netcore.csproj
+++ b/src/xunit.console.netcore/xunit.console.netcore.csproj
@@ -41,7 +41,9 @@
       <Link>Common\TestDiscoveryVisitor.cs</Link>
     </Compile>
     <Compile Include="CommandLine.cs" />
+    <Compile Include="Filters\ExtendedXunitFilters.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="Project\ExtendedXunitProject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RunnerCallbacks\RunnerCallback.cs" />
     <Compile Include="RunnerCallbacks\StandardRunnerCallback.cs" />


### PR DESCRIPTION
Workaround until https://github.com/xunit/xunit/issues/1701 is resolved. 
This allows methods/namespaces and classes to be skipped via command line switches.
This doesn't support regex or wildcards, so the names passed need to include a fully-qualified namespace. 

 
@weshaggard, could you take a look?

cc @sergiy-k 