### PR TITLE
Add pip install of psutil

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -37,6 +37,9 @@
       <CrashDumpFolder Condition="'$(CrashDumpFolder)' == '' and Exists('/cores/')">/cores/</CrashDumpFolder>
       <CrashDumpFolder Condition="'$(CrashDumpFolder)' == '' and '$(OS)' == 'Unix'">`pwd`</CrashDumpFolder>
     </PropertyGroup>
+    <ItemGroup>
+      <TestCommandLines Include="python -m pip install psutil" />
+    </ItemGroup>
     <ItemGroup Condition="'$(TargetOS)'!='Windows_NT'">
       <TestCommandLines Include="python DumplingHelper.py install_dumpling" />
       <TestCommandLines Include="__TIMESTAMP=`python DumplingHelper.py get_timestamp`" />


### PR DESCRIPTION
We need psutil install for the dumpling script to work. This will ensure
that we have it installed on the machine before we use it.