### PR TITLE
Fix a couple issues noted with standalone CloudTest targets usage

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -94,6 +94,7 @@
     <IsOfficial Condition="'$(IsOfficial)'!=''">false</IsOfficial>
     <HelixApiEndpoint Condition="'$(HelixApiEndpoint)'==''">https://helix.dot.net/api/2016-06-28/jobs</HelixApiEndpoint>
     <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">0</MaxRetryCount>
+    <ToolsDir Condition="'$(ToolsDir)' == ''">$(MSBuildThisFileDirectory)</ToolsDir>
   </PropertyGroup>
 
   <!-- Set Helix environment vars based on target platform -->

--- a/src/common/ZipFileCreateFromDirectory.cs
+++ b/src/common/ZipFileCreateFromDirectory.cs
@@ -58,8 +58,11 @@ namespace Microsoft.DotNet.Build.Tasks
                 }
 
                 Log.LogMessage(MessageImportance.High, "Compressing {0} into {1}...", SourceDirectory, DestinationArchive);
-                if (!Directory.Exists(Path.GetDirectoryName(DestinationArchive)))
-                    Directory.CreateDirectory(Path.GetDirectoryName(DestinationArchive));
+                string destinationDirectory = Path.GetDirectoryName(DestinationArchive);
+                if (!Directory.Exists(destinationDirectory) && !string.IsNullOrEmpty(destinationDirectory))
+                {
+                    Directory.CreateDirectory(destinationDirectory);
+                }
 
                 if (ExcludePatterns == null)
                 {


### PR DESCRIPTION
Issues when using this directly from NuPKg reference:

- Don't try to create directory if the destination directory is fully unset.
- ToolsDir isn't set in this case; if it's unset make it be the directory the .targets is in.

@adityapatwardhan FYI.