### PR TITLE
Updating Packaging.targets to support specifying the PackageType

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Extensions.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/Extensions.cs
@@ -117,6 +117,30 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             return source;
         }
 
+        public static string TrimAndGetNullForEmpty(this string s)
+        {
+            if (s == null)
+            {
+                return null;
+            }
+
+            s = s.Trim();
+
+            return s.Length == 0 ? null : s;
+        }
+
+        public static IEnumerable<string> TrimAndExcludeNullOrEmpty(this string[] strings)
+        {
+            if (strings == null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return strings
+                .Select(s => TrimAndGetNullForEmpty(s))
+                .Where(s => s != null);
+        }
+
         public static string ToStringSafe(this object value)
         {
             if (value == null)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/GenerateNuSpec.cs
@@ -69,6 +69,8 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
 
         public string Tags { get; set; }
 
+        public string[] PackageTypes { get; set; }
+
         public ITaskItem[] Dependencies { get; set; }
 
         public ITaskItem[] References { get; set; }
@@ -183,6 +185,7 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
             manifestMetadata.UpdateMember(x => x.Tags, Tags);
             manifestMetadata.UpdateMember(x => x.Title, Title);
             manifestMetadata.UpdateMember(x => x.Version, Version != null ? new NuGetVersion(Version) : null);
+            manifestMetadata.UpdateMember(x => x.PackageTypes, GetPackageTypes());
             manifestMetadata.Serviceable |= Serviceable;
 
             manifest.AddRangeToMember(x => x.Files, GetManifestFiles());
@@ -282,6 +285,29 @@ namespace Microsoft.DotNet.Build.Tasks.Packaging
                                        select reference.File
                                        )
                     ).ToList();
+        }
+
+        private List<PackageType> GetPackageTypes()
+        {
+            var listOfPackageTypes = new List<PackageType>();
+
+            // Copied and slightly modified from ParsePackageTypes():
+            // https://github.com/NuGet/NuGet.Client/blob/50af5271b98ac5cb2896a707569bc4cd1e87a017/src/NuGet.Core/NuGet.Build.Tasks.Pack/PackTaskLogic.cs#L338
+
+            foreach (var packageType in PackageTypes.TrimAndExcludeNullOrEmpty())
+            {
+                string[] packageTypeSplitInPart = packageType.Split(new char[] { ',' });
+                string packageTypeName = packageTypeSplitInPart[0].Trim();
+                var version = PackageType.EmptyVersion;
+                if (packageTypeSplitInPart.Length > 1)
+                {
+                    string versionString = packageTypeSplitInPart[1];
+                    System.Version.TryParse(versionString, out version);
+                }
+                listOfPackageTypes.Add(new PackageType(packageTypeName, version));
+            }
+
+            return listOfPackageTypes;
         }
 
         private static VersionRange AggregateVersions(VersionRange aggregate, VersionRange next)

--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -1209,7 +1209,8 @@
                     References="@(Reference)"
                     FrameworkReferences="@(FrameworkReference)"
                     Files="@(_packageFile)"
-                    Serviceable="$(Serviceable)"/>
+                    Serviceable="$(Serviceable)"
+                    PackageTypes="$(PackageType)"/>
   </Target>
 
   <Target Name="CreatePackage"


### PR DESCRIPTION
FYI. @weshaggard, this is the buildtools change required to support moving the ILProj SDK into CoreCLR (see https://github.com/dotnet/arcade/pull/317 for more details).