### PR TITLE
Add support for generating resource IDs as an enum

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -152,8 +152,8 @@ namespace Microsoft.DotNet.Build.Tasks
                 _targetStream.WriteLine($"namespace {accessorNamespace}");
                 _targetStream.WriteLine("{");
                 _targetStream.WriteLine("");
-                var accessor = AsEnum ? "enum" : "partial class";
-                _targetStream.WriteLine($"    internal static {accessor} {accessorClassName}");
+                var accessor = AsEnum ? "enum" : "static partial class";
+                _targetStream.WriteLine($"    internal {accessor} {accessorClassName}");
                 _targetStream.WriteLine("    {");
                 _targetStream.WriteLine("");
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets
@@ -105,7 +105,8 @@
         SRClassName="$(GenerateResourcesSRClassName)"
         ResourcesNamespace="$(GenerateResourcesResourcesNamespace)"
         ResourcesClassName="$(GenerateResourcesResourcesClassName)"
-        AsConstants="$(GenerateResourcesCodeAsConstants)">
+        AsConstants="$(GenerateResourcesCodeAsConstants)"
+        AsEnum="$(GenerateResourcesCodeAsEnum)">
     </GenerateResourcesCode>
 
     <ItemGroup>


### PR DESCRIPTION
/cc @tarekgh 

One remaining mode to address porting of desktop code.  Some libraries used an Enum to represent resource IDs.  I ran into a case where one library was mapping a range of that enum to a range of error codes and relying on a numeric conversion.

EG: resourceId = (ResourceEnumType) (ResourceEnumType.FirstErrrorId + (errorCode - firstErrorCode))
