### PR TITLE
Remove echo line breaks on Windows

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
+++ b/src/Microsoft.DotNet.Build.Tasks/GenerateTestExecutionScripts.cs
@@ -148,7 +148,10 @@ namespace Microsoft.DotNet.Build.Tasks
             foreach (string runCommand in TestCommands)
             {
                 testRunCommands.AppendLine($"{runCommand}");
-                testRunEchoes.AppendLine($"echo {runCommand}");
+                // Remove parentheses and quotes from echo command before wrapping it in quotes to avoid errors on Windows.
+                // Also, escape backtick and question mark characters to avoid running commands instead of echo'ing them.
+                string sanitizedRunCommand = runCommand.Replace("\"", "").Replace("(", "").Replace(")", "").Replace("`", "\\`").Replace("?", "\\").Replace("\r", "").Replace("\n", " ");
+                testRunEchoes.AppendLine($"echo {sanitizedRunCommand}");
             }
 
             cmdExecutionTemplate = cmdExecutionTemplate.Replace("[[TestRunCommands]]", testRunCommands.ToString());


### PR DESCRIPTION
Port the fix for echoes triggering commands to be re-executed to the Windows scripts. This correctly prevents running ILC a second time. This should be a complete fix for https://github.com/dotnet/corefx/issues/31723 (#2106 worked around it by not echoing for uapaot, but that doesn't handle netcoreappaot or any other case we might accidentally be hitting this today). 