### PR TITLE
Allow different source and target accounts for CopyBlobDirectory

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Feed.net45/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed.net45/project.json
@@ -5,7 +5,7 @@
     "NuGet.Packaging": "4.4.0",
     "System.Reflection.Metadata": "1.4.1",
     "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-beta-24813-03",
-    "sleetlib": "2.2.24"
+    "DotNet.SleetLib": "2.2.139"
   },
   "frameworks": {
     "net45": {

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/project.json
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/project.json
@@ -8,7 +8,7 @@
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Versioning": "4.4.0",
     "NuGet.Packaging": "4.4.0",
-    "SleetLib": "2.2.24",
+    "DotNet.SleetLib": "2.2.139",
     "WindowsAzure.Storage": "8.5.0"
   },
   "frameworks": {


### PR DESCRIPTION
@dagood

This is exclusively for use in the dotnet orchestration utilities for 2.1 and 2.2. For whatever reason, that repo is using a master branch of buildtools, so I can't just check this into 2.1 and use that (there are additional changes).

This allows me to automate the process of moving a private 2.1 and 2.2 build into the public locations without any manual steps. This requires a cross-account copy which is most efficiently done by not downloading to an intermediate location first.

Also update the sleet version so that the final package push is a lot faster.