### PR TITLE
[release/2.1] Implement additional ProdCon manifest updaters

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -10,6 +10,7 @@ using Microsoft.DotNet.VersionTools.BuildManifest;
 using Microsoft.DotNet.VersionTools.Dependencies;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBuild;
 using Microsoft.DotNet.VersionTools.Dependencies.Submodule;
 using System;
 using System.Collections.Generic;
@@ -134,6 +135,28 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                         };
                         break;
 
+                    case "Build attribute from orchestrated build":
+                        yield return CreateOrchestratedBuildUpdater(
+                            step,
+                            OrchestratedBuildUpdateHelpers.BuildAttribute(
+                                GetRequiredMetadata(step, "BuildName"),
+                                GetRequiredMetadata(step, "AttributeName")));
+                        break;
+
+                    case "Orchestrated blob feed attribute":
+                        yield return CreateOrchestratedBuildUpdater(
+                            step,
+                            OrchestratedBuildUpdateHelpers.OrchestratedFeedAttribute(
+                                GetRequiredMetadata(step, "AttributeName")));
+                        break;
+
+                    case "Orchestrated blob feed package version":
+                        yield return CreateOrchestratedBuildUpdater(
+                            step,
+                            OrchestratedBuildUpdateHelpers.OrchestratedFeedPackageVersion(
+                                GetRequiredMetadata(step, "PackageId")));
+                        break;
+
                     default:
                         throw new NotSupportedException(
                             $"Unsupported updater '{step.ItemSpec}': UpdaterType '{type}'.");
@@ -213,10 +236,53 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                     PackageId = packageId
                 };
             }
-            updater.Path = step.GetMetadata("Path");
-            updater.Regex = CreateXmlUpdateRegex(step.GetMetadata("ElementName"), "version");
-            updater.VersionGroupName = "version";
+            ConfigureFileRegexUpdater(updater, step);
             return updater;
+        }
+
+        private FileRegexUpdater ConfigureFileRegexUpdater(FileRegexUpdater updater, ITaskItem step)
+        {
+            updater.Path = step.GetMetadata("Path");
+
+            string elementName = step.GetMetadata("ElementName");
+            string manualRegex = step.GetMetadata("Regex");
+            if (!string.IsNullOrEmpty(elementName))
+            {
+                updater.Regex = CreateXmlUpdateRegex(elementName, nameof(elementName));
+                updater.VersionGroupName = nameof(elementName);
+            }
+            else if (!string.IsNullOrEmpty(manualRegex))
+            {
+                updater.Regex = new Regex(manualRegex);
+                updater.VersionGroupName = GetRequiredMetadata(step, "VersionGroupName");
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"On '{step.ItemSpec}', did not find 'ElementName' or 'Regex' metadata.");
+            }
+
+            return updater;
+        }
+
+        private IDependencyUpdater CreateOrchestratedBuildUpdater(
+            ITaskItem step,
+            Func<OrchestratedBuildDependencyInfo[], DependencyReplacement> updater)
+        {
+            string path = step.GetMetadata("SingleLineFile");
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                return new FileOrchestratedBuildCustomUpdater
+                {
+                    GetDesiredValue = updater,
+                    Path = path
+                };
+            }
+
+            return ConfigureFileRegexUpdater(
+                new FileRegexOrchestratedBuildCustomUpdater { GetDesiredValue = updater },
+                step);
         }
 
         private static BuildDependencyInfo CreateBuildInfoDependency(ITaskItem item, string cacheDir)

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildManifest
+{
+    public class OrchestratedBuildIdentityMatch
+    {
+        public static OrchestratedBuildIdentityMatch Find(
+            string buildName,
+            IEnumerable<IDependencyInfo> dependencyInfos)
+        {
+            OrchestratedBuildIdentityMatch[] matches = dependencyInfos
+                .OfType<OrchestratedBuildDependencyInfo>()
+                .SelectMany(info => info.OrchestratedBuildModel.Builds
+                    .Where(b => b.Name.Equals(buildName, StringComparison.OrdinalIgnoreCase))
+                    .Select(b => new OrchestratedBuildIdentityMatch { Info = info, Match = b }))
+                .ToArray();
+
+            if (matches.Length != 1)
+            {
+                throw new ArgumentException(
+                    $"Expected 1 build matching '{buildName}', but found {matches.Length}: " +
+                    $"'{string.Join(", ", matches.AsEnumerable())}'");
+            }
+
+            return matches[0];
+        }
+
+        public OrchestratedBuildDependencyInfo Info { get; set; }
+        public BuildIdentity Match { get; set; }
+
+        public void EnsureMatchHasCommit()
+        {
+            if (string.IsNullOrEmpty(Match.Commit))
+            {
+                throw new ArgumentException($"Match '{this}' has no commit.");
+            }
+        }
+
+        public string GetAttributeValue(string name)
+        {
+            string value;
+
+            if (!Match.Attributes.TryGetValue(name, out value))
+            {
+                throw new ArgumentException($"Could not find attribute '{name}' in '{this}'");
+            }
+
+            return value;
+        }
+
+        public override string ToString() => $"'{Match}' from '{Info.SimpleName}'";
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FilePackageUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/FilePackageUpdater.cs
@@ -2,21 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.VersionTools.Util;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput
 {
-    public class FilePackageUpdater : IDependencyUpdater
+    public class FilePackageUpdater : FileUpdater
     {
-        public string Path { get; set; }
-
         public string PackageId { get; set; }
 
-        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(
+        public override DependencyReplacement GetDesiredReplacement(
             IEnumerable<IDependencyInfo> dependencyInfos)
         {
             foreach (BuildDependencyInfo info in dependencyInfos.OfType<BuildDependencyInfo>())
@@ -24,36 +20,14 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput
                 string version;
                 if (info.RawPackages.TryGetValue(PackageId, out version))
                 {
-                    string originalValue = null;
-
-                    Action updateTask = FileUtils.GetUpdateFileContentsTask(
-                        Path,
-                        content =>
-                        {
-                            int firstLineLength = content.IndexOf(Environment.NewLine);
-                            // Handle files with no newline ending.
-                            if (firstLineLength == -1)
-                            {
-                                firstLineLength = content.Length;
-                            }
-
-                            originalValue = content.Substring(0, firstLineLength);
-                            return content
-                                .Remove(0, firstLineLength)
-                                .Insert(0, version);
-                        });
-
-                    if (updateTask != null)
-                    {
-                        yield return new DependencyUpdateTask(
-                            updateTask,
-                            new[] { info },
-                            new[] { $"In '{Path}', '{originalValue}' must be '{version}'." });
-                    }
-                    yield break;
+                    return new DependencyReplacement(
+                        version,
+                        new[] { info });
                 }
             }
+
             Trace.TraceError($"For '{Path}', Could not find '{PackageId}' package version information.");
+            return null;
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/FileOrchestratedBuildCustomUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/FileOrchestratedBuildCustomUpdater.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBuild
+{
+    public class FileOrchestratedBuildCustomUpdater : FileUpdater
+    {
+        public Func<OrchestratedBuildDependencyInfo[], DependencyReplacement> GetDesiredValue { get; set; }
+
+        public override DependencyReplacement GetDesiredReplacement(
+            IEnumerable<IDependencyInfo> dependencyInfos)
+        {
+            return GetDesiredValue(
+                dependencyInfos
+                    .OfType<OrchestratedBuildDependencyInfo>()
+                    .ToArray());
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/FileRegexOrchestratedBuildCustomUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/FileRegexOrchestratedBuildCustomUpdater.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBuild
+{
+    public class FileRegexOrchestratedBuildCustomUpdater : FileRegexUpdater
+    {
+        public Func<OrchestratedBuildDependencyInfo[], DependencyReplacement> GetDesiredValue { get; set; }
+
+        protected override string TryGetDesiredValue(
+            IEnumerable<IDependencyInfo> dependencyInfos,
+            out IEnumerable<IDependencyInfo> usedDependencyInfos)
+        {
+            DependencyReplacement replacement = GetDesiredValue(
+                dependencyInfos
+                    .OfType<OrchestratedBuildDependencyInfo>()
+                    .ToArray());
+
+            usedDependencyInfos = (replacement?.UsedDependencyInfos).NullAsEmpty();
+            return replacement?.Content;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
+using System;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBuild
+{
+    public static class OrchestratedBuildUpdateHelpers
+    {
+        public static Func<OrchestratedBuildDependencyInfo[], DependencyReplacement>
+            BuildAttribute(string buildName, string attributeName)
+        {
+            return infos =>
+            {
+                var match = OrchestratedBuildIdentityMatch.Find(buildName, infos);
+
+                string value;
+                if (match.Match.Attributes.TryGetValue(attributeName, out value))
+                {
+                    return new DependencyReplacement(value, new[] { match.Info });
+                }
+
+                return null;
+            };
+        }
+
+        public static Func<OrchestratedBuildDependencyInfo[], DependencyReplacement>
+            OrchestratedFeedAttribute(string attributeName)
+        {
+            return infos => infos
+                .Select(info =>
+                {
+                    EndpointModel feed = info.GetBlobFeed();
+
+                    string value;
+                    if (feed != null && feed.Attributes.TryGetValue(attributeName, out value))
+                    {
+                        return new DependencyReplacement(value, new[] { info });
+                    }
+
+                    return null;
+                })
+                .FirstOrDefault(r => r != null);
+        }
+
+        public static Func<OrchestratedBuildDependencyInfo[], DependencyReplacement>
+            OrchestratedFeedPackageVersion(string packageId)
+        {
+            return infos => infos
+                .Select(info =>
+                {
+                    PackageArtifactModel match = info.GetBlobFeed()?.Artifacts.Packages
+                        .FirstOrDefault(p => p.Id.Equals(packageId, StringComparison.OrdinalIgnoreCase));
+
+                    if (match != null)
+                    {
+                        return new DependencyReplacement(match.Version, new[] { info });
+                    }
+
+                    return null;
+
+                })
+                .FirstOrDefault(r => r != null);
+        }
+
+        private static EndpointModel GetBlobFeed(this OrchestratedBuildDependencyInfo info)
+        {
+            return info.OrchestratedBuildModel.Endpoints
+                .FirstOrDefault(e => e.IsOrchestratedBlobFeed);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/DependencyReplacement.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/DependencyReplacement.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public class DependencyReplacement
+    {
+        public DependencyReplacement(
+            string content,
+            IEnumerable<IDependencyInfo> usedDependencyInfos)
+        {
+            if (content == null)
+            {
+                throw new ArgumentNullException(nameof(content));
+            }
+
+            Content = content;
+            UsedDependencyInfos = usedDependencyInfos.NullAsEmpty();
+        }
+
+        public string Content { get; }
+
+        public IEnumerable<IDependencyInfo> UsedDependencyInfos { get; }
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileUpdater.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.VersionTools.Util;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.DotNet.VersionTools.Dependencies
+{
+    public abstract class FileUpdater : IDependencyUpdater
+    {
+        public string Path { get; set; }
+
+        public IEnumerable<DependencyUpdateTask> GetUpdateTasks(
+            IEnumerable<IDependencyInfo> dependencyInfos)
+        {
+            DependencyReplacement replacement = GetDesiredReplacement(dependencyInfos);
+
+            if (replacement == null)
+            {
+                Trace.TraceError($"For '{Path}', no replacement was found.");
+                yield break;
+            }
+
+            string originalContent = null;
+
+            Action updateTask = FileUtils.GetUpdateFileContentsTask(
+                Path,
+                content =>
+                {
+                    // Avoid Environment.NewLine to prevent issues when autocrlf isn't set up.
+                    int firstLineLength = new[] { '\r', '\n' }
+                        .Select(c =>
+                        {
+                            int? i = content.IndexOf(c);
+                            return i >= 0 ? i : null;
+                        })
+                        .FirstOrDefault(i => i.HasValue)
+                        // Replace entire file if it has no newline ending.
+                        ?? content.Length;
+
+                    originalContent = content.Substring(0, firstLineLength);
+                    return content
+                        .Remove(0, firstLineLength)
+                        .Insert(0, replacement.Content);
+                });
+
+            if (updateTask != null)
+            {
+                yield return new DependencyUpdateTask(
+                    updateTask,
+                    replacement.UsedDependencyInfos,
+                    new[] { $"In '{Path}', '{originalContent}' must be '{replacement.Content}'." });
+            }
+        }
+
+        public abstract DependencyReplacement GetDesiredReplacement(
+            IEnumerable<IDependencyInfo> dependencyInfos);
+    }
+}

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/OrchestratedBuildSubmoduleUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/Submodule/OrchestratedBuildSubmoduleUpdater.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using Microsoft.DotNet.VersionTools.Util;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
 {
@@ -28,27 +26,17 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
             IEnumerable<IDependencyInfo> dependencyInfos,
             out IEnumerable<IDependencyInfo> usedDependencyInfos)
         {
-            DependencyInfoMatch[] matches = dependencyInfos
-                .OfType<OrchestratedBuildDependencyInfo>()
-                .SelectMany(info => info.OrchestratedBuildModel.Builds
-                    .Where(b => b.Name.Equals(BuildName, StringComparison.OrdinalIgnoreCase))
-                    .Select(b => new DependencyInfoMatch { Info = info, Match = b }))
-                .ToArray();
+            OrchestratedBuildIdentityMatch match = OrchestratedBuildIdentityMatch.Find(
+                BuildName,
+                dependencyInfos);
 
-            if (matches.Length != 1)
+            if (match == null)
             {
-                throw new ArgumentException(
-                    $"For '{Path}', expected 1 build matching '{BuildName}', " +
-                    $"but found {matches.Length}: '{string.Join(", ", matches.AsEnumerable())}'");
+                usedDependencyInfos = null;
+                return null;
             }
 
-            DependencyInfoMatch match = matches[0];
-
-            if (string.IsNullOrEmpty(match.Match.Commit))
-            {
-                throw new ArgumentException(
-                    $"For '{Path}', found match '{match}', but no commit on '{match.Match}'.");
-            }
+            match.EnsureMatchHasCommit();
 
             usedDependencyInfos = new[] { match.Info };
             return match.Match.Commit;
@@ -59,14 +47,6 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.Submodule
             string refspec = $"+refs/heads/*:refs/remotes/{SyntheticRemoteName}/*";
             Trace.TraceInformation($"In '{Path}', fetching '{refspec}' from '{GitUrl}'...");
             GitCommand.Fetch(Path, GitUrl, refspec);
-        }
-
-        private class DependencyInfoMatch
-        {
-            public OrchestratedBuildDependencyInfo Info { get; set; }
-            public BuildIdentity Match { get; set; }
-
-            public override string ToString() => $"'{Match}' from '{Info.SimpleName}'";
         }
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
+++ b/src/Microsoft.DotNet.VersionTools/Microsoft.DotNet.VersionTools.csproj
@@ -47,6 +47,11 @@
     <Compile Include="BuildManifest\JoinSemaphoreGroup.cs" />
     <Compile Include="BuildManifest\SupplementaryUploadRequest.cs" />
     <Compile Include="Dependencies\BuildOutput\BuildDependencyInfo.cs" />
+    <Compile Include="Dependencies\BuildOutput\OrchestratedBuild\FileRegexOrchestratedBuildCustomUpdater.cs" />
+    <Compile Include="Dependencies\BuildOutput\OrchestratedBuild\OrchestratedBuildUpdateHelpers.cs" />
+    <Compile Include="Dependencies\FileUpdater.cs" />
+    <Compile Include="Dependencies\DependencyReplacement.cs" />
+    <Compile Include="Dependencies\BuildOutput\OrchestratedBuild\FileOrchestratedBuildCustomUpdater.cs" />
     <Compile Include="Dependencies\IDependencyInfo.cs" />
     <Compile Include="Dependencies\DependencyUpdateTask.cs" />
     <Compile Include="Automation\GitHubApi\GitHubClient.cs" />
@@ -56,6 +61,7 @@
     <Compile Include="Automation\PullRequestCreator.cs" />
     <Compile Include="Automation\GitHubApi\GitHubApiModel.cs" />
     <Compile Include="Dependencies\BuildManifest\OrchestratedBuildDependencyInfo.cs" />
+    <Compile Include="Dependencies\BuildManifest\OrchestratedBuildIdentityMatch.cs" />
     <Compile Include="Dependencies\Submodule\OrchestratedBuildSubmoduleUpdater.cs" />
     <Compile Include="Dependencies\Submodule\SubmoduleDependencyInfo.cs" />
     <Compile Include="Dependencies\BuildOutput\ToolVersionsUpdater.cs" />


### PR DESCRIPTION
 * Build attribute from orchestrated build
 * Orchestrated blob feed attribute
 * Orchestrated blob feed package version

Each updater can update a single-line file (e.g. BuildToolsVersion.txt) or make changes based on regex (with ElementName shortcut for XML).

Also fixes issue with CRLF/LF handling when updating a single-line file when autocrlf isn't set consistently with the running platform.

(cherry picked from commit 338f4b059ef26b1ee718aafca49cfb6cf69e7d6a)

---

Ports https://github.com/dotnet/buildtools/pull/2047 to `release/2.1`. No conflicts.