### PR TITLE
Set RestoreOutputPath to the values it used to have

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -7,6 +7,8 @@
 
   <PropertyGroup>
     <ProjectJson Condition="'$(ProjectJson)' == '' and '$(ContainsPackageReferences)' == 'true'">$(MSBuildProjectFullPath)</ProjectJson>
+    <RestoreOutputPath Condition="'$(RestoreOutputPath)' == '' And '$(ContainsPackageReferences)' != 'true' And '$(ProjectJson)' != ''">$([System.IO.Path]::GetDirectoryName('$(ProjectJson)'))/obj</RestoreOutputPath>
+    <RestoreOutputPath Condition="'$(RestoreOutputPath)' == ''">$(MSBuildProjectDirectory)</RestoreOutputPath>	
     <!-- SDK targets need this to be set in addition to RestoreOutputPath. See https://github.com/dotnet/sdk/issues/1057 -->
     <ProjectAssetsFile>$(RestoreOutputPath)/project.assets.json</ProjectAssetsFile>
     <ResolveNugetProjectFile Condition="'$(ResolveNugetProjectFile)' == ''">$(MSBuildProjectFullPath)</ResolveNugetProjectFile>


### PR DESCRIPTION
Set RestoreOutputPath to the values it used to have, if and only if it is unset when this targets file is imported.
(@ViktorHofer  if you want to make a more correct fix or something, to repro this I only had to run `set __TestIntermediateDir=int  && build.cmd checked x64  -priority=0` locally)