### PR TITLE
Make GenFacades errors appear in MSbuild logs

### DIFF
--- a/src/GenFacades/GenFacades.Core/GenFacades.cs
+++ b/src/GenFacades/GenFacades.Core/GenFacades.cs
@@ -637,12 +637,15 @@ namespace GenFacades
 
             private static void TraceDuplicateSeedTypeError(string docId, IReadOnlyList<INamedTypeDefinition> seedTypes)
             {
-                Trace.TraceError("The type '{0}' is defined in multiple seed assemblies. If this is intentional, specify one of the following arguments to choose the preferred seed type:", docId);
+                var sb = new StringBuilder();
+                sb.AppendFormat("The type '{0}' is defined in multiple seed assemblies. If this is intentional, specify one of the following arguments to choose the preferred seed type:", docId);
 
                 foreach (INamedTypeDefinition type in seedTypes)
                 {
-                    Trace.TraceError("  /preferSeedType:{0}={1}", docId.Substring("T:".Length), type.GetAssembly().Name.Value);
+                    sb.AppendFormat("  /preferSeedType:{0}={1}", docId.Substring("T:".Length), type.GetAssembly().Name.Value);
                 }
+
+                Trace.TraceError(sb.ToString());
             }
 
             private void AddTypeForward(Assembly assembly, INamedTypeDefinition seedType)

--- a/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
@@ -125,6 +125,29 @@ namespace Microsoft.DotNet.Build.Tasks
             _log = log;
         }
 
+        public override void TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, int id, string message)
+        {
+            TraceEvent(eventCache, source, eventType, id, message, null);
+        }
+
+        public override void TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, int id, string format, params object[] args)
+        {
+            string message = args == null ? format : string.Format(format, args);
+
+            if (eventType == TraceEventType.Error)
+            {
+                _log.LogError(message);
+            }
+            else if (eventType == TraceEventType.Warning)
+            {
+                _log.LogWarning(message);
+            }
+            else
+            {
+                _log.LogMessage(message);
+            }
+        }        
+
         public override void Write(string message)
         {
             _log.LogMessage(message);


### PR DESCRIPTION
Relates to https://github.com/dotnet/corefx/pull/29813