### PR TITLE
Ensure global prefix handles explicit interface implementations

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -80,6 +80,9 @@ namespace Microsoft.Cci.Writers.CSharp
                 WriteTypeName(method.Type, method.ContainingType, isDynamic: IsDynamic(method.ReturnValueAttributes));
             }
 
+            if (method.IsExplicitInterfaceMethod() && _forCompilationIncludeGlobalprefix)
+                Write("global::");
+
             WriteIdentifier(name);
 
             if (isOperator)

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Properties.cs
@@ -73,6 +73,9 @@ namespace Microsoft.Cci.Writers.CSharp
 
             WriteTypeName(property.Type, isDynamic: IsDynamic(property.Attributes));
 
+            if (property.IsExplicitInterfaceProperty() && _forCompilationIncludeGlobalprefix)
+                Write("global::");
+
             if (isIndexer)
             {
                 int index = property.Name.Value.LastIndexOf(".");

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/notsupported.targets
@@ -42,6 +42,7 @@
       <GenAPIArgs>$(GenAPIArgs) -libPath:"@(_referencePathDirectories)"</GenAPIArgs>
       <GenAPIArgs>$(GenAPIArgs) -out:"$(NotSupportedSourceFile)"</GenAPIArgs>
       <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssembly)' == 'true' OR '$(GeneratePlatformNotSupportedAssemblyMessage)' != ''">$(GenAPIArgs) -throw:"$(GeneratePlatformNotSupportedAssemblyMessage)"</GenAPIArgs>
+      <GenAPIArgs Condition="'$(GeneratePlatformNotSupportedAssemblyWithGlobalPrefix)' == 'true'">$(GenAPIArgs) -global</GenAPIArgs>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Also enable use of -global for not-supported assemblies

@luqunl hit this when trying to enable System.Runtime.WindowsRuntime's not-supported assembly.