### PR TITLE
Coverage: allow test projects with custom runtimeconfig.json

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -137,9 +137,9 @@
     </ItemGroup>
 
     <!-- SupplementalTestData has its own properties to control hard links, however, with the coverage dedicated runtime that will override the original -->
-    <Delete Condition="'$(UsingCoverageDedicatedRuntime)' == 'true' and Exists('$(TestPath)$(XunitRuntimeConfigFile)')"
+    <Delete Condition="'$(SkipXunitRuntimeConfigCopying)' != 'true' and '$(UsingCoverageDedicatedRuntime)' == 'true' and Exists('$(TestPath)$(XunitRuntimeConfigFile)')"
             Files="$(TestPath)$(XunitRuntimeConfigFile)" />
-    <Copy Condition="'$(UsingCoverageDedicatedRuntime)' == 'true'"
+    <Copy Condition="'$(SkipXunitRuntimeConfigCopying)' != 'true' and '$(UsingCoverageDedicatedRuntime)' == 'true'"
           SourceFiles="$(XunitRuntimeConfig)"
           DestinationFolder="$(TestPath)"
           UseHardLinksIfPossible="false" />


### PR DESCRIPTION
For tests that have custom xunit.console.runtimeconfig.json coverage runs need to respect the request to not setup the default xunit.console.runtimeconfig.json. Part of https://github.com/dotnet/corefx/issues/31041