### PR TITLE
Exclude System.Collections.Immutable

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -8,8 +8,8 @@
     "NuGet.Packaging": "4.4.0",
     "NuGet.ProjectModel": "4.4.0",
     "NuGet.Versioning": "4.4.0",
-    "System.Collections.Immutable": "1.5.0",
-    "System.Reflection.Metadata": "1.6.0",
+    "System.Collections.Immutable": "1.3.1",
+    "System.Reflection.Metadata": "1.4.2",
     "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Build.Tasks.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.net45/project.json
@@ -8,7 +8,10 @@
     "NuGet.Packaging": "4.4.0",
     "NuGet.ProjectModel": "4.4.0",
     "NuGet.Versioning": "4.4.0",
-    "System.Collections.Immutable": "1.3.1",
+    "System.Collections.Immutable": {
+      "version": "1.3.1",
+      "exclude": "runtime"
+     },
     "System.Reflection.Metadata": "1.4.2",
     "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03"
   },

--- a/src/Microsoft.DotNet.Build.Tasks/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks/project.json
@@ -21,7 +21,7 @@
     "System.IO.UnmanagedMemoryStream": "4.3.0",
     "System.Linq.Parallel": "4.0.1",
     "System.Net.Http": "4.1.0",
-    "System.Reflection.Metadata": "1.6.0",
+    "System.Reflection.Metadata": "1.4.2",
     "System.Xml.XPath.XmlDocument": "4.0.0"
   },
   "frameworks": {


### PR DESCRIPTION
System.Collections.Immutable is included with msbuild from at
least 15.7+ and between 15.7 and 15.8 they updated the version they
include which conflicts with our usages across both. To eliminate
this mismatch we instead stop carrying the version with our tasks
and depend on the one they carry with them.

cc @ericstj 

FYI @tmat