### PR TITLE
Remove line breaks from echoed run commands

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Build.Tasks
                 testRunCommands.Append($"{runCommand}\n");
                 // Remove parentheses and quotes from echo command before wrapping it in quotes to avoid errors on Linux.
                 // Also, escape backtick and question mark characters to avoid running commands instead of echo'ing them.
-                string sanitizedRunCommand = runCommand.Replace("\"", "").Replace("(", "").Replace(")", "").Replace("`", "\\`").Replace("?", "\\");
+                string sanitizedRunCommand = runCommand.Replace("\"", "").Replace("(", "").Replace(")", "").Replace("`", "\\`").Replace("?", "\\").Replace("\r","").Replace("\n"," ");
                 testRunEchoes.Append($"echo \"{sanitizedRunCommand}\"\n");
             }
             shExecutionTemplate = shExecutionTemplate.Replace("[[TestRunCommands]]", testRunCommands.ToString());


### PR DESCRIPTION
Remove line breaks from echoed run commands to keep from executing multiline commands (including ILC) during echo. Fixes #2044.