### PR TITLE
Use NullValueHandling.Ignore in GitHub client

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -29,7 +29,13 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
 
         private static JsonSerializerSettings s_jsonSettings = new JsonSerializerSettings
         {
-            ContractResolver = new CamelCasePropertyNamesContractResolver()
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+
+            // GitHub seems to have changed to no longer handle null in create tree calls. The API
+            // returns a 422 Unprocessable Entity error "Must supply tree.sha or tree.content" when
+            // we specify tree.sha as null *and* tree.content as the text content we want. Omit the
+            // tree.sha property completely to fix this.
+            NullValueHandling = NullValueHandling.Ignore
         };
 
         private static readonly string[] s_rateLimitHeaderNames =


### PR DESCRIPTION
GitHub seems to have changed to no longer handle null in create tree calls. The API returns a 422 Unprocessable Entity error "Must supply tree.sha or tree.content" when we specify tree.sha as null *and* tree.content as the text content we want. Omit the tree.sha property completely to fix this.

For example, this doesn't work anymore:

```js
{
  "base_tree": "1abcea798bad23c4ff88e89ebaf2a3ff51733c48",
  "tree": [
    {
      "path": "build-info/dotnet/core-setup/master/Last_Build_Packages.txt",
      "mode": "100644",
      "type": "blob",
      "sha": null,
      "content": "Microsoft.DotNet.PlatformAbstractions 3.0.0-preview-27316-0..."
    },
    // ...
  ]
}
```

This does:

```js
{
  "base_tree": "1abcea798bad23c4ff88e89ebaf2a3ff51733c48",
  "tree": [
    {
      "path": "build-info/dotnet/core-setup/master/Last_Build_Packages.txt",
      "mode": "100644",
      "type": "blob",
      "content": "Microsoft.DotNet.PlatformAbstractions 3.0.0-preview-27316-0..."
    },
    // ...
  ]
}
```

I sent a GitHub support request asking about this, too.

I'm getting ramped up to test it out locally, haven't run dev build buildtools in a while.