### PR TITLE
Fix break in generated VB resources code

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateResourcesCode.cs
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.Build.Tasks
             }
             else
             {
-                var accessor = AsEnum ? "Enum" : "Partial Class";
+                var accessor = AsEnum ? "Enum" : "Class";
                 _targetStream.WriteLine($"    End {accessor}");
                 _targetStream.WriteLine("End Namespace");
             }


### PR DESCRIPTION
Introduced in https://github.com/dotnet/buildtools/pull/2086.
Causing corefx builds to fail with errors like:
https://ci3.dot.net/job/dotnet_corefx/job/master/job/windows-TGroup_netcoreapp+CGroup_Debug+AGroup_x64+TestOuter_false_prtest/14179/consoleText
```
D:\j\workspace\windows-TGrou---74aa877a\bin\obj\AnyOS.AnyCPU.Debug\Microsoft.VisualBasic\netstandard\SR.vb(18,5): error BC30481: 'Class' statement must end with a matching 'End Class'. [D:\j\workspace\windows-TGrou---74aa877a\src\Microsoft.VisualBasic\src\Microsoft.VisualBasic.vbproj]
D:\j\workspace\windows-TGrou---74aa877a\bin\obj\AnyOS.AnyCPU.Debug\Microsoft.VisualBasic\netstandard\SR.vb(563,5): error BC30678: 'End' statement not valid. [D:\j\workspace\windows-TGrou---74aa877a\src\Microsoft.VisualBasic\src\Microsoft.VisualBasic.vbproj]
```

cc: @ericstj, @danmosemsft 