### PR TITLE
Update MSBuild references to `15.1.548`.

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/project.json
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.Build.Framework": "0.1.0-preview-00022",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build.Framework": "15.1.548",
+    "Microsoft.Build.Utilities.Core": "15.1.548",
     "System.Security.Cryptography.Algorithms": "4.2.0",
     "System.Reflection.Metadata": "1.3.0",
     "NETStandard.Library": "1.6.0",

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.Build.Framework": "0.1.0-preview-00022",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build.Framework": "15.1.548",
+    "Microsoft.Build.Utilities.Core": "15.1.548",
     "System.Security.Cryptography.Algorithms": "4.2.0",
     "System.Reflection.Metadata": "1.3.0",
     "NETStandard.Library": "1.6.0",

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "System.Reflection.Metadata": "1.3.0",
-    "Microsoft.Build.Framework": "0.1.0-preview-00022",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build.Framework": "15.1.548",
+    "Microsoft.Build.Utilities.Core": "15.1.548",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Commands": "4.4.0",
     "NuGet.Packaging": "4.4.0",

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/test/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "System.Reflection.Metadata": "1.3.0",
-    "Microsoft.Build.Framework": "0.1.0-preview-00022",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build.Framework": "15.1.548",
+    "Microsoft.Build.Utilities.Core": "15.1.548",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Packaging": "4.4.0",
     "NETStandard.Library": "1.6.0",

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "dependencies": {
-    "Microsoft.Build": "0.1.0-preview-00022",
-    "Microsoft.Build.Framework": "0.1.0-preview-00022",
-    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00022",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00022",
+    "Microsoft.Build": "15.1.548",
+    "Microsoft.Build.Framework": "15.1.548",
+    "Microsoft.Build.Tasks.Core": "15.1.548",
+    "Microsoft.Build.Utilities.Core": "15.1.548",
     "Microsoft.DiaSymReader.Converter": "1.1.0-beta1-62810-01",
     "Microsoft.DotNet.PlatformAbstractions": "1.2.0-beta-001090",
     "Microsoft.Tpl.Dataflow": {


### PR DESCRIPTION
This fixes the build errors https://github.com/dotnet/corefx/pull/30675. As it exists currently, the old MSBuild packages pull in references to System.Resources.ReaderWriter, which no longer exists. Thus when building on .NET Core's MSBuild, our tasks fail because that assembly can't be found.
Updating to an officially supported MSBuild package version updates the transitive references to System.Resources.Reader, which exists in the shared framework.