### PR TITLE
Update coverlet.msbuild to 2.2.1

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/CodeCoverage.targets
@@ -6,7 +6,7 @@
   -->
   <PropertyGroup>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
-    <CoverletMsbuildVersion>2.1.1</CoverletMsbuildVersion>
+    <CoverletMsbuildVersion>2.2.1</CoverletMsbuildVersion>
     <ReportGeneratorVersion>3.0.1</ReportGeneratorVersion>
     <CoverallsUploaderVersion>1.4</CoverallsUploaderVersion>
   </PropertyGroup>


### PR DESCRIPTION
This version has a performance improvement that will benefit corefx. I will update src/external/test-runtime/XUnit.Runtime.depproj as soon as dotnet-bot brings this change to corefx.