### PR TITLE
Add new [ConditionalClass] attribute 

### DIFF
--- a/src/xunit.netcore.extensions/Attributes/ConditionalClassAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ConditionalClassAttribute.cs
@@ -11,7 +11,7 @@ namespace Xunit
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public sealed class ConditionalClassAttribute : Attribute, ITraitAttribute
     {
-        public Type     CalleeType { get; private set; }
+        public Type CalleeType { get; private set; }
         public string[] ConditionMemberNames { get; private set; }
 
         public ConditionalClassAttribute(Type calleeType, params string[] conditionMemberNames)

--- a/src/xunit.netcore.extensions/Attributes/ConditionalClassAttribute.cs
+++ b/src/xunit.netcore.extensions/Attributes/ConditionalClassAttribute.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    [TraitDiscoverer("Xunit.NetCore.Extensions.ConditionalClassDiscoverer", "Xunit.NetCore.Extensions")]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class ConditionalClassAttribute : Attribute, ITraitAttribute
+    {
+        public Type     CalleeType { get; private set; }
+        public string[] ConditionMemberNames { get; private set; }
+
+        public ConditionalClassAttribute(Type calleeType, params string[] conditionMemberNames)
+        {
+            CalleeType = calleeType;
+            ConditionMemberNames = conditionMemberNames;
+        }
+    }
+}

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalClassDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalClassDiscoverer.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit.NetCore.Extensions
+{
+    /// <summary>
+    /// This class discovers all of the tests and test classes that have
+    /// applied the ConditionalClass attribute
+    /// </summary>
+    public class ConditionalClassDiscoverer : ITraitDiscoverer
+    {
+        /// <summary>
+        /// Gets the trait values from the Category attribute.
+        /// </summary>
+        /// <param name="traitAttribute">The trait attribute containing the trait values.</param>
+        /// <returns>The trait values.</returns>
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            // Parse the traitAttribute. We make sure it contains two parts:
+            // 1. Type 2. nameof(conditionMemberName)
+            object[] conditionArguments = traitAttribute.GetConstructorArguments().ToArray();
+            Debug.Assert(conditionArguments.Count() == 2);
+
+            // If evaluated to false, entirely skip the test class.
+            if (!ConditionalTestDiscoverer.EvaluateParameter(conditionArguments))
+            {
+                yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.Failing);
+            }
+        }
+    }
+}

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
@@ -105,41 +105,6 @@ namespace Xunit.NetCore.Extensions
             return testCases;
         }
 
-        internal static bool EvaluateParameter(object[] conditionArguments)
-        {
-            Type calleeType = null;
-            string[] conditionMemberNames = null;
-
-            if (CheckInputToSkipExecution(conditionArguments, ref calleeType, ref conditionMemberNames)) return true;
-
-            foreach (string entry in conditionMemberNames)
-            {
-                // Null condition member names are silently tolerated
-                if (string.IsNullOrWhiteSpace(entry)) continue;
-
-                MethodInfo conditionMethodInfo = LookupConditionalMethod(calleeType, entry);
-                if (conditionMethodInfo == null)
-                {
-                    // Unable to get MethodInfo. It's caused by bad user input.
-                    // We need to report some error here. For now, just don't run the test.
-                    return false;
-                }
-
-                try
-                {
-                    bool conditionMet = (bool)conditionMethodInfo.Invoke(null, null);
-                    // If one of the conditions is false, then return the category failing trait.
-                    if (!conditionMet) return false;
-                }
-                catch (Exception exc)
-                {
-                    throw exc;
-                }
-            }
-
-            return true;
-        }
-
         internal static string GetFailedLookupString(string name, Type type)
         {
             return

--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
@@ -25,44 +25,14 @@ namespace Xunit.NetCore.Extensions
                                                         IEnumerable<IXunitTestCase> testCases,
                                                         object[] conditionArguments)
         {
-            // A null or empty list of conditionMemberNames is treated as "no conditions".
-            // and the test cases will not be skipped.
-            // Example: [ConditionalFact()]
-            if (conditionArguments == null || conditionArguments.Length == 0)
-            {
-                return testCases;
-            }
+            Type calleeType = null;
+            string[] conditionMemberNames = null;
 
-            string [] conditionMemberNames;
-
-            Type calleeType = conditionArguments[0] as Type;
-            if (calleeType != null)
-            {
-                if (conditionArguments.Length < 2)
-                {
-                    // [ConditionalFact(typeof(x))] no provided methods.
-                    return testCases;
-                }
-
-                // [ConditionalFact(typeof(x), "MethodName")]
-                conditionMemberNames = conditionArguments[1] as string[];
-            }
-            else
-            {
-                // [ConditionalFact("MethodName")]
-                conditionMemberNames = conditionArguments[0] as string[];
-            }
-
-            // [ConditionalFact((string[]) null)]
-            int conditionCount = conditionMemberNames == null ? 0 : conditionMemberNames.Count();
-            if (conditionCount == 0)
-            {
-                return testCases;
-            }
+            if (CheckInputToSkipExecution(conditionArguments, ref calleeType, ref conditionMemberNames, testMethod)) return testCases;
 
             MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
             Type testMethodDeclaringType = testMethodInfo.DeclaringType;
-            List<string> falseConditions = new List<string>(conditionCount);
+            List<string> falseConditions = new List<string>(conditionMemberNames.Count());
 
             foreach (string entry in conditionMemberNames)
             {
@@ -135,6 +105,41 @@ namespace Xunit.NetCore.Extensions
             return testCases;
         }
 
+        internal static bool EvaluateParameter(object[] conditionArguments)
+        {
+            Type calleeType = null;
+            string[] conditionMemberNames = null;
+
+            if (CheckInputToSkipExecution(conditionArguments, ref calleeType, ref conditionMemberNames)) return true;
+
+            foreach (string entry in conditionMemberNames)
+            {
+                // Null condition member names are silently tolerated
+                if (string.IsNullOrWhiteSpace(entry)) continue;
+
+                MethodInfo conditionMethodInfo = LookupConditionalMethod(calleeType, entry);
+                if (conditionMethodInfo == null)
+                {
+                    // Unable to get MethodInfo. It's caused by bad user input.
+                    // We need to report some error here. For now, just don't run the test.
+                    return false;
+                }
+
+                try
+                {
+                    bool conditionMet = (bool)conditionMethodInfo.Invoke(null, null);
+                    // If one of the conditions is false, then return the category failing trait.
+                    if (!conditionMet) return false;
+                }
+                catch (Exception exc)
+                {
+                    throw exc;
+                }
+            }
+
+            return true;
+        }
+
         internal static string GetFailedLookupString(string name, Type type)
         {
             return
@@ -159,6 +164,40 @@ namespace Xunit.NetCore.Extensions
                 return pi.GetMethod;
 
             return LookupConditionalMethod(ti.BaseType, name);
+        }
+
+        internal static bool CheckInputToSkipExecution(object[] conditionArguments, ref Type calleeType, ref string[] conditionMemberNames, ITestMethod testMethod = null)
+        {
+            // A null or empty list of conditionArguments is treated as "no conditions".
+            // and the test cases will be executed.
+            // Example: [ConditionalClass()]
+            if (conditionArguments == null || conditionArguments.Length == 0) return true;
+
+            calleeType = conditionArguments[0] as Type;
+            if (calleeType != null)
+            {
+                if (conditionArguments.Length < 2)
+                {
+                    // [ConditionalFact(typeof(x))] no provided methods.
+                    return true;
+                }
+
+                // [ConditionalFact(typeof(x), "MethodName")]
+                conditionMemberNames = conditionArguments[1] as string[];
+            }
+            else
+            {
+                // For [ConditionalClass], unable to get the Type info. All test cases will be executed.
+                if (testMethod == null) return true;
+
+                // [ConditionalFact("MethodName")]
+                conditionMemberNames = conditionArguments[0] as string[];
+            }
+
+            // [ConditionalFact((string[]) null)]
+            if (conditionMemberNames == null || conditionMemberNames.Count() == 0) return true;
+
+            return false;
         }
     }
 }

--- a/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/SkipOnTargetFrameworkDiscoverer.cs
@@ -22,40 +22,40 @@ namespace Xunit.NetCore.Extensions
         /// <returns>The trait values.</returns>
         public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
         {
-            TargetFrameworkMonikers platform = (TargetFrameworkMonikers)traitAttribute.GetConstructorArguments().First();
-            if (platform.HasFlag(TargetFrameworkMonikers.Net45))
+            TargetFrameworkMonikers frameworks = (TargetFrameworkMonikers)traitAttribute.GetConstructorArguments().First();
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Net45))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet45Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Net451))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Net451))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet451Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Net452))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Net452))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet452Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Net46))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Net46))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet46Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Net461))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Net461))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet461Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Net462))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Net462))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet462Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Net463))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Net463))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNet463Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Netcore50))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcore50))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcore50Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Netcore50aot))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcore50aot))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcore50aotTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp1_0))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp1_0))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreapp1_0Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp1_1))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp1_1))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreapp1_1Test);
-            if (platform.HasFlag(TargetFrameworkMonikers.NetFramework))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.NetFramework))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetfxTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.Mono))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Mono))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonMonoTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.Netcoreapp))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.Netcoreapp))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreappTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.UapNotUapAot))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.UapNotUapAot))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.UapAot))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.UapAot))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonUapAotTest);
-            if (platform.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
+            if (frameworks.HasFlag(TargetFrameworkMonikers.NetcoreCoreRT))
                 yield return new KeyValuePair<string, string>(XunitConstants.Category, XunitConstants.NonNetcoreCoreRTTest);
         }
     }

--- a/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
+++ b/src/xunit.netcore.extensions/xunit.netcore.extensions.csproj
@@ -15,12 +15,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
+    <Compile Include="Attributes\ConditionalClassAttribute.cs" />
     <Compile Include="Attributes\ConditionalFactAttribute.cs" />
     <Compile Include="Attributes\ConditionalTheoryAttribute.cs" />
     <Compile Include="Attributes\ActiveIssueAttribute.cs" />
     <Compile Include="Attributes\PlatformSpecificAttribute.cs" />
     <Compile Include="Attributes\SkipOnTargetFrameworkAttribute.cs" />
     <Compile Include="Attributes\TestCategoryAttribute.cs" />
+    <Compile Include="Discoverers\ConditionalClassDiscoverer.cs" />
     <Compile Include="Discoverers\ConditionalFactDiscoverer.cs" />
     <Compile Include="Discoverers\ConditionalTestDiscoverer.cs" />
     <Compile Include="Discoverers\ConditionalTheoryDiscoverer.cs" />


### PR DESCRIPTION
This new attribute can help to disable an entire test class based on runtime information/conditions, instead of using `[ConditionalFact/Theory]` for each test method.

[ConditionalClass] is similar to [ConditionalFact/Theory], but here are the differences:

1. Implements ITraitAttribute, and has a `GetTraits` method returning an IEnumerable<KeyValuePair<string, string>> to skip test run.
 - The downside for this approach is that, we are not returning test cases (as `[ConditionalFact/Theory]` will do). So it won't notify developer how many test cases are "skipped", instead just silently not running them (behave like `ActiveIssue` and `SkipOnTargetFramework`).

2. Only has one ctor which accepts `Type` and `string[]`. 
 - Since [ConditionalClass] is used to disable the entire test class, we don't need the ctor overload which uses Reflection to peek into some values inside the test class (which might be skipped)

Verified the new attribute locally. This PR also changes a confusing naming in `SkipOnTargetFrameworkDiscoverer.cs`.