### PR TITLE
Add support for netcoreapp3.0 to packaging targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -35,14 +35,14 @@
     <IdPrefix Condition="'$(PackageTargetRuntime)' != ''">$(IdPrefix)$(PackageTargetRuntime).</IdPrefix>
     <IdPrefix Condition="'$(PackageTargetFramework)' != ''">$(IdPrefix)$(PackageTargetFramework).</IdPrefix>
   </PropertyGroup>
-   
-  <!-- If Signing is enabled, we'll always want to write *.nupkg_requires_signing files --> 
+
+  <!-- If Signing is enabled, we'll always want to write *.nupkg_requires_signing files -->
   <UsingTask AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" TaskName="WriteSigningRequired" />
   <PropertyGroup>
     <ShouldWritePkgSigningRequired Condition="'$(SkipSigning)' == 'true'">false</ShouldWritePkgSigningRequired>
     <ShouldWritePkgSigningRequired Condition="'$(SignType)' == 'public' or '$(SignType)' == 'oss'">false</ShouldWritePkgSigningRequired>
     <ShouldWritePkgSigningRequired Condition="'$(ShouldWritePkgSigningRequired)'==''">true</ShouldWritePkgSigningRequired>
-    <NuPkgAuthenticodeSig          Condition="'$(ShouldWritePkgSigningRequired)'=='true'">Microsoft</NuPkgAuthenticodeSig>    
+    <NuPkgAuthenticodeSig          Condition="'$(ShouldWritePkgSigningRequired)'=='true'">Microsoft</NuPkgAuthenticodeSig>
   </PropertyGroup>
 
   <!--
@@ -94,7 +94,7 @@
     <PlatformPackageVersion Condition="'$(PlatformPackageVersion)' == ''">1.0.1</PlatformPackageVersion>
   </PropertyGroup>
 
-  
+
   <!-- Determine if we actually need to build for this architecture -->
   <!-- Packages can specifically control their architecture by specifying the PackagePlatforms
        property as a semi-colon delimited list.
@@ -398,8 +398,8 @@
     </ItemGroup>
 
     <!-- Calculate the package version to harvest -->
-    <GetLastStablePackage Condition="'$(HarvestVersion)' == ''" 
-                          LatestPackages="@(_latestPackage)" 
+    <GetLastStablePackage Condition="'$(HarvestVersion)' == ''"
+                          LatestPackages="@(_latestPackage)"
                           StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)">
       <Output  TaskParameter="LastStablePackages" ItemName="_lastStablePackage"/>
@@ -410,20 +410,20 @@
     </PropertyGroup>
 
     <!-- Calculate the runtime package versions to use for applicability evaluation -->
-    <GetLastStablePackage Condition="'@(HarvestRuntimePackages)' == ''" 
-                          LatestPackages="@(_latestRuntimePackages)" 
+    <GetLastStablePackage Condition="'@(HarvestRuntimePackages)' == ''"
+                          LatestPackages="@(_latestRuntimePackages)"
                           StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestRuntimePackages"/>
     </GetLastStablePackage>
 
-    <GetLastStablePackage Condition="'@(HarvestAdditionalPackageIds)' != ''" 
-                          LatestPackages="@(HarvestAdditionalPackageIds)" 
+    <GetLastStablePackage Condition="'@(HarvestAdditionalPackageIds)' != ''"
+                          LatestPackages="@(HarvestAdditionalPackageIds)"
                           StablePackages="@(StablePackage)"
                           PackageIndexes="@(PackageIndex)">
       <Output  TaskParameter="LastStablePackages" ItemName="HarvestAdditionalPackages"/>
     </GetLastStablePackage>
-    
+
     <PropertyGroup>
       <HarvestFiles Condition="'$(HarvestFiles)' == ''">true</HarvestFiles>
     </PropertyGroup>
@@ -436,7 +436,7 @@
                     PackageVersion="$(HarvestVersion)"
                     PackagesFolder="$(PackagesDir)"
                     Files="@(File)"
-                    RuntimeFile="$(RuntimeIdGraphDefinitionFile)" 
+                    RuntimeFile="$(RuntimeIdGraphDefinitionFile)"
                     RuntimePackages="@(HarvestRuntimePackages);@(HarvestAdditionalPackages)"
                     IncludeAllPaths="$(HarvestIncludeAllPaths)"
                     HarvestAssets="$(HarvestFiles)"
@@ -469,7 +469,7 @@
                     Condition="'@(HarvestAdditionalPackages)' != ''" >
       <Output TaskParameter="HarvestedFiles" ItemName="File"/>
     </HarvestPackage>
-    
+
     <ItemGroup>
       <SupportedFramework Include="@(_HarvestedSupportedFramework)" Exclude="@(NotSupportedOnTargetFramework)" />
     </ItemGroup>
@@ -584,13 +584,13 @@
     <PropertyGroup>
       <_TargetFramework>%(File.TargetFramework)</_TargetFramework>
     </PropertyGroup>
-    
+
     <ItemGroup>
       <_harvestFile Include="@(File)" Condition="'%(File.HarvestDependencies)' == 'true' and '%(File.Extension)' == '.dll'" />
       <_missingHarvestFile Include="@(_harvestFile)" Condition="!Exists('%(FullPath)')" />
       <_harvestFile Remove="@(_missingHarvestFile)" Condition="'$(AllowPartialPackages)' == 'true'" />
 
-      <!-- add a fake dependency to represent the dependencies of any missing file 
+      <!-- add a fake dependency to represent the dependencies of any missing file
            this will prevent the package from installing on that platform. -->
       <FilePackageDependency Include="Unavailable" Condition="'$(AllowPartialPackages)' == 'true' AND '@(_missingHarvestFile)' != '' AND '$(_TargetFramework)' != ''">
         <TargetFramework>$(_TargetFramework)</TargetFramework>
@@ -612,14 +612,14 @@
       <Output TaskParameter="FrameworkReferences" ItemName="_FileFrameworkReference"/>
       <Output TaskParameter="PackageReferences" ItemName="_FilePackageReferenceUnfiltered"/>
     </SplitReferences>
-    
+
     <FilterUnknownPackages Condition="'@(_FilePackageReferenceUnfiltered)' != ''"
                            OriginalDependencies="@(_FilePackageReferenceUnfiltered)"
                            BaseLinePackages="@(BaseLinePackage)"
                            PackageIndexes="@(PackageIndex)">
       <Output TaskParameter="FilteredDependencies" ItemName="_FilePackageReference" />
     </FilterUnknownPackages>
-                           
+
 
     <ItemGroup Condition="'@(_FilePackageReference)' != ''">
       <_FilePackageReference Remove="corefx;mscorlib;System;System.Core;System.Xml;Windows" />
@@ -733,10 +733,10 @@
     </ApplyBaseLine>
 
 
-    <Error Condition="'@(_BaseLinedDependencies)' != '' AND '@(PackageIndex)' == '' AND '@(StablePackage)' == ''" 
+    <Error Condition="'@(_BaseLinedDependencies)' != '' AND '@(PackageIndex)' == '' AND '@(StablePackage)' == ''"
            Text="Neither PackageIndex nor StablePackage items are defined: ensure you have imported Microsoft.Private.PackageBaseLine.props from the Microsoft.Private.PackageBaseLine package" />
-    <ApplyPreReleaseSuffix Condition="'@(_BaseLinedDependencies)' != ''" 
-                           OriginalPackages="@(_BaseLinedDependencies)" 
+    <ApplyPreReleaseSuffix Condition="'@(_BaseLinedDependencies)' != ''"
+                           OriginalPackages="@(_BaseLinedDependencies)"
                            StablePackages="@(StablePackage)"
                            PackageIndexes="@(PackageIndex)"
                            PreReleaseSuffix="$(VersionSuffix)">
@@ -775,7 +775,7 @@
                                  RuntimeJsonTemplate="$(RuntimeFileSource)"
                                  RuntimeJson="$(RuntimeFilePath)"
                                  />
-    
+
     <ItemGroup Condition="'$(CreatePackedPackage)' == 'true'">
       <PackedPackageRuntimeDependency Include="@(RuntimeDependency->'$(PackedPackageNamePrefix).%(Identity)')">
         <TargetPackage>$(PackedPackageNamePrefix).%(TargetPackage)</TargetPackage>
@@ -834,7 +834,7 @@
     </ItemGroup>
 
     <ApplyPreReleaseSuffix Condition="'$(StableVersion)' == ''"
-                           OriginalPackages="@(_thisPackage)" 
+                           OriginalPackages="@(_thisPackage)"
                            StablePackages="@(StablePackage)"
                            PackageIndexes="@(PackageIndex)"
                            PreReleaseSuffix="$(VersionSuffix)" >
@@ -945,6 +945,10 @@
     <NETCoreApp22RIDs Condition="'@(NETCoreApp22RIDs)' == ''" Include="@(NETCoreApp21RIDs)" />
     <DefaultValidateFramework Include="netcoreapp2.2">
       <RuntimeIDs>@(NETCoreApp22RIDs)</RuntimeIDs>
+    </DefaultValidateFramework>
+    <NETCoreApp30RIDs Condition="'@(NETCoreApp30RIDs)' == ''" Include="@(NETCoreApp22RIDs)" />
+    <DefaultValidateFramework Include="netcoreapp3.0">
+      <RuntimeIDs>@(NETCoreApp30RIDs)</RuntimeIDs>
     </DefaultValidateFramework>
 
     <NETCore50RIDs Condition="'@(NETCore50RIDs)' == ''" Include="win10-x86;win10-x86-aot;win10-x64;win10-x64-aot;win10-arm;win10-arm-aot" />
@@ -1081,7 +1085,7 @@
                     Condition="'%(PackageFile.IsSourceCodeFile)'!='true'" />
     </ItemGroup>
   </Target>
-  
+
   <Target Name="GetPackageReport"
           DependsOnTargets="GetPackageAssets"
           Returns="$(PackageReportPath)">
@@ -1121,6 +1125,15 @@
       <SupportedFramework Condition="'%(SupportedFramework.Version)' == ''">
         <Version>$(_AssemblyVersion)</Version>
       </SupportedFramework>
+
+      <!--
+        Harvesting supported versions can sometimes lead to unknown versions when harvesting a package
+        which has placeholders for older frameworks like net45. We should just exclude those from validation
+        since we cannot easily determine what they are without looking at each specific platform itself.
+      -->
+      <ItemGroup>
+        <SupportedFramework Remove="@(SupportedFramework)" Condition="'%(SupportedFramework.Version)' == 'unknown'" />
+      </ItemGroup>
     </ItemGroup>
 
     <ValidatePackage ContractName="$(BaseId)"
@@ -1148,7 +1161,7 @@
                               ReportFile="$(PackageReportPath)"
                               Suppressions="@(ValidatePackageSuppression)" />
   </Target>
-  
+
   <Target Name="ValidatePackage"
           DependsOnTargets="ValidateLibraryPackage;ValidateFrameworkPackage"
           Condition="'$(SkipValidatePackage)' != 'true'" />
@@ -1252,17 +1265,17 @@
                       File="$(NuSpecPath).pkgpath"
                       Overwrite="true"
                       Condition="'$(_SkipCreatePackage)' != 'true'"/>
-                      
+
     <WriteSigningRequired Condition="'$(ShouldWritePkgSigningRequired)'=='true'"
                           AuthenticodeSig="$(NuPkgAuthenticodeSig)"
                           MarkerFile="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg.requires_nupkg_signing" />
     <WriteSigningRequired Condition="'$(ShouldWritePkgSigningRequired)'=='true'"
                           AuthenticodeSig="$(NuPkgAuthenticodeSig)"
-                          MarkerFile="$(SymbolPackageOutputPath)$(Id).$(PackageVersion).nupkg.requires_nupkg_signing" />                          
+                          MarkerFile="$(SymbolPackageOutputPath)$(Id).$(PackageVersion).nupkg.requires_nupkg_signing" />
     <ItemGroup Condition="'$(ShouldWritePkgSigningRequired)'=='true'">
       <FileWrites Include="$(SymbolPackageOutputPath)$(Id).$(PackageVersion).nupkg.requires_nupkg_signing"/>
       <FileWrites Include="$(PackageOutputPath)$(Id).$(PackageVersion).nupkg.requires_nupkg_signing"/>
-    </ItemGroup>                      
+    </ItemGroup>
 
   </Target>
 


### PR DESCRIPTION
Add the 3.0 supported tfm/rid combinations.

Also add a SupportedFramework filter to exclude unknown versions
from the set. The unknown version only comes from package harvesting
where we cannot figure out the version number from the package, in
those cases we don't have a great way to get the expected version so
we should just filter them out from validation.

cc @ericstj @joperezr 