### PR TITLE
Updating collected metrics.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -35,13 +35,18 @@
 
   <!-- Sets the flags for the performance counters to be collected in this run. -->
   <PropertyGroup Condition="'$(PerformanceType)'=='Profile'">
-    <!-- Collect allocated bytes in execution thread, stopwatch, and any user defined Clr events (through the xUnit Performance Api attributes) -->
-    <CollectFlags>default+gcapi</CollectFlags>
+    <!-- Collect, per benchmark, execution time (stopwatch). -->
+    <CollectFlags>stopwatch</CollectFlags>
     <RunId>Perf-Profile</RunId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PerformanceType)'=='Diagnostic'">
-    <!-- Collect the same data collected with the Profile run plus stack and Pmc counters through Etw. -->
+    <!-- Collect, per benchmarks, the following metrics:
+      1. Allocated bytes in execution thread,
+      2. Any user defined Clr events (through the xUnit Performance Api attributes),
+      3. CPU Usage (Utilization by Process, Stack),
+      4. CPU Performance Counters (Pmc Rollovers)
+    -->
     <CollectFlags>default+BranchMispredictions+CacheMisses+InstructionRetired+gcapi</CollectFlags>
     <RunId>Perf-Diagnostic</RunId>
   </PropertyGroup>
@@ -63,7 +68,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetOS)'=='Linux' and '$(LogToBenchview)' == 'true'">
-    <PerfTestCommandLines Include="if [ -a &quot;$(RunId)-$(AssemblyName).xml&quot; ]; then" />
+    <PerfTestCommandLines Include="if [ -f &quot;$(RunId)-$(AssemblyName).xml&quot; ]; then" />
     <PerfTestCommandLines Include="$(MeasurementPyCommand)" />
     <PerfTestCommandLines Include="fi" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(PerformanceType)'=='Diagnostic'">
-    <!-- Collect, per benchmarks, the following metrics:
+    <!-- Collect, per benchmark, the following metrics:
       1. Allocated bytes in execution thread,
       2. Any user defined Clr events (through the xUnit Performance Api attributes),
       3. CPU Usage (Utilization by Process, Stack),


### PR DESCRIPTION
1. Profile runs are not the same across operating systems because on Windows it collects extra information through Etw. In order to make results comparable across operating systems, I am changing how metrics are collected.
  * Profile now becomes time-only (stopwatch)
  * Diagnostic now becomes everything else: Clr events, GC API metrics, Pmc, Stopwatch, etc.
2. Fixed a file operator for bash: replaced `-a` (considered deprecated) with `-f`
