### PR TITLE
Move SupplementalTestData definition to tests.targets

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Build.Common.targets
@@ -33,14 +33,6 @@
     <ExcludeLocalizationImport Condition="'$(ExcludeLocalizationImport)'=='' And !Exists('$(MSBuildProjectDirectory)/MultilingualResources/$(MSBuildProjectName).de.xlf')">true</ExcludeLocalizationImport>
   </PropertyGroup>
 
-  <!-- used by test projects that need to copy supplemental content to the output directory -->
-  <ItemDefinitionGroup Condition="'$(IsTestProject)'=='true'">
-    <SupplementalTestData>
-      <DestinationDir />
-      <DestinationName />
-    </SupplementalTestData>
-  </ItemDefinitionGroup>
-
   <!-- Assembly metadata indicating that an assembly is a framework (as opposed to user) assembly:
        Test projects need to not have this because of the way "IsFrameworkAssembly" APIs work to check this. -->
   <ItemGroup Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' AND '$(IsTestProject)' != 'true'" >

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -8,6 +8,14 @@
   <UsingTask TaskName="GetTargetMachineInfo" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <UsingTask Condition="'$(BuildingUAPVertical)' == 'true'" TaskName="ExtractResWResourcesFromAssemblies" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
 
+  <!-- used by test projects that need to copy supplemental content to the output directory -->
+  <ItemDefinitionGroup Condition="'$(IsTestProject)' == 'true'">
+    <SupplementalTestData>
+      <DestinationDir />
+      <DestinationName />
+    </SupplementalTestData>
+  </ItemDefinitionGroup>
+
   <PropertyGroup>
     <SkipTestRun Condition="'$(IsTestProject)' != 'true' OR ('$(IsPerformanceTestProject)' == 'true' AND '$(Performance)' == 'false')">true</SkipTestRun>
     <TestDisabled Condition="'$(SkipTests)'=='true'">true</TestDisabled>


### PR DESCRIPTION
For the coverage runs it seems that coreclr doesn't import the Build.Common.targets and therefore the DefinitionGroup is missing. That issue didn't surface before as no custom attributes were used.

Moving the definitiongroup to tests.targets as it belongs there.