### PR TITLE
Removing the archaic two spaces after peroid in our copyright.

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.props
@@ -4,7 +4,7 @@
     <BuildToolsVersioningPropsHasBeenImported>true</BuildToolsVersioningPropsHasBeenImported>
 
     <Company Condition="'$(Company)' == ''">Microsoft Corporation</Company>
-    <Copyright Condition="'$(Copyright)' == ''">%A9 Microsoft Corporation.  All rights reserved.</Copyright>
+    <Copyright Condition="'$(Copyright)' == ''">%A9 Microsoft Corporation. All rights reserved.</Copyright>
     <Description Condition="'$(Description)' == ''">$(AssemblyName)</Description>
     <FileVersion Condition="'$(FileVersion)' == '' and '$(AssemblyFileVersion)' != ''">$(AssemblyFileVersion)</FileVersion>
     <InformationalVersion Condition="'$(InformationalVersion)' == ''">$(AssemblyFileVersion)$(BuiltByString)</InformationalVersion>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/versioning.targets
@@ -106,7 +106,7 @@
       <AssemblyInfoLines Include="internal static class ThisAssembly" />
       <AssemblyInfoLines Include="{" />
       <AssemblyInfoLines Include="%20%20%20%20internal const string Title = &quot;$(AssemblyName)&quot;%3B" />
-      <AssemblyInfoLines Include="%20%20%20%20internal const string Copyright = &quot;\u00A9 Microsoft Corporation.  All rights reserved.&quot;%3B" />
+      <AssemblyInfoLines Include="%20%20%20%20internal const string Copyright = &quot;\u00A9 Microsoft Corporation. All rights reserved.&quot;%3B" />
       <AssemblyInfoLines Include="%20%20%20%20internal const string Version = &quot;$(AssemblyVersion)&quot;%3B" />
       <AssemblyInfoLines Include="%20%20%20%20internal const string InformationalVersion = &quot;$(AssemblyFileVersion)&quot;%3B" />
       <AssemblyInfoLines Include="}" />
@@ -173,7 +173,7 @@
       <NativeVersionLines Include="#undef VER_FILEVERSION_STR" />
       <NativeVersionLines Include="#define VER_FILEVERSION_STR         &quot;$(MajorVersion).$(MinorVersion).$(BuildNumberMajor).$(BuildNumberMinor)$(BuiltByString)&quot;" />
       <NativeVersionLines Include="#ifndef VER_LEGALCOPYRIGHT_STR" />
-      <NativeVersionLines Include="#define VER_LEGALCOPYRIGHT_STR      &quot;\xa9 Microsoft Corporation.  All rights reserved.&quot;" />
+      <NativeVersionLines Include="#define VER_LEGALCOPYRIGHT_STR      &quot;\xa9 Microsoft Corporation. All rights reserved.&quot;" />
       <NativeVersionLines Include="#endif" />
       <NativeVersionLines Include="#ifndef VER_DEBUG" />
       <NativeVersionLines Condition="'$(Configuration)'=='Debug'" Include="#define VER_DEBUG                   VS_FF_DEBUG" />


### PR DESCRIPTION
The `<Copyright>` value has two spaces after the period. This breaks compliance checks with nuget.org, since they only expect a single space.

Part of https://github.com/dotnet/buildtools/issues/2144

CC @weshaggard @eerhardt 