### PR TITLE
Fix TaskCancelledException seen on HttpClient timeout

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/SendJobsToHelix.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/SendJobsToHelix.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Build.Utilities;
+using System.Threading;
 
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
@@ -78,16 +79,22 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 allBuilds.Add(JsonConvert.DeserializeObject<JObject>(buildJsonText));
             }
 
-            using (HttpClient client = new HttpClient())
+            using (HttpClient client = new HttpClient()
+            {
+                Timeout = TimeSpan.FromSeconds(30) // Default is 100 seconds
+            })
             {
                 const int MaxAttempts = 15;
                 // add a bit of randomness to the retry delay
                 var rng = new Random();
                 int retryCount = MaxAttempts;
 
+                // We'll use this to be sure TaskCancelledException comes from timeouts
+                CancellationTokenSource cancelTokenSource = new CancellationTokenSource();
+
                 foreach (JObject jobStartMessage in allBuilds)
                 {
-                    string queueId = (string) jobStartMessage["QueueId"];
+                    string queueId = (string)jobStartMessage["QueueId"];
                     // This should never happen.
                     if (string.IsNullOrEmpty(queueId))
                     {
@@ -97,13 +104,12 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     while (keepTrying)
                     {
                         HttpResponseMessage response = new HttpResponseMessage();
-
                         try
                         {
                             // This tortured way to get the HTTPContent is to work around that StringContent doesn't allow application/json
                             HttpContent contentStream = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jobStartMessage.ToString())));
                             contentStream.Headers.Add("Content-Type", "application/json");
-                            response = await client.PostAsync(apiUrl, contentStream);
+                            response = await client.PostAsync(apiUrl, contentStream, cancelTokenSource.Token);
 
                             if (response.IsSuccessStatusCode)
                             {
@@ -119,7 +125,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                                             responseObject = JObject.Load(jsonReader);
                                         }
                                     }
-                                    catch 
+                                    catch
                                     {
                                         Log.LogWarning($"Hit exception attempting to parse JSON response.  Raw response string: {Environment.NewLine} {jsonResponse}");
                                     }
@@ -151,7 +157,19 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                             Log.LogWarning("Exception thrown attempting to submit job to Helix:");
                             Log.LogWarningFromException(toLog, true);
                         }
-
+                        catch (TaskCanceledException possibleClientTimeout)
+                        {
+                            if (possibleClientTimeout.CancellationToken != cancelTokenSource.Token)
+                            {
+                                // This is a timeout.
+                                Log.LogWarning("HttpClient timeout while POSTing new job; will retry (if tries remaining).");
+                            }
+                            else
+                            {
+                                // Something else caused cancel, throw it.  Should not ever get here.
+                                throw;
+                            }
+                        }
                         if (retryCount-- <= 0)
                         {
                             Log.LogError($"Unable to publish to '{ApiEndpoint}' after {MaxAttempts} retries. Received status code: {response.StatusCode} {response.ReasonPhrase}");


### PR DESCRIPTION
…  give it a 30 second timeout and allow retrying.

@sunandabalu FYI.  You inspired me to learn about something we're doing wrong in many , many places. 