### PR TITLE
Fix compile error when AssemblyMetadata is empty.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenerateAssemblyInfo.Sdk.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/GenerateAssemblyInfo.Sdk.targets
@@ -24,7 +24,7 @@
       </AssemblyAttribute>
 
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata"
-                         Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true'">
+                         Condition="'$(SkipFrameworkAssemblyMetadata)' != 'true' and '@(AssemblyMetadata)' != ''">
         <_Parameter1>%(AssemblyMetadata.Identity)</_Parameter1>
         <_Parameter2>%(AssemblyMetadata.Value)</_Parameter2>
       </AssemblyAttribute>


### PR DESCRIPTION
There are some test projects that don't set AssemblyMetadata, and are failing to build using the Microsoft.NET.Sdk.  The fix is to not generate an assembly attribute in these cases.