### PR TITLE
Use HELIX_PYTHONPATH instead of python directly since it may not be on the path.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -38,20 +38,19 @@
       <CrashDumpFolder Condition="'$(CrashDumpFolder)' == '' and '$(OS)' == 'Unix'">`pwd`</CrashDumpFolder>
       <CrashDumpFolder Condition="'$(CrashDumpFolder)' == ''">\cores\</CrashDumpFolder>
     </PropertyGroup>
-    <ItemGroup>
-      <TestCommandLines Include="python -m pip install psutil" />
-    </ItemGroup>
     <ItemGroup Condition="'$(TargetOS)'!='Windows_NT'">
-      <TestCommandLines Include="python DumplingHelper.py install_dumpling" />
-      <TestCommandLines Include="__TIMESTAMP=`python DumplingHelper.py get_timestamp`" />
-      <PostExecutionTestCommandLines Include="python DumplingHelper.py collect_dump $%3F $(CrashDumpFolder) $__TIMESTAMP $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
+      <TestCommandLines Include="$HELIX_PYTHONPATH -m pip install psutil" />
+      <TestCommandLines Include="$HELIX_PYTHONPATH DumplingHelper.py install_dumpling" />
+      <TestCommandLines Include="__TIMESTAMP=`$HELIX_PYTHONPATH DumplingHelper.py get_timestamp`" />
+      <PostExecutionTestCommandLines Include="$HELIX_PYTHONPATH DumplingHelper.py collect_dump $%3F $(CrashDumpFolder) $__TIMESTAMP $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
-      <TestCommandLines Include="python DumplingHelper.py install_dumpling" />
+      <TestCommandLines Include="%HELIX_PYTHONPATH% -m pip install psutil" />
+      <TestCommandLines Include="%HELIX_PYTHONPATH% DumplingHelper.py install_dumpling" />
       <TestCommandLines Include="if not exist $(CrashDumpFolder) mkdir $(CrashDumpFolder)" />
       <!-- This gets a "before execution" timestamp. It is used in DumplingHelper.py to determine which crash dump files to consider uploading. -->
-      <TestCommandLines Include="for /f &quot;delims=&quot; %%a in ('python DumplingHelper.py get_timestamp') do @set __TIMESTAMP=%%a" />
-      <PostExecutionTestCommandLines Include="python DumplingHelper.py collect_dump %ERRORLEVEL% $(CrashDumpFolder) %__TIMESTAMP% $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
+      <TestCommandLines Include="for /f &quot;delims=&quot; %%a in ('%HELIX_PYTHONPATH% DumplingHelper.py get_timestamp') do @set __TIMESTAMP=%%a" />
+      <PostExecutionTestCommandLines Include="%HELIX_PYTHONPATH% DumplingHelper.py collect_dump %ERRORLEVEL% $(CrashDumpFolder) %__TIMESTAMP% $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Resolves the failures seen in https://github.com/dotnet/corefx/pull/29965.
https://mc.dot.net/#/user/ahsonkhan/pr~2Fjenkins~2Fdotnet~2Fcorefx~2Fmaster~2F/test~2Ffunctional~2Fcli~2F/a674b4ff48a0f4962b7dbe7406eabf17e2d92658/workItem/System.IO.Compression.Tests/wilogs
```text
2018-05-30 20:53:11,394: INFO: proc(54): run_and_log_output: Output: C:\dotnetbuild\work\9eacf393-d860-4035-b461-aaa39e2a3ab4\Work\f970046d-c748-42f9-9823-8f2f1a15c1e9\Unzip>python -m pip install psutil 
2018-05-30 20:53:11,394: INFO: proc(54): run_and_log_output: Output: 'python' is not recognized as an internal or external command,
2018-05-30 20:53:11,394: INFO: proc(54): run_and_log_output: Output: operable program or batch file.

```

cc @DrewScoggins, @MattGal 