### PR TITLE
Diff attributes applied to classes between contract and implementation

### DIFF
--- a/src/ApiCompat.Desktop/ApiCompat.Desktop.csproj
+++ b/src/ApiCompat.Desktop/ApiCompat.Desktop.csproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Cci.Extensions\Microsoft.Cci.Extensions.csproj" />
     <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Collections" />
     <TargetingPackReference Include="System.Core" />
     <TargetingPackReference Include="System.Reflection" />
     <TargetingPackReference Include="System.Runtime" />

--- a/src/ApiCompat/Program.cs
+++ b/src/ApiCompat/Program.cs
@@ -27,11 +27,13 @@ namespace ApiCompat
     {
         public static IEqualityComparer<ITypeReference> StaticSettings { get; set; }
         public static IDifferenceOperands  StaticOperands { get; set; }
+        public static IAttributeFilter StaticAttributeFilter { get; set; }
 
         public ExportCciSettings()
         {
             Settings = StaticSettings;
             Operands = StaticOperands;
+            AttributeFilter = StaticAttributeFilter;
         }
 
         [Export(typeof(IEqualityComparer<ITypeReference>))]
@@ -39,6 +41,9 @@ namespace ApiCompat
 
         [Export(typeof(IDifferenceOperands))]
         public IDifferenceOperands Operands { get; }
+
+        [Export(typeof(IAttributeFilter))]
+        public IAttributeFilter AttributeFilter { get; }
     }
 
     public class Program
@@ -198,6 +203,7 @@ namespace ApiCompat
                 Contract = s_contractOperand,
                 Implementation = s_implementationOperand,
             };
+            ExportCciSettings.StaticAttributeFilter = new AttributeFilter(s_excludeAttributesList);
 
             // Always compose the diff writer to allow it to import or provide exports
             container.SatisfyImports(diffWriter);
@@ -292,6 +298,7 @@ namespace ApiCompat
                 parser.DefineOptionalQualifier("leftOperand", ref s_contractOperand, "Name for left operand in comparison, default is 'contract'.");
                 parser.DefineAliases("rightOperand", "rhs");
                 parser.DefineOptionalQualifier("rightOperand", ref s_implementationOperand, "Name for right operand in comparison, default is 'implementation'.");
+                parser.DefineOptionalQualifier("excludeAttributes", ref s_excludeAttributesList, "Specify a api list in the DocId format of which attributes to exclude.");
                 parser.DefineParameter<string>("contracts", ref s_contractSet, "Comma delimited list of assemblies or directories of assemblies for all the contract assemblies.");
             }, args);
         }
@@ -306,6 +313,7 @@ namespace ApiCompat
         private static string s_remapFile;
         private static string s_contractOperand = "contract";
         private static string s_implementationOperand = "implementation";
+        public static string s_excludeAttributesList;
         private static bool s_groupByAssembly = true;
         private static bool s_mdil;
         private static bool s_resolveFx;

--- a/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
+++ b/src/Microsoft.Cci.Extensions/Microsoft.Cci.Extensions.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Writers\CSharp\CSDeclarationHelper.cs" />
     <Compile Include="Writers\CSharp\CSDeclarationWriter.Attributes.cs" />
     <Compile Include="Writers\CSharp\CSDeclarationWriter.cs" />
+    <Compile Include="Writers\CSharp\CSDeclarationWriter.Enums.cs" />
     <Compile Include="Writers\CSharp\CSDeclarationWriter.Events.cs" />
     <Compile Include="Writers\CSharp\CSDeclarationWriter.Fields.cs" />
     <Compile Include="Writers\CSharp\CSDeclarationWriter.Generics.cs" />

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Attributes.cs
@@ -255,13 +255,7 @@ namespace Microsoft.Cci.Writers.CSharp
             }
             else if (type.ResolvedType.IsEnum)
             {
-                //TODO: Do a better job translating the Enum value.
-                WriteSymbol("(");
-                WriteTypeName(type, noSpace: true);
-                WriteSymbol(")");
-                WriteSymbol("("); // Wrap value in parens to avoid issues with negative values
-                Write(value.ToString());
-                WriteSymbol(")");
+                WriteEnumValue(constant, constantType);
             }
             else if (value is string)
             {

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Enums.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Microsoft.Cci.Comparers;
+using Microsoft.Cci.Extensions;
+using Microsoft.Cci.Writers.Syntax;
+
+namespace Microsoft.Cci.Writers.CSharp
+{
+    public partial class CSDeclarationWriter
+    {
+        private void WriteEnumValue(IMetadataConstant constant, ITypeReference constantType = null)
+        {
+            ITypeReference enumType = (constantType == null ? constant.Type : constantType);
+            var resolvedType = enumType.ResolvedType;
+
+            if (resolvedType != null)
+            {
+                // First look for exact match
+                foreach (var enumField in resolvedType.Fields)
+                {
+                    var enumFieldValue = enumField?.Constant?.Value;
+                    if (enumFieldValue != null && enumFieldValue.Equals(constant.Value))
+                    {
+                        WriteTypeName(enumType, noSpace: true);
+                        WriteSymbol(".");
+                        WriteIdentifier(enumField.Name);
+                        return;
+                    }
+                }
+
+                // if flags and we didn't find an exact match, find a combination of flags that match
+                if (resolvedType.Attributes.Any(a => a.Type.GetTypeName() == "System.FlagsAttribute"))
+                {
+                    ulong value = ToULongUnchecked(constant.Value);
+                    ulong satisfiedValue = 0;
+
+                    // keep track of candidate flags
+                    List<IFieldDefinition> candidateFlagFields = new List<IFieldDefinition>();
+
+                    // ensure stable sort
+                    IEnumerable<IFieldDefinition> sortedFields = resolvedType.Fields.OrderBy(f => f.Name.Value, StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var candidateFlagField in sortedFields)
+                    {
+                        object candidateFlagObj = candidateFlagField?.Constant?.Value;
+                        if (candidateFlagObj == null)
+                        {
+                            continue;
+                        }
+
+                        ulong candidateFlag = ToULongUnchecked(candidateFlagObj);
+
+                        if ((value & candidateFlag) == candidateFlag)
+                        {
+                            // reduce: find out if the current flag is better or worse
+                            // than any of those we've already seen
+                            bool shouldAdd = true;
+                            for (int i = 0; i < candidateFlagFields.Count; i++)
+                            {
+                                ulong otherFlagValue = ToULongUnchecked(candidateFlagFields[i].Constant.Value);
+
+                                ulong intersectingFlagValue = candidateFlag & otherFlagValue;
+
+                                if (intersectingFlagValue == otherFlagValue)
+                                {
+                                    // other flag is completely redundant
+                                    // remove it, but continue looking as other
+                                    // flags may also be redundant
+                                    candidateFlagFields.RemoveAt(i--);
+                                }
+                                else if (intersectingFlagValue == candidateFlag)
+                                {
+                                    // this flag is redundant, don't add it and stop
+                                    // comparing
+                                    shouldAdd = false;
+                                    break;
+                                }
+                            }
+
+                            if (shouldAdd)
+                            {
+                                candidateFlagFields.Add(candidateFlagField);
+                                satisfiedValue |= candidateFlag;
+
+                                if (value == satisfiedValue)
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    // we found a valid combination of flags
+                    if (value == satisfiedValue)
+                    {
+                        for (int i = 0; i < candidateFlagFields.Count; i++)
+                        {
+                            if (i != 0)
+                            {
+                                WriteSymbol(" | ");
+                            }
+                            WriteTypeName(enumType, noSpace: true);
+                            WriteSymbol(".");
+                            WriteIdentifier(candidateFlagFields[i].Name);
+                        }
+
+                        return;
+                    }
+                }
+            }
+
+            // couldn't find a symbol for enum, just cast it
+            WriteSymbol("(");
+            WriteTypeName(enumType, noSpace: true);
+            WriteSymbol(")");
+            WriteMetadataConstant(constant);
+        }
+        
+        private static ulong ToULongUnchecked(object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (value is byte)
+            {
+                return (ulong)(byte)value;
+            }
+            if (value is sbyte)
+            {
+                return unchecked((ulong)(sbyte)value & 0xFF);
+            }
+            if (value is char)
+            {
+                return (ulong)(char)value;
+            }
+            if (value is ushort)
+            {
+                return (ulong)(ushort)value;
+            }
+            if (value is short)
+            {
+                return unchecked((ulong)(short)value & 0xFFFF);
+            }
+            if (value is uint)
+            {
+                return (ulong)(uint)value;
+            }
+            if (value is int)
+            {
+                return unchecked((ulong)(int)value & 0xFFFFFFFF);
+            }
+            if (value is ulong)
+            {
+                return (ulong)value;
+            }
+            if (value is long)
+            {
+                return unchecked((ulong)(long)value);
+            }
+
+            throw new ArgumentException($"Unsupported type {value.GetType()}", nameof(value));
+        }
+    }
+}

--- a/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
+++ b/src/Microsoft.Cci.Extensions/Writers/CSharp/CSDeclarationWriter.Fields.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Cci.Writers.CSharp
                     WriteSymbol("=", true);
                     if (field.Type.IsEnum)
                     {
-                        WriteFieldDefinitionValue(field);
+                        WriteEnumValue(field.Constant, field.Type);
                     }
                     else
                     {
@@ -87,32 +87,6 @@ namespace Microsoft.Cci.Writers.CSharp
                 }
                 WriteSymbol(",");
             }
-        }
-
-        private void WriteFieldDefinitionValue(IFieldDefinition field)
-        {
-            var resolvedType = field.Type.ResolvedType;
-
-            if (resolvedType != null)
-            {
-                foreach (var enumField in resolvedType.Fields)
-                {
-                    var enumFieldValue = enumField?.Constant?.Value;
-                    if (enumFieldValue != null && enumFieldValue.Equals(field.Constant.Value))
-                    {
-                        WriteTypeName(field.Type, noSpace: true);
-                        WriteSymbol(".");
-                        WriteIdentifier(enumField.Name);
-                        return;
-                    }
-                }
-            }
-
-            // couldn't find a symbol for enum, just cast it
-            WriteSymbol("(");
-            WriteTypeName(field.Type, noSpace: true);
-            WriteSymbol(")");
-            WriteMetadataConstant(field.Constant);
         }
     }
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ApiCompat.targets
@@ -44,6 +44,7 @@
       <ApiCompatArgs>$(ApiCompatArgs) "$(ReferenceAssembly)"</ApiCompatArgs>
       <ApiCompatArgs>$(ApiCompatArgs) -contractDepends:"@(_ContractDependencyDirectories, ','),"</ApiCompatArgs>
       <ApiCompatArgs>$(ApiCompatArgs) -implDirs:"$(IntermediateOutputPath),@(_DependencyDirectories, ','),"</ApiCompatArgs>
+      <ApiCompatArgs Condition="'$(ApiCompatExcludeAttributeList)' != ''">$(ApiCompatArgs) -excludeAttributes:"$(ApiCompatExcludeAttributeList)"</ApiCompatArgs>
       <ApiCompatArgs Condition="'$(BaselineAllAPICompatError)'!='true' and Exists('$(ApiCompatBaseline)')">$(ApiCompatArgs) -baseline:"$(ApiCompatBaseline)"</ApiCompatArgs>
       <ApiCompatBaselineAll Condition="'$(BaselineAllAPICompatError)'=='true'">&gt; $(ApiCompatBaseline)</ApiCompatBaselineAll>
       <ApiCompatExitCode>0</ApiCompatExitCode>
@@ -96,6 +97,7 @@
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -lhs:implementation</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -implDirs:"@(_ImplementationDependencyDirectories, ','),"</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs>$(MatchingRefApiCompatArgs) -rhs:reference</MatchingRefApiCompatArgs>
+      <MatchingRefApiCompatArgs Condition="'$(ApiCompatExcludeAttributeList)' != ''">$(MatchingRefApiCompatArgs) -excludeAttributes:"$(ApiCompatExcludeAttributeList)"</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatArgs Condition="'$(BaselineAllMatchingRefApiCompatError)'!='true' and Exists('$(MatchingRefApiCompatBaseline)')">$(MatchingRefApiCompatArgs) -baseline:"$(MatchingRefApiCompatBaseline)"</MatchingRefApiCompatArgs>
       <MatchingRefApiCompatBaselineAll Condition="'$(BaselineAllMatchingRefApiCompatError)'=='true'">&gt; $(MatchingRefApiCompatBaseline)</MatchingRefApiCompatBaselineAll>
 


### PR DESCRIPTION
This makes ApiCompat diff attributes applied to classes between contract and implementation.

By default all attributes are included and attributes can be opted out via an exclude list, similar
to how we exclude the same attributes from being written by GenAPI.