### PR TITLE
[release/2.1] Update authenticode certs from sha1 to sha2

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
+++ b/src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets
@@ -42,7 +42,7 @@
     <ShouldWritePkgSigningRequired Condition="'$(SkipSigning)' == 'true'">false</ShouldWritePkgSigningRequired>
     <ShouldWritePkgSigningRequired Condition="'$(SignType)' == 'public' or '$(SignType)' == 'oss'">false</ShouldWritePkgSigningRequired>
     <ShouldWritePkgSigningRequired Condition="'$(ShouldWritePkgSigningRequired)'==''">true</ShouldWritePkgSigningRequired>
-    <NuPkgAuthenticodeSig          Condition="'$(ShouldWritePkgSigningRequired)'=='true'">Microsoft</NuPkgAuthenticodeSig>    
+    <NuPkgAuthenticodeSig          Condition="'$(ShouldWritePkgSigningRequired)'=='true'">Microsoft400</NuPkgAuthenticodeSig>    
   </PropertyGroup>
 
   <!--

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/sign.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <AuthenticodeSig Condition="'$(AuthenticodeSig)' == ''">Microsoft</AuthenticodeSig>
+    <AuthenticodeSig Condition="'$(AuthenticodeSig)' == ''">Microsoft400</AuthenticodeSig>
     <StrongNameSig Condition="'$(StrongNameSig)' == '' and '$(SignType)' == 'real' and '$(UseOpenKey)' != 'true'">StrongName</StrongNameSig>
   </PropertyGroup>
 


### PR DESCRIPTION
modified:   src/Microsoft.DotNet.Build.Tasks.Packaging/src/PackageFiles/Packaging.targets