### PR TITLE
Fix build for VS2015 tools

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -128,20 +128,21 @@
       <RunTestsForProjectInputs Include="@(AllItemsFullPathWithTargetPath)" />
     </ItemGroup>
     <ItemGroup Condition="'$(BuildingNETFxVertical)' != 'true'">
-      <!-- SupplementalTestData has its own properties to control hard links, however, with the coverage dedicated runtime that will override the original -->
-      <Delete Condition="'@(UsingCoverageDedicatedRuntime)' == 'true' and Exists('$(TestPath)$(XunitRuntimeConfigFile)')"
-              Files="'$(TestPath)$(XunitRuntimeConfigFile)'" />
-      <Copy Condition="'@(UsingCoverageDedicatedRuntime)' == 'true'"
-            SourceFiles="$(XunitRuntimeConfig)"
-            DestinationFolder="$(TestPath)"
-            UseHardLinksIfPossible="false" />
-      <SupplementalTestData Condition="'$(SkipXunitRuntimeConfigCopying)' != 'true' and '@(UsingCoverageDedicatedRuntime)' != 'true'" Include="$(XunitRuntimeConfig)" />
+      <SupplementalTestData Condition="'$(SkipXunitRuntimeConfigCopying)' != 'true' and '$(UsingCoverageDedicatedRuntime)' != 'true'" Include="$(XunitRuntimeConfig)" />
       <SupplementalTestData Include="$(RuntimePath)xunit.console.netcore.exe" />
     </ItemGroup>
     <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'">
       <SupplementalTestData Include="$(RuntimePath)xunit.console.exe" />
       <SupplementalTestData Include="$(RuntimePath)xunit.execution.desktop.dll" />
     </ItemGroup>
+
+    <!-- SupplementalTestData has its own properties to control hard links, however, with the coverage dedicated runtime that will override the original -->
+    <Delete Condition="'$(UsingCoverageDedicatedRuntime)' == 'true' and Exists($(TestPath)$(XunitRuntimeConfigFile))"
+            Files="$(TestPath)$(XunitRuntimeConfigFile)" />
+    <Copy Condition="'$(UsingCoverageDedicatedRuntime)' == 'true'"
+          SourceFiles="$(XunitRuntimeConfig)"
+          DestinationFolder="$(TestPath)"
+          UseHardLinksIfPossible="false" />
   </Target>
 
   <Target Name="AddDefaultTestReferences" BeforeTargets="SetupDefaultReferences">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -137,7 +137,7 @@
     </ItemGroup>
 
     <!-- SupplementalTestData has its own properties to control hard links, however, with the coverage dedicated runtime that will override the original -->
-    <Delete Condition="'$(UsingCoverageDedicatedRuntime)' == 'true' and Exists($(TestPath)$(XunitRuntimeConfigFile))"
+    <Delete Condition="'$(UsingCoverageDedicatedRuntime)' == 'true' and Exists('$(TestPath)$(XunitRuntimeConfigFile)')"
             Files="$(TestPath)$(XunitRuntimeConfigFile)" />
     <Copy Condition="'$(UsingCoverageDedicatedRuntime)' == 'true'"
           SourceFiles="$(XunitRuntimeConfig)"


### PR DESCRIPTION
VS2015 tools are less forgiving: the two tasks that I added to tests.targets were under an ItemGroup and that is fine for VS2017 tools, but for VS2015 they need to be at the Target level. This should fix the issues with https://github.com/dotnet/coreclr/pull/18694