### PR TITLE
Allow auto-updating from on-disk ProdCon manifest; add SkipIfNoReplacementFound

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -9,6 +9,7 @@
     <ProjectGuid>{B3331D88-7569-42D5-919B-F267DA011911}</ProjectGuid>
     <DefineConstants>net45</DefineConstants>
     <TargetFrameworkProfile />
+    <VersionToolsProjectReferenceSuffix>.net45</VersionToolsProjectReferenceSuffix>
   </PropertyGroup>
   <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.csproj" />
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -135,10 +135,9 @@
       <Project>{2179f9b5-1dba-4563-9402-a94de75ea9fa}</Project>
       <Name>Microsoft.Cci.Extensions</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj">
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix)\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix).csproj">
       <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
       <Name>Microsoft.DotNet.VersionTools</Name>
-      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -138,6 +138,7 @@
     <ProjectReference Include="..\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix)\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix).csproj">
       <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
       <Name>Microsoft.DotNet.VersionTools</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.VersionTools;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Automation.GitHubApi;
 using Microsoft.DotNet.VersionTools.BuildManifest;
+using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.DotNet.VersionTools.Dependencies;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
@@ -15,8 +16,10 @@ using Microsoft.DotNet.VersionTools.Dependencies.Submodule;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Build.Tasks.VersionTools
 {
@@ -203,6 +206,15 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                             GetRequiredMetadata(info, CurrentRefMetadataName),
                             GetRequiredMetadata(info, "BasePath"),
                             new BuildManifestClient(GitHubClient)).Result;
+                        break;
+
+                    case "Orchestrated build file":
+                        dependencyInfo = new OrchestratedBuildDependencyInfo(
+                            info.ItemSpec,
+                            OrchestratedBuildModel.Parse(
+                                XElement.Parse(
+                                    File.ReadAllText(
+                                        GetRequiredMetadata(info, "Path")))));
                         break;
 
                     default:

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
@@ -31,24 +31,20 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildManifest
                     $"'{project.Segments}' '{basePath}' ref '{@ref}'");
             }
 
-            return new OrchestratedBuildDependencyInfo(simpleName, basePath, model);
+            return new OrchestratedBuildDependencyInfo(simpleName, model);
         }
 
         public string SimpleName { get; }
 
         public string SimpleVersion => OrchestratedBuildModel.Identity.BuildId;
 
-        public string BasePath { get; }
-
         public OrchestratedBuildModel OrchestratedBuildModel { get; }
 
         public OrchestratedBuildDependencyInfo(
             string simpleName,
-            string basePath,
             OrchestratedBuildModel model)
         {
             SimpleName = simpleName;
-            BasePath = basePath;
             OrchestratedBuildModel = model;
         }
     }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
@@ -47,5 +47,7 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildManifest
             SimpleName = simpleName;
             OrchestratedBuildModel = model;
         }
+
+        public override string ToString() => $"{SimpleName} {SimpleVersion}";
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
@@ -22,14 +22,14 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildManifest
                     .Select(b => new OrchestratedBuildIdentityMatch { Info = info, Match = b }))
                 .ToArray();
 
-            if (matches.Length != 1)
+            if (matches.Length > 1)
             {
                 throw new ArgumentException(
-                    $"Expected 1 build matching '{buildName}', but found {matches.Length}: " +
+                    $"Expected only 1 build matching '{buildName}', but found {matches.Length}: " +
                     $"'{string.Join(", ", matches.AsEnumerable())}'");
             }
 
-            return matches[0];
+            return matches.FirstOrDefault();
         }
 
         public OrchestratedBuildDependencyInfo Info { get; set; }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBuild
@@ -18,12 +19,20 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBui
             {
                 var match = OrchestratedBuildIdentityMatch.Find(buildName, infos);
 
+                if (match == null)
+                {
+                    Trace.TraceInformation($"No build identity match for '{buildName}'.");
+                    return null;
+                }
+
                 string value;
                 if (match.Match.Attributes.TryGetValue(attributeName, out value))
                 {
                     return new DependencyReplacement(value, new[] { match.Info });
                 }
 
+                Trace.TraceInformation(
+                    $"In build identity '{buildName}', no attribute '{attributeName}'.");
                 return null;
             };
         }
@@ -42,6 +51,8 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBui
                         return new DependencyReplacement(value, new[] { info });
                     }
 
+                    Trace.TraceInformation(
+                        $"No blob feed or '{attributeName}' attribute for '{info}'.");
                     return null;
                 })
                 .FirstOrDefault(r => r != null);
@@ -61,8 +72,8 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBui
                         return new DependencyReplacement(match.Version, new[] { info });
                     }
 
+                    Trace.TraceInformation($"No package '{packageId}' match in '{info}'.");
                     return null;
-
                 })
                 .FirstOrDefault(r => r != null);
         }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using Microsoft.DotNet.VersionTools.Util;
 using System;
 using System.Collections.Generic;
@@ -18,6 +17,11 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
         public Regex Regex { get; set; }
         public string VersionGroupName { get; set; }
 
+        /// <summary>
+        /// Instead of throwing an exception, skip this updater if no replacement value is found.
+        /// </summary>
+        public bool SkipIfNoReplacementFound { get; set; }
+
         public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos)
         {
             IEnumerable<IDependencyInfo> usedInfos;
@@ -25,7 +29,10 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
 
             if (newValue == null)
             {
-                Trace.TraceError($"Could not find version information to change '{Path}' with '{Regex}'");
+                if (!SkipIfNoReplacementFound)
+                {
+                    Trace.TraceError($"For '{Path}', a replacement value for '{Regex}' was not found.");
+                }
             }
             else
             {

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileUpdater.cs
@@ -14,6 +14,11 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
     {
         public string Path { get; set; }
 
+        /// <summary>
+        /// Instead of throwing an exception, skip this updater if no replacement value is found.
+        /// </summary>
+        public bool SkipIfNoReplacementFound { get; set; }
+
         public IEnumerable<DependencyUpdateTask> GetUpdateTasks(
             IEnumerable<IDependencyInfo> dependencyInfos)
         {
@@ -21,7 +26,10 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
 
             if (replacement == null)
             {
-                Trace.TraceError($"For '{Path}', no replacement was found.");
+                if (!SkipIfNoReplacementFound)
+                {
+                    Trace.TraceError($"For '{Path}', a replacement value was not found.");
+                }
                 yield break;
             }
 

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -51,7 +51,6 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
-    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
 
     <file src="..\obj\version.txt" target="" />
   </files>

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -51,6 +51,7 @@
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\Microsoft.DotNet.Build.Tasks.Packaging.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.Build.Tasks.Packaging.Desktop\NuGet.*.dll" target="lib\net46" />
     <file src="Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.dll" target="lib" />
+    <file src="Microsoft.DotNet.VersionTools.net45\Microsoft.DotNet.VersionTools.dll" target="lib\net46" />
 
     <file src="..\obj\version.txt" target="" />
   </files>


### PR DESCRIPTION
On-disk manifest allows you to download or generate a manifest, then use it to update without uploading it to GitHub (dotnet/versions) first.

`SkipIfNoReplacementFound` reduces the maintenance burden in source-build. Right now we have to disable updaters when ProdCon stops building particular repos. More importantly, we have to remember to enable them again later or we start missing updates. With this attribute, we can leave the updaters enabled all the time.

If this looks ok to merge, I'm porting to `release/2.1` immediately.