### PR TITLE
Add Corefx Ibc Package support

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OptimizationDataVersion Condition="'$(OptimizationDataVersion)'==''">2.0.0-rc-61101-16</OptimizationDataVersion>
-    <CoreFxOptimizationDataVersion Condition="'$(CoreFxOptimizationDataVersion)'==''">99.99.99-master-20180730-0151</CoreFxOptimizationDataVersion>
+    <CoreFxOptimizationDataVersion Condition="'$(CoreFxOptimizationDataVersion)'==''">99.99.99-master-20180815-0120</CoreFxOptimizationDataVersion>
     <OptimizationDataPackageName Condition="'$(OptimizationDataPackageName)'==''">RoslynDependencies.OptimizationData</OptimizationDataPackageName>
     <CoreFxOptimizationDataPackageName Condition="'$(CoreFxOptimizationDataPackageName)'==''">optimization.windows_nt-x64.IBC.CoreFx</CoreFxOptimizationDataPackageName>
     <OptimizationDataDir Condition="'$(OptimizationDataDir)'==''">$(ToolsDir)OptimizationData/</OptimizationDataDir>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -29,7 +29,7 @@
       <TargetOptimizationDataFile>$(OptimizationDataDir)$(AssemblyName).pgo</TargetOptimizationDataFile>
     </PropertyGroup>
     <ItemGroup>
-      <RawOptimizationDataFiles Include="$(OptimizationDataDir)$(AssemblyName)*.ibc" />
+      <RawOptimizationDataFiles Include="$(OptimizationDataDir)$(AssemblyName).ibc" />
     </ItemGroup>
 
     <!-- Merge the optimization data into the source DLL -->
@@ -100,8 +100,8 @@
     <!-- Copy the restored files into a more accessible location -->
     <ItemGroup>
       <_OptimizationDataFiles Include="$(PackagesDir)/$(OptimizationDataPackageName)/$(OptimizationDataVersion)/content/OptimizationData/*.pgo" />
-      <_OptimizationDataFiles Include="$(PackagesDir)/$(OptimizationDataPackageName)/$(OptimizationDataVersion)/content/OptimizationData/*.dll" />
-      <_OptimizationDataFiles Include="$(PackagesDir)/$(OptimizationDataPackageName)/$(OptimizationDataVersion)/content/OptimizationData/*.ibc" />
+      <_OptimizationDataFiles Include="$(PackagesDir)/$(CoreFxOptimizationDataPackageName)/$(CoreFxOptimizationDataVersion)/data/*.dll" />
+      <_OptimizationDataFiles Include="$(PackagesDir)/$(CoreFxOptimizationDataPackageName)/$(CoreFxOptimizationDataVersion)/data/*.ibc" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_OptimizationDataFiles)"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -4,7 +4,9 @@
 
   <PropertyGroup>
     <OptimizationDataVersion Condition="'$(OptimizationDataVersion)'==''">2.0.0-rc-61101-16</OptimizationDataVersion>
+    <CoreFxOptimizationDataVersion Condition="'$(CoreFxOptimizationDataVersion)'==''">99.99.99-master-20180718-0214</CoreFxOptimizationDataVersion>
     <OptimizationDataPackageName Condition="'$(OptimizationDataPackageName)'==''">RoslynDependencies.OptimizationData</OptimizationDataPackageName>
+    <CoreFxOptimizationDataPackageName Condition="'$(CoreFxOptimizationDataPackageName)'==''">optimization.windows_nt-x64.IBC.CoreCLR</CoreFxOptimizationDataPackageName>
     <OptimizationDataDir Condition="'$(OptimizationDataDir)'==''">$(ToolsDir)OptimizationData/</OptimizationDataDir>
     <RestoreDefaultOptimizationDataPackage Condition="'$(RestoreDefaultOptimizationDataPackage)'==''">true</RestoreDefaultOptimizationDataPackage>
     <UsePartialNGENOptimization Condition="'$(UsePartialNGENOptimization)'==''">true</UsePartialNGENOptimization>
@@ -88,14 +90,18 @@
     <PropertyGroup>
       <OptimizationDataProject>$(MSBuildThisFileDirectory)OptimizationData.msbuild</OptimizationDataProject>
       <OptimizationDataNuGetFeed Condition="'$(OptimizationDataNuGetFeed)'==''">https:%2F%2Fdotnet.myget.org/F/roslyn/api/v3/index.json</OptimizationDataNuGetFeed>
+      <CoreFxOptimizationDataNuGetFeed Condition="'$(CoreFxOptimizationDataNuGetFeed)'==''">https:%2F%2Fdotnet.myget.org/F/dotnet-core-optimization-data/api/v3/index.json</CoreFxOptimizationDataNuGetFeed>
     </PropertyGroup>
 
     <!-- Restore the OptimizationData package -->
     <Exec Command="$(DnuRestoreCommand) $(OptimizationDataProject) --source $(OptimizationDataNuGetFeed) /p:OptimizationDataPackageName=$(OptimizationDataPackageName) /p:OptimizationDataVersion=$(OptimizationDataVersion) /p:BaseIntermediateOutputPath=$(OptimizationDataDir)" StandardOutputImportance="Low"/>
+    <Exec Command="$(DnuRestoreCommand) $(OptimizationDataProject) --source $(CorefxOptimizationDataNuGetFeed) /p:OptimizationDataPackageName=$(CoreFxOptimizationDataPackageName) /p:OptimizationDataVersion=$(CoreFxOptimizationDataVersion) /p:BaseIntermediateOutputPath=$(OptimizationDataDir)" StandardOutputImportance="Low"/>
 
     <!-- Copy the restored files into a more accessible location -->
     <ItemGroup>
       <_OptimizationDataFiles Include="$(PackagesDir)/$(OptimizationDataPackageName)/$(OptimizationDataVersion)/content/OptimizationData/*.pgo" />
+      <_OptimizationDataFiles Include="$(PackagesDir)/$(OptimizationDataPackageName)/$(OptimizationDataVersion)/content/OptimizationData/*.dll" />
+      <_OptimizationDataFiles Include="$(PackagesDir)/$(OptimizationDataPackageName)/$(OptimizationDataVersion)/content/OptimizationData/*.ibc" />
     </ItemGroup>
 
     <Copy SourceFiles="@(_OptimizationDataFiles)"

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -4,9 +4,9 @@
 
   <PropertyGroup>
     <OptimizationDataVersion Condition="'$(OptimizationDataVersion)'==''">2.0.0-rc-61101-16</OptimizationDataVersion>
-    <CoreFxOptimizationDataVersion Condition="'$(CoreFxOptimizationDataVersion)'==''">99.99.99-master-20180718-0214</CoreFxOptimizationDataVersion>
+    <CoreFxOptimizationDataVersion Condition="'$(CoreFxOptimizationDataVersion)'==''">99.99.99-master-20180730-0151</CoreFxOptimizationDataVersion>
     <OptimizationDataPackageName Condition="'$(OptimizationDataPackageName)'==''">RoslynDependencies.OptimizationData</OptimizationDataPackageName>
-    <CoreFxOptimizationDataPackageName Condition="'$(CoreFxOptimizationDataPackageName)'==''">optimization.windows_nt-x64.IBC.CoreCLR</CoreFxOptimizationDataPackageName>
+    <CoreFxOptimizationDataPackageName Condition="'$(CoreFxOptimizationDataPackageName)'==''">optimization.windows_nt-x64.IBC.CoreFx</CoreFxOptimizationDataPackageName>
     <OptimizationDataDir Condition="'$(OptimizationDataDir)'==''">$(ToolsDir)OptimizationData/</OptimizationDataDir>
     <RestoreDefaultOptimizationDataPackage Condition="'$(RestoreDefaultOptimizationDataPackage)'==''">true</RestoreDefaultOptimizationDataPackage>
     <UsePartialNGENOptimization Condition="'$(UsePartialNGENOptimization)'==''">true</UsePartialNGENOptimization>


### PR DESCRIPTION
This change adds support to consume IBC data packages that are created by the dotnet/optimization repository. With these changes and https://github.com/dotnet/core-setup/pull/4385 to enable PartialNGEN for crossgening NetCoreApp, and changes to coreclr to enable IBC optimizations for System.Private.CoreLib, we will see a 32% decrease in the size of NetCoreApp (and an overall decrease of 16%), a 30% reduction in ref set, a 5% improvement in time to first request and steady state performance for MusicStore.

**Size**

  | Crossgen | Partial | Partial vs Crossgen (lower is better)
-- | -- | -- | --
Shared (MB) | 185.6 | 137.3 | 0.74
Microsoft.NETCore.App (MB) | 115.6 | 67.4 | 0.58

**RefSet**

MusicStore

  | Crossgen | Partial | Partial vs Crossgen (lower is better)
-- | -- | -- | --
Total | 19.389 | 13.472 | 0.69

AllReady

Crossgen | Partial | Partial vs Crossgen (lower is better)
-- | -- | --
Total | 17.58 | 12.214 | 0.69

**Performance**

MusicStore

  | Crossgen | Partial | Partial vs Crossgen (lower is better)
-- | -- | -- | --
Server Start (ms) | 870 | 870.6 | 1.00
First request (ms) | 3532.6 | 3386.6 | 0.95
Steady State (ms) | 2.926 | 2.79 | 0.95

AllReady

Crossgen | Partial | Partial vs Crossgen (lower is better)
-- | -- | --
Server Start (ms) | 2102 | 1942.4 | 0.92
First Request (ms) | 4263.2 | 4126 | 0.96
Steady State (ms) | 5.69 | 5.68 | 1.00

TechEmpower Plaintext

Crossgen | Partial | Partial vs Crossgen (lower is better)
-- | -- | --
Requests per Second | 1928649.8 | 1893183.8 | 1.02
First Request (ms) | 76.14 | 80.11 | 1.05
Startup (ms) | 391 | 372.8 | 0.95
Working Set (MB) | 382.2 | 373.4 | 0.98

