### PR TITLE
Fix python path for coverage runs

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -25,9 +25,16 @@
     <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/usr/lib/libSystem.B.dylib" />
     <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/usr/lib/libc++.1.dylib" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(HELIX_PYTHONPATH)'==''">
+    <!-- env var not defined, assume that python is already on the path, e.g.: Jenkins -->
+    <PythonPath>python</PythonPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(HELIX_PYTHONPATH)'!=''">
+    <PythonPath>$(HELIX_PYTHONPATH)</PythonPath>
+  </PropertyGroup>
   <Target Name="PreinstallDumpling"
           BeforeTargets="TestAllProjects">
-    <Exec Command="python $(MSBuildThisFileDirectory)DumplingHelper.py install_dumpling" />
+    <Exec Command="$(PythonPath) $(MSBuildThisFileDirectory)DumplingHelper.py install_dumpling" />
   </Target>
   <!-- Setup Dumpling service to collect crash dumps -->
   <Target Name="SetupDumpling"
@@ -39,18 +46,18 @@
       <CrashDumpFolder Condition="'$(CrashDumpFolder)' == ''">\cores\</CrashDumpFolder>
     </PropertyGroup>
     <ItemGroup Condition="'$(TargetOS)'!='Windows_NT'">
-      <TestCommandLines Include="$HELIX_PYTHONPATH -m pip install psutil" />
-      <TestCommandLines Include="$HELIX_PYTHONPATH DumplingHelper.py install_dumpling" />
-      <TestCommandLines Include="__TIMESTAMP=`$HELIX_PYTHONPATH DumplingHelper.py get_timestamp`" />
-      <PostExecutionTestCommandLines Include="$HELIX_PYTHONPATH DumplingHelper.py collect_dump $%3F $(CrashDumpFolder) $__TIMESTAMP $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
+      <TestCommandLines Include="$(PythonPath) -m pip install psutil" />
+      <TestCommandLines Include="$(PythonPath) DumplingHelper.py install_dumpling" />
+      <TestCommandLines Include="__TIMESTAMP=`$(PythonPath) DumplingHelper.py get_timestamp`" />
+      <PostExecutionTestCommandLines Include="$(PythonPath) DumplingHelper.py collect_dump $%3F $(CrashDumpFolder) $__TIMESTAMP $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
-      <TestCommandLines Include="%HELIX_PYTHONPATH% -m pip install psutil" />
-      <TestCommandLines Include="%HELIX_PYTHONPATH% DumplingHelper.py install_dumpling" />
+      <TestCommandLines Include="$(PythonPath) -m pip install psutil" />
+      <TestCommandLines Include="$(PythonPath) DumplingHelper.py install_dumpling" />
       <TestCommandLines Include="if not exist $(CrashDumpFolder) mkdir $(CrashDumpFolder)" />
       <!-- This gets a "before execution" timestamp. It is used in DumplingHelper.py to determine which crash dump files to consider uploading. -->
-      <TestCommandLines Include="for /f &quot;delims=&quot; %%a in ('%HELIX_PYTHONPATH% DumplingHelper.py get_timestamp') do @set __TIMESTAMP=%%a" />
-      <PostExecutionTestCommandLines Include="%HELIX_PYTHONPATH% DumplingHelper.py collect_dump %ERRORLEVEL% $(CrashDumpFolder) %__TIMESTAMP% $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
+      <TestCommandLines Include="for /f &quot;delims=&quot; %%a in ('$(PythonPath) DumplingHelper.py get_timestamp') do @set __TIMESTAMP=%%a" />
+      <PostExecutionTestCommandLines Include="$(PythonPath) DumplingHelper.py collect_dump %ERRORLEVEL% $(CrashDumpFolder) %__TIMESTAMP% $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -25,12 +25,9 @@
     <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/usr/lib/libSystem.B.dylib" />
     <DumplingIncPaths Condition="'$(TargetOS)'=='OSX'" Include="/usr/lib/libc++.1.dylib" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(HELIX_PYTHONPATH)'==''">
-    <!-- env var not defined, assume that python is already on the path, e.g.: Jenkins -->
-    <PythonPath>python</PythonPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(HELIX_PYTHONPATH)'!=''">
+  <PropertyGroup>
     <PythonPath>$(HELIX_PYTHONPATH)</PythonPath>
+    <PythonPath Condition="'$(PythonPath)' == ''">python</PythonPath>
   </PropertyGroup>
   <Target Name="PreinstallDumpling"
           BeforeTargets="TestAllProjects">


### PR DESCRIPTION
Coverage runs are without dumplings due to the dependency on HELIX_PYTHONPATH env var. 

On my local box I noticed the following:

1. DumplingHelper.py requires Python 2.7 (no problem, just noticing)
2. My runs on local box report:
```
  Traceback (most recent call last):
    File "C:\s\github\pjanotti\corefx\bin\tests\System.Net.Mail.Unit.Tests\netcoreapp-Windows_NT-Debug-x64/dumpling.py", line 18, in <module>

  ImportError: No module named requests
  C:\Python27\python.exe: can't open file 'C:\Users\pauloja/.dumpling/dumpling.py': [Errno 2] No such file or directory
  C:\Python27\python.exe: can't open file 'C:\Users\pauloja/.dumpling/dumpling.py': [Errno 2] No such file or directory
```
not sure if this is something to pursue or not.