### PR TITLE
Updating init-tools.cmd to also restore Microsoft.NETCore.Compilers

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -26,6 +26,7 @@ set MSBUILD_PROJECT_CONTENT= ^
   ^^^<ItemGroup^^^> ^
     ^^^<PackageReference Include=^"MicroBuild.Core^" Version=^"%MICROBUILD_VERSION%^" /^^^> ^
     ^^^<PackageReference Include=^"Microsoft.Net.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
+    ^^^<PackageReference Include=^"Microsoft.NETCore.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
   ^^^</ItemGroup^^^> ^
   ^^^<Import Project=^"Sdk.targets^" Sdk=^"Microsoft.NET.Sdk^" /^^^> ^
  ^^^</Project^^^>


### PR DESCRIPTION
This updates init-tools.cmd to also restore Microsoft.NETCore.Compilers which allows CoreCLR to be compiled using `dotnet msbuild` on Windows.