### PR TITLE
[release/2.1] Port orchestrated build manifest updater enhancements

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/Microsoft.DotNet.Build.Tasks.net45.csproj
@@ -9,6 +9,7 @@
     <ProjectGuid>{B3331D88-7569-42D5-919B-F267DA011911}</ProjectGuid>
     <DefineConstants>net45</DefineConstants>
     <TargetFrameworkProfile />
+    <VersionToolsProjectReferenceSuffix>.net45</VersionToolsProjectReferenceSuffix>
   </PropertyGroup>
   <Import Project="$(ImportedProjectRelativePath)Microsoft.DotNet.Build.Tasks.csproj" />
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
+++ b/src/Microsoft.DotNet.Build.Tasks/Microsoft.DotNet.Build.Tasks.csproj
@@ -135,7 +135,7 @@
       <Project>{2179f9b5-1dba-4563-9402-a94de75ea9fa}</Project>
       <Name>Microsoft.Cci.Extensions</Name>
     </ProjectReference>
-    <ProjectReference Include="..\Microsoft.DotNet.VersionTools\Microsoft.DotNet.VersionTools.csproj">
+    <ProjectReference Include="..\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix)\Microsoft.DotNet.VersionTools$(VersionToolsProjectReferenceSuffix).csproj">
       <Project>{8d524fa5-a8c5-4ebd-ba8b-2a4fed03ee58}</Project>
       <Name>Microsoft.DotNet.VersionTools</Name>
       <Private>False</Private>

--- a/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/VersionTools/BaseDependenciesTask.cs
@@ -33,6 +33,8 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
         internal const string PackageIdMetadataName = "PackageId";
         internal const string VersionMetadataName = "Version";
         internal const string DependencyTypeMetadataName = "DependencyType";
+        internal const string ReplacementSubstituteOldMetadataName = "ReplacementSubstituteOld";
+        internal const string ReplacementSubstituteNewMetadataName = "ReplacementSubstituteNew";
 
         [Required]
         public ITaskItem[] DependencyInfo { get; set; }
@@ -260,6 +262,22 @@ namespace Microsoft.DotNet.Build.Tasks.VersionTools
                 step.GetMetadata(nameof(updater.SkipIfNoReplacementFound)),
                 "true",
                 StringComparison.OrdinalIgnoreCase);
+
+            // GetMetadata doesn't return null: empty string whether or not metadata is assigned.
+            string oldValue = step.GetMetadata(ReplacementSubstituteOldMetadataName);
+            string newValue = step.GetMetadata(ReplacementSubstituteNewMetadataName);
+
+            if (!string.IsNullOrEmpty(oldValue))
+            {
+                updater.ReplacementTransform = v => v.Replace(oldValue, newValue);
+            }
+            else if (!string.IsNullOrEmpty(newValue))
+            {
+                Log.LogError(
+                    $"Metadata {ReplacementSubstituteNewMetadataName} supplied for updater " +
+                    $"{step.ItemSpec} without {ReplacementSubstituteOldMetadataName}. " +
+                    "It is impossbile to replace the empty string with something.");
+            }
 
             return updater;
         }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildDependencyInfo.cs
@@ -31,25 +31,23 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildManifest
                     $"'{project.Segments}' '{basePath}' ref '{@ref}'");
             }
 
-            return new OrchestratedBuildDependencyInfo(simpleName, basePath, model);
+            return new OrchestratedBuildDependencyInfo(simpleName, model);
         }
 
         public string SimpleName { get; }
 
         public string SimpleVersion => OrchestratedBuildModel.Identity.BuildId;
 
-        public string BasePath { get; }
-
         public OrchestratedBuildModel OrchestratedBuildModel { get; }
 
         public OrchestratedBuildDependencyInfo(
             string simpleName,
-            string basePath,
             OrchestratedBuildModel model)
         {
             SimpleName = simpleName;
-            BasePath = basePath;
             OrchestratedBuildModel = model;
         }
+
+        public override string ToString() => $"{SimpleName} {SimpleVersion}";
     }
 }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildManifest/OrchestratedBuildIdentityMatch.cs
@@ -22,14 +22,14 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildManifest
                     .Select(b => new OrchestratedBuildIdentityMatch { Info = info, Match = b }))
                 .ToArray();
 
-            if (matches.Length != 1)
+            if (matches.Length > 1)
             {
                 throw new ArgumentException(
-                    $"Expected 1 build matching '{buildName}', but found {matches.Length}: " +
+                    $"Expected only 1 build matching '{buildName}', but found {matches.Length}: " +
                     $"'{string.Join(", ", matches.AsEnumerable())}'");
             }
 
-            return matches[0];
+            return matches.FirstOrDefault();
         }
 
         public OrchestratedBuildDependencyInfo Info { get; set; }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/BuildOutput/OrchestratedBuild/OrchestratedBuildUpdateHelpers.cs
@@ -5,6 +5,7 @@
 using Microsoft.DotNet.VersionTools.BuildManifest.Model;
 using Microsoft.DotNet.VersionTools.Dependencies.BuildManifest;
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBuild
@@ -18,12 +19,20 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBui
             {
                 var match = OrchestratedBuildIdentityMatch.Find(buildName, infos);
 
+                if (match == null)
+                {
+                    Trace.TraceInformation($"No build identity match for '{buildName}'.");
+                    return null;
+                }
+
                 string value;
                 if (match.Match.Attributes.TryGetValue(attributeName, out value))
                 {
                     return new DependencyReplacement(value, new[] { match.Info });
                 }
 
+                Trace.TraceInformation(
+                    $"In build identity '{buildName}', no attribute '{attributeName}'.");
                 return null;
             };
         }
@@ -42,6 +51,8 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBui
                         return new DependencyReplacement(value, new[] { info });
                     }
 
+                    Trace.TraceInformation(
+                        $"No blob feed or '{attributeName}' attribute for '{info}'.");
                     return null;
                 })
                 .FirstOrDefault(r => r != null);
@@ -61,8 +72,8 @@ namespace Microsoft.DotNet.VersionTools.Dependencies.BuildOutput.OrchestratedBui
                         return new DependencyReplacement(match.Version, new[] { info });
                     }
 
+                    Trace.TraceInformation($"No package '{packageId}' match in '{info}'.");
                     return null;
-
                 })
                 .FirstOrDefault(r => r != null);
         }

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileRegexUpdater.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using Microsoft.DotNet.VersionTools.Util;
 using System;
 using System.Collections.Generic;
@@ -18,6 +17,11 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
         public Regex Regex { get; set; }
         public string VersionGroupName { get; set; }
 
+        /// <summary>
+        /// Instead of throwing an exception, skip this updater if no replacement value is found.
+        /// </summary>
+        public bool SkipIfNoReplacementFound { get; set; }
+
         public IEnumerable<DependencyUpdateTask> GetUpdateTasks(IEnumerable<IDependencyInfo> dependencyInfos)
         {
             IEnumerable<IDependencyInfo> usedInfos;
@@ -25,7 +29,10 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
 
             if (newValue == null)
             {
-                Trace.TraceError($"Could not find version information to change '{Path}' with '{Regex}'");
+                if (!SkipIfNoReplacementFound)
+                {
+                    Trace.TraceError($"For '{Path}', a replacement value for '{Regex}' was not found.");
+                }
             }
             else
             {

--- a/src/Microsoft.DotNet.VersionTools/Dependencies/FileUpdater.cs
+++ b/src/Microsoft.DotNet.VersionTools/Dependencies/FileUpdater.cs
@@ -14,6 +14,11 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
     {
         public string Path { get; set; }
 
+        /// <summary>
+        /// Instead of throwing an exception, skip this updater if no replacement value is found.
+        /// </summary>
+        public bool SkipIfNoReplacementFound { get; set; }
+
         public IEnumerable<DependencyUpdateTask> GetUpdateTasks(
             IEnumerable<IDependencyInfo> dependencyInfos)
         {
@@ -21,7 +26,10 @@ namespace Microsoft.DotNet.VersionTools.Dependencies
 
             if (replacement == null)
             {
-                Trace.TraceError($"For '{Path}', no replacement was found.");
+                if (!SkipIfNoReplacementFound)
+                {
+                    Trace.TraceError($"For '{Path}', a replacement value was not found.");
+                }
                 yield break;
             }
 


### PR DESCRIPTION
Port:
https://github.com/dotnet/buildtools/pull/2069 Allow auto-updating from on-disk ProdCon manifest; add SkipIfNoReplacementFound
https://github.com/dotnet/buildtools/pull/2088 Support simple auto-update value substitutions

These are needed for source-build `release/2.1` auto-update: https://github.com/dotnet/core-eng/issues/3815.