### PR TITLE
Support simple auto-update value substitutions

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -261,6 +261,14 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                 "true",
                 StringComparison.OrdinalIgnoreCase);
 
+            string oldValue = step.GetMetadata("ReplacementSubstituteOld");
+            string newValue = step.GetMetadata("ReplacementSubstituteNew");
+
+            if (!string.IsNullOrEmpty(oldValue) && !string.IsNullOrEmpty(newValue))
+            {
+                updater.ReplacementTransform = v => v.Replace(oldValue, newValue);
+            }
+
             return updater;
         }
 

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -33,6 +33,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
         internal const string PackageIdMetadataName = "PackageId";
         internal const string VersionMetadataName = "Version";
         internal const string DependencyTypeMetadataName = "DependencyType";
+        internal const string ReplacementSubstituteOldMetadataName = "ReplacementSubstituteOld";
+        internal const string ReplacementSubstituteNewMetadataName = "ReplacementSubstituteNew";
 
         [Required]
         public ITaskItem[] DependencyInfo { get; set; }
@@ -261,12 +263,20 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                 "true",
                 StringComparison.OrdinalIgnoreCase);
 
-            string oldValue = step.GetMetadata("ReplacementSubstituteOld");
-            string newValue = step.GetMetadata("ReplacementSubstituteNew");
+            // GetMetadata doesn't return null: empty string whether or not metadata is assigned.
+            string oldValue = step.GetMetadata(ReplacementSubstituteOldMetadataName);
+            string newValue = step.GetMetadata(ReplacementSubstituteNewMetadataName);
 
-            if (!string.IsNullOrEmpty(oldValue) && !string.IsNullOrEmpty(newValue))
+            if (!string.IsNullOrEmpty(oldValue))
             {
                 updater.ReplacementTransform = v => v.Replace(oldValue, newValue);
+            }
+            else if (!string.IsNullOrEmpty(newValue))
+            {
+                Log.LogError(
+                    $"Metadata {ReplacementSubstituteNewMetadataName} supplied for updater " +
+                    $"{step.ItemSpec} without {ReplacementSubstituteOldMetadataName}. " +
+                    "It is impossbile to replace the empty string with something.");
             }
 
             return updater;


### PR DESCRIPTION
Add `ReplacementSubstituteOld` / `ReplacementSubstituteNew`, which can be used to replace a part of the new value being updated to.

---

This continues from https://github.com/dotnet/buildtools/pull/2069 "Allow auto-updating from on-disk ProdCon manifest". The on-disk manifest might not have the exact values the repo should auto-update to.

Originally I was going to modify the manifest itself (https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Orchestration-Utilities/pullrequest/128309) but here the logic is more flexible and might be useful for other things.

Used for https://github.com/dotnet/core-eng/issues/3815.