### PR TITLE
Allow BlobNamePrefixes with slashes while syncing from Azure

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureConnectionStringBuildTask.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureConnectionStringBuildTask.cs
@@ -1,0 +1,57 @@
+using Microsoft.Build.Utilities;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public abstract class AzureConnectionStringBuildTask : Task
+    {
+        /// <summary>
+        /// Azure Storage account connection string.  Supersedes Account Key / Name.  
+        /// Will cause errors if both are set.
+        /// </summary>
+        public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// The Azure account key used when creating the connection string.
+        /// When we fully deprecate these, can just make them get; only.
+        /// </summary>
+        public string AccountKey { get; set; }
+
+        /// <summary>
+        /// The Azure account name used when creating the connection string.
+        /// When we fully deprecate these, can just make them get; only.
+        /// </summary>
+        public string AccountName { get; set; }
+
+        public void ParseConnectionString()
+        {
+            if (!string.IsNullOrEmpty(ConnectionString))
+            {
+                if (!(string.IsNullOrEmpty(AccountKey) && string.IsNullOrEmpty(AccountName)))
+                {
+                    Log.LogError("If the ConnectionString property is set, you must not provide AccountKey / AccountName.  These values will be deprecated in the future.");
+                }
+                else
+                {
+                    Regex storageConnectionStringRegex = new Regex("AccountName=(?<name>.+?);AccountKey=(?<key>.+?);");
+
+                    MatchCollection matches = storageConnectionStringRegex.Matches(ConnectionString);
+                    if (matches.Count > 0)
+                    {
+                        // When we deprecate this format, we'll want to demote these to private
+                        AccountName = matches[0].Groups["name"].Value;
+                        AccountKey = matches[0].Groups["key"].Value;
+                    }
+                    else
+                    {
+                        Log.LogError("Error parsing connection string.  Please review its value.");
+                    }
+                }
+            }
+            else if (string.IsNullOrEmpty(AccountKey) || string.IsNullOrEmpty(AccountName))
+            {
+                Log.LogError("Error, must provide either ConnectionString or AccountName with AccountKey");
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -24,40 +25,38 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         ///     The storage api version.
         /// </summary>
         public static readonly string StorageApiVersion = "2015-04-05";
-
         public const string DateHeaderString = "x-ms-date";
-
         public const string VersionHeaderString = "x-ms-version";
-
         public const string AuthorizationHeaderString = "Authorization";
+        public const string CacheControlString = "x-ms-blob-cache-control";
+        public const string ContentTypeString = "x-ms-blob-content-type";
 
         public enum SasAccessType
         {
-            Read, 
+            Read,
             Write,
         };
 
         public static string AuthorizationHeader(
-            string storageAccount, 
-            string storageKey, 
-            string method, 
+            string storageAccount,
+            string storageKey,
+            string method,
             DateTime now,
-            HttpRequestMessage request, 
-            string ifMatch = "", 
-            string contentMD5 = "", 
-            string size = "", 
+            HttpRequestMessage request,
+            string ifMatch = "",
+            string contentMD5 = "",
+            string size = "",
             string contentType = "")
         {
             string stringToSign = string.Format(
-                "{0}\n\n\n{1}\n{5}\n{6}\n\n\n{2}\n\n\n\n{3}{4}", 
-                method, 
-                (size == string.Empty) ? string.Empty : size, 
-                ifMatch, 
-                GetCanonicalizedHeaders(request), 
-                GetCanonicalizedResource(request.RequestUri, storageAccount), 
-                contentMD5, 
+                "{0}\n\n\n{1}\n{5}\n{6}\n\n\n{2}\n\n\n\n{3}{4}",
+                method,
+                (size == string.Empty) ? string.Empty : size,
+                ifMatch,
+                GetCanonicalizedHeaders(request),
+                GetCanonicalizedResource(request.RequestUri, storageAccount),
+                contentMD5,
                 contentType);
-
             byte[] signatureBytes = Encoding.UTF8.GetBytes(stringToSign);
             string authorizationHeader;
             using (HMACSHA256 hmacsha256 = new HMACSHA256(Convert.FromBase64String(storageKey)))
@@ -70,10 +69,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         }
 
         public static string CreateContainerSasToken(
-            string accountName, 
-            string containerName, 
-            string key, 
-            SasAccessType accessType, 
+            string accountName,
+            string containerName,
+            string key,
+            SasAccessType accessType,
             int validityTimeInDays)
         {
             string signedPermissions = string.Empty;
@@ -96,11 +95,11 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             string signedVersion = StorageApiVersion;
 
             string stringToSign = ConstructServiceStringToSign(
-                signedPermissions, 
-                signedVersion, 
-                signedExpiry, 
-                canonicalizedResource, 
-                signedIdentifier, 
+                signedPermissions,
+                signedVersion,
+                signedExpiry,
+                canonicalizedResource,
+                signedIdentifier,
                 signedStart);
 
             byte[] signatureBytes = Encoding.UTF8.GetBytes(stringToSign);
@@ -111,12 +110,12 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
 
             string sasToken = string.Format(
-                "?sv={0}&sr={1}&sig={2}&st={3}&se={4}&sp={5}", 
-                WebUtility.UrlEncode(signedVersion), 
-                WebUtility.UrlEncode("c"), 
-                WebUtility.UrlEncode(signature), 
-                WebUtility.UrlEncode(signedStart), 
-                WebUtility.UrlEncode(signedExpiry), 
+                "?sv={0}&sr={1}&sig={2}&st={3}&se={4}&sp={5}",
+                WebUtility.UrlEncode(signedVersion),
+                WebUtility.UrlEncode("c"),
+                WebUtility.UrlEncode(signature),
+                WebUtility.UrlEncode(signedStart),
+                WebUtility.UrlEncode(signedExpiry),
                 WebUtility.UrlEncode(signedPermissions));
 
             return sasToken;
@@ -255,13 +254,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     if (validationCallback == null)
                     {
                         // check if the response code is within the range of failures
-                        if (IsWithinRetryRange(response.StatusCode))
+                        if (!IsWithinRetryRange(response.StatusCode))
                         {
-                            loggingHelper.LogWarning("Request failed with status code {0}", response.StatusCode);
-                        }
-                        else
-                        {
-                            loggingHelper.LogMessage(MessageImportance.Low, "Response completed with status code {0}", response.StatusCode);
                             return response;
                         }
                     }
@@ -300,35 +294,35 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
         }
 
         private static string ConstructServiceStringToSign(
-            string signedPermissions, 
-            string signedVersion, 
-            string signedExpiry, 
-            string canonicalizedResource, 
-            string signedIdentifier, 
-            string signedStart, 
-            string signedIP = "", 
-            string signedProtocol = "", 
-            string rscc = "", 
-            string rscd = "", 
-            string rsce = "", 
-            string rscl = "", 
+            string signedPermissions,
+            string signedVersion,
+            string signedExpiry,
+            string canonicalizedResource,
+            string signedIdentifier,
+            string signedStart,
+            string signedIP = "",
+            string signedProtocol = "",
+            string rscc = "",
+            string rscd = "",
+            string rsce = "",
+            string rscl = "",
             string rsct = "")
         {
             // constructing string to sign based on spec in https://msdn.microsoft.com/en-us/library/azure/dn140255.aspx
             var stringToSign = string.Join(
-                "\n", 
-                signedPermissions, 
-                signedStart, 
-                signedExpiry, 
-                canonicalizedResource, 
-                signedIdentifier, 
-                signedIP, 
-                signedProtocol, 
-                signedVersion, 
-                rscc, 
-                rscd, 
-                rsce, 
-                rscl, 
+                "\n",
+                signedPermissions,
+                signedStart,
+                signedExpiry,
+                canonicalizedResource,
+                signedIdentifier,
+                signedIP,
+                signedProtocol,
+                signedVersion,
+                rscc,
+                rscd,
+                rsce,
+                rscl,
                 rsct);
             return stringToSign;
         }
@@ -338,7 +332,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             Dictionary<string, HashSet<string>> values = new Dictionary<string, HashSet<string>>();
             //Decode this to allow the regex to pull out the correct groups for signing
             address = new Uri(WebUtility.UrlDecode(address.ToString()));
-            Regex newreg = new Regex(@"\?(\w+)\=([\w|\=]+)|\&(\w+)\=([\w|\=]+)");
+            Regex newreg = new Regex(@"(?:\?|&)([^=]+)=([^&]+)");
             MatchCollection matches = newreg.Matches(address.Query);
             foreach (Match match in matches)
             {
@@ -396,6 +390,73 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             }
 
             return dictionary;
+        }
+
+        public static Func<HttpRequestMessage> RequestMessage(string method, string url, string accountName, string accountKey, List<Tuple<string, string>> additionalHeaders = null, string body = null)
+        {
+            Func<HttpRequestMessage> requestFunc = () =>
+            {
+                HttpMethod httpMethod = HttpMethod.Get;
+                if(method == "PUT")
+                {
+                    httpMethod = HttpMethod.Put;
+                }
+                else if (method == "DELETE")
+                {
+                    httpMethod = HttpMethod.Delete;
+                }
+                DateTime dateTime = DateTime.UtcNow;
+                var request = new HttpRequestMessage(httpMethod, url);
+                request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
+                request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
+                if (additionalHeaders != null)
+                {
+                    foreach (Tuple<string, string> additionalHeader in additionalHeaders)
+                    {
+                        request.Headers.Add(additionalHeader.Item1, additionalHeader.Item2);
+                    }
+                }
+                if (body != null)
+                {
+                    request.Content = new StringContent(body);
+                    request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
+                        accountName,
+                        accountKey,
+                        method,
+                        dateTime,
+                        request,
+                        "",
+                        "",
+                        request.Content.Headers.ContentLength.ToString(),
+                        request.Content.Headers.ContentType.ToString()));
+                }
+                else
+                {
+                    request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
+                        accountName,
+                        accountKey,
+                        method,
+                        dateTime,
+                        request));
+                }
+                return request;
+            };
+            return requestFunc;
+        }
+
+        public static string GetRootRestUrl(string accountName)
+        {
+            return $"https://{accountName}.blob.core.windows.net";
+        } 
+       
+        public static string GetContainerRestUrl(string accountName, string containerName)
+        {
+            return $"{GetRootRestUrl(accountName)}/{containerName}";
+        }
+
+        public static string GetBlobRestUrl(string accountName, string containerName, string blob)
+        {
+            return $"{GetContainerRestUrl(accountName, containerName)}/{blob}";
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -12,24 +12,10 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Xml;
 
-using Task = Microsoft.Build.Utilities.Task;
-
 namespace Microsoft.DotNet.Build.CloudTestTasks
 {
-    public sealed class DownloadFromAzure : Task
+    public sealed class DownloadFromAzure : AzureConnectionStringBuildTask
     {
-        /// <summary>
-        /// The Azure account name used when creating the connection string.
-        /// </summary>
-        [Required]
-        public string AccountName { get; set; }
-
-        /// <summary>
-        /// The Azure account key used when creating the connection string.
-        /// </summary>
-        [Required]
-        public string AccountKey { get; set; }
-
         /// <summary>
         /// The name of the container to access.  The specified name must be in the correct format, see the
         /// following page for more info.  https://msdn.microsoft.com/en-us/library/azure/dd135715.aspx
@@ -45,6 +31,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
         public string BlobNamePrefix { get; set; }
 
+        public ITaskItem[] BlobNames { get; set; }
+        
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -52,89 +40,99 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
 
         public async Task<bool> ExecuteAsync()
         {
+            ParseConnectionString();
+            // If the connection string AND AccountKey & AccountName are provided, error out.
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
             Log.LogMessage(MessageImportance.Normal, "Downloading contents of container {0} from storage account '{1}' to directory {2}.",
                 ContainerName, AccountName, DownloadDirectory);
 
-            string blobprefix = string.IsNullOrEmpty(BlobNamePrefix) ? "" : "&prefix=" + BlobNamePrefix;
-
-            List<string> blobsNames = new List<string>();
-            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list{2}", AccountName, ContainerName, blobprefix);
-
-            Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
-
-            using (HttpClient client = new HttpClient())
+            try
             {
-                try
+                List<string> blobNames = new List<string>();
+                if (BlobNames == null)
                 {
-                    Func<HttpRequestMessage> createRequest = () =>
+                    ListAzureBlobs listAzureBlobs = new ListAzureBlobs()
                     {
-                        DateTime dateTime = DateTime.UtcNow;
-                        var request = new HttpRequestMessage(HttpMethod.Get, urlListBlobs);
-                        request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
-                        request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                        request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
-                                AccountName,
-                                AccountKey,
-                                "GET",
-                                dateTime,
-                                request));
-                        return request;
-                    };
-
-                    XmlDocument responseFile;
-                    using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
+                        AccountName = AccountName,
+                        AccountKey = AccountKey,
+                        ContainerName = ContainerName,
+                        FilterBlobNames = BlobNamePrefix,
+                        BuildEngine = this.BuildEngine,
+                        HostObject = this.HostObject
+                    };                    
+                    listAzureBlobs.Execute();
+                    blobNames = listAzureBlobs.BlobNames.ToList();
+                }
+                else
+                {
+                    blobNames = BlobNames.Select(b => b.ItemSpec).ToList<string>();
+                    if (BlobNamePrefix != null)
                     {
-                        responseFile = new XmlDocument();
-                        responseFile.LoadXml(await response.Content.ReadAsStringAsync());
-                        XmlNodeList elemList = responseFile.GetElementsByTagName("Name");
-
-                        blobsNames = elemList.Cast<XmlNode>()
-                                                    .Select(x => x.InnerText)
-                                                    .ToList();
-
-                        if (blobsNames.Count == 0)
-                            Log.LogWarning("No blobs were found.");
+                        blobNames = blobNames.Where(b => b.StartsWith(BlobNamePrefix)).ToList<string>();
                     }
-
-                    // track the number of blobs that fail to download
-                    int failureCount = 0;
-
-                    foreach (string blob in blobsNames)
+                }
+                // track the number of blobs that fail to download
+                int failureCount = 0;
+                using (HttpClient client = new HttpClient())
+                {
+                    foreach (string blob in blobNames)
                     {
                         Log.LogMessage(MessageImportance.Low, "Downloading BLOB - {0}", blob);
-                        string urlGetBlob = string.Format("https://{0}.blob.core.windows.net/{1}/{2}", AccountName, ContainerName, blob);
+                        string urlGetBlob = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, blob);
 
-                        string filename = Path.Combine(DownloadDirectory, blob);
-                        string blobDirectory = blob.Substring(0, blob.LastIndexOf("/"));
+                        int dirIndex = blob.LastIndexOf("/");
+                        string blobDirectory = string.Empty;
+                        string blobFilename = string.Empty;
+
+                        if (dirIndex == -1)
+                        {
+                            blobFilename = blob;
+                        }
+                        else
+                        {
+                            blobDirectory = blob.Substring(0, dirIndex);
+                            blobFilename = blob.Substring(dirIndex + 1);
+
+                            // Trim blob name prefix (directory part) from download to blob directory
+                            if(BlobNamePrefix != null)
+                            {
+                                if(BlobNamePrefix.Length > dirIndex)
+                                {
+                                    BlobNamePrefix = BlobNamePrefix.Substring(0, dirIndex);
+                                }
+                                blobDirectory = blobDirectory.Substring(BlobNamePrefix.Length);
+                            }
+                        }
                         string downloadBlobDirectory = Path.Combine(DownloadDirectory, blobDirectory);
                         if (!Directory.Exists(downloadBlobDirectory))
                         {
                             Directory.CreateDirectory(downloadBlobDirectory);
                         }
+                        string filename = Path.Combine(downloadBlobDirectory, blobFilename);
 
-                        createRequest = () =>
-                        {
-                            DateTime dateTime = DateTime.UtcNow;
-                            var request = new HttpRequestMessage(HttpMethod.Get, urlGetBlob);
-                            request.Headers.Add(AzureHelper.DateHeaderString, dateTime.ToString("R", CultureInfo.InvariantCulture));
-                            request.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                            request.Headers.Add(AzureHelper.AuthorizationHeaderString, AzureHelper.AuthorizationHeader(
-                                    AccountName,
-                                    AccountKey,
-                                    "GET",
-                                    dateTime,
-                                    request));
-                            return request;
-                        };
+                        var createRequest = AzureHelper.RequestMessage("GET", urlGetBlob, AccountName, AccountKey);
 
                         using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
                         {
                             if (response.IsSuccessStatusCode)
                             {
-                                Stream responseStream = await response.Content.ReadAsStreamAsync();
-                                using (FileStream sourceStream = File.Open(filename, FileMode.Create))
+                                // Blobs can be files but have the name of a directory.  We'll skip those and log something weird happened.
+                                if (!string.IsNullOrEmpty(Path.GetFileName(filename)))
                                 {
-                                    responseStream.CopyTo(sourceStream);
+                                    Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                                    using (FileStream sourceStream = File.Open(filename, FileMode.Create))
+                                    {
+                                        responseStream.CopyTo(sourceStream);
+                                    }
+                                }
+                                else
+                                {
+                                    Log.LogWarning($"Unable to download blob '{blob}' as it has a directory-like name.  This may cause problems if it was needed.");
                                 }
                             }
                             else
@@ -144,16 +142,14 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                             }
                         }
                     }
-
-                    // if no blobs failed to download the task succeeded
-                    return (failureCount == 0);
                 }
-                catch (Exception e)
-                {
-                    Log.LogErrorFromException(e, true);
-                    return false;
-                }
+                Log.LogMessage($"{failureCount} errors seen downloading blobs.");
             }
+            catch (Exception e)
+            {
+                Log.LogErrorFromException(e, true);
+            }
+            return !Log.HasLoggedErrors;
         }
     }
 }

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureBlobs.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/ListAzureBlobs.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Xml;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public partial class ListAzureBlobs : AzureConnectionStringBuildTask
+    {
+
+        /// <summary>
+        /// The name of the container to access.  The specified name must be in the correct format, see the
+        /// following page for more info.  https://msdn.microsoft.com/en-us/library/azure/dd135715.aspx
+        /// </summary>
+        [Required]
+        public string ContainerName { get; set; }
+
+        [Output]
+        public string[] BlobNames { get; set; }
+
+        public string FilterBlobNames { get; set; }
+
+        public override bool Execute()
+        {
+            return ExecuteAsync().GetAwaiter().GetResult();
+        }
+
+        public static string [] Execute(string accountName,
+                                   string accountKey,
+                                   string connectionString,
+                                   string containerName,
+                                   string filterBlobNames,
+                                   IBuildEngine buildengine,
+                                   ITaskHost taskHost)
+        {
+            ListAzureBlobs getAzureBlobList = new ListAzureBlobs()
+            {
+                AccountName = accountName,
+                AccountKey = accountKey,
+                ContainerName = containerName,
+                FilterBlobNames = filterBlobNames,
+                BuildEngine = buildengine,
+                HostObject = taskHost
+            };
+            getAzureBlobList.Execute();
+            return getAzureBlobList.BlobNames;
+        }
+
+        // This code is duplicated in BuildTools task DownloadFromAzure, and that code should be refactored to permit blob listing.
+        public async Task<bool> ExecuteAsync()
+        {
+            ParseConnectionString();
+
+            if (Log.HasLoggedErrors)
+            {
+                return false;
+            }
+
+            List<string> blobsNames = new List<string>();
+            string urlListBlobs = string.Format("https://{0}.blob.core.windows.net/{1}?restype=container&comp=list", AccountName, ContainerName);
+            if (!string.IsNullOrWhiteSpace(FilterBlobNames))
+            {
+                urlListBlobs += $"&prefix={FilterBlobNames}";
+            }
+            Log.LogMessage(MessageImportance.Low, "Sending request to list blobsNames for container '{0}'.", ContainerName);
+
+            using (HttpClient client = new HttpClient())
+            {
+                try
+                {
+                    var createRequest = AzureHelper.RequestMessage("GET", urlListBlobs, AccountName, AccountKey);
+
+                    XmlDocument responseFile;
+                    string nextMarker = string.Empty;
+                    using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
+                    {
+                        responseFile = new XmlDocument();
+                        responseFile.LoadXml(await response.Content.ReadAsStringAsync());
+                        XmlNodeList elemList = responseFile.GetElementsByTagName("Name");
+
+                        blobsNames.AddRange(elemList.Cast<XmlNode>()
+                                                    .Select(x => x.InnerText)
+                                                    .ToList());
+
+                        nextMarker = responseFile.GetElementsByTagName("NextMarker").Cast<XmlNode>().FirstOrDefault()?.InnerText;
+                    }
+                    while (!string.IsNullOrEmpty(nextMarker))
+                    {
+                        urlListBlobs = string.Format($"https://{AccountName}.blob.core.windows.net/{ContainerName}?restype=container&comp=list&marker={nextMarker}");
+                        var nextRequest = AzureHelper.RequestMessage("GET", urlListBlobs, AccountName, AccountKey);
+                        using (HttpResponseMessage nextResponse = AzureHelper.RequestWithRetry(Log, client, nextRequest).GetAwaiter().GetResult())
+                        {
+                            responseFile = new XmlDocument();
+                            responseFile.LoadXml(await nextResponse.Content.ReadAsStringAsync());
+                            XmlNodeList elemList = responseFile.GetElementsByTagName("Name");
+
+                            blobsNames.AddRange(elemList.Cast<XmlNode>()
+                                                        .Select(x => x.InnerText)
+                                                        .ToList());
+
+                            nextMarker = responseFile.GetElementsByTagName("NextMarker").Cast<XmlNode>().FirstOrDefault()?.InnerText;
+                        }
+                    }
+                    BlobNames = blobsNames.ToArray();
+                }
+                catch (Exception e)
+                {
+                    Log.LogErrorFromException(e, true);
+                }
+                return !Log.HasLoggedErrors;
+            }
+        }
+    }
+
+}

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/Microsoft.DotNet.Build.CloudTestTasks.csproj
@@ -20,11 +20,13 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AzureConnectionStringBuildTask.cs" />
     <Compile Include="AzureHelper.cs" />
     <Compile Include="CreateAzureContainer.cs" />
     <Compile Include="DownloadFromAzure.cs" />
     <Compile Include="FilterForUpload.cs" />
     <Compile Include="GetPerfTestAssemblies.cs" />
+    <Compile Include="ListAzureBlobs.cs" />
     <Compile Include="ListAzureContainers.cs" />
     <Compile Include="SendToHelix.cs" />
     <Compile Include="UploadClient.cs" />


### PR DESCRIPTION
Partial port of https://github.com/dotnet/buildtools/pull/1572, https://github.com/dotnet/buildtools/pull/1535, and https://github.com/dotnet/buildtools/pull/1321. Allows for passing `/p:BlobNamePrefix=path/with/slashes`, which previously gave an error.

@chcosta PTAL