### PR TITLE
Setting the targetFramework Dynamically

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+__TargetFramework=${3:-}
+
+if [ -z "$__TargetFramework" ]; then
+    __TargetFramework="netcoreapp2.0"
+fi
+
 # Restores crossgen and runs it on all tools components.
 usage()
 {
@@ -18,7 +24,7 @@ restore_crossgen()
 
     __pjDir=$__toolsDir/crossgen
     mkdir -p $__pjDir
-    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><DisableImplicitNuGetFallbackFolder>false</DisableImplicitNuGetFallbackFolder><TreatWarningsAsErrors>false</TreatWarningsAsErrors><NoWarn>\$(NoWarn);NU1605;NU1103</NoWarn><TargetFramework>netcoreapp2.0</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.App\" Version=\"$__sharedFxVersion\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
+    echo "<Project Sdk=\"Microsoft.NET.Sdk\"><PropertyGroup><DisableImplicitNuGetFallbackFolder>false</DisableImplicitNuGetFallbackFolder><TreatWarningsAsErrors>false</TreatWarningsAsErrors><NoWarn>\$(NoWarn);NU1605;NU1103</NoWarn><TargetFramework>$__TargetFramework</TargetFramework><DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences><RuntimeIdentifiers>$__packageRid</RuntimeIdentifiers></PropertyGroup><ItemGroup><PackageReference Include=\"Microsoft.NETCore.App\" Version=\"$__sharedFxVersion\" /></ItemGroup></Project>" > "$__pjDir/crossgen.csproj"
     $__dotnet restore $__pjDir/crossgen.csproj --packages $__packagesDir --source $__MyGetFeed
     __crossgen=$__packagesDir/runtime.$__packageRid.microsoft.netcore.app/$__sharedFxVersion/tools/crossgen
     if [ ! -e $__crossgen ]; then

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
@@ -1,16 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-__TargetFramework=${3:-}
-
-if [ -z "$__TargetFramework" ]; then
-    __TargetFramework="netcoreapp2.0"
-fi
-
 # Restores crossgen and runs it on all tools components.
 usage()
 {
-    echo "crossgen.sh <directory> <rid>"
+    echo "crossgen.sh <directory> <rid> <targetframework>"
     echo "    Restores crossgen and runs it on all assemblies in <directory>."
     exit 0
 }
@@ -84,6 +78,7 @@ fi
 __MyGetFeed=${BUILDTOOLS_CROSSGEN_FEED:-https://dotnet.myget.org/F/dotnet-core/api/v3/index.json}
 __targetDir=$1
 __packageRid=${2:-}
+__TargetFramework=${3:-}
 __scriptpath=$(cd "$(dirname "$0")"; pwd -P)
 __toolsDir=$__scriptpath/../Tools
 __dotnet=$__toolsDir/dotnetcli/dotnet
@@ -111,6 +106,10 @@ if [ "$__packageRid" == "osx-x64" ]; then
     __libraryExtension=dylib
 else
     __libraryExtension=so
+fi
+
+if [ -z "$__TargetFramework" ]; then
+    __TargetFramework="netcoreapp2.0"
 fi
 
 restore_crossgen


### PR DESCRIPTION
Currently the buildtools gives error if we try to use them with netcoreapp3.0 

```
/git/machinelearning/Tools/crossgen/crossgen.csproj : error NU1202: Package Microsoft.NETCore.App 3.0.0-preview-27324-5 is not compatible with netcoreapp2.0 (.NETCoreApp,Version=v2.0). Package Microsoft.NETCore.App 3.0.0-preview-27324-5 supports: netcoreapp3.0 (.NETCoreApp,Version=v3.0)
/git/machinelearning/Tools/crossgen/crossgen.csproj : error NU1202: Package Microsoft.NETCore.App 3.0.0-preview-27324-5 is not compatible with netcoreapp2.0 (.NETCoreApp,Version=v2.0) / linux-x64. Package Microsoft.NETCore.App 3.0.0-preview-27324-5 supports: netcoreapp3.0 (.NETCoreApp,Version=v3.0)
```
