### PR TITLE
Adding parameter to control timeout of feed lock

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed/GetBlobFeedPackageList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/GetBlobFeedPackageList.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public ITaskItem[] PackageInfos { get; set; }
 
         /// <summary>
-        /// Specify max number of minutes that the lock of the feed container will be hold.
+        /// Specify the maximum wait time that the task will wait to acquire the lock, after which it will error out.
         /// </summary>
         public int FeedLockTimeoutMinutes { get; set; } = int.MaxValue;
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/GetBlobFeedPackageList.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/GetBlobFeedPackageList.cs
@@ -26,6 +26,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         [Output]
         public ITaskItem[] PackageInfos { get; set; }
 
+        /// <summary>
+        /// Specify max number of minutes that the lock of the feed container will be hold.
+        /// </summary>
+        public int FeedLockTimeoutMinutes { get; set; } = int.MaxValue;
+
         public override bool Execute()
         {
             return ExecuteAsync().GetAwaiter().GetResult();
@@ -37,7 +42,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
             {
                 Log.LogMessage(MessageImportance.High, "Listing blob feed packages...");
 
-                BlobFeedAction action = new BlobFeedAction(ExpectedFeedUrl, AccountKey, Log);
+                BlobFeedAction action = new BlobFeedAction(ExpectedFeedUrl, AccountKey, FeedLockTimeoutMinutes, Log);
 
                 ISet<PackageIdentity> packages = await action.GetPackageIdentitiesAsync();
 

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/PushToBlobFeed.cs
@@ -34,6 +34,11 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
         public bool Overwrite { get; set; }
 
         /// <summary>
+        /// Specify max number of minutes that the lock of the feed container will be hold.
+        /// </summary>
+        public int FeedLockTimeoutMinutes { get; set; } = int.MaxValue;
+
+        /// <summary>
         /// Enables idempotency when Overwrite is false.
         /// 
         /// false: (default) Attempting to upload an item that already exists fails.
@@ -90,7 +95,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 }
                 else
                 {
-                    BlobFeedAction blobFeedAction = new BlobFeedAction(ExpectedFeedUrl, AccountKey, Log);
+                    BlobFeedAction blobFeedAction = new BlobFeedAction(ExpectedFeedUrl, AccountKey, FeedLockTimeoutMinutes, Log);
 
                     IEnumerable<BlobArtifactModel> blobArtifacts = Enumerable.Empty<BlobArtifactModel>();
                     IEnumerable<PackageArtifactModel> packageArtifacts = Enumerable.Empty<PackageArtifactModel>();


### PR DESCRIPTION
Closes: dotnet/core-eng#4180

Add support for informing a timeout for the feed container lock.