### PR TITLE
Fix parameter evaluation of publish task

### DIFF
--- a/tools-local/versions-fix/versions-fix.proj
+++ b/tools-local/versions-fix/versions-fix.proj
@@ -17,6 +17,10 @@
         <RestoreSources>https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json</RestoreSources>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(ShippedNuGetPackageGlobPath)'!=''">
+        <ShippedNuGetPackage Include="$(ShippedNuGetPackageGlobPath)" />
+    </ItemGroup>
+
     <UsingTask TaskName="UpdatePublishedVersions" AssemblyFile="packages\microsoft.dotnet.buildtools\$(BuildToolsVersion)\lib\Microsoft.DotNet.Build.Tasks.dll" />
     <Target Name="UpdatePublishedVersions">
         <UpdatePublishedVersions 


### PR DESCRIPTION
This fixes evaluation of the glob path to shipping NuGet packages.

@dagood Davis Goodin FTE Please have a look.