### PR TITLE
Adding ILDasm restore and resources switches in order to be able to produce resources for System.Runtime.CompilerServices.Unsafe.dll

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/IL.targets
@@ -43,6 +43,7 @@
       <_IlasmSwitches Condition="'$(DebugType)' == 'Impl'">$(_IlasmSwitches) -DEBUG=IMPL</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(DebugType)' == 'PdbOnly'">$(_IlasmSwitches) -DEBUG=OPT</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(Optimize)' == 'True'">$(_IlasmSwitches) -OPTIMIZE</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(IlasmResourceFile)' != ''">$(_IlasmSwitches) -RESOURCES=$(IlasmResourceFile)</_IlasmSwitches>
     </PropertyGroup>
 
     <Exec Command="$(IlasmToolPath) $(_IlasmSwitches) $(_OutputTypeArgument) $(IlasmFlags) -OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile, ' ')">

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ilasm/ilasm.depproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(ILAsmPackageVersion)" />
+    <PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(ILAsmPackageVersion)" />
 
     <!-- ILAsm has a very unfortunate runtime dependency on CoreCLR, so we need to grab that too -->
     <!-- https://github.com/dotnet/coreclr/issues/15059 -->


### PR DESCRIPTION
This is in order to fix this issue: https://github.com/dotnet/corefx/issues/24012

S.R.CS.Unsafe is built as an ilproj where we call ilasm directly. This causes that the write version headers are not built into the managed library. With these changes (plus a PR comming up in corefx) we will be able to produce a resource file and then pass it down to ilasm so that the dll will have the right headers on it.