### PR TITLE
Launch xunit.console.dll using 'dotnet' in CoreRT testing

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/tests.targets
@@ -87,11 +87,11 @@
   </PropertyGroup>
 
   <!-- netcoreapp (not aot) uses the dotnet host. -->
-  <PropertyGroup Condition="'$(BuildingNETCoreAppVertical)' == 'true' AND '$(UseDotNetNativeToolchain)' != 'true'">
+  <PropertyGroup Condition="'$(UseDotNetNativeToolchain)' != 'true'">
     <TestHostExecutablePath Condition="'$(TestHostExecutablePath)' == '' AND '$(RunningOnUnix)' != 'true'">%RUNTIME_PATH%\dotnet.exe</TestHostExecutablePath>
     <TestHostExecutablePath Condition="'$(TestHostExecutablePath)' == '' AND '$(RunningOnUnix)' == 'true'">$RUNTIME_PATH/dotnet</TestHostExecutablePath>
-    <TestProgram Condition="'$(BuildingNETCoreAppVertical)' == 'true'">$(TestHostExecutablePath)</TestProgram>
-    <TestArguments Condition="'$(BuildingNETCoreAppVertical)' == 'true'">$(XunitExecutable) $(XunitArguments)</TestArguments>
+    <TestProgram>$(TestHostExecutablePath)</TestProgram>
+    <TestArguments>$(XunitExecutable) $(XunitArguments)</TestArguments>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This change modifies the test execution script generator so that,
in CoreRT, it uses the 'dotnet' command to execute xunit.console.dll;
when we launch the app using 'call' from the VS 2019 developer
prompt, it crashes due to being unable to find System.Runtime
4.2.0.0.

Thanks

Tomas