### PR TITLE
Fix 'File is already strong-name signed'

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/OpenSourceSign.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/OpenSourceSign.cs
@@ -30,6 +30,17 @@ namespace Microsoft.DotNet.Build.Tasks
         }
 
         /// <summary>
+        /// Whether the task should fail in the case the file is already signed. If not, it will re-sign.
+        /// By default it does not fail, because this condition can occur simply because the build was 
+        /// interrupted at an inopportune moment.
+        /// </summary>
+        public bool FailIfAlreadySigned
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// The number of bytes from the start of the <see cref="CorHeader"/> to its <see cref="CorFlags"/>.
         /// </summary>
         private const int OffsetFromStartOfCorHeaderToFlags =
@@ -94,7 +105,7 @@ namespace Microsoft.DotNet.Build.Tasks
             }
 
             CorHeader header = peReader.PEHeaders.CorHeader;
-            if ((header.Flags & CorFlags.StrongNameSigned) == CorFlags.StrongNameSigned)
+            if (FailIfAlreadySigned && ((header.Flags & CorFlags.StrongNameSigned) == CorFlags.StrongNameSigned))
             {
                 LogError("PE file is already strong-name signed.");
                 return false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/29495

The OpenSourceSign task modifies the file in place. It also has a test when it runs that the file has not been already signed. Its execution is gated by comparing the assembly timestamp against a fake file with the extension ".oss_signed" which is written after the task executes.

Modifying a file in place is not good practice for builds because it is hard to fail atomically. Eg., if the build is interrupted between the signing and the writing of the ".oss_signed" file then the next build will attempt to sign again and get the error. There are likely other failure modes.

Options to fix include 
(1) signing to a new location (note - signing to a temporary location then renaming back does not count.)
(2) stop erroring when file is already signed, just re-sign it

Since (2) is simple and makes things no worse, this does (2).