### PR TITLE
Do not log a warning when a retry will happen

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/AzureHelper.cs
@@ -241,11 +241,14 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                 }
                 catch (Exception e)
                 {
-                    loggingHelper.LogWarningFromException(e, true);
-
                     // if this is the final iteration let the exception bubble up
                     if (retries + 1 == retryCount)
+                    {
+                        loggingHelper.LogErrorFromException(e, true);
                         throw;
+                    }
+
+                    loggingHelper.LogMessage(MessageImportance.Low, "Caught exception while sending, retrying: {0}", e.Message);
                 }
 
                 // response can be null if we fail to send the request


### PR DESCRIPTION
Because a retry logged a warning, even though upload passed on the second try, cli enables warnings-as-errors and the build will fail.