### PR TITLE
Bump version to preview4

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -13,7 +13,7 @@
 
     <!-- Use the same package version for all output packages. -->
     <DoNotGeneratePackageVersion>true</DoNotGeneratePackageVersion>
-    <PackageVersion>3.0.0-preview1-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
+    <PackageVersion>3.0.0-preview4-$(BuildNumberMajor)-$(BuildNumberMinor)</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In keeping with branching buildtools to release/3.0, which is marked preview3: https://github.com/dotnet/buildtools/commit/2912fd36eaffe4e998073044d0be9319ff5213dd

CC @danmosemsft @leecow @mmitche 