### PR TITLE
Using eval and explicit variables

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -34,9 +34,9 @@ __PORTABLETARGETS_PROJECT_CONTENT="
 
 __PUBLISH_TFM=netcoreapp2.0
 
-__DEFAULT_RESTORE_ARGS="--no-cache --packages \"${__PACKAGES_DIR}\""
-__INIT_TOOLS_RESTORE_ARGS="${__DEFAULT_RESTORE_ARGS} --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
-__TOOLRUNTIME_RESTORE_ARGS="--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS}"
+__DEFAULT_RESTORE_ARGS="--no-cache --packages"
+__INIT_TOOLS_SOURCES="--source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json"
+__TOOLRUNTIME_SOURCES="--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
 
 if [ ! -d "$__PROJECT_DIR" ]; then
     echo "ERROR: Cannot find project root path at '$__PROJECT_DIR'. Please pass in the source directory as the 1st parameter."
@@ -66,8 +66,8 @@ cp -R $__TOOLS_DIR/* $__TOOLRUNTIME_DIR
 
 __TOOLRUNTIME_PROJECT=$__TOOLS_DIR/tool-runtime/project.csproj
 
-echo "Running: $__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_RESTORE_ARGS"
-$__DOTNET_CMD restore "${__TOOLRUNTIME_PROJECT}" $__TOOLRUNTIME_RESTORE_ARGS
+echo "Running: eval \"$__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_SOURCES ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}\""
+eval "$__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_SOURCES ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}"
 
 echo "Running: $__DOTNET_CMD publish --no-restore \"${__TOOLRUNTIME_PROJECT}\" -f ${__PUBLISH_TFM} -o $__TOOLRUNTIME_DIR"
 $__DOTNET_CMD publish --no-restore "${__TOOLRUNTIME_PROJECT}" -f ${__PUBLISH_TFM} -o $__TOOLRUNTIME_DIR
@@ -78,8 +78,8 @@ __PORTABLETARGETS_PROJECT=${__TOOLRUNTIME_DIR}/generated/project.csproj
 
 echo $__PORTABLETARGETS_PROJECT_CONTENT > "${__PORTABLETARGETS_PROJECT}"
 
-echo "Running: \"$__DOTNET_CMD\" restore \"${__PORTABLETARGETS_PROJECT}\" $__INIT_TOOLS_RESTORE_ARGS"
-$__DOTNET_CMD restore "${__PORTABLETARGETS_PROJECT}" $__INIT_TOOLS_RESTORE_ARGS
+echo "Running: eval \"$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECT}\" ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}\""
+eval "$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECT}\" ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}"
 
 # Copy MicroBuild targets from packages, allowing for lowercased package IDs.
 cp -R "${__PACKAGES_DIR}"/[Mm]icro[Bb]uild.[Cc]ore/"${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
@@ -110,8 +110,8 @@ if [ "$__ILASM_PACKAGE_VERSION" ]; then
         exit 1
     fi
 
-    echo "Running: \"$__DOTNET_CMD\" build \"${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj\""
-    $__DOTNET_CMD build "${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj" $__DEFAULT_RESTORE_ARGS --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -r $__ILASM_PACKAGE_RID -p:ILAsmPackageVersion=$__ILASM_PACKAGE_VERSION
+    echo "Running: eval \"$__DOTNET_CMD build \"${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj\"\""
+    eval "$__DOTNET_CMD build "${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj" $__DEFAULT_RESTORE_ARGS \"$__PACKAGES_DIR\" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -r $__ILASM_PACKAGE_RID -p:ILAsmPackageVersion=$__ILASM_PACKAGE_VERSION"
 fi
 
 # Download the package version props file, if passed in the environment.

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -34,8 +34,8 @@ __PORTABLETARGETS_PROJECT_CONTENT="
 
 __PUBLISH_TFM=netcoreapp2.0
 
-__DEFAULT_RESTORE_ARGS="--no-cache --packages"
-__INIT_TOOLS_SOURCES="--source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json"
+__DEFAULT_RESTORE_ARGS="--no-cache"
+__INIT_TOOLS_SOURCES="--source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
 __TOOLRUNTIME_SOURCES="--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"
 
 if [ ! -d "$__PROJECT_DIR" ]; then
@@ -66,8 +66,8 @@ cp -R $__TOOLS_DIR/* $__TOOLRUNTIME_DIR
 
 __TOOLRUNTIME_PROJECT=$__TOOLS_DIR/tool-runtime/project.csproj
 
-echo "Running: eval \"$__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_SOURCES ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}\""
-eval "$__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_SOURCES ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}"
+echo "Running: eval \"$__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_SOURCES ${__DEFAULT_RESTORE_ARGS} --packages \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}\""
+eval "$__DOTNET_CMD restore \"${__TOOLRUNTIME_PROJECT}\" $__TOOLRUNTIME_SOURCES ${__DEFAULT_RESTORE_ARGS} --packages \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}"
 
 echo "Running: $__DOTNET_CMD publish --no-restore \"${__TOOLRUNTIME_PROJECT}\" -f ${__PUBLISH_TFM} -o $__TOOLRUNTIME_DIR"
 $__DOTNET_CMD publish --no-restore "${__TOOLRUNTIME_PROJECT}" -f ${__PUBLISH_TFM} -o $__TOOLRUNTIME_DIR
@@ -78,8 +78,8 @@ __PORTABLETARGETS_PROJECT=${__TOOLRUNTIME_DIR}/generated/project.csproj
 
 echo $__PORTABLETARGETS_PROJECT_CONTENT > "${__PORTABLETARGETS_PROJECT}"
 
-echo "Running: eval \"$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECT}\" ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}\""
-eval "$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECT}\" ${__DEFAULT_RESTORE_ARGS} \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}"
+echo "Running: eval \"$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECT}\" ${__DEFAULT_RESTORE_ARGS} --packages \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}\""
+eval "$__DOTNET_CMD restore \"${__PORTABLETARGETS_PROJECT}\" ${__DEFAULT_RESTORE_ARGS} --packages \"${__PACKAGES_DIR}\" ${__INIT_TOOLS_SOURCES}"
 
 # Copy MicroBuild targets from packages, allowing for lowercased package IDs.
 cp -R "${__PACKAGES_DIR}"/[Mm]icro[Bb]uild.[Cc]ore/"${__MICROBUILD_VERSION}/build/." "$__TOOLRUNTIME_DIR/."
@@ -111,7 +111,7 @@ if [ "$__ILASM_PACKAGE_VERSION" ]; then
     fi
 
     echo "Running: eval \"$__DOTNET_CMD build \"${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj\"\""
-    eval "$__DOTNET_CMD build "${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj" $__DEFAULT_RESTORE_ARGS \"$__PACKAGES_DIR\" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -r $__ILASM_PACKAGE_RID -p:ILAsmPackageVersion=$__ILASM_PACKAGE_VERSION"
+    eval "$__DOTNET_CMD build "${__TOOLRUNTIME_DIR}/ilasm/ilasm.depproj" $__DEFAULT_RESTORE_ARGS --packages \"$__PACKAGES_DIR\" --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -r $__ILASM_PACKAGE_RID -p:ILAsmPackageVersion=$__ILASM_PACKAGE_VERSION"
 fi
 
 # Download the package version props file, if passed in the environment.


### PR DESCRIPTION
Fixes https://github.com/dotnet/buildtools/issues/2224
dotnet cli team changed on how we pass arguments to dotnet commands. The change was introduced in this https://github.com/dotnet/cli/pull/9892

More info is available here https://github.com/dotnet/cli/issues/10802

I tested 4 testcases here
- path without spaces on netcore2.1
- path without spaces on netcore3.0
- path with spaces on netcore2.1
- path with spaces on netcore3.0

@safern @eerhardt any other good way to test these changes 
