### PR TITLE
Fix OptionalTooling so it works on .NET Core

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateEncryptedNuGetConfig.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateEncryptedNuGetConfig.cs
@@ -24,6 +24,8 @@ namespace Microsoft.DotNet.Build.Tasks
         [Required]
         public ITaskItem[] Sources { get; set; }
 
+        public string PackagesDir { get; set; }
+
         public override bool Execute()
         {
             Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath));
@@ -32,6 +34,11 @@ namespace Microsoft.DotNet.Build.Tasks
             var settings = new Settings(
                 Path.GetDirectoryName(ConfigPath),
                 Path.GetFileName(ConfigPath));
+
+            if (!string.IsNullOrEmpty(PackagesDir))
+            {
+                settings.SetValue("config", "globalPackagesFolder", Path.GetFullPath(PackagesDir));
+            }
 
             var sourceProvider = new PackageSourceProvider(settings);
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
@@ -71,7 +71,8 @@
     </PropertyGroup>
 
     <GenerateEncryptedNuGetConfig ConfigPath="$(OptionalRestoreConfigPath)"
-                                  Sources="@(OptionalRestoreSource)" />
+                                  Sources="@(OptionalRestoreSource)"
+                                  PackagesDir="$(PackagesDir)" />
 
     <!-- restore the project.json file, if it is being used -->
     <EncryptedConfigNuGetRestore Condition="'$(OptionalToolingProjectJsonPath)' != ''"
@@ -81,7 +82,7 @@
   
     <!-- restore the MSBuild project file, if it is being used -->
     <Exec Condition="Exists('$(OptionalToolingProjectPath)')" 
-          Command="$(DotnetToolCommand) restore $(OptionalToolingProjectPath) --packages $(PackagesDir) --configfile $(OptionalRestoreConfigPath) /p:RestoreOutputPath=$(OptionalToolingDir)" />
+          Command="$(DotnetToolCommand) restore $(OptionalToolingProjectPath) --configfile $(OptionalRestoreConfigPath) /p:RestoreOutputPath=$(OptionalToolingDir)" />
   
   </Target>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
@@ -8,7 +8,6 @@
 
   <Target Name="RestoreOptionalToolingPackages"
           DependsOnTargets="RestoreOptionalToolingEncrypted;
-                            RestoreOptionalToolingUnencrypted;
                             CleanOptionalToolingRestore"
           BeforeTargets="Sync"
           Condition="'$(OptionalToolSource)'!=''" />
@@ -28,38 +27,44 @@
   </Target>
 
   <!--
-    Determine the paths of the optional tool runtime project.json and lockfile.
+    Determine the paths of the optional tool runtime project.json/MSBuild project and lockfile.
+    Note: Either project.json ($(OptionalToolingJsonPath)) or MSBuild project ($(OptionalToolingProjectPath))
+    should be set at one time.
   -->
   <Target Name="GetOptionalToolingPaths">
     <PropertyGroup>
       <OptionalToolingDir>$(ToolsDir)optional-tool-runtime\</OptionalToolingDir>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OptionalToolingProjectPath)' == ''">
       <OptionalToolingJsonPath Condition="'$(OptionalToolingJsonPath)' == ''">$(OptionalToolingDir)optional.json</OptionalToolingJsonPath>
       <OptionalToolingProjectJsonPath>$(OptionalToolingDir)project.json</OptionalToolingProjectJsonPath>
       <OptionalToolingProjectLockJsonPath>$(OptionalToolingDir)project.lock.json</OptionalToolingProjectLockJsonPath>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(OptionalToolingProjectPath)' != ''">
+      <OptionalToolingProjectAssetsJsonPath>$(OptionalToolingDir)project.assets.json</OptionalToolingProjectAssetsJsonPath>
+    </PropertyGroup>
   </Target>
 
-  <!--
-    Copy the mangled "optional.json" file to "project.json", so that we can restore it. The name
-    is optional.json so that recursive restore will not normally find the file: it contains
-    optional tooling that typical recursive restores do not provide, such as the buildtools build.
-  -->
-  <Target Name="PrepareOptionalToolProjectJson"
+  <Target Name="PrepareOptionalToolProject"
           DependsOnTargets="GetOptionalToolingPaths">
 
-    <Copy SourceFiles="$(OptionalToolingJsonPath)"
+    <!--
+      Copy the mangled "optional.json" file to "project.json", so that we can restore it. The name
+      is optional.json so that recursive restore will not normally find the file: it contains
+      optional tooling that typical recursive restores do not provide, such as the buildtools build.
+    -->
+    <Copy Condition="'$(OptionalToolingProjectJsonPath)' != ''"
+          SourceFiles="$(OptionalToolingJsonPath)"
           DestinationFiles="$(OptionalToolingProjectJsonPath)"
           SkipUnchangedFiles="true" />
   </Target>
 
   <!--
     Restore optional tooling using a NuGet.Config on disk with encrypted credentials inside.
-    Not supported on .NET Core.
   -->
   <Target Name="RestoreOptionalToolingEncrypted"
           DependsOnTargets="CreateOptionalRestoreFeedItems;
-                            PrepareOptionalToolProjectJson"
-          Condition="'$(MSBuildRuntimeType)'!='core'">
+                            PrepareOptionalToolProject">
     <PropertyGroup>
       <GeneratedNuGetConfigDir>$(ObjDir)generatedNuGetConfig/</GeneratedNuGetConfigDir>
       <OptionalRestoreConfigPath>$(GeneratedNuGetConfigDir)optional.NuGet.Config</OptionalRestoreConfigPath>
@@ -68,33 +73,16 @@
     <GenerateEncryptedNuGetConfig ConfigPath="$(OptionalRestoreConfigPath)"
                                   Sources="@(OptionalRestoreSource)" />
 
-    <EncryptedConfigNuGetRestore Inputs="$(OptionalToolingProjectJsonPath)"
+    <!-- restore the project.json file, if it is being used -->
+    <EncryptedConfigNuGetRestore Condition="'$(OptionalToolingProjectJsonPath)' != ''"
+                                 Inputs="$(OptionalToolingProjectJsonPath)"
                                  ConfigFile="$(OptionalRestoreConfigPath)"
                                  PackagesDir="$(PackagesDir)" />
-  </Target>
-
-  <!--
-    Restore optional tooling by generating the XML string of a NuGet.Config with plaintext
-    credentials, then injecting it into "dotnet restore" using /dev/stdin.
-    Not supported on Windows.
-  -->
-  <Target Name="RestoreOptionalToolingUnencrypted"
-          DependsOnTargets="CreateOptionalRestoreFeedItems;
-                            PrepareOptionalToolProjectJson"
-          Condition="'$(MSBuildRuntimeType)'=='core'">
-    <PropertyGroup>
-      <!-- Create a new restore command with no source parameters, only configfile. -->
-      <OptionalRestoreCommand>"$(DnuToolPath)"</OptionalRestoreCommand>
-      <OptionalRestoreCommand>$(OptionalRestoreCommand) restore</OptionalRestoreCommand>
-      <OptionalRestoreCommand Condition="'$(UseNuGetHttpCache)'!='true'">$(OptionalRestoreCommand) --no-cache</OptionalRestoreCommand>
-      <OptionalRestoreCommand>$(OptionalRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))"</OptionalRestoreCommand>
-      <OptionalRestoreCommand>$(OptionalRestoreCommand) --configfile $(OptionalRestoreConfigPath)</OptionalRestoreCommand>
-    </PropertyGroup>
-
-    <Error Text="Restoring optional tooling with in-memory credentials is not supported on Windows. Use the desktop framework for the encrypted credential flow."
-           Condition="'$(RunningOnUnix)'!='true'" />
-
-    <Error Text="Restoring optional tooling with in-memory credentials is not yet implemented. No cross-platform optional tooling exists yet." />
+  
+    <!-- restore the MSBuild project file, if it is being used -->
+    <Exec Condition="Exists('$(OptionalToolingProjectPath)')" 
+          Command="$(DotnetToolCommand) restore $(OptionalToolingProjectPath) --packages $(PackagesDir) --configfile $(OptionalRestoreConfigPath) /p:RestoreOutputPath=$(OptionalToolingDir)" />
+  
   </Target>
 
   <!--
@@ -118,14 +106,19 @@
   <Target Name="ResolveOptionalTools"
           DependsOnTargets="GetOptionalToolingPaths">
 
+    <PropertyGroup>
+      <OptionalToolingProjectLockFilePath>$(OptionalToolingProjectLockJsonPath)</OptionalToolingProjectLockFilePath>
+      <OptionalToolingProjectLockFilePath Condition="'$(OptionalToolingProjectLockFilePath)' == ''">$(OptionalToolingProjectAssetsJsonPath)</OptionalToolingProjectLockFilePath>
+    </PropertyGroup>
+    
     <Error Text="Optional tooling has not been restored. Use the 'RestoreOptionalToolingPackages' target first."
-           Condition="!Exists('$(OptionalToolingProjectLockJsonPath)')" />
+           Condition="!Exists('$(OptionalToolingProjectLockFilePath)')" />
 
     <ItemGroup>
       <OptionalToolingTargetMoniker Include=".NETFramework,Version=v4.5" />
     </ItemGroup>
 
-    <PrereleaseResolveNuGetPackageAssets ProjectLockFile="$(OptionalToolingProjectLockJsonPath)"
+    <PrereleaseResolveNuGetPackageAssets ProjectLockFile="$(OptionalToolingProjectLockFilePath)"
                                          TargetMonikers="@(OptionalToolingTargetMoniker)">
       <Output TaskParameter="ResolvedReferences" ItemName="ResolvedOptionalToolReferences" />
     </PrereleaseResolveNuGetPackageAssets>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/OptionalTooling.targets
@@ -81,7 +81,7 @@
                                  PackagesDir="$(PackagesDir)" />
   
     <!-- restore the MSBuild project file, if it is being used -->
-    <Exec Condition="Exists('$(OptionalToolingProjectPath)')" 
+    <Exec Condition="'$(OptionalToolingProjectPath)' != ''" 
           Command="$(DotnetToolCommand) restore $(OptionalToolingProjectPath) --configfile $(OptionalRestoreConfigPath) /p:RestoreOutputPath=$(OptionalToolingDir)" />
   
   </Target>


### PR DESCRIPTION
Need to add support for MSBuild projects instead of project.json files, so builds running on .NET Core can restore optional tooling.

Partial change for https://github.com/dotnet/corefx/issues/30758