### PR TITLE
Workaround new errors from genfacades

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenFacadesTask.cs
@@ -136,7 +136,9 @@ namespace Microsoft.DotNet.Build.Tasks
 
             if (eventType == TraceEventType.Error)
             {
-                _log.LogError(message);
+                // Disabled until we fix warnings -https://github.com/dotnet/corefx/issues/29861
+                //_log.LogError(message);
+                _log.LogWarning(message);
             }
             else if (eventType == TraceEventType.Warning)
             {


### PR DESCRIPTION
Previously some detailed errors/warnings/messages were not reaching the build log at all. Recent change fixed that but there are some errors in CoreFX. Temporarily changing errors to warnings while the cause is fixed.

https://github.com/dotnet/corefx/issues/29861