### PR TITLE
Add OverrideRestoreOutputPath switch for coreclr

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/packageresolve.targets
@@ -7,8 +7,8 @@
 
   <PropertyGroup>
     <ProjectJson Condition="'$(ProjectJson)' == '' and '$(ContainsPackageReferences)' == 'true'">$(MSBuildProjectFullPath)</ProjectJson>
-    <RestoreOutputPath Condition="'$(RestoreOutputPath)' == '' And '$(ContainsPackageReferences)' != 'true' And '$(ProjectJson)' != ''">$([System.IO.Path]::GetDirectoryName('$(ProjectJson)'))/obj</RestoreOutputPath>
-    <RestoreOutputPath Condition="'$(RestoreOutputPath)' == ''">$(MSBuildProjectDirectory)</RestoreOutputPath>	
+    <RestoreOutputPath Condition="'$(OverrideRestoreOutputPath)' == 'true' And '$(ContainsPackageReferences)' != 'true' And '$(ProjectJson)' != ''">$([System.IO.Path]::GetDirectoryName('$(ProjectJson)'))/obj</RestoreOutputPath>
+    <RestoreOutputPath Condition="'$(OverrideRestoreOutputPath)' == 'true' And '$(RestoreOutputPath)' == ''">$(MSBuildProjectDirectory)</RestoreOutputPath>	
     <!-- SDK targets need this to be set in addition to RestoreOutputPath. See https://github.com/dotnet/sdk/issues/1057 -->
     <ProjectAssetsFile>$(RestoreOutputPath)/project.assets.json</ProjectAssetsFile>
     <ResolveNugetProjectFile Condition="'$(ResolveNugetProjectFile)' == ''">$(MSBuildProjectFullPath)</ResolveNugetProjectFile>


### PR DESCRIPTION
Relates to https://github.com/dotnet/coreclr/pull/19728/files#diff-0b192804a6349e8c26d2b027afbd89a2

It seems that there is a default RestoreOutputPath set in coreclr. Adding a switch so that we override the default RestoreOutputPath but only for coreclr.