### PR TITLE
Updating init-tools to always use PACKAGES_DIR

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -5,9 +5,6 @@ set PROJECT_DIR=%~1
 set DOTNET_CMD=%~2
 set TOOLRUNTIME_DIR=%~3
 set PACKAGES_DIR=%4
-if [%PACKAGES_DIR%] == [] set PACKAGES_DIR=%TOOLRUNTIME_DIR%
-:: Remove quotes to the packages directory
-set PACKAGES_DIR=%PACKAGES_DIR:"=%
 set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
 set ROSLYNCOMPILERS_VERSION=2.8.0-beta4
@@ -31,7 +28,8 @@ set MSBUILD_PROJECT_CONTENT= ^
 
 set PUBLISH_TFM=netcoreapp2.0
 
-set INIT_TOOLS_RESTORE_ARGS=--source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
+set DEFAULT_RESTORE_ARGS=--no-cache --packages "%PACKAGES_DIR%"
+set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
 set TOOLRUNTIME_RESTORE_ARGS=--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
 
 if not exist "%PROJECT_DIR%" (
@@ -41,6 +39,16 @@ if not exist "%PROJECT_DIR%" (
 
 if not exist "%DOTNET_CMD%" (
   echo ERROR: Cannot find dotnet cli at [%DOTNET_CMD%]. Please pass in the path to dotnet.exe as the 2nd parameter.
+  exit /b 1
+)
+
+if [%TOOLRUNTIME_DIR%] == [] (
+  echo ERROR: Please pass in the tools directory as the 3rd parameter.
+  exit /b 1
+)
+
+if [%PACKAGES_DIR%] == [] (
+  echo ERROR: Please pass in the packages directory as the 4th parameter.
   exit /b 1
 )
 
@@ -80,11 +88,11 @@ Robocopy "%TOOLRUNTIME_DIR%\runtimes\any\native" "%TOOLRUNTIME_DIR%\."
 Robocopy "%BUILDTOOLS_PACKAGE_DIR%\." "%TOOLRUNTIME_DIR%\." "MSBuild.runtimeconfig.json"
 
 :: Copy Portable Targets Over to ToolRuntime
-if not exist "%PACKAGES_DIR%\generated" mkdir "%PACKAGES_DIR%\generated"
-set PORTABLETARGETS_PROJECT=%PACKAGES_DIR%\generated\project.csproj
+if not exist "%TOOLRUNTIME_DIR%\generated" mkdir "%TOOLRUNTIME_DIR%\generated"
+set PORTABLETARGETS_PROJECT=%TOOLRUNTIME_DIR%\generated\project.csproj
 echo %MSBUILD_PROJECT_CONTENT% > "%PORTABLETARGETS_PROJECT%"
 @echo on
-call "%DOTNET_CMD%" restore "%PORTABLETARGETS_PROJECT%" %INIT_TOOLS_RESTORE_ARGS% --packages "%PACKAGES_DIR%\."
+call "%DOTNET_CMD%" restore "%PORTABLETARGETS_PROJECT%" %INIT_TOOLS_RESTORE_ARGS%
 set RESTORE_PORTABLETARGETS_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%RESTORE_PORTABLETARGETS_ERROR_LEVEL%]==[0] (
@@ -100,7 +108,7 @@ Robocopy "%PACKAGES_DIR%\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%
 if [%ILASMCOMPILER_VERSION%]==[] goto :afterILAsmRestore
 
 @echo on
-call "%DOTNET_CMD%" build "%TOOLRUNTIME_DIR%\ilasm\ilasm.depproj" -r %NATIVE_TOOLS_RID% --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --packages "%PACKAGES_DIR%\." /p:ILAsmPackageVersion=%ILASMCOMPILER_VERSION%
+call "%DOTNET_CMD%" build "%TOOLRUNTIME_DIR%\ilasm\ilasm.depproj" %DEFAULT_RESTORE_ARGS% -r %NATIVE_TOOLS_RID% --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json /p:ILAsmPackageVersion=%ILASMCOMPILER_VERSION%
 set RESTORE_ILASM_ERROR_LEVEL=%ERRORLEVEL%
 @echo off
 if not [%RESTORE_ILASM_ERROR_LEVEL%]==[0] (

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -11,7 +11,7 @@ set -o pipefail
 __PROJECT_DIR=${1:-}
 __DOTNET_CMD=${2:-}
 __TOOLRUNTIME_DIR=${3:-}
-__PACKAGES_DIR=${4:-$__TOOLRUNTIME_DIR}
+__PACKAGES_DIR=${4:-}
 __TOOLS_DIR=$(cd "$(dirname "$0")"; pwd -P)
 __MICROBUILD_VERSION=0.2.0
 __ROSLYNCOMPILER_VERSION=2.8.0-beta4
@@ -27,9 +27,11 @@ __PORTABLETARGETS_PROJECT_CONTENT="
     <PackageReference Include=\"Microsoft.NETCore.Compilers\" Version=\"$__ROSLYNCOMPILER_VERSION\" />
   </ItemGroup>
 </Project>"
+
 __PUBLISH_TFM=netcoreapp2.0
 
-__INIT_TOOLS_RESTORE_ARGS="--source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
+__DEFAULT_RESTORE_ARGS="--no-cache --packages \"${__PACKAGES_DIR}\""
+__INIT_TOOLS_RESTORE_ARGS="${__DEFAULT_RESTORE_ARGS} --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
 __TOOLRUNTIME_RESTORE_ARGS="--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS}"
 
 if [ ! -d "$__PROJECT_DIR" ]; then
@@ -44,6 +46,11 @@ fi
 
 if [ -z "$__TOOLRUNTIME_DIR" ]; then
     echo "ERROR: Please pass in the tools directory as the 3rd parameter."
+    exit 1
+fi
+
+if [ -z "$__PACKAGES_DIR" ]; then
+    echo "ERROR: Please pass in the packages directory as the 4th parameter."
     exit 1
 fi
 
@@ -62,13 +69,13 @@ echo "Running: $__DOTNET_CMD publish --no-restore \"${__TOOLRUNTIME_PROJECT}\" -
 $__DOTNET_CMD publish --no-restore "${__TOOLRUNTIME_PROJECT}" -f ${__PUBLISH_TFM} -o $__TOOLRUNTIME_DIR
 
 # Copy Portable Targets Over to ToolRuntime
-if [ ! -d "${__PACKAGES_DIR}/generated" ]; then mkdir "${__PACKAGES_DIR}/generated"; fi
-__PORTABLETARGETS_PROJECT=${__PACKAGES_DIR}/generated/project.csproj
+if [ ! -d "${__TOOLRUNTIME_DIR}/generated" ]; then mkdir "${__TOOLRUNTIME_DIR}/generated"; fi
+__PORTABLETARGETS_PROJECT=${__TOOLRUNTIME_DIR}/generated/project.csproj
 
 echo $__PORTABLETARGETS_PROJECT_CONTENT > "${__PORTABLETARGETS_PROJECT}"
 
-echo "Running: \"$__DOTNET_CMD\" restore \"${__PORTABLETARGETS_PROJECT}\" $__INIT_TOOLS_RESTORE_ARGS --packages \"${__PACKAGES_DIR}/.\""
-$__DOTNET_CMD restore "${__PORTABLETARGETS_PROJECT}" $__INIT_TOOLS_RESTORE_ARGS --packages "${__PACKAGES_DIR}/."
+echo "Running: \"$__DOTNET_CMD\" restore \"${__PORTABLETARGETS_PROJECT}\" $__INIT_TOOLS_RESTORE_ARGS"
+$__DOTNET_CMD restore "${__PORTABLETARGETS_PROJECT}" $__INIT_TOOLS_RESTORE_ARGS
 
 # Copy MicroBuild targets from packages, allowing for lowercased package IDs.
 cp -R "${__PACKAGES_DIR}"/[Mm]icro[Bb]uild.[Cc]ore/"${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
@@ -100,7 +107,7 @@ if [ "$__ILASM_PACKAGE_VERSION" ]; then
     fi
 
     echo "Running: \"$__DOTNET_CMD\" build \"${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj\""
-    $__DOTNET_CMD build "${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj" --packages "${__PACKAGES_DIR}/." --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -r $__ILASM_PACKAGE_RID -p:ILAsmPackageVersion=$__ILASM_PACKAGE_VERSION
+    $__DOTNET_CMD build "${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj" $__DEFAULT_RESTORE_ARGS --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -r $__ILASM_PACKAGE_RID -p:ILAsmPackageVersion=$__ILASM_PACKAGE_VERSION
 fi
 
 # Download the package version props file, if passed in the environment.


### PR DESCRIPTION
This ensures that all packages get restored to `PACKAGES_DIR`, rather than a mix of `PACKAGES_DIR` and the NuGet default.