### PR TITLE
Only construct HttpClient once in the DownloadFromAzure task

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/DownloadFromAzure.cs
@@ -99,8 +99,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     Directory.CreateDirectory(DownloadDirectory);
                 }
                 using (var clientThrottle = new SemaphoreSlim(this.MaxClients, this.MaxClients))
+                using (HttpClient client = new HttpClient())
                 {
-                    await Task.WhenAll(blobNames.Select(item => DownloadItem(ct, item, clientThrottle)));
+                    client.Timeout = TimeSpan.FromMinutes(10);
+                    await Task.WhenAll(blobNames.Select(item => DownloadItem(client, ct, item, clientThrottle)));
                 }
             }
             catch (Exception e)
@@ -110,76 +112,72 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             return !Log.HasLoggedErrors;
         }
 
-        private async Task DownloadItem(CancellationToken ct, string blob, SemaphoreSlim clientThrottle)
+        private async Task DownloadItem(HttpClient client, CancellationToken ct, string blob, SemaphoreSlim clientThrottle)
         {
             await clientThrottle.WaitAsync();
             string filename = string.Empty;
             try {
-                using (HttpClient client = new HttpClient())
+                Log.LogMessage(MessageImportance.Low, "Downloading BLOB - {0}", blob);
+                string blobUrl = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, blob);
+                filename = Path.Combine(DownloadDirectory, Path.GetFileName(blob));
+
+                if (!DownloadFlatFiles)
                 {
-                    client.Timeout = TimeSpan.FromMinutes(10);
-                    Log.LogMessage(MessageImportance.Low, "Downloading BLOB - {0}", blob);
-                    string blobUrl = AzureHelper.GetBlobRestUrl(AccountName, ContainerName, blob);
-                    filename = Path.Combine(DownloadDirectory, Path.GetFileName(blob));
+                    int dirIndex = blob.LastIndexOf("/");
+                    string blobDirectory = string.Empty;
+                    string blobFilename = string.Empty;
 
-                    if (!DownloadFlatFiles)
+                    if (dirIndex == -1)
                     {
-                        int dirIndex = blob.LastIndexOf("/");
-                        string blobDirectory = string.Empty;
-                        string blobFilename = string.Empty;
-
-                        if (dirIndex == -1)
-                        {
-                            blobFilename = blob;
-                        }
-                        else
-                        {
-                            blobDirectory = blob.Substring(0, dirIndex);
-                            blobFilename = blob.Substring(dirIndex + 1);
-
-                            // Trim blob name prefix (directory part) from download to blob directory
-                            if (BlobNamePrefix != null)
-                            {
-                                if (BlobNamePrefix.Length > dirIndex)
-                                {
-                                    BlobNamePrefix = BlobNamePrefix.Substring(0, dirIndex);
-                                }
-                                blobDirectory = blobDirectory.Substring(BlobNamePrefix.Length);
-                            }
-                        }
-                        string downloadBlobDirectory = Path.Combine(DownloadDirectory, blobDirectory);
-                        if (!Directory.Exists(downloadBlobDirectory))
-                        {
-                            Directory.CreateDirectory(downloadBlobDirectory);
-                        }
-                        filename = Path.Combine(downloadBlobDirectory, blobFilename);
+                        blobFilename = blob;
                     }
-
-                    var createRequest = AzureHelper.RequestMessage("GET", blobUrl, AccountName, AccountKey);
-
-                    using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
+                    else
                     {
-                        if (response.IsSuccessStatusCode)
-                        {
-                            // Blobs can be files but have the name of a directory.  We'll skip those and log something weird happened.
-                            if (!string.IsNullOrEmpty(Path.GetFileName(filename)))
-                            {
-                                Stream responseStream = await response.Content.ReadAsStreamAsync();
+                        blobDirectory = blob.Substring(0, dirIndex);
+                        blobFilename = blob.Substring(dirIndex + 1);
 
-                                using (FileStream sourceStream = File.Open(filename, FileMode.Create))
-                                {
-                                    responseStream.CopyTo(sourceStream);
-                                }
-                            }
-                            else
+                        // Trim blob name prefix (directory part) from download to blob directory
+                        if (BlobNamePrefix != null)
+                        {
+                            if (BlobNamePrefix.Length > dirIndex)
                             {
-                                Log.LogWarning($"Unable to download blob '{blob}' as it has a directory-like name.  This may cause problems if it was needed.");
+                                BlobNamePrefix = BlobNamePrefix.Substring(0, dirIndex);
+                            }
+                            blobDirectory = blobDirectory.Substring(BlobNamePrefix.Length);
+                        }
+                    }
+                    string downloadBlobDirectory = Path.Combine(DownloadDirectory, blobDirectory);
+                    if (!Directory.Exists(downloadBlobDirectory))
+                    {
+                        Directory.CreateDirectory(downloadBlobDirectory);
+                    }
+                    filename = Path.Combine(downloadBlobDirectory, blobFilename);
+                }
+
+                var createRequest = AzureHelper.RequestMessage("GET", blobUrl, AccountName, AccountKey);
+
+                using (HttpResponseMessage response = await AzureHelper.RequestWithRetry(Log, client, createRequest))
+                {
+                    if (response.IsSuccessStatusCode)
+                    {
+                        // Blobs can be files but have the name of a directory.  We'll skip those and log something weird happened.
+                        if (!string.IsNullOrEmpty(Path.GetFileName(filename)))
+                        {
+                            Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                            using (FileStream sourceStream = File.Open(filename, FileMode.Create))
+                            {
+                                responseStream.CopyTo(sourceStream);
                             }
                         }
                         else
                         {
-                            Log.LogError("Failed to retrieve blob {0}, the status code was {1}", blob, response.StatusCode);
+                            Log.LogWarning($"Unable to download blob '{blob}' as it has a directory-like name.  This may cause problems if it was needed.");
                         }
+                    }
+                    else
+                    {
+                        Log.LogError("Failed to retrieve blob {0}, the status code was {1}", blob, response.StatusCode);
                     }
                 }
             }


### PR DESCRIPTION
This change modifies the DownloadFromAzure task by only constructing
the HttpClient once in ExecuteAsync and passing it to DownloadItem
instead of allocating it over and over again for each file; after
I checked in the compiled binary of CloudTestTasks with this fix
into ProjectN about 3 weeks back, we stopped seeing the occasional
failure when accessing the Azure storage:

System.Net.Http.HttpRequestException: An error occurred while
sending the request. ---> System.Net.WebException: Unable to connect
to the remote server ---> System.Net.Sockets.SocketException:
Only one usage of each socket address (protocol/network address/port)
is normally permitted 13.88.144.240:443

Thanks

Tomas

P.S. Sadly the diff looks extensive due to honoring whitespace
that naturally changed after I removed one nesting level from
DownloadItem. Ignoring whitespace reduces the diff to about 4 lines.