### PR TITLE
Opt out of importing Directory.Build.props/targets in generated project.csproj

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -15,15 +15,19 @@ if [%NATIVE_TOOLS_RID%]==[] (
 )
 
 set MSBUILD_PROJECT_CONTENT= ^
- ^^^<Project Sdk=^"Microsoft.NET.Sdk^"^^^> ^
+ ^^^<Project^^^> ^
   ^^^<PropertyGroup^^^> ^
+    ^^^<ImportDirectoryBuildProps^^^>false^^^</ImportDirectoryBuildProps^^^> ^
+    ^^^<ImportDirectoryBuildTargets^^^>false^^^</ImportDirectoryBuildTargets^^^> ^
     ^^^<TargetFrameworks^^^>netcoreapp1.0;net46^^^</TargetFrameworks^^^> ^
     ^^^<DisableImplicitFrameworkReferences^^^>true^^^</DisableImplicitFrameworkReferences^^^> ^
   ^^^</PropertyGroup^^^> ^
+  ^^^<Import Project=^"Sdk.props^" Sdk=^"Microsoft.NET.Sdk^" /^^^> ^
   ^^^<ItemGroup^^^> ^
     ^^^<PackageReference Include=^"MicroBuild.Core^" Version=^"%MICROBUILD_VERSION%^" /^^^> ^
     ^^^<PackageReference Include=^"Microsoft.Net.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
   ^^^</ItemGroup^^^> ^
+  ^^^<Import Project=^"Sdk.targets^" Sdk=^"Microsoft.NET.Sdk^" /^^^> ^
  ^^^</Project^^^>
 
 set PUBLISH_TFM=netcoreapp2.0

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -17,15 +17,19 @@ __MICROBUILD_VERSION=0.2.0
 __ROSLYNCOMPILER_VERSION=2.9.0
 
 __PORTABLETARGETS_PROJECT_CONTENT="
-<Project Sdk=\"Microsoft.NET.Sdk\">
+<Project>
   <PropertyGroup>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
     <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
+  <Import Project=\"Sdk.props\" Sdk=\"Microsoft.NET.Sdk\" />
   <ItemGroup>
     <PackageReference Include=\"MicroBuild.Core\" Version=\"$__MICROBUILD_VERSION\" />
     <PackageReference Include=\"Microsoft.NETCore.Compilers\" Version=\"$__ROSLYNCOMPILER_VERSION\" />
   </ItemGroup>
+  <Import Project=\"Sdk.targets\" Sdk=\"Microsoft.NET.Sdk\" />
 </Project>"
 
 __PUBLISH_TFM=netcoreapp2.0


### PR DESCRIPTION
Since the generated `project.csproj` is an SDK style project, it was automatically importing the root `Directory.Build.props/targets` in SDK-style repos that consumed it. This was causing problems - for example, in CoreFx & Standard, `project.csproj` would get PackageReferences that were defined in Arcade, but didn't have access to the right RestoreSource, causing restore errors if those packages weren't already in the cache. This PR turns off the automatic `Directory.Build.props/targets` imports.

@weshaggard @ericstj PTAL