### PR TITLE
Add HelixBlobPrefix

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -48,6 +48,7 @@
        ContainerName     - Container name for uploaded files.                                 Default: build-<Random GUID>. 
        IsOfficial        - Boolean flag for display on Mission Control.                       Default: False
        IsDropPublic      - Boolean flag allowing anonymous access to build drop container.    Default: False
+       HelixBlobPrefix   - Prefix for all blobs uploaded to Azure during Helix prep           Default: <Blank>
        HelixApiEndpoint  - Endpoint to send jobs to.                                          Default: https://helix.dot.net/api/2016-06-28/jobs
        CloudResultsReadTokenValidDays  - Days that result URLs produced will be readble       Default: 30
        CloudResultsWriteTokenValidDays - Days that result URLs produced will be writeable     Default: 4
@@ -167,7 +168,7 @@
     <RemoveDir Directories="$(SupplementalPayloadDir)"/>
     <ItemGroup>
       <SupplementalPayload Condition="'@(RunnerScripts->Count())'!='0'" Include="$(SupplementalPayloadFile)">
-        <RelativeBlobPath>$(SupplementalPayloadFilename)</RelativeBlobPath>
+        <RelativeBlobPath>$(HelixBlobPrefix)$(SupplementalPayloadFilename)</RelativeBlobPath>
       </SupplementalPayload>
     </ItemGroup>
   </Target>
@@ -210,12 +211,13 @@
   <!-- Upload content to Azure (Everything except test list) -->
   <Target Name="UploadContent" DependsOnTargets="CreateAzureStorage">
     <ItemGroup>
+      <!-- TODO: Should we to apply the prefix here? -->
       <LocalFileForUpload Include="@(HelixProcessedWorkItem->Metadata('PayloadFile'))">
         <RelativeBlobPath>%(RelativeBlobPath)</RelativeBlobPath>
       </LocalFileForUpload>
-      <!-- For now assume these all go in the root of the container -->
+
       <LocalPayloadFileForUpload Include="@(HelixCorrelationPayloadFile)">
-        <RelativeBlobPath>%(FileName)%(Extension)</RelativeBlobPath>
+        <RelativeBlobPath>$(HelixBlobPrefix)%(FileName)%(Extension)</RelativeBlobPath>
       </LocalPayloadFileForUpload>
     </ItemGroup>
 
@@ -291,7 +293,7 @@
     <WriteItemsToJson JsonFileName="$(HelixLogFolder)$(TestListFilename)" Items="@(HelixProcessedWorkItemForList)" ForceJsonArray="true" />
     <ItemGroup>
       <HelixWorkItemList Include="$(HelixLogFolder)$(TestListFilename)">
-        <RelativeBlobPath>$(TestListFilename)</RelativeBlobPath>
+        <RelativeBlobPath>$(HelixBlobPrefix)$(TestListFilename)</RelativeBlobPath>
         <BuildCompleteJson>$(HelixLogFolder)BuildComplete.json</BuildCompleteJson>
         <OfficialBuildJson>$(HelixLogFolder)OfficialBuild.json</OfficialBuildJson>
         <HelixJobUploadCompletePath>$(HelixLogFolder)helixjobuploadcomplete.sem</HelixJobUploadCompletePath>
@@ -363,6 +365,12 @@
     <CreateItem Include="%(HelixWorkItemList.BuildCompleteJson)" AdditionalMetadata="RelativeBlobPath=JobStartJsonMessages.json">
       <Output TaskParameter="Include" ItemName="JobStartJsons" />
     </CreateItem>
+
+    <ItemGroup>
+      <JobStartJsons>
+        <RelativeBlobPath>$(HelixBlobPrefix)%(RelativeBlobPath)</RelativeBlobPath>
+      </JobStartJsons>
+    </ItemGroup>
     
     <UploadToAzure
      ConnectionString="$(CloudDropConnectionString)"
@@ -395,7 +403,7 @@
     <WriteItemsToJson JsonFileName="$(HelixLogFolder)$(HelixCorrelationInfoFileName)" Items="@(GeneratedCorrelationId)" ForceJsonArray="true" />
     <ItemGroup>
       <CorrelationFile Include="$(HelixLogFolder)$(HelixCorrelationInfoFileName)">
-        <RelativeBlobPath>Tracking/$(HelixCorrelationInfoFileName)</RelativeBlobPath>
+        <RelativeBlobPath>$(HelixBlobPrefix)Tracking/$(HelixCorrelationInfoFileName)</RelativeBlobPath>
       </CorrelationFile>
     </ItemGroup>
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -99,6 +99,7 @@
     <ToolsDir Condition="'$(ToolsDir)' == ''">$(MSBuildThisFileDirectory)</ToolsDir>
     <IsDropPublic Condition="'$(IsDropPublic)' == ''">false</IsDropPublic>
     <!-- Make sure HelixBlobPrefix ends with '/' -->
+    <!-- Note: EnsureTrailingSlash works in >=Dev15 MSBuild -->
     <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$([MSBuild]::EnsureTrailingSlash('$(HelixBlobPrefix)'))', "\\", "/"))</HelixBlobPrefix>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -213,7 +213,6 @@
   <!-- Upload content to Azure (Everything except test list) -->
   <Target Name="UploadContent" DependsOnTargets="CreateAzureStorage">
     <ItemGroup>
-      <!-- TODO: Should we to apply the prefix here? -->
       <LocalFileForUpload Include="@(HelixProcessedWorkItem->Metadata('PayloadFile'))">
         <RelativeBlobPath>$(HelixBlobPrefix)%(RelativeBlobPath)</RelativeBlobPath>
       </LocalFileForUpload>

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/PackageFiles/CloudTest.Helix.targets
@@ -98,6 +98,8 @@
     <MaxRetryCount Condition="'$(MaxRetryCount)' == ''">0</MaxRetryCount>
     <ToolsDir Condition="'$(ToolsDir)' == ''">$(MSBuildThisFileDirectory)</ToolsDir>
     <IsDropPublic Condition="'$(IsDropPublic)' == ''">false</IsDropPublic>
+    <!-- Make sure HelixBlobPrefix ends with '/' -->
+    <HelixBlobPrefix Condition="'$(HelixBlobPrefix)' != ''">$([System.Text.RegularExpressions.Regex]::Replace('$([MSBuild]::EnsureTrailingSlash('$(HelixBlobPrefix)'))', "\\", "/"))</HelixBlobPrefix>
   </PropertyGroup>
 
   <!-- Set Helix environment vars based on target platform -->
@@ -213,7 +215,7 @@
     <ItemGroup>
       <!-- TODO: Should we to apply the prefix here? -->
       <LocalFileForUpload Include="@(HelixProcessedWorkItem->Metadata('PayloadFile'))">
-        <RelativeBlobPath>%(RelativeBlobPath)</RelativeBlobPath>
+        <RelativeBlobPath>$(HelixBlobPrefix)%(RelativeBlobPath)</RelativeBlobPath>
       </LocalFileForUpload>
 
       <LocalPayloadFileForUpload Include="@(HelixCorrelationPayloadFile)">


### PR DESCRIPTION
Adds the `HelixBlobPrefix` property to the Helix targets file.  This property allows users to specify a prefix that gets applied to all uploaded blobs, i.e., allows the specification of a relative root for all artifacts used for Helix.

## Usage

Users just need to specify the property `HelixBlobPrefix` in their proj file.  This will be applied to the `RelativeBlobPath` metadata field of all `ItemGroups` that are uploaded via `UploadToAzure` tasks.  This _includes_ the work items, which typically already have a relative path specified by users.

## Implications


The default value for this property is `''`, so current usage won't change.  Making use of this new property, however, will allow for the CoreFX build pipeline to generate fewer Azure Storage containers because uniqueness information can now be moved to the blob path rather than the container name.

CC - @sergiy-k @MattGal @adityamandaleeka @weshaggard 