### PR TITLE
Cleanup feeds

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,4 +1,4 @@
-Microsoft.DotNet.BuildTools=1.0.27-prerelease-01205-03
+Microsoft.DotNet.BuildTools=1.0.27-experimental-10000-01
 Microsoft.DotNet.BuildTools.Run=1.0.1-prerelease-01205-03
 Microsoft.DotNet.Build.Tasks.Feed=2.2.0-preview1-02804-02 
 NuGet.CommandLine=3.4.3

--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 This repo has been replaced by [Arcade](https://github.com/dotnet/arcade). It's still used for servicing older releases of .NET Core but new code shouldn't use it. As a result, we dont accept new PRs in this code base.
 
-### Windows
-[![Build Status](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Windows_NT/)
-
-### Ubuntu 14.04
-[![Build Status](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/badge/icon)](https://ci.dot.net/job/dotnet_buildtools/job/master/job/Ubuntu14.04/)
-
-[![Packages](https://img.shields.io/dotnet.myget/dotnet-buildtools/v/Microsoft.DotNet.BuildTools.svg?label=Packages)](https://dotnet.myget.org/gallery/dotnet-buildtools/)
-
 This repository contains supporting build tools that are necessary for building
 the [.NET Core][dotnet-corefx] projects. These projects consume the build tools
 via the corresponding [Microsoft.DotNet.BuildTools][Microsoft.DotNet.BuildTools]
@@ -23,5 +15,5 @@ performing [strong name signing][sn-sign].
 outside of the .NET Core projects.
 
 [dotnet-corefx]: https://github.com/dotnet/corefx
-[Microsoft.DotNet.BuildTools]: https://dotnet.myget.org/feed/dotnet-buildtools/package/nuget/Microsoft.DotNet.BuildTools
+[Microsoft.DotNet.BuildTools]: https://dev.azure.com/dnceng/public/_packaging?_a=package&feed=myget-legacy&package=Microsoft.DotNet.BuildTools&protocolType=NuGet
 [sn-sign]: https://github.com/dotnet/corefx/wiki/Strong%20Naming

--- a/bootstrap/bootstrap.ps1
+++ b/bootstrap/bootstrap.ps1
@@ -92,15 +92,15 @@ $pjContent = $pjContent + "}, `"frameworks`": { `"netcoreapp1.0`": { } } }"
 $pjContent | Out-File $projectJson
 
 # now restore the packages
-$buildToolsSource = "https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json"
-$nugetOrgSource = "https://api.nuget.org/v3/index.json"
+$buildToolsSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json"
+$dotnetPublicSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
 if ($env:buildtools_source -ne $null)
 {
     $buildToolsSource = $env:buildtools_source
 }
 $packagesPath = Join-Path $RepositoryRoot "packages"
 $dotNetExe = Join-Path $cliLocalPath "dotnet.exe"
-$restoreArgs = "restore $projectJson --packages $packagesPath --source $buildToolsSource --source $nugetOrgSource"
+$restoreArgs = "restore $projectJson --packages $packagesPath --source $buildToolsSource --source $dotnetPublicSource"
 $process = Start-Process -Wait -NoNewWindow -FilePath $dotNetExe -ArgumentList $restoreArgs -PassThru
 if ($process.ExitCode -ne 0)
 {

--- a/bootstrap/bootstrap.ps1
+++ b/bootstrap/bootstrap.ps1
@@ -94,13 +94,14 @@ $pjContent | Out-File $projectJson
 # now restore the packages
 $buildToolsSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json"
 $dotnetPublicSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+$tempBuildToolsSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json"
 if ($env:buildtools_source -ne $null)
 {
     $buildToolsSource = $env:buildtools_source
 }
 $packagesPath = Join-Path $RepositoryRoot "packages"
 $dotNetExe = Join-Path $cliLocalPath "dotnet.exe"
-$restoreArgs = "restore $projectJson --packages $packagesPath --source $buildToolsSource --source $dotnetPublicSource"
+$restoreArgs = "restore $projectJson --packages $packagesPath --source $buildToolsSource --source $dotnetPublicSource --source $tempBuildToolsSource"
 $process = Start-Process -Wait -NoNewWindow -FilePath $dotNetExe -ArgumentList $restoreArgs -PassThru
 if ($process.ExitCode -ne 0)
 {

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -229,10 +229,11 @@ echo $pjContent > $projectJson
 # now restore the packages
 buildToolsSource="${BUILDTOOLS_SOURCE:-https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json}"
 dotnetPublicSource="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
+tempBuildToolsSource="https://pkgs.dev.azure.com/dnceng/public/_packaging/general-testing/nuget/v3/index.json"
 
 packagesPath="$repoRoot/packages"
 dotNetExe="$cliLocalPath/dotnet"
-restoreArgs="restore $projectJson --packages $packagesPath --source $buildToolsSource --source $dotnetPublicSource"
+restoreArgs="restore $projectJson --packages $packagesPath --source $buildToolsSource --source $dotnetPublicSource --source $tempBuildToolsSource"
 say_verbose "Running $dotNetExe $restoreArgs"
 $dotNetExe $restoreArgs
 if [ $? != 0 ]; then

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -227,12 +227,12 @@ pjContent="$pjContent }, \"frameworks\": { \"netcoreapp1.0\": { } } }"
 echo $pjContent > $projectJson
 
 # now restore the packages
-buildToolsSource="${BUILDTOOLS_SOURCE:-https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json}"
-nugetOrgSource="https://api.nuget.org/v3/index.json"
+buildToolsSource="${BUILDTOOLS_SOURCE:-https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json}"
+dotnetPublicSource="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
 
 packagesPath="$repoRoot/packages"
 dotNetExe="$cliLocalPath/dotnet"
-restoreArgs="restore $projectJson --packages $packagesPath --source $buildToolsSource --source $nugetOrgSource"
+restoreArgs="restore $projectJson --packages $packagesPath --source $buildToolsSource --source $dotnetPublicSource"
 say_verbose "Running $dotNetExe $restoreArgs"
 $dotNetExe $restoreArgs
 if [ $? != 0 ]; then

--- a/dir.props
+++ b/dir.props
@@ -62,8 +62,8 @@
 
   <!-- list of nuget package sources passed to nuget.exe -->
   <ItemGroup>
-    <NuGetSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools" />
-    <NuGetSourceList Include="https:%2F%2Fwww.nuget.org/api/v2" />
+    <NuGetSourceList Include="https:%2F%2Fpkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <NuGetSourceList Include="https:%2F%2Fpkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </ItemGroup>
 
   <!-- Common nuget properties -->
@@ -84,13 +84,9 @@
   <!-- list of nuget package sources passed to dnu -->
   <ItemGroup>
     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. -->
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader-native/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/symreader-converter/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/nuget-build/api/v3/index.json" />
-    <DnuSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fdotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json" />
+    <DnuSourceList Include="https:%2F%2Fpkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <DnuSourceList Include="https:%2F%2Fpkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </ItemGroup>
 
   <!-- list of directories to perform batch restore -->

--- a/run.ps1
+++ b/run.ps1
@@ -10,8 +10,7 @@ if ((Test-Path $bootStrapperPath) -eq 0)
         mkdir $toolsLocalPath | Out-Null
     }
 
-    # download boot-strapper script
-    Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/buildtools/master/bootstrap/bootstrap.ps1" -OutFile $bootStrapperPath
+    Copy-Item (Join-Path (Get-Location) ".\bootstrap\bootstrap.ps1") -Destination $bootStrapperPath
 }
 
 # now execute it

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/codeOptimization.targets
@@ -89,8 +89,8 @@
     <!-- Dynamically create a project.json file used to restore the optimization data-->
     <PropertyGroup>
       <OptimizationDataProject>$(MSBuildThisFileDirectory)OptimizationData.msbuild</OptimizationDataProject>
-      <OptimizationDataNuGetFeed Condition="'$(OptimizationDataNuGetFeed)'==''">https:%2F%2Fdotnet.myget.org/F/roslyn/api/v3/index.json</OptimizationDataNuGetFeed>
-      <CoreFxOptimizationDataNuGetFeed Condition="'$(CoreFxOptimizationDataNuGetFeed)'==''">https:%2F%2Fdotnet.myget.org/F/dotnet-core-optimization-data/api/v3/index.json</CoreFxOptimizationDataNuGetFeed>
+      <OptimizationDataNuGetFeed Condition="'$(OptimizationDataNuGetFeed)'==''">https:%2F%2Fpkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json</OptimizationDataNuGetFeed>
+      <CoreFxOptimizationDataNuGetFeed Condition="'$(CoreFxOptimizationDataNuGetFeed)'==''">https:%2F%2Fhttps://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json</CoreFxOptimizationDataNuGetFeed>
     </PropertyGroup>
 
     <!-- Restore the OptimizationData package -->

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/crossgen.sh
@@ -75,7 +75,7 @@ if [[ -z "${1:-}" || "$1" == "-?" || "$1" == "--help" || "$1" == "-h" ]]; then
     usage
 fi
 
-__MyGetFeed=${BUILDTOOLS_CROSSGEN_FEED:-https://dotnet.myget.org/F/dotnet-core/api/v3/index.json}
+__MyGetFeed=${BUILDTOOLS_CROSSGEN_FEED:-https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json}
 __targetDir=$1
 __packageRid=${2:-}
 __TargetFramework=${3:-}

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.cmd
@@ -33,8 +33,8 @@ set MSBUILD_PROJECT_CONTENT= ^
 set PUBLISH_TFM=netcoreapp2.0
 
 set DEFAULT_RESTORE_ARGS=--no-cache --packages "%PACKAGES_DIR%"
-set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
-set TOOLRUNTIME_RESTORE_ARGS=%INIT_TOOLS_RESTORE_ARGS% --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json
+set INIT_TOOLS_RESTORE_ARGS=%DEFAULT_RESTORE_ARGS% --source https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json %INIT_TOOLS_RESTORE_ARGS%
+set TOOLRUNTIME_RESTORE_ARGS=%INIT_TOOLS_RESTORE_ARGS% --source https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json --source https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json
 
 if not exist "%PROJECT_DIR%" (
   echo ERROR: Cannot find project root path at [%PROJECT_DIR%]. Please pass in the source directory as the 1st parameter.

--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/init-tools.sh
@@ -35,8 +35,8 @@ __PORTABLETARGETS_PROJECT_CONTENT="
 __PUBLISH_TFM=netcoreapp2.0
 
 __DEFAULT_RESTORE_ARGS="--no-cache"
-__INIT_TOOLS_SOURCES="--source https://dotnet.myget.org/F/roslyn/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://api.nuget.org/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
-__TOOLRUNTIME_SOURCES="--source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json"
+__INIT_TOOLS_SOURCES="--source https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json ${__INIT_TOOLS_RESTORE_ARGS:-}"
+__TOOLRUNTIME_SOURCES="--source https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json --source https://dotnetfeed.blob.core.windows.net/dotnet-coreclr/index.json"
 
 if [ ! -d "$__PROJECT_DIR" ]; then
     echo "ERROR: Cannot find project root path at '$__PROJECT_DIR'. Please pass in the source directory as the 1st parameter."

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -10,9 +10,8 @@
     <add key="repositoryPath" value="..\packages" />
   </config>
   <packageSources>
-    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <add key="myget.org nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="dotnet-core-legacy" value="https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="myget-legacy" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Cleanup nuget feeds.

To handle bootstrap problems, this also makes potentially temporary changes of:

- Bootstrap from self instead of going to GitHub (to get script with fixed URLs)
- Replace BuildTools dependency with experimental version having updated feed URLs