### PR TITLE
Update xunit version to 2.4.0

### DIFF
--- a/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
+++ b/src/xunit.netcore.extensions/Discoverers/ConditionalTestDiscoverer.cs
@@ -33,6 +33,8 @@ namespace Xunit.NetCore.Extensions
             MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
             Type testMethodDeclaringType = testMethodInfo.DeclaringType;
             List<string> falseConditions = new List<string>(conditionMemberNames.Count());
+            TestMethodDisplay defaultMethodDisplay = discoveryOptions.MethodDisplayOrDefault();
+            TestMethodDisplayOptions defaultMethodDisplayOptions = discoveryOptions.MethodDisplayOptionsOrDefault();
 
             foreach (string entry in conditionMemberNames)
             {
@@ -73,7 +75,8 @@ namespace Xunit.NetCore.Extensions
                     {
                         new ExecutionErrorTestCase(
                             diagnosticMessageSink,
-                            discoveryOptions.MethodDisplayOrDefault(),
+                            defaultMethodDisplay,
+                            defaultMethodDisplayOptions,
                             testMethod,
                             GetFailedLookupString(conditionMemberName, declaringType))
                     };

--- a/src/xunit.netcore.extensions/SkippedTestCase.cs
+++ b/src/xunit.netcore.extensions/SkippedTestCase.cs
@@ -18,6 +18,10 @@ namespace Xunit.NetCore.Extensions
         private readonly IXunitTestCase _testCase;
         private readonly string _skippedReason;
 
+        public SkippedTestCase()
+        {
+        }
+
         internal SkippedTestCase(IXunitTestCase testCase, string skippedReason)
         {
             _testCase = testCase;
@@ -39,6 +43,10 @@ namespace Xunit.NetCore.Extensions
         public Dictionary<string, List<string>> Traits { get { return _testCase.Traits; } }
 
         public string UniqueID { get { return _testCase.UniqueID; } }
+
+        public Exception InitializationException { get { return null; } }
+
+        public int Timeout { get { return 0; } }
 
         public void Deserialize(IXunitSerializationInfo info) { _testCase.Deserialize(info); }
 

--- a/src/xunit.netcore.extensions/project.json
+++ b/src/xunit.netcore.extensions/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "NETStandard.Library": "1.6.0",
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.4.0"
   },
   "__comment": "RuntimeInformation and OSPlatform are not on netstandard1.0 hence 1.1 was selected",
   "frameworks": {


### PR DESCRIPTION
Not sure if we should target NS2.0 instead and also get rid of the project.json?

Related https://github.com/Microsoft/xunit-performance/pull/269