### PR TITLE
Temp workaround to collect dumplings for coverage runs

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/Dumpling.targets
@@ -44,13 +44,18 @@
       <TestCommandLines Include="__TIMESTAMP=`$HELIX_PYTHONPATH DumplingHelper.py get_timestamp`" />
       <PostExecutionTestCommandLines Include="$HELIX_PYTHONPATH DumplingHelper.py collect_dump $%3F $(CrashDumpFolder) $__TIMESTAMP $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
     </ItemGroup>
+    <!-- As of 07/2018 Coverage runs are not on Helix machines so it can't rely on HELIX_PYTHONPATH being defined -->
+    <PropertyGroup>
+      <PythonPath>%HELIX_PYTHONPATH%</PythonPath>
+      <PythonPath Condition="'$(CodeCoverageEnabled)'=='true'">python</PythonPath>
+    </PropertyGroup>
     <ItemGroup Condition="'$(TargetOS)'=='Windows_NT'">
-      <TestCommandLines Include="%HELIX_PYTHONPATH% -m pip install psutil" />
-      <TestCommandLines Include="%HELIX_PYTHONPATH% DumplingHelper.py install_dumpling" />
+      <TestCommandLines Include="$(PythonPath) -m pip install psutil" />
+      <TestCommandLines Include="$(PythonPath) DumplingHelper.py install_dumpling" />
       <TestCommandLines Include="if not exist $(CrashDumpFolder) mkdir $(CrashDumpFolder)" />
       <!-- This gets a "before execution" timestamp. It is used in DumplingHelper.py to determine which crash dump files to consider uploading. -->
-      <TestCommandLines Include="for /f &quot;delims=&quot; %%a in ('%HELIX_PYTHONPATH% DumplingHelper.py get_timestamp') do @set __TIMESTAMP=%%a" />
-      <PostExecutionTestCommandLines Include="%HELIX_PYTHONPATH% DumplingHelper.py collect_dump %ERRORLEVEL% $(CrashDumpFolder) %__TIMESTAMP% $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
+      <TestCommandLines Include="for /f &quot;delims=&quot; %%a in ('$(PythonPath) DumplingHelper.py get_timestamp') do @set __TIMESTAMP=%%a" />
+      <PostExecutionTestCommandLines Include="$(PythonPath) DumplingHelper.py collect_dump %ERRORLEVEL% $(CrashDumpFolder) %__TIMESTAMP% $(MSBuildProjectName) $(__DumplingIncPathsArg)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
This is meant as a temporary workaround to get dumps for coverage runs, long term we should move them to Helix instead. The fix is targeted only at what is broken on coverage runs to avoid the problems of the previous attempt to fix it in https://github.com/dotnet/buildtools/pull/2094