### PR TITLE
Option to use coverlet.msbuild for coverage (allow coverage in Unix)

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -14,7 +14,7 @@
   <!-- Coverage options -->
   <PropertyGroup>
     <CodeCoverageEnabled>false</CodeCoverageEnabled>
-    <CodeCoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(RunningOnUnix)' != 'true' and '$(Coverage)' == 'true' and '$(Performance)' != 'true'">true</CodeCoverageEnabled>
+    <CodeCoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(Coverage)' == 'true' and '$(Performance)' != 'true'">true</CodeCoverageEnabled>
     <UseCoverlet Condition="'$(Coverage)' == 'true' and ('$(RunningOnUnix)' == 'true' or '$(UseCoverlet)' == 'true')">true</UseCoverlet>
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(TestWorkingDir)coverage\</CoverageReportDir>
 
@@ -169,7 +169,6 @@
       <_AllDlls Include="$(CoverageRuntimeDir)/*.dll"/>
       <_AllAssemblies Include="@(_AllDlls -> '%(Filename)')" />
       <_AllAssemblies Remove="@(_CodeCoverageAssemblies)" />
-      <_CoverletExcludedAssemblies Include="@(_AllAssemblies)" />
     </ItemGroup>
     <PropertyGroup>
       <CoverletExclusionFilter>@(_AllAssemblies->'[%(Identity)]*', ',')</CoverletExclusionFilter>
@@ -202,8 +201,10 @@
   <!-- Report Generator Properties -->
   <PropertyGroup>
     <CoverageReportAssemblyFilters Condition="'$(CodeCoverageAssemblies)' != 'all'">"-assemblyfilters:@(_CodeCoverageAssemblies->'+%(Identity)', ';')"</CoverageReportAssemblyFilters>
-    <CoverageReportGeneratorOptions>-targetdir:$(CoverageReportDir) -reporttypes:Html;Badges $(CoverageReportAssemblyFilters)</CoverageReportGeneratorOptions>
-    <CoverageReportGeneratorCommandLine>$(PackagesDir)ReportGenerator\$(ReportGeneratorVersion)\tools\ReportGenerator.exe $(CoverageReportGeneratorOptions)</CoverageReportGeneratorCommandLine>
+    <CoverageReportGeneratorOptions>-targetdir:$(CoverageReportDir) "-reporttypes:Html;Badges" $(CoverageReportAssemblyFilters)</CoverageReportGeneratorOptions>
+    <CoverageReportTool>$(PackagesDir)ReportGenerator\$(ReportGeneratorVersion)\tools\ReportGenerator.exe</CoverageReportTool>
+    <CoverageReportTool Condition="'$(RunningOnUnix)' == 'true'">reportgenerator</CoverageReportTool>
+    <CoverageReportGeneratorCommandLine>$(CoverageReportTool) $(CoverageReportGeneratorOptions)</CoverageReportGeneratorCommandLine>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GenerateIndividualCoverageReport)'=='true'">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -45,7 +45,6 @@
     <GenerateFullCoverageReportAfterTargets Condition="'$(GenerateFullCoverageReportAfterTargets)'==''">TestAllProjects</GenerateFullCoverageReportAfterTargets>
   </PropertyGroup>
 
-  <!-- Start of Coverlet -->
   <PropertyGroup Condition="'$(UseCoverlet)'=='true'">
     <CoverletOutputFormat Condition="$(CoverletOutputFormat) == ''">opencover</CoverletOutputFormat>
     <CoverletOutputDirectory Condition="$(CoverletOutputDirectory) == ''">$(CoverageReportDir)</CoverletOutputDirectory>
@@ -70,7 +69,6 @@
       Threshold="$(Threshold)"
       ThresholdType="$(ThresholdType)" />
   </Target>
-  <!-- End of Coverlet -->
 
   <Target Name="CreateCoverageFilter" BeforeTargets="GenerateTestExecutionScripts">
     <!-- By default, code coverage data is only gathered for the assembly being tested. 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -6,6 +6,7 @@
   -->
   <PropertyGroup>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
+    <CoverletMsbuildVersion>2.1.1</CoverletMsbuildVersion>
     <ReportGeneratorVersion>3.0.1</ReportGeneratorVersion>
     <CoverallsUploaderVersion>1.4</CoverallsUploaderVersion>
   </PropertyGroup>
@@ -14,6 +15,7 @@
   <PropertyGroup>
     <CodeCoverageEnabled>false</CodeCoverageEnabled>
     <CodeCoverageEnabled Condition="'$(SkipTests)' != 'true' and '$(RunningOnUnix)' != 'true' and '$(Coverage)' == 'true' and '$(Performance)' != 'true'">true</CodeCoverageEnabled>
+    <UseCoverlet Condition="'$(Coverage)' == 'true' and ('$(RunningOnUnix)' == 'true' or '$(UseCoverlet)' == 'true')">true</UseCoverlet>
     <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$(TestWorkingDir)coverage\</CoverageReportDir>
 
     <UseCoverageDedicatedRuntime Condition="'$(UseCoverageDedicatedRuntime)' == ''">true</UseCoverageDedicatedRuntime>
@@ -38,6 +40,37 @@
     -->
     <SerializeProjects Condition="'$(CodeCoverageEnabled)'=='true'">true</SerializeProjects>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GenerateFullCoverageReport)'=='true'">
+    <GenerateFullCoverageReportAfterTargets Condition="'$(GenerateFullCoverageReportAfterTargets)'==''">TestAllProjects</GenerateFullCoverageReportAfterTargets>
+  </PropertyGroup>
+
+  <!-- Start of Coverlet -->
+  <PropertyGroup Condition="'$(UseCoverlet)'=='true'">
+    <CoverletOutputFormat Condition="$(CoverletOutputFormat) == ''">opencover</CoverletOutputFormat>
+    <CoverletOutputDirectory Condition="$(CoverletOutputDirectory) == ''">$(CoverageReportDir)</CoverletOutputDirectory>
+    <CoverletOutputName Condition=" '$(CoverletOutputName)' == '' ">$(MSBuildProjectName).coverlet</CoverletOutputName>
+    <CoverletOutput>$([MSBuild]::EnsureTrailingSlash('$(CoverletOutputDirectory)'))$(CoverletOutputName).xml</CoverletOutput>
+    <CoverageOutputFilePath>$(CoverletOutput)</CoverageOutputFilePath>
+    <CoverageInputFilter>*.coverlet.xml</CoverageInputFilter>
+    <ExcludeByFile Condition="$(ExcludeByFile) == ''"></ExcludeByFile>
+    <Threshold Condition="$(Threshold) == ''">0</Threshold>
+    <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
+    <CollectCoverage Condition="$(CollectCoverage) == ''">$(CodeCoverageEnabled)</CollectCoverage>
+  </PropertyGroup>
+
+  <UsingTask Condition="'$(UseCoverlet)'=='true'" TaskName="Coverlet.MSbuild.Tasks.InstrumentationTask" AssemblyFile="$(PackagesDir)coverlet.msbuild/$(CoverletMsbuildVersion)/build/netstandard2.0/coverlet.msbuild.tasks.dll" />
+  <UsingTask Condition="'$(UseCoverlet)'=='true'" TaskName="Coverlet.MSbuild.Tasks.CoverageResultTask" AssemblyFile="$(PackagesDir)coverlet.msbuild/$(CoverletMsbuildVersion)/build/netstandard2.0/coverlet.msbuild.tasks.dll" />
+ 
+  <Target Condition="'$(UseCoverlet)'=='true'" Name="GenerateCoverageResult" AfterTargets="$(GenerateIndividualCoverageReportAfterTargets)">
+    <Coverlet.MSbuild.Tasks.CoverageResultTask
+      Condition="'$(CollectCoverage)' == 'true'"
+      Output="$(CoverletOutput)"
+      OutputFormat="$(CoverletOutputFormat)"
+      Threshold="$(Threshold)"
+      ThresholdType="$(ThresholdType)" />
+  </Target>
+  <!-- End of Coverlet -->
 
   <Target Name="CreateCoverageFilter" BeforeTargets="GenerateTestExecutionScripts">
     <!-- By default, code coverage data is only gathered for the assembly being tested. 
@@ -99,7 +132,7 @@
 
   <Target Name="GenerateWindowsPdbsForAssemblyBeingTested" 
     BeforeTargets="GenerateTestExecutionScripts"
-    Condition="'$(CodeCoverageEnabled)' == 'true' and '$(TargetOS)'=='Windows_NT'">
+    Condition="'$(CodeCoverageEnabled)' == 'true' and '$(TargetOS)'=='Windows_NT' and '$(UseCoverlet)'!='true'">
 
     <!-- We look for the DLL being tested for coverage and its PDB create a WindowsPDB\*.pdb which has
          the windows PDB.  -->
@@ -131,12 +164,37 @@
   </Target>
   <!-- *********************************************************************************************** -->
 
-  <!-- xUnit command line with coverage enabled -->
-  <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true'">
+  <Target Name="InstrumentModulesAfterBuild" BeforeTargets="GenerateTestExecutionScripts" Condition="'$(UseCoverlet)'=='true'">
+    <ItemGroup>
+      <_AllDlls Include="$(CoverageRuntimeDir)/*.dll"/>
+      <_AllAssemblies Include="@(_AllDlls -> '%(Filename)')" />
+      <_AllAssemblies Remove="@(_CodeCoverageAssemblies)" />
+      <_CoverletExcludedAssemblies Include="@(_AllAssemblies)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <CoverletExclusionFilter>@(_AllAssemblies->'[%(Identity)]*', ',')</CoverletExclusionFilter>
+    </PropertyGroup>
+    <Coverlet.MSbuild.Tasks.InstrumentationTask
+      Condition="'$(CollectCoverage)' == 'true'"
+      Exclude="$(CoverletExclusionFilter)"
+      ExcludeByFile="$(ExcludeByFile)"
+      Path="$(CoverageRuntimeDir)/" />
+
+    <!-- Instrumented assemblies call coverlet.tracker.dll -->
+    <Copy
+      SourceFiles="$(PackagesDir)coverlet.msbuild/$(CoverletMsbuildVersion)/build/netstandard2.0/coverlet.tracker.dll"
+      DestinationFolder="$(TestPath)"
+      SkipUnchangedFiles="true"
+      UseHardlinksIfPossible="true" />
+  </Target>
+
+  <!-- xUnit command line with coverage enabled using OpenCover -->
+  <PropertyGroup Condition="'$(CoverageEnabledForProject)'=='true' and '$(UseCoverlet)'!='true'">
     <CoverageHost>$(PackagesDir)OpenCover\$(OpenCoverVersion)\tools\OpenCover.Console.exe</CoverageHost>
     <CoverageOutputFilePath>$(CoverageReportDir)$(MSBuildProjectName).coverage.xml</CoverageOutputFilePath>
     <CoverageOptions>-oldStyle -filter:"{CoverageFilter}" -excludebyfile:"*\Common\src\System\SR.*" -nodefaultfilters -excludebyattribute:*.ExcludeFromCodeCoverage* -skipautoprops -hideskipped:All -threshold:1</CoverageOptions>
     <CoverageCommandLine>$(CoverageOptions) -returntargetcode -register:user -target:$(TestProgram) -output:$(CoverageOutputFilePath)</CoverageCommandLine>
+    <CoverageInputFilter>*.coverage.xml</CoverageInputFilter>
     <TestHost>$(CoverageHost)</TestHost>
     <TestCommandLine>$(TestHost) $(CoverageCommandLine) -targetargs:"$(TestArguments) {XunitTraitOptions} -notrait Benchmark=true"</TestCommandLine>
   </PropertyGroup>
@@ -167,18 +225,14 @@
 
   </Target>
 
-  <PropertyGroup Condition="'$(GenerateFullCoverageReport)'=='true'">
-    <GenerateFullCoverageReportAfterTargets Condition="'$(GenerateFullCoverageReportAfterTargets)'==''">TestAllProjects</GenerateFullCoverageReportAfterTargets>
-  </PropertyGroup>
-
   <!-- Generate coverage report for all the projects. -->
   <Target Name="GenerateFullCoverageReport"
          AfterTargets="$(GenerateFullCoverageReportAfterTargets)"
-         Inputs="$(CoverageReportDir)\*.coverage.xml"
+         Inputs="$(CoverageReportDir)\$(CoverageInputFilter)"
          Outputs="$(CoverageReportDir)index.htm"
          Condition="'$(GenerateFullCoverageReport)'=='true'">
 
-    <Exec Command="$(CoverageReportGeneratorCommandLine) -reports:$(CoverageReportDir)\*.coverage.xml"
+    <Exec Command="$(CoverageReportGeneratorCommandLine) -reports:$(CoverageReportDir)\$(CoverageInputFilter)"
           ContinueOnError="ErrorAndContinue"
           WorkingDirectory="$(ProjectDir)" />
 
@@ -187,7 +241,7 @@
 
     <PropertyGroup>
       <CoverallsUploaderCommandLine>$(PackagesDir)coveralls.io.$(CoverallsUploaderVersion)\tools\coveralls.net.exe</CoverallsUploaderCommandLine>
-      <CoverallsUploaderOptions>--opencover $(CoverageReportDir)\*.coverage.xml --repo-token $(CoverallsToken)</CoverallsUploaderOptions>
+      <CoverallsUploaderOptions>--opencover $(CoverageReportDir)\$(CoverageInputFilter) --repo-token $(CoverallsToken)</CoverallsUploaderOptions>
     </PropertyGroup>
 
     <Exec Command="$(CoverallsUploaderCommandLine) $(CoverallsUploaderOptions)"
@@ -203,10 +257,10 @@
   <Target Name="GenerateVisitedReport"
           AfterTargets="Test"
           Condition="'$(GenerateVisitedMethodsReport)' == 'true'"
-          Inputs="$(CoverageReportDir)*.coverage.xml"
+          Inputs="$(CoverageReportDir)$(CoverageInputFilter)"
           Outputs="$(CoverageReportDir)\VisitedMethodsReport.xml">
     <ItemGroup>
-      <Reports Include="$(CoverageReportDir)*.coverage.xml"/>
+      <Reports Include="$(CoverageReportDir)$(CoverageInputFilter)"/>
     </ItemGroup>
     <ParseTestCoverageInfo CoverageReports="@(Reports)"
                            OutputReport="$(CoverageReportDir)\VisitedMethodsReport.xml"/>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -176,13 +176,6 @@
       Exclude="$(CoverletExclusionFilter)"
       ExcludeByFile="$(ExcludeByFile)"
       Path="$(CoverageRuntimeDir)/" />
-
-    <!-- Instrumented assemblies call coverlet.tracker.dll -->
-    <Copy
-      SourceFiles="$(PackagesDir)coverlet.msbuild/$(CoverletMsbuildVersion)/build/netstandard2.0/coverlet.tracker.dll"
-      DestinationFolder="$(TestPath)"
-      SkipUnchangedFiles="true"
-      UseHardlinksIfPossible="true" />
   </Target>
 
   <!-- xUnit command line with coverage enabled using OpenCover -->


### PR DESCRIPTION
[EDIT: Updated instructions after validation on macOS 10.13]

/cc @tarekgh @tonerdo @stephentoub 

This change allows one to experiment with coverlet.msbuild to generate coverage information on the CoreFx repo. Some notes:

* There are some issues to consume dotnet/cli global tools on CoreFx repo, it is possible to workaround them but I opted to use the msbuild due to the large set of exclusion files, making easier for me to debug/tweak things via a msbuild task.
* There is a related PR in CoreFx to bring the coverlet.msbuild package, see https://github.com/dotnet/corefx/pull/31171.
* Once this reach the CoreFx repo I will update the wiki with the instructions below - please, review them too.

# Cross-platform Coverage 
As of 07/2018 CoreFx is only able to get coverage information on Windows. To correct this we are experimenting with [coverlet](https://github.com/tonerdo/coverlet).

## Know Issues ##

1. Instrumenting "System.Private.CoreLib" is causing test to crash (both on Windows and Unix).

## Windows Instructions ##
On Windows by default coverage runs will use OpenCover instead of coverlet, use the build property `UseCoverlet` to change this default. Currently the use of `dotnet msbuild` is required to avoid a problem with one of the coverlet dependencies. Here is the command:

```
dotnet msbuild /t:RebuildAndTest /p:Coverage=True /p:UseCoverlet=True
``` 

## Unix Instructions ##
On Unix just specifying `/p:Coverage=True` triggers the usage of coverlet. However, in order to generate the html report a few setup steps are needed.

1. Install the [dotnet/cli global tool reportgenerator](https://www.nuget.org/packages/dotnet-reportgenerator-globaltool), add it to the PATH if not automatically added by dotnet/cli (it can be only for the current session)
2. On Linux install the Arial font required for report generation: `sudo apt-get install ttf-mscorefonts-installer`

After that you request a coverage run using either `dotnet msbuild` or the `msbuild.sh` from a test folder, e.g.:

```
dotnet msbuild /t:RebuildAndTest /p:Coverage=True
```

Open index.htm located at bin/tests/coverage to see the results of the coverage run.

