### PR TITLE
When building perf tests, the build fails because it can't find OptimizeForBenchmarks.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -75,8 +75,10 @@
 
   <!-- Optimizations to configure Xunit for performance -->
   <ItemGroup Condition="'$(IncludePerformanceTests)' == 'true'">
-    <AssemblyInfoUsings Include="using Microsoft.Xunit.Performance%3B" />
-    <AssemblyInfoLines Include="[assembly:OptimizeForBenchmarks]" />
+    <!-- TODO: when we no longer need to support legacy .csprojs, this can be converted to 
+        <AssemblyAttribute Include="Microsoft.Xunit.Performance.OptimizeForBenchmarks" />
+    -->
+    <AssemblyInfoLines Include="[assembly:Microsoft.Xunit.Performance.OptimizeForBenchmarks]" />
   </ItemGroup>
 
   <Target Name="UploadToBenchview" Condition="'$(LogToBenchview)' == 'true'" AfterTargets="TestAllProjects">


### PR DESCRIPTION
The fix is to fully qualify the attribute.

Fix https://github.com/dotnet/corefx/issues/31053