### PR TITLE
Port 'Add blob prefix support' to 1.0.0 buildtools

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -56,10 +56,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Log.LogMessage(MessageImportance.Normal, "Downloading contents of container {0} from storage account '{1}' to directory {2}.",
                 ContainerName, AccountName, DownloadDirectory);
 
-            string blobprefix = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
+            string optionalBlobPrefixForQuery = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
             
             List<string> blobsNames = new List<string>();
-            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list{2}", AccountName, ContainerName, blobprefix);
+            string urlListBlobs = $"https://{AccountName}.blob.core.windows.net/{ContainerName}?restype=container&comp=list{optionalBlobPrefixForQuery}";
 
             Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -43,6 +43,9 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         [Required]
         public string DownloadDirectory { get; set; }
 
+        public string BlobNamePrefix { get; set; }
+
+
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -53,8 +56,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Log.LogMessage(MessageImportance.Normal, "Downloading contents of container {0} from storage account '{1}' to directory {2}.",
                 ContainerName, AccountName, DownloadDirectory);
 
-            List<string> blobsNames = null;
-            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list", AccountName, ContainerName);
+            string blobprefix = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
+            
+            List<string> blobsNames = new List<string>();
+            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list{2}", AccountName, ContainerName, blobprefix);
 
             Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
@@ -12,8 +12,8 @@
     <Error Condition="'$(PublishPattern)' == ''" Text="Please specify a value for PublishPattern using standard msbuild 'include' syntax." />
 
     <PropertyGroup>
-      <ReleativeBlobPathBase>$(BlobNamePrefix)</ReleativeBlobPathBase>
-      <ReleativeBlobPathBase Condition="'$(ReleativeBlobPathBase)' != '' and !HasTrailingSlash('$(ReleativeBlobPathBase)')">$(ReleativeBlobPathBase)</ReleativeBlobPathBase>
+      <RelativeBlobPathBase>$(BlobNamePrefix)</RelativeBlobPathBase>
+      <RelativeBlobPathBase Condition="'$(RelativeBlobPathBase)' != '' and !HasTrailingSlash('$(RelativeBlobPathBase)')">$(RelativeBlobPathBase)/</RelativeBlobPathBase>
     </PropertyGroup>
     <ItemGroup>
       <ForPublishing Include="$(PublishPattern)" />
@@ -21,7 +21,7 @@
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>
-        <RelativeBlobPath>$(ReleativeBlobPathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+        <RelativeBlobPath>$(RelativeBlobPathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
       </ForPublishing>
     </ItemGroup>
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/PublishContent.targets
@@ -10,13 +10,18 @@
   <!-- gathers the items to be published -->
   <Target Name="GatherItemsForPattern">
     <Error Condition="'$(PublishPattern)' == ''" Text="Please specify a value for PublishPattern using standard msbuild 'include' syntax." />
+
+    <PropertyGroup>
+      <ReleativeBlobPathBase>$(BlobNamePrefix)</ReleativeBlobPathBase>
+      <ReleativeBlobPathBase Condition="'$(ReleativeBlobPathBase)' != '' and !HasTrailingSlash('$(ReleativeBlobPathBase)')">$(ReleativeBlobPathBase)</ReleativeBlobPathBase>
+    </PropertyGroup>
     <ItemGroup>
       <ForPublishing Include="$(PublishPattern)" />
     </ItemGroup>
     <!-- add relative blob path metadata -->
     <ItemGroup>
       <ForPublishing>
-        <RelativeBlobPath>$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath> 
+        <RelativeBlobPath>$(ReleativeBlobPathBase)$([System.String]::Copy('%(RecursiveDir)%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
       </ForPublishing>
     </ItemGroup>
     <Error Condition="'@(ForPublishing)' == ''" Text="No items were found matching pattern '$(PublishPattern)'." />

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/SyncCloudContent.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/SyncCloudContent.targets
@@ -25,6 +25,7 @@
     <DownloadFromAzure AccountName="$(CloudDropAccountName)"
                        AccountKey="$(CloudDropAccessToken)"
                        ContainerName="$(ContainerName)"
+                       BlobNamePrefix="$(BlobNamePrefix)"
                        DownloadDirectory="$(DownloadDirectory)" />
   </Target>
   


### PR DESCRIPTION
Port of https://github.com/dotnet/buildtools/pull/2070 for 1.0.0. We need this so that we can download packages from a specific folder in blob storage in core-setup 1.x.x. Without it, we're currently restoring 2 different versions of buildtools, and only using the second one for downloading stuff from Azure.

@dagood PTAL.