### PR TITLE
Updating the toolset compiler to use the cross-platform package and target v3.1.0-beta1-19172-05

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
@@ -15,13 +15,4 @@
     <DebugType Condition="'$(RunningOnCore)' == 'true'">Portable</DebugType>
   </PropertyGroup>
 
-  <!-- If we're not using the compiler server, set ToolPath/Exe to direct to
-       the exes in this package -->
-  <PropertyGroup Condition="'$(UseRoslynCompilers)' != 'false' and '$(RoslynIncompatibleMsbuildVersion)' == 'true'">
-    <CscToolPath>$(_RoslynTasksDirectory)</CscToolPath>
-    <CscToolExe>csc.exe</CscToolExe>
-    <VbcToolPath>$(_RoslynTasksDirectory)</VbcToolPath>
-    <VbcToolExe>vbc.exe</VbcToolExe>
-  </PropertyGroup>
-
 </Project>

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/Roslyn.Common.props
@@ -1,37 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynVersion>3.0.0-beta4-final</RoslynVersion>
-    <RoslynPackageName>Microsoft.Net.Compilers</RoslynPackageName>
+    <RoslynVersion>3.1.0-beta1-19172-05</RoslynVersion>
+    <RoslynPackageName>Microsoft.Net.Compilers.Toolset</RoslynPackageName>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <RoslynPropsFile Condition="'$(RoslynPropsFile)' == '' and '$(RunningOnCore)' != 'true'">$(BuildToolsTaskDir)roslyn/build/Microsoft.Net.Compilers.props</RoslynPropsFile>
-  </PropertyGroup>
-
-  <!--
-    On Unix we always use a version of Roslyn we restore from NuGet and we have to work around some known issues.
-  -->
-  <PropertyGroup Condition="'$(RoslynPropsFile)' == '' and '$(RunningOnCore)' == 'true'">
-    <RoslynPackageName>Microsoft.NETCore.Compilers</RoslynPackageName>
+  <PropertyGroup Condition="'$(RoslynPropsFile)' == ''">
     <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName.ToLower())/$(RoslynVersion)/</RoslynPackageDir>
     <RoslynPropsFile>$(RoslynPackageDir)build/$(RoslynPackageName).props</RoslynPropsFile>
 
     <!--
       Portable PDBs are now supported in Linux and OSX with .Net Core MSBuild.
     -->
-    <DebugType>Portable</DebugType>
+    <DebugType Condition="'$(RunningOnCore)' == 'true'">Portable</DebugType>
   </PropertyGroup>
-
 
   <!-- If we're not using the compiler server, set ToolPath/Exe to direct to
        the exes in this package -->
   <PropertyGroup Condition="'$(UseRoslynCompilers)' != 'false' and '$(RoslynIncompatibleMsbuildVersion)' == 'true'">
-    <CscToolPath Condition="'$(RunningOnCore)' == 'true'">$(RoslynPackageDir)tools</CscToolPath>
-    <CscToolPath Condition="'$(RunningOnCore)' != 'true'">$(BuildToolsTaskDir)roslyn/tools</CscToolPath>
+    <CscToolPath>$(_RoslynTasksDirectory)</CscToolPath>
     <CscToolExe>csc.exe</CscToolExe>
-    <VbcToolPath Condition="'$(RunningOnCore)' == 'true'">$(RoslynPackageDir)tools</VbcToolPath>
-    <VbcToolPath Condition="'$(RunningOnCore)' != 'true'">$(BuildToolsTaskDir)roslyn/tools</VbcToolPath>
+    <VbcToolPath>$(_RoslynTasksDirectory)</VbcToolPath>
     <VbcToolExe>vbc.exe</VbcToolExe>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -7,7 +7,7 @@ set TOOLRUNTIME_DIR=%~3
 set PACKAGES_DIR=%~4
 set BUILDTOOLS_PACKAGE_DIR=%~dp0
 set MICROBUILD_VERSION=0.2.0
-set ROSLYNCOMPILERS_VERSION=3.0.0-beta4-final
+set ROSLYNCOMPILERS_VERSION=3.1.0-beta1-19172-05
 
 :: Default to x64 native tools if nothing was specified.
 if [%NATIVE_TOOLS_RID%]==[] (
@@ -25,8 +25,7 @@ set MSBUILD_PROJECT_CONTENT= ^
   ^^^<Import Project=^"Sdk.props^" Sdk=^"Microsoft.NET.Sdk^" /^^^> ^
   ^^^<ItemGroup^^^> ^
     ^^^<PackageReference Include=^"MicroBuild.Core^" Version=^"%MICROBUILD_VERSION%^" /^^^> ^
-    ^^^<PackageReference Include=^"Microsoft.Net.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
-    ^^^<PackageReference Include=^"Microsoft.NETCore.Compilers^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
+    ^^^<PackageReference Include=^"Microsoft.Net.Compilers.Toolset^" Version=^"%ROSLYNCOMPILERS_VERSION%^" /^^^> ^
   ^^^</ItemGroup^^^> ^
   ^^^<Import Project=^"Sdk.targets^" Sdk=^"Microsoft.NET.Sdk^" /^^^> ^
  ^^^</Project^^^>
@@ -34,7 +33,7 @@ set MSBUILD_PROJECT_CONTENT= ^
 set PUBLISH_TFM=netcoreapp2.0
 
 set DEFAULT_RESTORE_ARGS=--no-cache --packages "%PACKAGES_DIR%"
-set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
+set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
 set TOOLRUNTIME_RESTORE_ARGS=%INIT_TOOLS_RESTORE_ARGS% --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json
 
 if not exist "%PROJECT_DIR%" (
@@ -105,9 +104,6 @@ if not [%RESTORE_PORTABLETARGETS_ERROR_LEVEL%]==[0] (
   exit /b %RESTORE_PORTABLETARGETS_ERROR_LEVEL%
 )
 Robocopy "%PACKAGES_DIR%\MicroBuild.Core\%MICROBUILD_VERSION%\build\." "%TOOLRUNTIME_DIR%\." /E
-
-:: Copy Roslyn Compilers Over to ToolRuntime
-Robocopy "%PACKAGES_DIR%\Microsoft.Net.Compilers\%ROSLYNCOMPILERS_VERSION%\." "%TOOLRUNTIME_DIR%\net46\roslyn\." /E
 
 :: Restore ILAsm if the caller asked for it by setting the environment variable
 if [%ILASMCOMPILER_VERSION%]==[] goto :afterILAsmRestore

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -14,7 +14,7 @@ __TOOLRUNTIME_DIR=${3:-}
 __PACKAGES_DIR=${4:-}
 __TOOLS_DIR=$(cd "$(dirname "$0")"; pwd -P)
 __MICROBUILD_VERSION=0.2.0
-__ROSLYNCOMPILER_VERSION=3.0.0-beta4-final
+__ROSLYNCOMPILER_VERSION=3.1.0-beta1-19172-05
 
 __PORTABLETARGETS_PROJECT_CONTENT="
 <Project>
@@ -27,7 +27,7 @@ __PORTABLETARGETS_PROJECT_CONTENT="
   <Import Project=\"Sdk.props\" Sdk=\"Microsoft.NET.Sdk\" />
   <ItemGroup>
     <PackageReference Include=\"MicroBuild.Core\" Version=\"$__MICROBUILD_VERSION\" />
-    <PackageReference Include=\"Microsoft.NETCore.Compilers\" Version=\"$__ROSLYNCOMPILER_VERSION\" />
+    <PackageReference Include=\"Microsoft.Net.Compilers.Toolset\" Version=\"$__ROSLYNCOMPILER_VERSION\" />
   </ItemGroup>
   <Import Project=\"Sdk.targets\" Sdk=\"Microsoft.NET.Sdk\" />
 </Project>"
@@ -35,7 +35,7 @@ __PORTABLETARGETS_PROJECT_CONTENT="
 __PUBLISH_TFM=netcoreapp2.0
 
 __DEFAULT_RESTORE_ARGS="--no-cache"
-__INIT_TOOLS_SOURCES="--source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
+__INIT_TOOLS_SOURCES="--source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
 __TOOLRUNTIME_SOURCES="--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json"
 
 if [ ! -d "$__PROJECT_DIR" ]; then


### PR DESCRIPTION
CC. @jaredpar, @jkotas, @safern 

This pulls in the latest compiler (same one as CoreFX was just moved to) in order to get some of the nullable fixes that have recently gone in.

We now have `Microsoft.Net.Compilers.Toolset` that contains both .NET Core and Desktop binaries, rather than having separate/independent packages.