### PR TITLE
Replaces CoreLib with respective IL when doing coverage runs

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -16,7 +16,7 @@
     <CodeCoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(RunningOnUnix)' != 'true' and '$(Coverage)' == 'true' and '$(Performance)' != 'true'">true</CodeCoverageEnabled>
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(TestWorkingDir)coverage\</CoverageReportDir>
 
-    <RestoreCrossgenWithHardlinks Condition="'$(RestoreCrossgenWithHardlinks)' == ''">true</RestoreCrossgenWithHardlinks>
+    <RestoreIlPdbsWithHardlinks Condition="'$(RestoreIlPdbsWithHardlinks)' == ''">true</RestoreIlPdbsWithHardlinks>
 
     <!-- This targets file has two modes one for individual projects and one for all -->
     <GenerateCodeCoverageReportForAll Condition="'$(GenerateCodeCoverageReportForAll)'==''">false</GenerateCodeCoverageReportForAll>
@@ -52,46 +52,45 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Crossgen assemblies need to be replaced by their respective ILs in order for proper coverage reporting -->
-  <Target Name="CopyIlAssembliesToTestHost"  BeforeTargets="GenerateTestExecutionScripts" Condition="'$(CodeCoverageEnabled)'=='true'">
-    <Message Importance="high" Text="Replacing cross gen assemblies targeted for code coverage with respective IL assemblies." />
+  <!-- Workaround OpenCover symbol matching behavior by moving pdb files for coverage runs -->
+  <Target Name="ReplaceIlPdbsOnTestHost"  BeforeTargets="GenerateTestExecutionScripts" Condition="'$(CodeCoverageEnabled)'=='true'">
+    <Message Importance="high" Text="Replacing IL pdbs with respective pdbs for crossgen images (workaround OpenCover issue)." />
     <ItemGroup>
-      <SelectedIlAssemblies Include="@(_CodeCoverageAssemblies -> '$(NETCoreAppTestSharedFrameworkPath)il/%(Identity).dll')"
-        Condition="Exists('$(NETCoreAppTestSharedFrameworkPath)/il/%(Identity).dll') AND Exists('$(NETCoreAppTestSharedFrameworkPath)/ni/%(Identity).dll')">
-          <NativeImagePath>$(NETCoreAppTestSharedFrameworkPath)%(Identity).dll</NativeImagePath>
-      </SelectedIlAssemblies>
+      <SelectedNiPdbFiles Include="@(_CodeCoverageAssemblies -> '$(NETCoreAppTestSharedFrameworkPath)ni/%(Identity).ni.pdb')"
+        Condition="Exists('$(NETCoreAppTestSharedFrameworkPath)/il/%(Identity).pdb') AND Exists('$(NETCoreAppTestSharedFrameworkPath)/ni/%(Identity).ni.pdb')" >
+          <IlPdbPath>$(NETCoreAppTestSharedFrameworkPath)%(Identity).pdb</IlPdbPath>
+      </SelectedNiPdbFiles>
     </ItemGroup>
 
     <!-- Delete the files under the test host to break any existing hardlinks -->
-    <Delete Files="@(SelectedIlAssemblies->'%(NativeImagePath)')" />
+    <Delete Files="@(SelectedNiPdbFiles -> '%(IlPdbPath)')" />
 
-    <!-- Put IL versions in place -->
-    <Copy SourceFiles="@(SelectedIlAssemblies)" 
-      DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
+    <!-- Put renamed pdbs in place -->
+    <Copy SourceFiles="@(SelectedNiPdbFiles)" 
+      DestinationFiles="%(SelectedNiPdbFiles.IlPdbPath)"
       SkipUnchangedFiles="true" />
   </Target>
 
-  <!-- General task to restore crossgen assemblies -->
-  <Target Name="RestoreCrossgenAssemblies">
+  <!-- General task to restore pdbs that may have been replaced for OpenCover workaround -->
+  <Target Name="RestoreIlPdbs">
     <ItemGroup>
-       <!-- Assume that all ni images were replaced (ensures full restore when generating coverage for all tests -->
-      <CrossgenAssembliesToRestore Include="$(NETCoreAppTestSharedFrameworkPath)ni/*.*" />
+       <!-- Assume that all ni pdbs were replaced (ensures full restore) -->
+      <PdbsToRestore Include="$(NETCoreAppTestSharedFrameworkPath)il/*.pdb" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(CrossgenAssembliesToRestore)" 
+    <Copy SourceFiles="@(PdbsToRestore)" 
       DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
       SkipUnchangedFiles="true"
-      UseHardlinksIfPossible="$(RestoreCrossgenWithHardlinks)" />
+      UseHardlinksIfPossible="$(RestoreIlPdbsWithHardlinks)" />
   </Target>
 
-  <!-- Crossgen assemblies may need to be restored due to previous coverage runs that replaced them with IL versions -->
-  <Target Name="RestoreCrossgenAssembliesForTestRun"
+  <!-- Il pdbs may need to be restored due to previous coverage runs that replaced them with IL versions -->
+  <Target Name="RestoreIlPdbsForTestRun"
     BeforeTargets="GenerateTestExecutionScripts"
-    DependsOnTargets="RestoreCrossgenAssemblies"
+    DependsOnTargets="RestoreIlPdbs"
     Condition="'$(CodeCoverageEnabled)' != 'true' AND '$(SkipTests)' != 'true'">
-    <Message Importance="normal" Text="Restoring cross gen assemblies that were potentially replaced with respective IL assemblies." />
+    <Message Importance="normal" Text="Restoring IL pdbs that were potentially replaced with respective crossgen pdbs." />
   </Target>
-
 
   <!-- *********************************************************************************************** -->
   <!-- As of 10/2017 OpenCover does not support portable PDBs, but we want the builds to generate
@@ -212,12 +211,12 @@
     <ParseTestCoverageInfo CoverageReports="@(Reports)"
                            OutputReport="$(CoverageReportDir)\VisitedMethodsReport.xml"/>
   </Target>
-  
-  <!-- Restore Crossgen assemblies to testhost -->
-  <Target Name="RestoreCrossgenAssembliesToTestHostAfterCoverageReports"
+
+  <!-- Restore IL pdbs to testhost -->
+  <Target Name="RestoreIlPdbsToTestHostAfterCoverageReports"
     AfterTargets="GenerateIndividualCoverageReport;GenerateFullCoverageReport"
-    DependsOnTargets="RestoreCrossgenAssemblies">
-    <Message Importance="high" Text="Restoring cross gen assemblies that were potentially replaced with respective IL assemblies." />
+    DependsOnTargets="RestoreIlPdbs">
+    <Message Importance="normal" Text="Restoring IL pdbs that were potentially replaced with respective crossgen pdbs." />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -16,6 +16,8 @@
     <CodeCoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(RunningOnUnix)' != 'true' and '$(Coverage)' == 'true' and '$(Performance)' != 'true'">true</CodeCoverageEnabled>
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(TestWorkingDir)coverage\</CoverageReportDir>
 
+    <RestoreCrossgenWithHardlinks Condition="'$(RestoreCrossgenWithHardlinks)' == ''">true</RestoreCrossgenWithHardlinks>
+
     <!-- This targets file has two modes one for individual projects and one for all -->
     <GenerateCodeCoverageReportForAll Condition="'$(GenerateCodeCoverageReportForAll)'==''">false</GenerateCodeCoverageReportForAll>
     <CoverageEnabledForProject Condition="'$(GenerateCodeCoverageReportForAll)'=='true'">false</CoverageEnabledForProject>
@@ -50,6 +52,47 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Crossgen assemblies need to be replaced by their respective ILs in order for proper coverage reporting -->
+  <Target Name="CopyIlAssembliesToTestHost"  BeforeTargets="GenerateTestExecutionScripts" Condition="'$(CodeCoverageEnabled)'=='true'">
+    <Message Importance="high" Text="Replacing cross gen assemblies targeted for code coverage with respective IL assemblies." />
+    <ItemGroup>
+      <SelectedIlAssemblies Include="@(_CodeCoverageAssemblies -> '$(NETCoreAppTestSharedFrameworkPath)il/%(Identity).dll')"
+        Condition="Exists('$(NETCoreAppTestSharedFrameworkPath)/il/%(Identity).dll') AND Exists('$(NETCoreAppTestSharedFrameworkPath)/ni/%(Identity).dll')">
+          <NativeImagePath>$(NETCoreAppTestSharedFrameworkPath)%(Identity).dll</NativeImagePath>
+      </SelectedIlAssemblies>
+    </ItemGroup>
+
+    <!-- Delete the files under the test host to break any existing hardlinks -->
+    <Delete Files="@(SelectedIlAssemblies->'%(NativeImagePath)')" />
+
+    <!-- Put IL versions in place -->
+    <Copy SourceFiles="@(SelectedIlAssemblies)" 
+      DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
+      SkipUnchangedFiles="true" />
+  </Target>
+
+  <!-- General task to restore crossgen assemblies -->
+  <Target Name="RestoreCrossgenAssemblies">
+    <ItemGroup>
+       <!-- Assume that all ni images were replaced (ensures full restore when generating coverage for all tests -->
+      <CrossgenAssembliesToRestore Include="$(NETCoreAppTestSharedFrameworkPath)ni/*.*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(CrossgenAssembliesToRestore)" 
+      DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
+      SkipUnchangedFiles="true"
+      UseHardlinksIfPossible="$(RestoreCrossgenWithHardlinks)" />
+  </Target>
+
+  <!-- Crossgen assemblies may need to be restored due to previous coverage runs that replaced them with IL versions -->
+  <Target Name="RestoreCrossgenAssembliesForTestRun"
+    BeforeTargets="GenerateTestExecutionScripts"
+    DependsOnTargets="RestoreCrossgenAssemblies"
+    Condition="'$(CodeCoverageEnabled)' != 'true' AND '$(SkipTests)' != 'true'">
+    <Message Importance="normal" Text="Restoring cross gen assemblies that were potentially replaced with respective IL assemblies." />
+  </Target>
+
+
   <!-- *********************************************************************************************** -->
   <!-- As of 10/2017 OpenCover does not support portable PDBs, but we want the builds to generate
        portable PDBs.  Thus we generate windows PDBs from portable PDBs here.   Can be removed
@@ -62,12 +105,14 @@
     <!-- We look for the DLL being tested for coverage and its PDB create a WindowsPDB\*.pdb which has
          the windows PDB.  -->
     <ItemGroup>
-      <PortableDllsToConvert Include="$(NETCoreAppTestSharedFrameworkPath)$(AssemblyBeingTestedName).dll">
-        <PdbPath>$(NETCoreAppTestSharedFrameworkPath)$(AssemblyBeingTestedName).pdb</PdbPath>
-        <TargetPath>$(NETCoreAppTestSharedFrameworkPath)WindowsPDB/$(AssemblyBeingTestedName).pdb</TargetPath>
-      </PortableDllsToConvert>
+      <CandidateAssemblies Include="@(_CodeCoverageAssemblies -> '$(NETCoreAppTestSharedFrameworkPath)%(Identity)')" />
 
-      <ExistingPortableDllsToConvert Include="@(PortableDllsToConvert)" Condition="Exists('%(PortableDllsToConvert.Identity)') AND Exists('%(PortableDllsToConvert.PdbPath)')"/>
+      <ExistingPortableDllsToConvert
+        Include="@(CandidateAssemblies -> '%(Identity).dll' )"
+        Condition="Exists('%(CandidateAssemblies.Identity).dll') AND Exists('%(CandidateAssemblies.Identity).pdb')">
+        <PdbPath>%(Identity).pdb</PdbPath>
+        <TargetPath>%(RootDir)/%(Directory)WindowsPDB/%(Filename)%(Extension).pdb</TargetPath>
+      </ExistingPortableDllsToConvert>
     </ItemGroup>
 
     <!-- There are two file in CoreFX, (System.Security.Permissions and Microsoft.Win32.Registry.AccessControl.pdb)  
@@ -168,4 +213,11 @@
                            OutputReport="$(CoverageReportDir)\VisitedMethodsReport.xml"/>
   </Target>
   
+  <!-- Restore Crossgen assemblies to testhost -->
+  <Target Name="RestoreCrossgenAssembliesToTestHostAfterCoverageReports"
+    AfterTargets="GenerateIndividualCoverageReport;GenerateFullCoverageReport"
+    DependsOnTargets="RestoreCrossgenAssemblies">
+    <Message Importance="high" Text="Restoring cross gen assemblies that were potentially replaced with respective IL assemblies." />
+  </Target>
+
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -88,7 +88,7 @@
   <Target Name="RestoreIlPdbsForTestRun"
     BeforeTargets="GenerateTestExecutionScripts"
     DependsOnTargets="RestoreIlPdbs"
-    Condition="'$(CodeCoverageEnabled)' != 'true' AND '$(SkipTests)' != 'true'">
+    Condition="'$(CodeCoverageEnabled)' != 'true' AND '$(SkipTests)' != 'true' AND '$(RunningOnUnix)' != 'true'">
     <Message Importance="normal" Text="Restoring IL pdbs that were potentially replaced with respective crossgen pdbs." />
   </Target>
 


### PR DESCRIPTION
This is another part of https://github.com/dotnet/corefx/issues/23588

This one replaces CoreLib crossgen in coverage runs that specified it as one of the included assemblies. It tries to restore the crossgen version at the end of the coverage run, but also whenever starting any test to avoid running against the IL version unexpectedly.