### PR TITLE
Package Microsoft.DiaSymReader assemblies in buildtools nuget package.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>Microsoft.DotNet.Build.Tasks</AssemblyName>
     <CLSCompliant>false</CLSCompliant>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <CopyNugetImplementations>true</CopyNugetImplementations>
     <NuGetTargetMoniker>.NETStandard,Version=v1.5</NuGetTargetMoniker>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -26,6 +26,7 @@
     <file src="Microsoft.DotNet.Build.CloudTestTasks\RunnerScripts\**\*.*" target="lib\RunnerScripts" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DiaSymReader*.dll" target="lib" />
     <file src="Run\run.exe" target="lib" />
     <file src="Run\run.runtimeconfig.json" target="lib" />
     <file src="BclRewriter\BclRewriter.exe" target="lib" />

--- a/src/nuget/Microsoft.DotNet.BuildTools.nuspec
+++ b/src/nuget/Microsoft.DotNet.BuildTools.nuspec
@@ -25,8 +25,9 @@
     <file src="Microsoft.DotNet.Build.CloudTestTasks\PackageFiles\**\*.*" target="lib" />
     <file src="Microsoft.DotNet.Build.CloudTestTasks\RunnerScripts\**\*.*" target="lib\RunnerScripts" />
     <file src="Microsoft.DotNet.Build.Tasks\PackageFiles\**\*.*" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DiaSymReader.Converter.dll" target="lib" />
+    <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DiaSymReader.dll" target="lib" />
     <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DotNet.Build.Tasks.dll" target="lib" />
-    <file src="Microsoft.DotNet.Build.Tasks\Microsoft.DiaSymReader*.dll" target="lib" />
     <file src="Run\run.exe" target="lib" />
     <file src="Run\run.runtimeconfig.json" target="lib" />
     <file src="BclRewriter\BclRewriter.exe" target="lib" />


### PR DESCRIPTION
This allows GenFacades (and other tasks that depend on DiaSymReader) to use DiaSymReader on .NET Core's MSBuild.

This is needed in order to get corefx's build on Windows to use .NET Core MSBuild.