### PR TITLE
[release/1.0.0] Import MicroBuild props

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -16,4 +16,9 @@
     <CompilerResponseFile Condition="'$(CheckSumSHA256)'!='false'">$(MSBuildThisFileDirectory)checksum.rsp</CompilerResponseFile>
   </PropertyGroup>
 
+
+  <!--
+    import the MicroBuild boot-strapper props (only relevant for shipping binaries)
+  -->
+  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.props" Condition="'$(IsTestProject)'!='true'" />
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.props
@@ -20,5 +20,5 @@
   <!--
     import the MicroBuild boot-strapper props (only relevant for shipping binaries)
   -->
-  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.props" Condition="'$(IsTestProject)'!='true'" />
+  <Import Project="$(MSBuildThisFileDirectory)MicroBuild.Core.props" Condition="'$(IsTestProject)'!='true' AND Exists('$(MSBuildThisFileDirectory)MicroBuild.Core.props')" />
 </Project>


### PR DESCRIPTION
We need to address https://github.com/dotnet/buildtools/issues/1186 in 1.0 tools because the 1.0 servicing branches moved passed the pinned microbuild version.

Ports https://github.com/dotnet/buildtools/pull/1199 and https://github.com/dotnet/buildtools/pull/1200

cc @wtgodbe @ericstj 