### PR TITLE
Decouple AoT and UAP testing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -8,7 +8,7 @@
   <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask Condition="'$(BuildingUAPVertical)' == 'true'" TaskName="ExtractResWResourcesFromAssemblies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
-    <!-- Which categories of tests to run by default -->
+  <!-- Which categories of tests to run by default -->
   <PropertyGroup>
     <TestDisabled>false</TestDisabled>
     <TestDisabled Condition="'$(IsTestProject)'!='true' Or '$(SkipTests)'=='true' Or '$(RunTestsForProject)'=='false'">true</TestDisabled>
@@ -37,8 +37,8 @@
   <PropertyGroup Condition="'$(BuildingNETFxVertical)' != 'true'">
     <TestRuntimeEnvVar Condition="'$(RunningOnUnix)'!='true'">%RUNTIME_PATH%\</TestRuntimeEnvVar>
     <TestRuntimeEnvVar Condition="'$(RunningOnUnix)'=='true'">$RUNTIME_PATH/</TestRuntimeEnvVar>
-    <TestHostExecutablePath Condition="'$(RunningOnUnix)'!='true' AND '$(TestHostExecutablePath)' == '' AND '$(BuildingUAPAOTVertical)' != 'true'">$(TestRuntimeEnvVar)dotnet.exe</TestHostExecutablePath>
-    <TestHostExecutablePath Condition="'$(RunningOnUnix)'=='true' AND '$(TestHostExecutablePath)' == '' AND '$(BuildingUAPAOTVertical)' != 'true'">$(TestRuntimeEnvVar)dotnet</TestHostExecutablePath>
+    <TestHostExecutablePath Condition="'$(RunningOnUnix)'!='true' AND '$(TestHostExecutablePath)' == '' AND '$(UseDotNetNativeToolchain)' != 'true'">$(TestRuntimeEnvVar)dotnet.exe</TestHostExecutablePath>
+    <TestHostExecutablePath Condition="'$(RunningOnUnix)'=='true' AND '$(TestHostExecutablePath)' == '' AND '$(UseDotNetNativeToolchain)' != 'true'">$(TestRuntimeEnvVar)dotnet</TestHostExecutablePath>
 
     <XunitExecutable Condition="'$(XunitExecutable)' == ''">xunit.console.netcore.exe</XunitExecutable>
     <XunitRuntimeConfigFile>xunit.console.netcore.runtimeconfig.json</XunitRuntimeConfigFile>
@@ -61,7 +61,7 @@
     <_XunitOptions Condition="'$(Performance)'!='true' and '$(Outerloop)' != 'true'">$(_XunitOptions) -notrait Benchmark=true</_XunitOptions>
     <!-- Don't run performance tests in parallel, even in "functional" outerloop runs. -->
     <_XunitOptions Condition="'$(Performance)'!='true' and '$(Outerloop)' == 'true' and '$(IncludePerformanceTests)' == 'true'">$(_XunitOptions) -parallel none</_XunitOptions>
-    <_XunitOptions Condition="'$(BuildingUAPAOTVertical)'=='true'">$(_XunitOptions) -redirectoutput</_XunitOptions>
+    <_XunitOptions Condition="'$(UseDotNetNativeToolchain)'=='true'">$(_XunitOptions) -redirectoutput</_XunitOptions>
     <_XunitOptions>$(_XunitOptions) -notrait category=non$(_bc_TargetGroup)tests</_XunitOptions>
 
     <TargetOS Condition="'$(TargetOS)' == ''">$(DefaultOSGroup)</TargetOS>
@@ -200,17 +200,17 @@
     <_PriListFile>$(_MakePriHelpersDir)/prilist.RESFILES</_PriListFile>
     <_ExternalReswOutputPath>$(ResourcesFolderPath)/external/</_ExternalReswOutputPath>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(BuildingUAPVertical)' == 'true'">
     <_AllRuntimeDllFiles Include="$(RuntimePath)\*.dll" />
     <_ExternalReswFiles Include="$(_ExternalReswOutputPath)*.resw" />
-    
+
     <!-- The first time the CreateReswFilesForExternalDependencies target is executed the itemgroup _ExternalReswFiles will be empty
     and that will avoid the target from executing, so we add a dummy file if they are empty so that the target is executed the first time. -->
     <_ExternalReswFiles Condition="@(_ExternalReswFiles) == ''" Include="$(_ExternalReswOutputPath)dummy.resw" />
   </ItemGroup>
 
-  <Target Name="CreateReswFilesForExternalDependencies" 
+  <Target Name="CreateReswFilesForExternalDependencies"
           Condition="'$(BuildingUAPVertical)' == 'true' AND '$(ShouldSkipExternalResources)' != 'true'"
           Inputs="@(_AllRuntimeDllFiles)"
           Outputs="@(_ExternalReswFiles)">
@@ -240,7 +240,7 @@
   </Target>
 
   <!-- This target gets all the resw files to be used to create the UAP runner's resources.pri file -->
-  <Target Name="CalculateResWFiles" 
+  <Target Name="CalculateResWFiles"
           Condition="'$(BuildingUAPVertical)' == 'true'"
           DependsOnTargets="CreateReswFilesForExternalDependencies">
 
@@ -369,22 +369,22 @@
       Overwrite="true"
       Encoding="Ascii" />
 
-      <!--======================================================
+    <!--======================================================
                       Section for netfx test runs
           ====================================================== -->
     <ItemGroup Condition="'$(BuildingNETFxVertical)' == 'true'" >
       <TestCommandLines Include="set DEVPATH=%RUNTIME_PATH%" />
     </ItemGroup>
 
-        <!--======================================================
-                      Section for uapaot ilc test runs
+    <!--======================================================
+                      Section for aot ilc test runs
             ====================================================== -->
     <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' == 'true'">
       <ILCBuildType Condition="'$(ILCBuildType)' == ''">ret</ILCBuildType>
       <_UseSharedAssemblies Condition="'$(EnableMultiFileILCTests)' == 'true'">-useSharedAssemblies</_UseSharedAssemblies>
       <_TestILCFolder>%RUNTIME_PATH%\TestILC</_TestILCFolder>
       <_Runtime_Path>%RUNTIME_PATH%\ILCInputFolder\</_Runtime_Path>
-      <!-- Currently (and probably forever) we can't build UAPAOT on ARM,
+      <!-- Currently (and probably forever) we can't build AOT on ARM,
            So if we're running on ARM, what we really want to do is encapsulate
            the test command into a script that can be run on another machine -->
       <TestCommandLine Condition="'$(ArchGroup)'=='arm'">echo $(TestCommandLine)> .\RunContinuation.cmd </TestCommandLine>
@@ -414,7 +414,7 @@ robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
       <PostExecutionTestCommandLines Condition="'$(ArchGroup)'!='arm'" Include="copy /y testResults.xml %EXECUTION_DIR%\" />
     </ItemGroup>
 
-        <!--======================================================
+    <!--======================================================
                       Section for uap F5 test runs
             ====================================================== -->
     <PropertyGroup Condition="'$(BuildingUAPVertical)' == 'true'">
@@ -505,7 +505,7 @@ robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\
           >
 
     <MakeDir Condition="'$(CoverageEnabledForProject)'=='true'" Directories="$(CoverageReportDir)" />
-    <Error Text="TestILCFolder property is required for running uapaot tests. Please pass in the full path to the directory that contains ilc.exe to msbuild using /p:TestILCFolder=path_to_ilc_dir.exe" Condition="'$(BuildingUAPAOTVertical)' == 'true' AND !Exists('$(TestHostRootPath)\TestILC')" />
+    <Error Text="TestILCFolder property is required for running aot tests. Please pass in the full path to the directory that contains ilc.exe to msbuild using /p:TestILCFolder=path_to_ilc_dir.exe" Condition="'$(UseDotNetNativeToolchain)'=='true' AND !Exists('$(TestHostRootPath)\TestILC')" />
 
     <!-- For UAP, make sure the Runner and Launcher folder exist, otherwise the tests cannot run -->
     <Error Text="We cannot run the tests for UAP because either the Runner or the Launcher could not be found. You need to specify the UAPToolsFolder property when calling build.cmd to fix this."

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -384,6 +384,7 @@
       <_UseSharedAssemblies Condition="'$(EnableMultiFileILCTests)' == 'true'">-useSharedAssemblies</_UseSharedAssemblies>
       <_TestILCFolder>%RUNTIME_PATH%\TestILC</_TestILCFolder>
       <_Runtime_Path>%RUNTIME_PATH%\ILCInputFolder\</_Runtime_Path>
+      <_ILCWin32 Condition="'$(_bc_TargetGroup)'!='uapaot'">-win32</_ILCWin32>
       <!-- Currently (and probably forever) we can't build AOT on ARM,
            So if we're running on ARM, what we really want to do is encapsulate
            the test command into a script that can be run on another machine -->
@@ -399,7 +400,7 @@
       <TestCommandLines Include="rmdir /S /Q %EXECUTION_DIR%int" />
       <TestCommandLines Include="rmdir /S /Q %EXECUTION_DIR%native" />
       <TestCommandLines Include="@(TargetExecutableNames -> '
-call %RUNTIME_PATH%\TestILC\ilc.exe -ExeName %(Identity) -in %EXECUTION_DIR% -out %EXECUTION_DIR%int\%(Identity)\ -usedefaultpinvoke -buildtype $(ILCBuildType) -v diag $(_UseSharedAssemblies)
+call %RUNTIME_PATH%\TestILC\ilc.exe -ExeName %(Identity) -in %EXECUTION_DIR% -out %EXECUTION_DIR%int\%(Identity)\ -usedefaultpinvoke -buildtype $(ILCBuildType) -v diag $(_UseSharedAssemblies) $(_ILCWin32)
 set ILCERRORLEVEL=%ERRORLEVEL%
 if NOT [%ILCERRORLEVEL%] == [0] exit /b %ILCERRORLEVEL%
 robocopy /S /NP %EXECUTION_DIR%int\%(Identity)\ %EXECUTION_DIR%native\

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -384,7 +384,7 @@
       <_UseSharedAssemblies Condition="'$(EnableMultiFileILCTests)' == 'true'">-useSharedAssemblies</_UseSharedAssemblies>
       <_TestILCFolder>%RUNTIME_PATH%\TestILC</_TestILCFolder>
       <_Runtime_Path>%RUNTIME_PATH%\ILCInputFolder\</_Runtime_Path>
-      <_ILCWin32 Condition="'$(_bc_TargetGroup)'!='uapaot'">-win32</_ILCWin32>
+      <_ILCWin32 Condition="'$(BuildingUAPAOTVertical)'!='true'">-win32</_ILCWin32>
       <!-- Currently (and probably forever) we can't build AOT on ARM,
            So if we're running on ARM, what we really want to do is encapsulate
            the test command into a script that can be run on another machine -->


### PR DESCRIPTION
As part of adding the netcoreappaot flavor in https://github.com/dotnet/corefx/pull/30980, this change decouples AoT and UAP testing by switching to using the UseDotNetNativeToolchain build variable. It also enables testing with the ```-win32``` ILC flag, which disables WinRT support and matches the netcoreappaot profile.

The CoreFX and Buildtools changes can be merged in either order (it just won't be possible to test the CoreFX change until the Buildtools change is merged). 