### PR TITLE
Create a runtime dedicated to coverage using IL only

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -17,6 +17,7 @@
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(TestWorkingDir)coverage\</CoverageReportDir>
 
     <RestoreIlPdbsWithHardlinks Condition="'$(RestoreIlPdbsWithHardlinks)' == ''">true</RestoreIlPdbsWithHardlinks>
+    <UseCoverageDedicatedRuntime Condition="'$(UseCoverageDedicatedRuntime)' == ''">true</UseCoverageDedicatedRuntime>
 
     <!-- This targets file has two modes one for individual projects and one for all -->
     <GenerateCodeCoverageReportForAll Condition="'$(GenerateCodeCoverageReportForAll)'==''">false</GenerateCodeCoverageReportForAll>
@@ -53,7 +54,9 @@
   </Target>
 
   <!-- Workaround OpenCover symbol matching behavior by moving pdb files for coverage runs -->
-  <Target Name="ReplaceIlPdbsOnTestHost"  BeforeTargets="GenerateTestExecutionScripts" Condition="'$(CodeCoverageEnabled)'=='true'">
+  <Target Name="ReplaceIlPdbsOnTestHost"
+    BeforeTargets="GenerateTestExecutionScripts"
+    Condition="'$(CodeCoverageEnabled)'=='true' and '$(UseCoverageDedicatedRuntime)'!='true'">
     <Message Importance="high" Text="Replacing IL pdbs with respective pdbs for crossgen images (workaround OpenCover issue)." />
     <ItemGroup>
       <SelectedNiPdbFiles Include="@(_CodeCoverageAssemblies -> '$(NETCoreAppTestSharedFrameworkPath)ni/%(Identity).ni.pdb')"
@@ -130,6 +133,38 @@
     <Copy SourceFiles="%(ExistingPortableDllsToConvert.TargetPath)" DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)" Condition="Exists('%(ExistingPortableDllsToConvert.TargetPath)')"/>
   </Target>
   <!-- *********************************************************************************************** -->
+
+  <Target Name="CreateCoverageDedicatedRuntime"
+    BeforeTargets="GenerateTestExecutionScripts"
+    DependsOnTargets="GenerateWindowsPdbsForAssemblyBeingTested"
+    Condition="'$(CodeCoverageEnabled)'=='true' and '$(UseCoverageDedicatedRuntime)'=='true'">
+    <PropertyGroup>
+      <CoverageDedicatedRuntimeDir>$(TestHostRootPath)shared/Microsoft.NETCore.App/10.10.10</CoverageDedicatedRuntimeDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <RuntimeFiles Include="$(NETCoreAppTestSharedFrameworkPath)/*.*" />
+      <RuntimeFiles Include="$(NETCoreAppTestSharedFrameworkPath)il/*.*" />
+      <RuntimeFilesAmd64 Include="$(NETCoreAppTestSharedFrameworkPath)amd64/*.*" />
+      <RuntimeFilesx86 Include="$(NETCoreAppTestSharedFrameworkPath)x86/*.*" />
+      <RuntimeWindowsPdbs Include="$(NETCoreAppTestSharedFrameworkPath)WindowsPDB/*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RuntimeFiles)"
+          DestinationFolder="$(CoverageDedicatedRuntimeDir)"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="false" />
+    <Copy SourceFiles="@(RuntimeFilesAmd64)"
+          DestinationFolder="$(CoverageDedicatedRuntimeDir)/amd64/"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="false" />
+    <Copy SourceFiles="@(RuntimeFilesx86)"
+          DestinationFolder="$(CoverageDedicatedRuntimeDir)/x86/"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="false" />
+    <Copy SourceFiles="@(RuntimeWindowsPdbs)"
+          DestinationFolder="$(CoverageDedicatedRuntimeDir)/WindowsPDB/"
+          SkipUnchangedFiles="true"
+          UseHardlinksIfPossible="false" />
+  </Target>
 
   <!-- xUnit command line with coverage enabled -->
   <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true'">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -16,7 +16,6 @@
     <CodeCoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(RunningOnUnix)' != 'true' and '$(Coverage)' == 'true' and '$(Performance)' != 'true'">true</CodeCoverageEnabled>
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(TestWorkingDir)coverage\</CoverageReportDir>
 
-    <RestoreIlPdbsWithHardlinks Condition="'$(RestoreIlPdbsWithHardlinks)' == ''">true</RestoreIlPdbsWithHardlinks>
     <UseCoverageDedicatedRuntime Condition="'$(UseCoverageDedicatedRuntime)' == ''">true</UseCoverageDedicatedRuntime>
 
     <!-- This targets file has two modes one for individual projects and one for all -->
@@ -51,48 +50,6 @@
       <CoverageFilter>@(_CodeCoverageAssemblies->'+[%(Identity)]*', ' ')</CoverageFilter>
       <CoverageFilter Condition="'$(CodeCoverageAssemblies)' == 'all'">[*]*</CoverageFilter>
     </PropertyGroup>
-  </Target>
-
-  <!-- Workaround OpenCover symbol matching behavior by moving pdb files for coverage runs -->
-  <Target Name="ReplaceIlPdbsOnTestHost"
-    BeforeTargets="GenerateTestExecutionScripts"
-    Condition="'$(CodeCoverageEnabled)'=='true' and '$(UseCoverageDedicatedRuntime)'!='true'">
-    <Message Importance="high" Text="Replacing IL pdbs with respective pdbs for crossgen images (workaround OpenCover issue)." />
-    <ItemGroup>
-      <SelectedNiPdbFiles Include="@(_CodeCoverageAssemblies -> '$(NETCoreAppTestSharedFrameworkPath)ni/%(Identity).ni.pdb')"
-        Condition="Exists('$(NETCoreAppTestSharedFrameworkPath)/il/%(Identity).pdb') AND Exists('$(NETCoreAppTestSharedFrameworkPath)/ni/%(Identity).ni.pdb')" >
-          <IlPdbPath>$(NETCoreAppTestSharedFrameworkPath)%(Identity).pdb</IlPdbPath>
-      </SelectedNiPdbFiles>
-    </ItemGroup>
-
-    <!-- Delete the files under the test host to break any existing hardlinks -->
-    <Delete Files="@(SelectedNiPdbFiles -> '%(IlPdbPath)')" />
-
-    <!-- Put renamed pdbs in place -->
-    <Copy SourceFiles="@(SelectedNiPdbFiles)" 
-      DestinationFiles="%(SelectedNiPdbFiles.IlPdbPath)"
-      SkipUnchangedFiles="true" />
-  </Target>
-
-  <!-- General task to restore pdbs that may have been replaced for OpenCover workaround -->
-  <Target Name="RestoreIlPdbs">
-    <ItemGroup>
-       <!-- Assume that all ni pdbs were replaced (ensures full restore) -->
-      <PdbsToRestore Include="$(NETCoreAppTestSharedFrameworkPath)il/*.pdb" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(PdbsToRestore)" 
-      DestinationFolder="$(NETCoreAppTestSharedFrameworkPath)"
-      SkipUnchangedFiles="true"
-      UseHardlinksIfPossible="$(RestoreIlPdbsWithHardlinks)" />
-  </Target>
-
-  <!-- Il pdbs may need to be restored due to previous coverage runs that replaced them with IL versions -->
-  <Target Name="RestoreIlPdbsForTestRun"
-    BeforeTargets="GenerateTestExecutionScripts"
-    DependsOnTargets="RestoreIlPdbs"
-    Condition="'$(CodeCoverageEnabled)' != 'true' AND '$(SkipTests)' != 'true' AND '$(RunningOnUnix)' != 'true'">
-    <Message Importance="normal" Text="Restoring IL pdbs that were potentially replaced with respective crossgen pdbs." />
   </Target>
 
   <!-- *********************************************************************************************** -->
@@ -245,13 +202,6 @@
     </ItemGroup>
     <ParseTestCoverageInfo CoverageReports="@(Reports)"
                            OutputReport="$(CoverageReportDir)\VisitedMethodsReport.xml"/>
-  </Target>
-
-  <!-- Restore IL pdbs to testhost -->
-  <Target Name="RestoreIlPdbsToTestHostAfterCoverageReports"
-    AfterTargets="GenerateIndividualCoverageReport;GenerateFullCoverageReport"
-    DependsOnTargets="RestoreIlPdbs">
-    <Message Importance="normal" Text="Restoring IL pdbs that were potentially replaced with respective crossgen pdbs." />
   </Target>
 
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/coverage/xunit.console.netcore.runtimeconfig.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/coverage/xunit.console.netcore.runtimeconfig.json
@@ -1,0 +1,8 @@
+{
+	"runtimeOptions": {
+		"framework": {
+			"name": "Microsoft.NETCore.App",
+			"version": "10.10.10"
+		}
+	}
+}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -35,7 +35,6 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(BuildingNETFxVertical)' != 'true'">
-    <XunitRuntimeConfig>$(ToolsDir)\xunit.console.netcore.runtimeconfig.json</XunitRuntimeConfig>
     <TestRuntimeEnvVar Condition="'$(RunningOnUnix)'!='true'">%RUNTIME_PATH%\</TestRuntimeEnvVar>
     <TestRuntimeEnvVar Condition="'$(RunningOnUnix)'=='true'">$RUNTIME_PATH/</TestRuntimeEnvVar>
     <TestHostExecutablePath Condition="'$(RunningOnUnix)'!='true' AND '$(TestHostExecutablePath)' == '' AND '$(BuildingUAPAOTVertical)' != 'true'">$(TestRuntimeEnvVar)dotnet.exe</TestHostExecutablePath>
@@ -96,6 +95,18 @@
 
   <!-- The Code Coverage targets will override TestHost and TestCommandLine if coverage is enabled -->
   <Import Project="$(MSBuildThisFileDirectory)CodeCoverage.targets" />
+  <Choose>
+    <When Condition="'$(CodeCoverageEnabled)'=='true' and '$(UseCoverageDedicatedRuntime)'=='true'">
+      <PropertyGroup>
+        <XunitRuntimeConfig>$(ToolsDir)coverage/xunit.console.netcore.runtimeconfig.json</XunitRuntimeConfig>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <XunitRuntimeConfig>$(ToolsDir)xunit.console.netcore.runtimeconfig.json</XunitRuntimeConfig>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <!-- In VS (2015 Preview or later currently required): Debug to run unit tests on CoreCLR. -->
   <PropertyGroup Condition="'$(IsTestProject)'=='true'">


### PR DESCRIPTION
This allows OpenCover to get source information for CoreLib (perhaps an issue to be investigated separately, since in theory it should have worked with the ni image and respective PDB). It also makes easier to experiment with tools that perform IL rewrite instead of relying on Profiler API.

Related to https://github.com/dotnet/corefx/issues/23588