### PR TITLE
Better handle renamespacing SR

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 _targetStream.WriteLine("");
                 _targetStream.WriteLine($"    internal static partial class {_srClassName}");
                 _targetStream.WriteLine("    {");
-                _targetStream.WriteLine($"        internal static Type ResourceType {{ get; }} = typeof({_resourcesName}.SR); ");
+                _targetStream.WriteLine($"        internal static System.Type ResourceType {{ get; }} = typeof({_resourcesName}.SR); ");
                 _targetStream.WriteLine("    }");
                 _targetStream.WriteLine("}");
                 _targetStream.WriteLine("");
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 _targetStream.WriteLine($"Namespace {_srNamespace}");
                 _targetStream.WriteLine("");
                 _targetStream.WriteLine($"    Friend Partial Class {_srClassName}");
-                _targetStream.WriteLine($"        Friend Shared ReadOnly Property ResourceType As Type = GetType({_resourcesName}.SR)");
+                _targetStream.WriteLine($"        Friend Shared ReadOnly Property ResourceType As System.Type = GetType({_resourcesName}.SR)");
                 _targetStream.WriteLine("    End Class");
                 _targetStream.WriteLine("End Namespace");
                 _targetStream.WriteLine("");

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -11,8 +11,12 @@
   <PropertyGroup>
     <ResourcesSourceOutputDirectory Condition="'$(ResourcesSourceOutputDirectory)' == ''">$(MSBuildProjectDirectory)/Resources/</ResourcesSourceOutputDirectory>
     <StringResourcesPath Condition="'$(StringResourcesPath)'=='' And Exists('$(ResourcesSourceOutputDirectory)Strings.resx')">$(ResourcesSourceOutputDirectory)Strings.resx</StringResourcesPath>
-    <IntermediateResOutputFileFullPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(IntermediateOutputPath)SR.cs</IntermediateResOutputFileFullPath>
-    <IntermediateResOutputFileFullPath Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(IntermediateOutputPath)SR.vb</IntermediateResOutputFileFullPath>
+    <ResourcesSourceFileExtension Condition="'$(MSBuildProjectExtension)' == '.csproj'">.cs</ResourcesSourceFileExtension>
+    <ResourcesSourceFileExtension Condition="'$(MSBuildProjectExtension)' == '.vbproj'">.vb</ResourcesSourceFileExtension>
+    <IntermediateResOutputFileFullPath>$(IntermediateOutputPath)SR$(ResourcesSourceFileExtension)</IntermediateResOutputFileFullPath>
+    <CommonSRSourceFile Condition="'$(CommonSRSourceFile)' == ''">$(CommonPath)/System/SR$(ResourcesSourceFileExtension)</CommonSRSourceFile>
+    <IntermediateCommonSRFileFullPath>$(IntermediateOutputPath)SR.common$(ResourcesSourceFileExtension)</IntermediateCommonSRFileFullPath>
+    <ShouldGenerateCommonSRFile Condition="'$(ShouldGenerateCommonSRFile)' == '' AND ('$(GenerateResourcesSRNamespace)' != '' OR '$(GenerateResourcesSRClassName)' != '')">true</ShouldGenerateCommonSRFile>
     <DefineConstants Condition="'$(ConfigurationGroup)' == 'Debug'">$(DefineConstants);DEBUGRESOURCES</DefineConstants>
   </PropertyGroup>
 
@@ -65,6 +69,7 @@
       <CompileDependsOn>
           NormalizeAssemblyName;
           GenerateResourcesSource;
+          GenerateCommonSRSource;
           $(CompileDependsOn);
       </CompileDependsOn>
   </PropertyGroup>
@@ -113,6 +118,32 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="GenerateCommonSRSource"
+          Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true' AND '$(SkipCommonResourcesIncludes)'=='' AND '$(ShouldGenerateCommonSRFile)'=='true'"
+          Inputs="$(CommonSRSourceFile)"
+          Outputs="$(IntermediateCommonSRFileFullPath)">
+
+    <WriteLinesToFile File="$(IntermediateCommonSRFileFullPath)" Overwrite="true"
+                      Lines="$([System.IO.File]::ReadAllText('$(CommonSRSourceFile)').Replace('#CUSTOM_SR_NAMESPACE#', '$(GenerateResourcesSRNamespace)').Replace('#CUSTOM_SR_CLASSNAME#', '$(GenerateResourcesSRClassName)'))" />
+
+    <PropertyGroup>
+      <DefineConstants Condition="'$(GenerateResourcesSRNamespace)' != ''">$(DefineConstants);CUSTOM_SR_NAMESPACE</DefineConstants>
+      <DefineConstants Condition="'$(GenerateResourcesSRClassName)' != ''">$(DefineConstants);CUSTOM_SR_CLASSNAME</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Compile Include="$(IntermediateCommonSRFileFullPath)">
+        <Visible>true</Visible>
+        <Link>Resources/Common/SR$(ResourcesSourceFileExtension)</Link>
+      </Compile>
+    </ItemGroup>
+
+
+    <ItemGroup>
+      <FileWrites Include="$(IntermediateCommonSRFileFullPath)" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup Condition="'$(StringResourcesPath)'!='' AND '$(OmitResources)'!='true'">
     <EmbeddedResource Include="$(StringResourcesPath)">
       <Visible>true</Visible>
@@ -124,25 +155,13 @@
   </ItemGroup>
 
   <Choose>
-    <When Condition="Exists('$(StringResourcesPath)') And '$(SkipCommonResourcesIncludes)'=='' AND '$(OmitResources)'!='true'">
-      <Choose>
-        <When Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-          <ItemGroup>
-            <Compile Include="$(CommonPath)/System/SR.cs">
-              <Visible>true</Visible>
-              <Link>Resources/Common/SR.cs</Link>
-            </Compile>
-          </ItemGroup>
-        </When>
-        <When Condition="'$(MSBuildProjectExtension)' == '.vbproj'">
-          <ItemGroup>
-            <Compile Include="$(CommonPath)/System/SR.vb">
-              <Visible>true</Visible>
-              <Link>Resources/Common/SR.vb</Link>
-            </Compile>
-          </ItemGroup>
-        </When>
-      </Choose>
+    <When Condition="Exists('$(StringResourcesPath)') AND '$(OmitResources)'!='true' AND '$(SkipCommonResourcesIncludes)'=='' AND '$(ShouldGenerateCommonSRFile)'==''">
+      <ItemGroup>
+        <Compile Include="$(CommonSRSourceFile)">
+          <Visible>true</Visible>
+          <Link>Resources/Common/SR$(ResourcesSourceFileExtension)</Link>
+        </Compile>
+      </ItemGroup>
     </When>
   </Choose>
 </Project>


### PR DESCRIPTION
Previously I added support for customizing the namespace and class name of the generated
SR class.  This led to some duplication of the common SR source
with the new namespace / class name.

To better handle this I'll allow reuse of the common source.

In conjunction with this change the common SR can be changed as follows:
```C#
#if CUSTOM_SR_NAMESPACE
using System;
namespace #CUSTOM_SR_NAMESPACE#
#else
namespace System
#endif
{
#if CUSTOM_SR_CLASSNAME
    internal partial class #CUSTOM_SR_CLASSNAME#
#else
    internal partial class SR
#endif
```
This change need not be made in order to ingest the changes, only if folks want to use the changes.

In addition to this I also am fixing a problem where we need to qualify System.Type when specifying a non-system namespace.

All of these changes are handing supporting a set of assemblies I'm trying to port with minimum code-churn that were previously sharing internals (including SR classes) via InternalsVisibleTo.