### PR TITLE
Trace body when submitting tree to GitHub

### DIFF
--- a/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
+++ b/src/Microsoft.DotNet.VersionTools/Automation/GitHubApi/GitHubClient.cs
@@ -326,7 +326,7 @@ namespace Microsoft.DotNet.VersionTools.Automation.GitHubApi
             var bodyContent = new StringContent(body);
             using (HttpResponseMessage response = await _httpClient.PostAsync(url, bodyContent))
             {
-                Trace.TraceInformation($"Posting new tree to {project.Segments}");
+                Trace.TraceInformation($"Posting new tree to {project.Segments}:\n{body}");
                 return await DeserializeSuccessfulAsync<GitTree>(response);
             }
         }


### PR DESCRIPTION
In Core-Setup, I upgraded buildtools, but continue to get 422 error responses from this method in the official build. I strongly suspect there's some cleanup or stale DLL issue because it hasn't repro'd in any other situation, but  I want to print the tree to narrow it down for sure. This also makes the method more diagnosable in general.

Tested by copying the new VersionTools DLL into a Core-Setup Tools dir.