### PR TITLE
Update to latest S.R.Metadata and S.C.Immutable

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -8,8 +8,8 @@
     "NuGet.Packaging": "4.4.0",
     "NuGet.ProjectModel": "4.4.0",
     "NuGet.Versioning": "4.4.0",
-    "System.Collections.Immutable": "1.3.1",
-    "System.Reflection.Metadata": "1.4.2",
+    "System.Collections.Immutable": "1.5.0",
+    "System.Reflection.Metadata": "1.6.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -21,7 +21,7 @@
     "System.IO.UnmanagedMemoryStream": "4.3.0",
     "System.Linq.Parallel": "4.0.1",
     "System.Net.Http": "4.1.0",
-    "System.Reflection.Metadata": "1.4.2",
+    "System.Reflection.Metadata": "1.6.0",
     "System.Xml.XPath.XmlDocument": "4.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
Newer versions of VS/msbuild have higher versions of these
and so our tasks need to align with the higher versions in order
to unify with those higher versions.

Addresses https://github.com/dotnet/corefx/issues/31925