### PR TITLE
Update MSBuildToolsVersion check to support "Current"

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
@@ -6,7 +6,7 @@
          the third part is for bugfixes, the fourth is for hotfixes/securtity-updates -->
     <APIVersion>$([System.Version]::Parse('$(AssemblyVersion)').ToString(2))</APIVersion>
 
-    <_usingRoslyn Condition="'$(MSBuildToolsVersion)' == 'dogfood' OR '$(MSBuildToolsVersion)' &gt;= '14.0'">true</_usingRoslyn>
+    <_usingRoslyn Condition="'$(MSBuildToolsVersion)' == 'dogfood' OR Condition="'$(MSBuildToolsVersion)' == 'Current' OR '$(MSBuildToolsVersion)' &gt;= '14.0'">true</_usingRoslyn>
 
     <!-- Create a common root output directory for all reference assemblies -->
     <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(BaseOutputPath)ref/</ReferenceAssemblyOutputPath>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/ReferenceAssemblies.targets
@@ -6,7 +6,7 @@
          the third part is for bugfixes, the fourth is for hotfixes/securtity-updates -->
     <APIVersion>$([System.Version]::Parse('$(AssemblyVersion)').ToString(2))</APIVersion>
 
-    <_usingRoslyn Condition="'$(MSBuildToolsVersion)' == 'dogfood' OR Condition="'$(MSBuildToolsVersion)' == 'Current' OR '$(MSBuildToolsVersion)' &gt;= '14.0'">true</_usingRoslyn>
+    <_usingRoslyn Condition="'$(MSBuildToolsVersion)' == 'dogfood' OR '$(MSBuildToolsVersion)' == 'Current' OR '$(MSBuildToolsVersion)' &gt;= '14.0'">true</_usingRoslyn>
 
     <!-- Create a common root output directory for all reference assemblies -->
     <ReferenceAssemblyOutputPath Condition="'$(ReferenceAssemblyOutputPath)' == ''">$(BaseOutputPath)ref/</ReferenceAssemblyOutputPath>


### PR DESCRIPTION
I'm not sure if this _usingRoslyn check is still meaningful (don't we always build with Roslyn now?), but recent Visual Studio builds include a tools version coming back as "Current", which then causes the failure:
```
error MSB4086: A numeric comparison was attempted on "$(MSBuildToolsVersion)" that evaluates to "Current" instead of a number, in condition "'$(MSBuildToolsVersion)' == 'dogfood' OR '$(MSBuildToolsVersion)' >= '14.0'"
```
when building Corelib, so I'm adding "Current" to the list of versions that means we're using Roslyn.

Fixes https://github.com/dotnet/coreclr/issues/21069
cc: @danmosemsft, @jkotas 