### PR TITLE
Fix bad merge which accidently added net47 twice

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -989,10 +989,6 @@
     <DefaultValidateFramework Include="net47" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
       <RuntimeIDs>;@(NET47RIDs)</RuntimeIDs>
     </DefaultValidateFramework>
-    <NET47RIDs Condition="'@(NET47RIDs)' == ''" Include="@(NET462RIDs)" />
-    <DefaultValidateFramework Include="net47" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
-      <RuntimeIDs>;@(NET47RIDs)</RuntimeIDs>
-    </DefaultValidateFramework>
     <NET471RIDs Condition="'@(NET471RIDs)' == ''" Include="@(NET47RIDs)" />
     <DefaultValidateFramework Include="net471" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
       <RuntimeIDs>;@(NET471RIDs)</RuntimeIDs>


### PR DESCRIPTION
Hit another bad merge that needs fixed from https://github.com/dotnet/buildtools/pull/2142.
