### PR TITLE
Add option to exclude importing ApiCompat.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -220,7 +220,7 @@
   <Import Project="$(MSBuildThisFileDirectory)partialfacades.targets" Condition="'$(ExcludePartialFacadesImport)' != 'true'"/>
 
    <!-- Import the ApiCompat targets. -->
-  <Import Project="$(MSBuildThisFileDirectory)ApiCompat.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)ApiCompat.targets" Condition="'$(ExcludeApiCompatImport)' != 'true'"/>
 
   <!--
     Import the contract resolution targets


### PR DESCRIPTION
Adds a property `ExcludeApiCompatImport` to allow for consumers to opt-out of importing `ApiCompat.targets`. This is similar to `ExcludePartialFacadesImport` at https://github.com/dotnet/buildtools/compare/master...wtgodbe:ExcludeApiCompat?expand=1#diff-c368ca147f7a6d95f33280f334ff9e84L220. We need this in order for Buildtools consumers to use the `Microsoft.DotNet.ApiCompat` package being produced by Arcade.

@weshaggard PTAL