### PR TITLE
Support using the Microsoft.NET.Sdk with dotnet/buildtools

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -104,14 +104,14 @@
           Condition="'$(MSBuildProjectExtension)' == '.depproj'" />
 
   <Import Project="IL.targets"
-           Condition="'$(MSBuildProjectExtension)' == '.ilproj' AND '$(SkipImportILTargets)'!='true'" />
+           Condition="'$(MSBuildProjectExtension)' == '.ilproj' AND '$(SkipImportILTargets)'!='true' and '$(UsingMicrosoftNETSdk)' != 'true'" />
 
-  <!--
-      workaround file casing issue where it has different casing in different places which fails on linux builds
-      https://github.com/dotnet/buildtools/issues/1464
-  -->
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' != 'true'">
     <CSharpTargetsFile>$(MSBuildToolsPath)\Microsoft.CSharp.targets</CSharpTargetsFile>
+    <!--
+        workaround file casing issue where it has different casing in different places which fails on linux builds
+        https://github.com/dotnet/buildtools/issues/1464
+    -->
     <CSharpTargetsFile Condition="!Exists('$(CSharpTargetsFile)')">$(MSBuildToolsPath)\Microsoft.CSharp.Targets</CSharpTargetsFile>
   </PropertyGroup>
 
@@ -123,7 +123,7 @@
  
 
   <Import Project="$(CSharpTargetsFile)"
-          Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj'" />
+          Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.csproj' and '$(UsingMicrosoftNETSdk)' != 'true'" />
 
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft.VisualBasic.targets"
            Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj' and '$(RunningOnCore)' == 'true'" />
@@ -133,7 +133,7 @@
           Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj' and '$(RunningOnCore)' != 'true'" />
 
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets"
-          Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj'" />
+          Condition="'$(TargetFrameworkIdentifier)' != '.NETPortable' and '$(MSBuildProjectExtension)' == '.vbproj' and '$(UsingMicrosoftNETSdk)' != 'true'" />
 
   <PropertyGroup>
     <!--

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenerateAssemblyInfo.NonSdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenerateAssemblyInfo.NonSdk.targets
@@ -1,0 +1,65 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="GenerateAssemblyInfo"
+      Inputs="$(MSBuildProjectFile)"
+      Outputs="$(AssemblyInfoFile)"
+      Condition="'$(GenerateAssemblyInfo)'=='true'"
+      DependsOnTargets="CreateVersionFileDuringBuild;DecideIfWeNeedToIncludeDllSafeSearchPathAttribute">
+
+    <Error Condition="!Exists('$(IntermediateOutputPath)')" Text="GenerateAssemblyInfo failed because IntermediateOutputPath isn't set to a valid directory" />
+
+    <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+      <AssemblyInfoUsings Include="using System%3B" />
+      <AssemblyInfoUsings Include="using System.Reflection%3B" />
+      <AssemblyInfoLines Include="[assembly:AssemblyTitle(&quot;$(AssemblyTitle)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyDescription(&quot;$(Description)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyDefaultAlias(&quot;$(AssemblyName)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyCompany(&quot;$(Company)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyProduct(&quot;$(Product)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyCopyright(&quot;$(Copyright)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyVersion(&quot;$(AssemblyVersion)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyFileVersion(&quot;$(FileVersion)&quot;)]" />
+      <AssemblyInfoLines Include="[assembly:AssemblyInformationalVersion(@&quot;$(InformationalVersion)&quot;)]" />
+      <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="[assembly:CLSCompliant(true)]" />
+      <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="[assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))]" />
+      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'"
+        Include="[assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)]" />
+
+      <AssemblyInfoLines Condition="'$(IncludeDllSafeSearchPathAttribute)'=='true'" 
+        Include="[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.vbproj'">
+      <AssemblyInfoUsings Include="Imports System" />
+      <AssemblyInfoUsings Include="Imports System.Reflection" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyTitle(&quot;$(AssemblyTitle)&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyDescription(&quot;$(Description)&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyDefaultAlias(&quot;$(AssemblyName)&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyCompany(&quot;$(Company)&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyProduct(&quot;$(Product)k&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyCopyright(&quot;$(Copyright)&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyVersion(&quot;$(AssemblyVersion)&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyFileVersion(&quot;$(FileVersion)&quot;)&gt;" />
+      <AssemblyInfoLines Include="&lt;Assembly:AssemblyInformationalVersion(&quot;$(InformationalVersion)&quot;)&gt;" />
+      <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="&lt;Assembly:CLSCompliant(True)&gt;" />
+      <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="&lt;Assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))&gt;" />
+      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'"
+          Include="&lt;assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)&gt;" />
+
+      <AssemblyInfoLines Condition="'$(IncludeDllSafeSearchPathAttribute)'=='true'" 
+        Include="&lt;Assembly:System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)&gt;" />
+    </ItemGroup>
+
+    <WriteLinesToFile
+      File="$(AssemblyInfoFile)"
+      Lines="@(AssemblyInfoUsings);@(AssemblyInfoLines)"
+      Overwrite="true" />
+
+    <ItemGroup>
+      <Compile Include="$(AssemblyInfoFile)" />
+      <FileWrites Include="$(AssemblyInfoFile)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenerateAssemblyInfo.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenerateAssemblyInfo.Sdk.targets
@@ -1,0 +1,66 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- BuildTools never generated this attribute before, so don't let the SDK generate it. -->
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+
+    <!--
+    When using the Microsoft.NET.Sdk, Company and Product are defaulted to $(AssemblyName)
+    in Microsoft.NET.Sdk.BeforeCommon.targets, which means we would have to default them in
+    a props file. However, the versioning.props file has to be imported during versioning.targets
+    in order to get all the version properties set correctly.
+    So overwrite these two properties here, so they are set correctly.
+    -->
+    <Company>Microsoft Corporation</Company>
+    <Product>Microsoft%AE .NET Framework</Product>
+  </PropertyGroup>
+
+  <Target Name="_ComputeBuildToolsAssemblyInfoAttributes"
+          DependsOnTargets="CreateVersionFileDuringBuild;DecideIfWeNeedToIncludeDllSafeSearchPathAttribute"
+          BeforeTargets="GetAssemblyAttributes">
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Reflection.AssemblyDefaultAliasAttribute">
+        <_Parameter1>$(AssemblyName)</_Parameter1>
+      </AssemblyAttribute>
+
+      <AssemblyAttribute Include="System.Reflection.AssemblyMetadata"
+                         Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'">
+        <_Parameter1>%(AssemblyMetadata.Identity)</_Parameter1>
+        <_Parameter2>%(AssemblyMetadata.Value)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
+  <!-- Work around https://github.com/Microsoft/msbuild/issues/3412 by writing the non-string assembly attributes manually -->
+  <!-- Note: ReferenceAssemblies.targets still uses @(AssemblyInfoLines) as well. So if you remove this, those need to migrate too. -->
+  <Target Name="_WriteNonStringAssemblyInfoAttributes"
+          AfterTargets="CoreGenerateAssemblyInfo"
+          Inputs="$(MSBuildProjectFile)"
+          Outputs="$(AssemblyInfoFile)">
+
+    <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+      <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="[assembly:System.CLSCompliant(true)]" />
+
+      <AssemblyInfoLines Condition="'$(IncludeDllSafeSearchPathAttribute)'=='true'"
+        Include="[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.vbproj'">
+      <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="&lt;Assembly:System.CLSCompliant(True)&gt;" />
+
+      <AssemblyInfoLines Condition="'$(IncludeDllSafeSearchPathAttribute)'=='true'"
+        Include="&lt;Assembly:System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)&gt;" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(AssemblyInfoFile)"
+                      Lines="@(AssemblyInfoLines)"
+                      Condition="'@(AssemblyInfoLines)' != ''"
+                      Overwrite="true" />
+
+    <ItemGroup Condition="'@(AssemblyInfoLines)' != ''">
+      <Compile Include="$(AssemblyInfoFile)" />
+      <FileWrites Include="$(AssemblyInfoFile)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -41,8 +41,7 @@
   </PropertyGroup>
 
   <Target Name="DecideIfWeNeedToIncludeDllSafeSearchPathAttribute" 
-    Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' AND '$(IsTestProject)' != 'true'"
-    BeforeTargets="GenerateAssemblyInfo">
+    Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' AND '$(IsTestProject)' != 'true'">
     
     <!-- We want to apply the IncludeDllSafeSearchPathAttribute on all DotNet assemblies (non test) that have a reference to System.Runtime.InteropServices -->
     <PropertyGroup Condition="'$(IncludeDllSafeSearchPathAttribute)'==''">
@@ -52,77 +51,12 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="GenerateAssemblyInfo"
-      Inputs="$(MSBuildProjectFile)"
-      Outputs="$(AssemblyInfoFile)"
-      Condition="'$(GenerateAssemblyInfo)'=='true'"
-      DependsOnTargets="CreateVersionFileDuringBuild">
+  <PropertyGroup>
+    <_GenerateAssemblyInfoTargetsFilePath Condition="'$(UsingMicrosoftNETSdk)' == 'true'">GenerateAssemblyInfo.Sdk.targets</_GenerateAssemblyInfoTargetsFilePath>
+    <_GenerateAssemblyInfoTargetsFilePath Condition="'$(UsingMicrosoftNETSdk)' != 'true'">GenerateAssemblyInfo.NonSdk.targets</_GenerateAssemblyInfoTargetsFilePath>
+  </PropertyGroup>
 
-    <Error Condition="!Exists('$(IntermediateOutputPath)')" Text="GenerateAssemblyInfo failed because IntermediateOutputPath isn't set to a valid directory" />
-
-    <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-      <AssemblyInfoUsings Include="using System%3B" />
-      <AssemblyInfoUsings Include="using System.Reflection%3B" />
-      <AssemblyInfoLines Include="[assembly:AssemblyTitle(&quot;$(AssemblyTitle)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyDescription(&quot;$(Description)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyDefaultAlias(&quot;$(AssemblyName)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyCompany(&quot;$(Company)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyProduct(&quot;$(Product)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyCopyright(&quot;$(Copyright)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyVersion(&quot;$(AssemblyVersion)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyFileVersion(&quot;$(FileVersion)&quot;)]" />
-      <AssemblyInfoLines Include="[assembly:AssemblyInformationalVersion(@&quot;$(InformationalVersion)&quot;)]" />
-      <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="[assembly:CLSCompliant(true)]" />
-      <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="[assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))]" />
-      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'"
-        Include="[assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)]" />
-
-      <AssemblyInfoLines Condition="'$(IncludeDllSafeSearchPathAttribute)'=='true'" 
-        Include="[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.vbproj'">
-      <AssemblyInfoUsings Include="Imports System" />
-      <AssemblyInfoUsings Include="Imports System.Reflection" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyTitle(&quot;$(AssemblyTitle)&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyDescription(&quot;$(Description)&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyDefaultAlias(&quot;$(AssemblyName)&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyCompany(&quot;$(Company)&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyProduct(&quot;$(Product)k&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyCopyright(&quot;$(Copyright)&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyVersion(&quot;$(AssemblyVersion)&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyFileVersion(&quot;$(FileVersion)&quot;)&gt;" />
-      <AssemblyInfoLines Include="&lt;Assembly:AssemblyInformationalVersion(&quot;$(InformationalVersion)&quot;)&gt;" />
-      <AssemblyInfoLines Condition="'$(CLSCompliant)'=='true'" Include="&lt;Assembly:CLSCompliant(True)&gt;" />
-      <AssemblyInfoLines Condition="'$(AssemblyComVisible)'!=''" Include="&lt;Assembly:System.Runtime.InteropServices.ComVisible($(AssemblyComVisible))&gt;" />
-      <AssemblyInfoLines Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'"
-          Include="&lt;assembly:System.Reflection.AssemblyMetadata(&quot;%(AssemblyMetadata.Identity)&quot;, &quot;%(AssemblyMetadata.Value)&quot;)&gt;" />
-
-      <AssemblyInfoLines Condition="'$(IncludeDllSafeSearchPathAttribute)'=='true'" 
-        Include="&lt;Assembly:System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)&gt;" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' And '$(GenerateThisAssemblyClass)' == 'true'">
-      <AssemblyInfoLines Include="internal static class ThisAssembly" />
-      <AssemblyInfoLines Include="{" />
-      <AssemblyInfoLines Include="%20%20%20%20internal const string Title = &quot;$(AssemblyName)&quot;%3B" />
-      <AssemblyInfoLines Include="%20%20%20%20internal const string Copyright = &quot;\u00A9 Microsoft Corporation.  All rights reserved.&quot;%3B" />
-      <AssemblyInfoLines Include="%20%20%20%20internal const string Version = &quot;$(AssemblyVersion)&quot;%3B" />
-      <AssemblyInfoLines Include="%20%20%20%20internal const string InformationalVersion = &quot;$(AssemblyFileVersion)&quot;%3B" />
-      <AssemblyInfoLines Include="}" />
-    </ItemGroup>
-
-    <WriteLinesToFile
-      File="$(AssemblyInfoFile)"
-      Lines="@(AssemblyInfoUsings);@(AssemblyInfoLines);@(AssemblyInfoSource)"
-      Overwrite="true" />
-
-    <ItemGroup>
-      <Compile Include="$(AssemblyInfoFile)" />
-      <FileWrites Include="$(AssemblyInfoFile)" />
-    </ItemGroup>
-
-  </Target>
+  <Import Project="$(_GenerateAssemblyInfoTargetsFilePath)" />
 
   <ItemGroup Condition="'$(GenerateAssemblyInfo)'=='true' AND '$(StringResourcesPath)' != '' AND '$(ExcludeAssemblyInfoPartialFile)' != 'true'">
     <Compile Include="$(AssemblyInfoPartialFile)">


### PR DESCRIPTION
- Don't import Microsoft.$(Language).targets in buildtools - the SDK will do that.
- Use the Sdk's GenerateAssemblyInfo target when possible

Still support non-SDK projects for backwards compatiblity.

Note: I removed support for @(AssemblyInfoSource) during GenerateAssemblyInfo because it is no longer used as of dotnet/corefx/pull/30400.