### PR TITLE
Ensure global prefix is used for not supported assembly message

### DIFF
--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Methods.cs
@@ -224,12 +224,19 @@ namespace Microsoft.Cci.Writers.CSharp
                 Write("throw new ");
                 if (_forCompilationIncludeGlobalprefix)
                     Write("global::");
-                if(_platformNotSupportedExceptionMessage.Length == 0)
-                    Write("System.PlatformNotSupportedException();");
-                else if(_platformNotSupportedExceptionMessage.StartsWith("SR."))
-                    Write($"System.PlatformNotSupportedException(System.{_platformNotSupportedExceptionMessage}); ");
-                else
-                    Write($"System.PlatformNotSupportedException(\"{_platformNotSupportedExceptionMessage}\"); ");
+
+                Write("System.PlatformNotSupportedException(");
+
+                if (_platformNotSupportedExceptionMessage.StartsWith("SR."))
+                {
+                    if (_forCompilationIncludeGlobalprefix)
+                        Write("global::");
+                    Write($"System.{ _platformNotSupportedExceptionMessage}");
+                }
+                else if (_platformNotSupportedExceptionMessage.Length > 0)
+                    Write($"\"{_platformNotSupportedExceptionMessage}\"");
+
+                 Write(");");
             }
             else if (NeedsMethodBodyForCompilation(method))
             {


### PR DESCRIPTION
This should let us use this in S.R.WinRT: https://github.com/dotnet/corefx/blob/724ffdee9db1c95314ca3c45f2692c2b7f73d78e/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj#L17