### PR TITLE
adding BenchmarkDotNet support for CoreFX purpose

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -91,7 +91,6 @@
     <PerfRunnerAllArgs>--filter $(PerfRunnerFilter) $(PerfRunnerArgs) || $(CliExitErrorCommand)</PerfRunnerAllArgs>
     <PerfRunnerCommand Condition="'$(BuildingNETFxVertical)' != 'true'">$(PerfTestCommandDotnetExecutable) $(PerfRunnerExecutable) $(PerfRunnerAllArgs)</PerfRunnerCommand>
     <PerfRunnerCommand Condition="'$(BuildingNETFxVertical)' == 'true'">$(PerfRunnerExecutable) $(PerfRunnerAllArgs)</PerfRunnerCommand>
-    <MeasurementPyCommand>$(PythonCommand) "$(BenchviewDir)/measurement.py" xunit "$(RunId)-$(AssemblyName).xml" --better desc --append -o "$(ProjectDir)measurement.json" || $(CliExitErrorCommand)</MeasurementPyCommand>
   </PropertyGroup>
 
   <!-- Build the commands to be appended to the generated RunTest.[cmd|sh] script. -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/PerfTesting.targets
@@ -73,6 +73,26 @@
     <PerfRunnerCommand Condition="'$(BuildingNETFxVertical)' == 'true'">$(PerfRunnerArgs)</PerfRunnerCommand>
     <MeasurementPyCommand>$(PythonCommand) "$(BenchviewDir)/measurement.py" xunit "$(RunId)-$(AssemblyName).xml" --better desc --drop-first-value --append -o "$(ProjectDir)measurement.json" || $(CliExitErrorCommand)</MeasurementPyCommand>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsBenchmarkDotNetProject)' == 'true'">
+    <PerfRunnerExecutableName>BenchmarksRunner</PerfRunnerExecutableName>
+    <PerfRunnerExecutable>$(PerfRunnerExecutableName).exe</PerfRunnerExecutable>
+    <!-- by default we run all benchmarks from given folder -->
+    <PerfRunnerFilter>*</PerfRunnerFilter>
+    <!-- Unix OSes are replacing an asterisk with file name of every file in the directory, so we need to wrap it with '*' to make it work -->
+    <PerfRunnerFilter Condition="'$(TargetOS)'=='Linux'">'*'</PerfRunnerFilter>
+    <CollectFlags>BranchMispredictions+CacheMisses+InstructionRetired</CollectFlags>
+    <!-- currently BenchmarkDotNet uses ETW for Profiling on Windows, when we add new profiler for Unix we are going to add it here -->
+    <ProfilerName Condition="'$(TargetOS)'=='Windows_NT'">ETW</ProfilerName>
+    <!-- by default there are no args, this can be used by the users to pass BenchmarkDotNet arguments here -->
+    <PerfRunnerArgs></PerfRunnerArgs>
+    <!-- when we run a Diagnostic benchmark run we specify the profiler and the hardware counters we want to get -->
+    <PerfRunnerArgs Condition="'$(PerformanceType)'=='Diagnostic'">--profiler $(ProfilerName) --counters $(CollectFlags)</PerfRunnerArgs>
+    <PerfRunnerAllArgs>--filter $(PerfRunnerFilter) $(PerfRunnerArgs) || $(CliExitErrorCommand)</PerfRunnerAllArgs>
+    <PerfRunnerCommand Condition="'$(BuildingNETFxVertical)' != 'true'">$(PerfTestCommandDotnetExecutable) $(PerfRunnerExecutable) $(PerfRunnerAllArgs)</PerfRunnerCommand>
+    <PerfRunnerCommand Condition="'$(BuildingNETFxVertical)' == 'true'">$(PerfRunnerExecutable) $(PerfRunnerAllArgs)</PerfRunnerCommand>
+    <MeasurementPyCommand>$(PythonCommand) "$(BenchviewDir)/measurement.py" xunit "$(RunId)-$(AssemblyName).xml" --better desc --append -o "$(ProjectDir)measurement.json" || $(CliExitErrorCommand)</MeasurementPyCommand>
+  </PropertyGroup>
 
   <!-- Build the commands to be appended to the generated RunTest.[cmd|sh] script. -->
   <ItemGroup>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -200,6 +200,11 @@
       <ReferenceFromRuntime Include="xunit.performance.api" />
       <ReferenceFromRuntime Include="xunit.performance.core" />
     </ItemGroup>
+    
+    <ItemGroup Condition="'$(IsBenchmarkDotNetProject)' == 'true'">
+      <ReferenceFromRuntime Include="BenchmarkDotNet" />
+      <ReferenceFromRuntime Include="BenchmarkDotNet.Diagnostics.Windows" />
+    </ItemGroup>
 
     <!-- vs debugging / test explorer -->
     <ItemGroup Condition="'$(IncludeVSTestReferences)' == 'true' AND '$(BuildingNETCoreAppVertical)' == 'true'">


### PR DESCRIPTION
We are currently transitioning from xunit-performance to BenchmarkDotNet.

All of the benchmarks live in the performance repo, however when CoreFX developers want to run benchmarks against new API that is not exposed by any contracts yet they need to test it locally.

This is why I am adding support for BDN to CoreFX. Before I do that, I need these changes to merged and propagated ofc ;)

Some reasoning behind the changes:

1. All changes are inside a `'$(IsBenchmarkDotNetProject)' == 'true'` condition to make sure I don't break anybody
2. I did not remove xunit-performance stuff, just added BDN

How it's going to work in the CoreFX repo for running benchmarks against new API: exactly the same way it was with xunit-performance:

Default run:

> dotnet msbuild /t:BuildAndTest /p:ConfigurationGroup=Release /p:Performance=true

Diagnostics run with same Hardware Counters as xunit so far:

> dotnet msbuild /t:BuildAndTest /p:ConfigurationGroup=Release /p:Performance=true /p:PerformanceType=Diagnostic

New things: possibility to filter benchmarks using `/p:PerfRunnerFilter`:

> dotnet msbuild /t:BuildAndTest /p:ConfigurationGroup=Release /p:Performance=true /p:PerfRunnerFilter=*MyFilter*

Pass some extra BDN parameters using `/p:PerfRunnerArgs`:

dotnet msbuild /t:BuildAndTest /p:ConfigurationGroup=Release /p:Performance=true /p:PerfRunnerArgs=--join

I tested all of the combindations, including `/p:CoreCLROverridePath`. It works.

I am going to create the CoreFX PR as soon as @ViktorHofer gives me his MSBuild blessing for these changes ;)

/cc @danmosemsft 