### PR TITLE
Remove code that places source files in packages

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/PackageLibs.targets
@@ -182,12 +182,6 @@
         <TargetPath>%(TargetPath)%(FilesToPackage.SubFolder)</TargetPath>
       </FilesToPackage>
 
-      <!-- Include source files for symbol packages. -->
-      <FilesToPackage Include="@(Compile->'%(FullPath)')">
-        <TargetPath>src</TargetPath>
-        <TargetPath Condition="$([System.String]::new('%(FullPath)').StartsWith('$(ProjectRoot)'))">$(SourceFileTargetPathPrefix)$([System.String]::new('%(FullPath)').Substring('$(ProjectRootLength)'))</TargetPath>
-        <IsSourceCodeFile>true</IsSourceCodeFile>
-      </FilesToPackage>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -493,15 +493,6 @@
         <PackageVersion>$(PackageVersion)</PackageVersion>
       </PackageFile>
 
-      <PackageSymbolFiles Include="@(File)" Condition="'%(File.IsSymbolFile)'=='true'" />
-      <!-- Add a placeholder source file if there are symbols but no sources, so that MyGet will treat symbol packages as valid -->
-      <PackageSources Include="$(PlaceholderFile)" Condition="'@(PackageSymbolFiles)'!='' AND '@(PackageSources)'==''">
-        <IsSourceCodeFile>true</IsSourceCodeFile>
-        <TargetPath>src</TargetPath>
-      </PackageSources>
-      <PackageFile Include="@(PackageSources)" />
-
-
       <!-- Nuget will treat TargetPath as a directory if the extensions dont match,
            however we need to package files without an extension (Unix exectuables).
            As such nuget will always consider TargetPath to be a file path for these

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -493,6 +493,14 @@
         <PackageVersion>$(PackageVersion)</PackageVersion>
       </PackageFile>
 
+      <!-- Add a placeholder source file if there are symbols but no sources, so that MyGet will treat symbol packages as valid -->
+      <PackageSources Include="$(PlaceholderFile)" Condition="'@(PackageSymbolFiles)'!='' AND '@(PackageSources)'==''">
+        <IsSourceCodeFile>true</IsSourceCodeFile>
+        <TargetPath>src</TargetPath>
+      </PackageSources>
+      <PackageFile Include="@(PackageSources)" />
+
+
       <!-- Nuget will treat TargetPath as a directory if the extensions dont match,
            however we need to package files without an extension (Unix exectuables).
            As such nuget will always consider TargetPath to be a file path for these

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -493,19 +493,6 @@
         <PackageVersion>$(PackageVersion)</PackageVersion>
       </PackageFile>
 
-      <!-- Include Sources. Deduplicate so the nuspec doesn't contain multiple entries for each source file. -->
-      <PackageSources Include="@(File)"
-                      KeepMetadata="TargetPath;IsSourceCodeFile"
-                      KeepDuplicates="false"
-                      Condition="'%(File.IsSourceCodeFile)'=='true'" />
-      <!-- Add a placeholder source file if there are symbols but no sources. -->
-      <PackageSymbolFiles Include="@(File)" Condition="'%(File.IsSymbolFile)'=='true'" />
-      <PackageSources Include="$(PlaceholderFile)" Condition="'@(PackageSymbolFiles)'!='' AND '@(PackageSources)'==''">
-        <IsSourceCodeFile>true</IsSourceCodeFile>
-        <TargetPath>src</TargetPath>
-      </PackageSources>
-      <PackageFile Include="@(PackageSources)" />
-
       <!-- Nuget will treat TargetPath as a directory if the extensions dont match,
            however we need to package files without an extension (Unix exectuables).
            As such nuget will always consider TargetPath to be a file path for these

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -493,6 +493,7 @@
         <PackageVersion>$(PackageVersion)</PackageVersion>
       </PackageFile>
 
+      <PackageSymbolFiles Include="@(File)" Condition="'%(File.IsSymbolFile)'=='true'" />
       <!-- Add a placeholder source file if there are symbols but no sources, so that MyGet will treat symbol packages as valid -->
       <PackageSources Include="$(PlaceholderFile)" Condition="'@(PackageSymbolFiles)'!='' AND '@(PackageSources)'==''">
         <IsSourceCodeFile>true</IsSourceCodeFile>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/FrameworkTargeting.targets
@@ -331,13 +331,6 @@
       </_docFiles>
       <_itemsToSave Include="@(_docFiles)"/>
 
-      <!-- Include source files. -->
-      <!-- Here we use "sources" rather than "src" because MyGet treats packages with "src" as symbol packages  -->
-      <_itemsToSave Condition="'@(Compile)' != ''" Include="@(Compile->'%(FullPath)')">
-        <TargetPath>sources</TargetPath>
-        <TargetPath Condition="$([System.String]::Copy('%(FullPath)').StartsWith('$(ProjectDir)'))">sources/$([System.String]::Copy('%(FullPath)').Substring($(_projectDirLength)).Replace('\', '/'))</TargetPath>
-        <IsSourceCodeFile>true</IsSourceCodeFile>
-      </_itemsToSave>
     </ItemGroup>
 
     <Message Importance="low" Text="PackageFileDir: @(PackageFileDir)" />


### PR DESCRIPTION
This is a replacement for https://github.com/dotnet/corefx/pull/30850 - exclude source code files from packaging if the consuming repo sets `ExcludeSourceFiles=true`. I tested this locally, and the built packages in CoreFx wound up not including source files.

@weshaggard @dagood @ericstj @MattGal PTAL

Once this is in I'll repurpose https://github.com/dotnet/corefx/pull/30850 to set `ExcludeSourceFiles` & take a buildtools update.